### PR TITLE
Shared profile and post links get a generated preview card

### DIFF
--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -25,7 +25,12 @@ Related documents: [README](../README.md) (overview) ·
 - **Erlang and Elixir** to build the release — install via
   [mise](https://mise.jdx.dev/) (`mise install` reads the pinned versions from
   `.tool-versions`).
-- **libvips** for image processing (`apt-get install libvips-dev`).
+- **libvips** for image processing (`apt-get install libvips-dev`). The Debian
+  build includes Pango, which draws the text on the generated link-preview
+  cards (the picture LinkedIn, X, WhatsApp and the others show for a shared
+  profile or post). The cards use **Inter** when the host has it
+  (`apt-get install fonts-inter`, optional) and the system's sans-serif
+  otherwise; nothing breaks without it, the type just looks different.
 - **Chromium** (optional) — only for URL screenshots and moderation evidence
   screenshots. Without it those features quietly do nothing.
 - **poppler-utils** (optional, `apt-get install poppler-utils`) — renders the

--- a/docs/architecture/agents-and-seo.md
+++ b/docs/architecture/agents-and-seo.md
@@ -373,10 +373,38 @@ Every HTML page carries `og:*` + `twitter:card` tags derived in one chokepoint
 (`VutuvWeb.OpenGraph`, rendered by the root layout; the plain description meta
 shares the same derivation).
 
-Pages about a member preview their name, work info and avatar — served as a
-scraper-friendly square JPEG at `/:slug/avatar.jpg`
-(`VutuvWeb.AvatarController`; preview scrapers don't decode the site's AVIF),
-derived on the fly from the kept original, metadata-stripped.
+Pages about a member preview their name and work info, and as picture their
+**generated card** at `/:slug/og.png` (`VutuvWeb.OgImage`, served by
+`VutuvWeb.OgImageController`): a 1200×630 PNG with the face, the name, the
+headline, up to two rows of tags and the follower line, drawn with libvips and
+Pango — no Chromium, and no SVG loader either, the round avatar and the pills
+are masks computed from pixel coordinates. It replaced the square avatar as
+`og:image` because a square picture gets the *small* card on every platform
+(a thumbnail beside the title on Facebook, the `summary` card on X, a
+thumbnail on Slack and Signal), and the wide 1.91:1 shape is the one they all
+draw large. On X the picture is the whole card — since 2024 it shows nothing
+but the image, a tiny title overlay and the domain — so the card carries the
+words. The card's few words (followers, member since, the date) are in the
+member's own locale, one file for everybody who shares the link. The typeface
+is the first of a family list fontconfig finds (Inter when installed, else the
+platform sans), and the line metrics are measured at render time, never
+assumed. Every card renders from the anonymous public view, and a withheld
+profile answers a plain 404 like `/:slug/avatar.jpg` does.
+
+**LinkedIn is the exception, on purpose.** Its organic feed has drawn every
+shared link as a small square cut from the middle of the picture since 2024,
+whatever the picture's size (large cards are for sponsored posts only), so the
+wide card would arrive there as a strip of headline. `VutuvWeb.Plug.PreviewScraper`
+recognises its scraper (`LinkedInBot`) and assigns `:square_preview?`, on which
+`OpenGraph` names a square instead: the avatar (`/:slug/avatar.jpg`) for a
+profile, and for a post the **square post card** at
+`<permalink>/og-square.png` (`OgImage.square_png/1`: face, name and the first
+four lines in type large enough to survive a ninefold reduction — LinkedIn
+shows the square at about 128 px on a desktop and 80 px in its app). The plug
+also merges `user-agent` into the `Vary` header of every HTML response, so a
+cache between us and the scrapers never hands X the LinkedIn tag set; the
+agent-format siblings carry no preview tags and are left alone. The square
+avatar endpoint stays what the ActivityPub actor's `icon` points at.
 
 Pages about an **organization** preview the same way (issue #1581): the page's
 name as title, its own description flattened out of its Markdown as
@@ -388,13 +416,27 @@ both kinds of account page; a page that has claimed a root handle carries it as
 `profile:username`, and no page ever gets the `profile:first_name` /
 `profile:last_name` properties that only describe a person.
 
-Public posts preview as articles with their teaser line, date and first image
+Public posts preview as articles. The `og:title` is "Author: first line…"
+(`OpenGraph.title/1`; the `<title>` keeps its "Author · date" form) because on
+LinkedIn and X the title is all the text a card carries, and the
+`og:description` is the opening of the whole body (`PostTeaser.opening/2`, 200
+characters, paragraph breaks folded), which Bluesky, Mastodon, Slack and
+Facebook draw under the title. The picture is the post's first image
 (`/post_images/<token>/og.jpg`, derived on the fly by the authorizing proxy, so
-audience changes keep guarding it); restricted posts and teasers never leak the
-body or an image. That holds for a post published in an organization's name
-(`/organizations/:slug/posts/:id`) exactly as for a member's — whose post it is
-decides only the *fallback* picture: the post's own first image, else the
-author's avatar or the page's logo, else the brand card.
+audience changes keep guarding it), else — for a member's post — its own
+**generated card** at `<permalink>/og.png` (author, headline and the first six
+lines in the largest of three sizes that fits), else the author's card or the
+page's logo, else the brand card. Restricted posts and teasers never leak the
+body or an image, and the card endpoints refuse them too. A post published in
+an organization's name (`/organizations/:slug/posts/:id`) has no generated
+card yet and falls back to the page's logo.
+
+A federating member's pages also carry `<meta name="fediverse:creator">` with
+their `@handle@host` (`OpenGraph.creator/1`), which Mastodon 4.3+ turns into a
+"More from …" line with a follow button on the preview card — but only once
+the member's actor document lists this host under `attributionDomains`
+(`VutuvWeb.Fediverse.Docs.actor/2` names the apex and its `www.` spelling);
+without that line Mastodon reads the tag and ignores it.
 
 **One module decides which line that is.** `VutuvWeb.PostTeaser.line/2` — and
 its flattened twin `plain_line/2` — is the single owner of the app's one-line

--- a/lib/vutuv_web/components/ui.ex
+++ b/lib/vutuv_web/components/ui.ex
@@ -3633,6 +3633,19 @@ defmodule VutuvWeb.UI do
   def month_name(12), do: gettext("December")
 
   @doc """
+  A date with its month spelled out, in the reader's language: "September 9,
+  2026", German "9. September 2026". For the one place a bare numeric date
+  would leave the reader guessing which number is the day.
+  """
+  def long_date(%Date{} = date) do
+    gettext("%{month} %{day}, %{year}",
+      month: month_name(date.month),
+      day: date.day,
+      year: date.year
+    )
+  end
+
+  @doc """
   The two-letter names of the weekdays, Monday first — the column headings of
   any calendar grid.
 

--- a/lib/vutuv_web/controllers/controller_helpers.ex
+++ b/lib/vutuv_web/controllers/controller_helpers.ex
@@ -315,28 +315,33 @@ defmodule VutuvWeb.ControllerHelpers do
   end
 
   @doc """
-  Answers an `avatar.jpg` request with the derived bytes, or with the plain
-  404 every failure shares.
+  Answers a link-preview image request with the derived bytes, or with the
+  plain 404 every failure shares.
 
-  The two endpoints (`/:slug/avatar.jpg` for a member, `/organizations/:slug/avatar.jpg`
-  for a page) differ only in the lookup and its visibility gate; the answer is
-  the same both ways, and both halves of it are decisions rather than details:
-  the cache lifetime keeps repeat scraper traffic off libvips, and the
-  featureless plain-text 404 is what makes an unknown slug, a missing picture
-  and a page nobody may see indistinguishable from outside.
+  The scraper-image endpoints (`/:slug/avatar.jpg` for a member,
+  `/organizations/:slug/avatar.jpg` for a page, the generated `og.png` cards
+  of `VutuvWeb.OgImageController`) differ only in the lookup and its
+  visibility gate; the answer is the same for all of them, and both halves of
+  it are decisions rather than details: the cache lifetime keeps repeat
+  scraper traffic off libvips, and the featureless plain-text 404 is what
+  makes an unknown slug, a missing picture and a page nobody may see
+  indistinguishable from outside.
   """
-  def send_og_jpeg(%Conn{} = conn, {:ok, jpeg}) do
+  def send_og_image(%Conn{} = conn, {:ok, bytes}, content_type) do
     conn
-    |> Conn.put_resp_content_type("image/jpeg", nil)
+    |> Conn.put_resp_content_type(content_type, nil)
     |> Conn.put_resp_header("cache-control", "public, max-age=86400")
-    |> Conn.send_resp(200, jpeg)
+    |> Conn.send_resp(200, bytes)
   end
 
-  def send_og_jpeg(%Conn{} = conn, _missing) do
+  def send_og_image(%Conn{} = conn, _missing, _content_type) do
     conn
     |> Conn.put_resp_content_type("text/plain")
     |> Conn.send_resp(404, "Not Found")
   end
+
+  @doc "`send_og_image/3` for the JPEG avatar endpoints."
+  def send_og_jpeg(%Conn{} = conn, result), do: send_og_image(conn, result, "image/jpeg")
 
   @doc """
   Renders the bare `VutuvWeb.ErrorHTML` 403/404 page and halts: the one shape

--- a/lib/vutuv_web/controllers/og_image_controller.ex
+++ b/lib/vutuv_web/controllers/og_image_controller.ex
@@ -1,0 +1,138 @@
+defmodule VutuvWeb.OgImageController do
+  @moduledoc """
+  `GET /:slug/og.png`, `GET /:slug/posts/:id/og.png` and
+  `GET /:slug/posts/:id/og-square.png` — the generated link-preview cards
+  (`VutuvWeb.OgImage`) that `og:image` names on a member's pages and on their
+  posts (`VutuvWeb.OpenGraph`; the square one for LinkedIn's scraper alone).
+
+  Served outside the browser pipeline like `/:slug/avatar.jpg`, through the
+  same `ControllerHelpers.send_og_image/3`: an unknown slug, a withheld
+  profile and a post an anonymous reader may not see all answer the same
+  plain 404, so a scraper learns nothing from the difference. The card is
+  drawn from the **anonymous public view** only — the gates are the ones the
+  profile and the permalink ask with no viewer — and a restricted post has no
+  card at all rather than a card of its author, so its words never reach a
+  picture anybody can fetch by URL.
+
+  The card's few words (the follower line, the date) are written in the
+  **member's own** locale, not the scraper's: the picture is one file for
+  everybody who shares the link, and its author's language is the one guess
+  that is right for most of their readers.
+  """
+
+  use VutuvWeb, :controller
+
+  alias Vutuv.Accounts.User
+  alias Vutuv.Avatar
+  alias Vutuv.Moderation
+  alias Vutuv.Posts
+  alias Vutuv.Posts.Post
+  alias Vutuv.Repo
+  alias Vutuv.Social
+  alias VutuvWeb.ControllerHelpers
+  alias VutuvWeb.OgImage
+  alias VutuvWeb.OpenGraph
+  alias VutuvWeb.Plug.Locale
+  alias VutuvWeb.PostTeaser
+  alias VutuvWeb.UI
+  alias VutuvWeb.UserHelpers
+  alias VutuvWeb.UserHTML
+
+  # How many tags the profile card offers the pill rows; the renderer keeps
+  # as many as fit two rows.
+  @tags_shown 8
+
+  def profile(conn, %{"slug" => slug}) do
+    png =
+      with %User{} = user <- public_member(slug) do
+        in_locale(user, fn -> OgImage.profile_png(profile_data(user)) end)
+      end
+
+    ControllerHelpers.send_og_image(conn, png, "image/png")
+  end
+
+  def post(conn, params), do: post_card(conn, params, &OgImage.post_png/1)
+
+  def post_square(conn, params), do: post_card(conn, params, &OgImage.square_png/1)
+
+  # Resolved by the id alone, never by the handle beside it (a handle goes
+  # stale the moment its owner renames). Member posts only for now: a page's
+  # post keeps previewing with its logo (`VutuvWeb.OpenGraph`). For a member's
+  # post `Posts.visible_to?/2` with no viewer already refuses a restricted one.
+  defp post_card(conn, %{"id" => id}, render) do
+    png =
+      with %Post{} = post <- Posts.get_post(id),
+           %User{} = author <- Posts.author(post),
+           true <- Moderation.profile_visible_to?(author, nil),
+           true <- Posts.visible_to?(post, nil) do
+        in_locale(author, fn -> render.(post_data(post, author)) end)
+      end
+
+    ControllerHelpers.send_og_image(conn, png, "image/png")
+  end
+
+  defp public_member(slug) do
+    with %User{} = user <- Repo.get_by(User, username: slug),
+         true <- Moderation.profile_visible_to?(user, nil) do
+      user
+    end
+  end
+
+  defp profile_data(%User{} = user) do
+    Map.merge(author_fields(user), %{tags: tags(user), meta: profile_meta(user)})
+  end
+
+  defp post_data(%Post{} = post, %User{} = author) do
+    Map.merge(author_fields(author), %{
+      text: PostTeaser.opening(post, length: 600),
+      meta: UI.long_date(post.published_on)
+    })
+  end
+
+  # What both cards say about the member: name, headline, face and address.
+  defp author_fields(%User{} = user) do
+    job = UserHelpers.current_job(user)
+
+    %{
+      name: UserHelpers.full_name(user),
+      headline: UserHelpers.profile_headline(user, job, 120),
+      avatar: avatar(user),
+      footer: address(user)
+    }
+  end
+
+  defp avatar(%User{} = user) do
+    case Avatar.og_jpeg(user) do
+      {:ok, jpeg} -> jpeg
+      :error -> nil
+    end
+  end
+
+  # The member's tags in endorsement order, the same order the profile's Tags
+  # card lists them in.
+  defp tags(%User{} = user) do
+    case Map.get(UserHelpers.tag_summary_map([user], @tags_shown), user.id) do
+      %{top: user_tags} -> Enum.map(user_tags, & &1.tag.name)
+      nil -> []
+    end
+  end
+
+  # "7 followers · Member since 2016"; each half only when it has something to
+  # say.
+  defp profile_meta(%User{} = user) do
+    [OpenGraph.follower_detail(Social.follower_count(user)), UserHTML.member_since(user)]
+    |> Enum.reject(&(&1 in [nil, ""]))
+    |> Enum.join(" · ")
+  end
+
+  # The profile's address as a reader would type it: host and handle, no
+  # scheme — `www.` included when the installation serves under it.
+  defp address(%User{username: username}), do: "#{VutuvWeb.Endpoint.host()}/#{username}"
+
+  # The member's locale for the card's words, falling back to the request's
+  # for a locale this installation does not serve.
+  defp in_locale(%User{locale: locale}, fun) do
+    locale = if Locale.locale_supported?(locale), do: locale, else: Gettext.get_locale()
+    Gettext.with_locale(VutuvWeb.Gettext, locale, fun)
+  end
+end

--- a/lib/vutuv_web/fediverse/docs.ex
+++ b/lib/vutuv_web/fediverse/docs.ex
@@ -163,8 +163,29 @@ defmodule VutuvWeb.Fediverse.Docs do
       "featured" => featured_url(user)
     })
     |> put_icon(user)
+    |> put_attribution_domains()
     |> put_also_known_as(user)
     |> put_moved_to(user)
+  end
+
+  # The `toot:` term for `attributionDomains`, the way Mastodon's own actor
+  # documents declare it.
+  @attribution_context %{
+    "toot" => "http://joinmastodon.org/ns#",
+    "attributionDomains" => %{"@id" => "toot:attributionDomains", "@type" => "@id"}
+  }
+
+  # Which sites may name this member as the author of a page: this one, in
+  # both its spellings. Mastodon 4.3+ honours a page's `fediverse:creator` tag
+  # (`VutuvWeb.OpenGraph.creator/1`) only when the page's host is on the
+  # named actor's list, and draws a "More from …" follow line on the preview
+  # card when it is. Without this the tag is read and ignored, silently.
+  defp put_attribution_domains(doc) do
+    apex = String.replace_prefix(VutuvWeb.Endpoint.host(), "www.", "")
+
+    doc
+    |> Map.update!("@context", &(&1 ++ [@attribution_context]))
+    |> Map.put("attributionDomains", [apex, "www." <> apex])
   end
 
   # The picture, named only while there is one. It used to be advertised

--- a/lib/vutuv_web/live/notification_live/index.ex
+++ b/lib/vutuv_web/live/notification_live/index.ex
@@ -1371,11 +1371,7 @@ defmodule VutuvWeb.NotificationLive.Index do
         gettext("Yesterday")
 
       true ->
-        gettext("%{month} %{day}, %{year}",
-          month: month_name(day.month),
-          day: day.day,
-          year: day.year
-        )
+        long_date(day)
     end
   end
 

--- a/lib/vutuv_web/og_card.ex
+++ b/lib/vutuv_web/og_card.ex
@@ -35,6 +35,8 @@ defmodule VutuvWeb.OgCard do
       Image.write(logo, out)
   """
 
+  alias Vix.Vips.Image, as: Vimage
+
   @width 1200
   @height 630
   @logo_width 560
@@ -89,10 +91,40 @@ defmodule VutuvWeb.OgCard do
   # Load the pre-rasterized white wordmark (white letters on transparent,
   # tightly cropped) and size it for the card. Only the PNG loader is used, so
   # this never depends on the librsvg loader being on the libvips path.
-  defp white_wordmark do
+  defp white_wordmark, do: white_wordmark(@logo_width)
+
+  defp white_wordmark(width) do
     path =
       Path.join(Application.app_dir(:vutuv, "priv"), "static/images/vutuv-wordmark-white.png")
 
-    Image.thumbnail(path, @logo_width)
+    Image.thumbnail(path, width)
+  end
+
+  @doc """
+  The wordmark `width` px wide in any `color` (a CSS hex), as an RGBA image
+  with the letters' own alpha — the same asset as the brand card, recoloured
+  through it, so a logo change lands on every generated card at once. Built
+  once per size and colour and kept in `:persistent_term`, materialised, so a
+  card render pays no file read for it.
+  """
+  def wordmark(width, color) do
+    key = {__MODULE__, :wordmark, width, color}
+
+    case :persistent_term.get(key, nil) do
+      nil ->
+        with {:ok, white} <- white_wordmark(width),
+             {_rgb, alpha} when not is_nil(alpha) <- Image.split_alpha(white),
+             {:ok, fill} <- Image.new(Image.width(white), Image.height(white), color: color),
+             {:ok, mark} <- Image.add_alpha(fill, alpha),
+             {:ok, mark} <- Vimage.copy_memory(mark) do
+          :persistent_term.put(key, mark)
+          {:ok, mark}
+        else
+          _ -> :error
+        end
+
+      mark ->
+        {:ok, mark}
+    end
   end
 end

--- a/lib/vutuv_web/og_image.ex
+++ b/lib/vutuv_web/og_image.ex
@@ -1,0 +1,634 @@
+defmodule VutuvWeb.OgImage do
+  @moduledoc """
+  The generated link-preview picture (`og:image`, 1200×630) for a page about
+  one member or one post: what LinkedIn, X, Facebook, Bluesky, Mastodon,
+  WhatsApp, Slack and iMessage draw when a vutuv URL is shared.
+
+  A square avatar (`/:slug/avatar.jpg`, 512 px) gets the *small* card on every
+  one of them — a thumbnail beside the title on LinkedIn and Facebook, the
+  `summary` card on X — and X shows no title at all outside the picture, so a
+  page shared there was a face and a domain. The wide card that carries the
+  member's name, their headline and the opening of the post in its own pixels
+  is the only shape every platform renders large.
+
+  Composed with libvips (`Image`): text through Pango (`Vix.Vips.Operation.text`
+  with markup), the round avatar and the tag pills through masks computed from
+  pixel coordinates rather than rasterised SVG, so the card never depends on
+  the librsvg loader that `VutuvWeb.OgCard` documents as absent on some hosts.
+  The typeface is the first of `@font` fontconfig finds — Inter when the host
+  has it (`fonts-inter` on Debian), else the platform sans — so the line
+  metrics are measured at render time rather than assumed.
+
+  The third shape, `square_png/1`, is for LinkedIn alone: its organic feed
+  cuts a small square from the middle of whatever `og:image` it is given and
+  shows it at roughly 128 px, so a square drawn as one — the face, the name
+  and the first three or four lines in very large type — is what survives
+  there, where the wide card's middle is a strip of headline.
+
+  All three take plain data, not schemas, so the controller builds the map
+  from the records and a script can build one from anything (that is how the
+  design was iterated). `:error` on any libvips failure: the page falls back
+  to the brand card, never to a 500 on a scraper's GET.
+  """
+
+  alias Vix.Vips.Image, as: Vimage
+  alias Vix.Vips.Operation
+  alias VutuvWeb.OgCard
+
+  @width 1200
+  @height 630
+  @margin 72
+  @bar 12
+  @lift 24
+  @square 1200
+  @wordmark_width 150
+
+  @font "Inter, Helvetica Neue, Helvetica, Arial, DejaVu Sans, sans-serif"
+
+  # A line of invisible glyphs spanning ascender to descender (see `pango/5`).
+  @ghost_line ~s(<span fgalpha="1">Ẫǧ</span>)
+
+  # Direction A tokens (assets/css/app.css): slate ink on white, brand blue.
+  @ink "#0f172a"
+  @muted "#64748b"
+  @faint "#94a3b8"
+  @brand_700 "#1e40af"
+  @brand_600 "#1d4ed8"
+  @brand_500 "#2563eb"
+  @brand_50 "#eff6ff"
+  @white "#ffffff"
+
+  def width, do: @width
+  def height, do: @height
+  def square, do: @square
+
+  @typedoc """
+  What a card is drawn from. `:avatar` is the member's square JPEG bytes
+  (`Vutuv.Avatar.og_jpeg/1`), nil for a member without a picture.
+  """
+  @type data :: %{
+          required(:name) => String.t(),
+          optional(:headline) => String.t() | nil,
+          optional(:avatar) => binary() | nil,
+          optional(:tags) => [String.t()],
+          optional(:footer) => String.t() | nil,
+          optional(:text) => String.t() | nil,
+          optional(:meta) => String.t() | nil
+        }
+
+  @doc """
+  The profile card: the avatar on the left, and beside it — vertically
+  centred as a block — the name, the headline, up to two rows of tag pills
+  and the follower line; the profile's address in the footer.
+  """
+  @spec profile_png(data()) :: {:ok, binary()} | :error
+  def profile_png(data) do
+    render(fn card ->
+      avatar_size = 260
+      # Centred a little above the middle: the footer takes the bottom band.
+      avatar_y = @bar + div(@height - @bar - avatar_size, 2) - @lift
+      column_x = @margin + avatar_size + 56
+      column_width = @width - @margin - column_x
+
+      with {:ok, card} <- place_avatar(card, data[:avatar], avatar_size, @margin, avatar_y),
+           {:ok, blocks} <-
+             blocks([
+               {fn -> text_block(data.name, column_width, 54, weight: :bold, lines: 2) end, 0},
+               {fn -> text_block(data[:headline], column_width, 30, color: @muted, lines: 2) end,
+                14},
+               {fn -> pill_row(data[:tags] || [], column_width) end, 28},
+               {fn -> text_block(data[:meta], column_width, 26, color: @faint) end, 26}
+             ]),
+           {:ok, card} <- stack(card, blocks, column_x, centred_top(blocks) - @lift) do
+        footer(card, data[:footer])
+      end
+    end)
+  end
+
+  @doc """
+  The post card: the author's avatar, name and headline as the header, the
+  opening of the post as the body, the date and the post's address in the
+  footer.
+  """
+  @spec post_png(data()) :: {:ok, binary()} | :error
+  def post_png(data) do
+    render(fn card ->
+      avatar_size = 88
+      header_x = @margin + avatar_size + 24
+      header_width = @width - @margin - header_x
+      body_top = @margin + avatar_size + 40
+      body_height = @height - body_top - @margin - 56
+
+      with {:ok, card} <- place_avatar(card, data[:avatar], avatar_size, @margin, @margin),
+           {:ok, header} <-
+             blocks([
+               {fn -> text_block(data.name, header_width, 34, weight: :bold) end, 0},
+               {fn -> text_block(data[:headline], header_width, 24, color: @muted) end, 6}
+             ]),
+           {:ok, card} <- stack(card, header, header_x, @margin + 4),
+           {:ok, body} <- body_block(data[:text], @width - 2 * @margin, body_height),
+           {:ok, card} <- place(card, body, @margin, body_top) do
+        footer(card, data[:footer], data[:meta])
+      end
+    end)
+  end
+
+  @doc """
+  The square post card for LinkedIn's thumbnail: the face and the name on
+  top, the opening of the post in type large enough to survive a ninefold
+  reduction, the wordmark at the foot. No headline, no date, no address —
+  at 128 px none of them would be legible.
+  """
+  @spec square_png(data()) :: {:ok, binary()} | :error
+  def square_png(data) do
+    margin = 80
+    avatar_size = 240
+    name_x = margin + avatar_size + 40
+    name_width = @square - margin - name_x
+    body_top = margin + avatar_size + 72
+    body_height = @square - body_top - margin - 100
+
+    render({@square, @square}, fn card ->
+      with {:ok, card} <- place_avatar(card, data[:avatar], avatar_size, margin, margin),
+           {:ok, name} <-
+             blocks([
+               {fn -> text_block(data.name, name_width, 88, weight: :bold, lines: 2) end, 0}
+             ]),
+           {:ok, card} <-
+             stack(card, name, name_x, margin + div(avatar_size - stack_height(name), 2)),
+           {:ok, body} <-
+             body_block(data[:text], @square - 2 * margin, body_height, [136, 120, 108], 4),
+           {:ok, card} <- place(card, body, margin, body_top),
+           {:ok, mark} <- OgCard.wordmark(200, @brand_600) do
+        Image.compose(card, mark, x: margin, y: @square - margin - Image.height(mark))
+      end
+    end)
+  end
+
+  # ---------------------------------------------------------------- canvas
+
+  defp render(size \\ {@width, @height}, draw)
+
+  defp render({width, height}, draw) do
+    with {:ok, card} <- Image.new(width, height, color: @white),
+         {:ok, bar} <- bar(width),
+         {:ok, card} <- Image.compose(card, bar, x: 0, y: 0),
+         {:ok, card} <- draw.(card),
+         {:ok, card} <- Image.flatten(card),
+         {:ok, png} <- Image.write(card, :memory, suffix: ".png") do
+      {:ok, png}
+    else
+      _ -> :error
+    end
+  rescue
+    # A libvips failure (a missing font, a corrupt avatar) degrades to "no
+    # generated card" — the page keeps its brand card — never to a 500.
+    _ -> :error
+  end
+
+  # The brand gradient along the top edge, built once per width.
+  defp bar(width) do
+    cached({:bar, width}, fn ->
+      Image.linear_gradient(width, @bar,
+        start_color: @brand_700,
+        finish_color: @brand_500,
+        angle: 90
+      )
+    end)
+  end
+
+  # The wordmark bottom-left in brand blue; an address and, on a post card, a
+  # date bottom-right in the faint ink.
+  defp footer(card, address, meta \\ nil) do
+    baseline = @height - @margin - 36
+
+    with {:ok, mark} <- OgCard.wordmark(@wordmark_width, @brand_600),
+         {:ok, card} <- Image.compose(card, mark, x: @margin, y: baseline + 2),
+         {:ok, line} <- text_block(joined(meta, address), @width - 2 * @margin, 24, color: @faint) do
+      place(card, line, @width - @margin - block_width(line), baseline)
+    end
+  end
+
+  # Pixels that are the same on every card — the bar, the avatar masks — are
+  # built once, materialised (a lazy libvips graph would be re-evaluated on
+  # every write) and kept in `:persistent_term` beside the font metrics.
+  defp cached(key, build) do
+    case :persistent_term.get({__MODULE__, key}, nil) do
+      nil ->
+        with {:ok, img} <- build.(),
+             {:ok, img} <- Vimage.copy_memory(img) do
+          :persistent_term.put({__MODULE__, key}, img)
+          {:ok, img}
+        end
+
+      img ->
+        {:ok, img}
+    end
+  end
+
+  defp joined(nil, address), do: address
+  defp joined(meta, nil), do: meta
+  defp joined(meta, address), do: "#{meta}   ·   #{address}"
+
+  # ---------------------------------------------------------------- blocks
+
+  # A block is an image (or nil for "nothing to draw") that a card stacks
+  # vertically. `blocks/1` builds a list of `{image, gap_before}` from thunks,
+  # dropping the empty ones together with their gap, so a member with no
+  # headline does not leave a hole where it would have been.
+  defp blocks(thunks) do
+    Enum.reduce_while(thunks, {:ok, []}, fn {thunk, gap}, {:ok, acc} ->
+      case thunk.() do
+        {:ok, nil} -> {:cont, {:ok, acc}}
+        {:ok, img} -> {:cont, {:ok, [{img, if(acc == [], do: 0, else: gap)} | acc]}}
+        error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, acc} -> {:ok, Enum.reverse(acc)}
+      error -> error
+    end
+  end
+
+  defp stack_height(blocks),
+    do: Enum.reduce(blocks, 0, fn {img, gap}, sum -> sum + gap + Image.height(img) end)
+
+  # The y at which a stack sits vertically centred in the card below the bar.
+  defp centred_top(blocks), do: @bar + div(@height - @bar - stack_height(blocks), 2)
+
+  defp stack(card, blocks, x, y) do
+    Enum.reduce_while(blocks, {:ok, card, y}, fn {img, gap}, {:ok, card, y} ->
+      case Image.compose(card, img, x: x, y: y + gap) do
+        {:ok, card} -> {:cont, {:ok, card, y + gap + Image.height(img)}}
+        error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, card, _y} -> {:ok, card}
+      error -> error
+    end
+  end
+
+  defp place(card, nil, _x, _y), do: {:ok, card}
+  defp place(card, img, x, y), do: Image.compose(card, img, x: x, y: y)
+
+  defp block_width(nil), do: 0
+  defp block_width(img), do: Image.width(img)
+
+  # ---------------------------------------------------------------- text
+
+  # `string` wrapped to `width` in `size` px, at most `:lines` lines (default
+  # 1): a longer text is cut on a word boundary and ends in an ellipsis. A
+  # string with nothing drawable in it (nil, "", emoji alone) is no block at
+  # all.
+  defp text_block(string, width, size, style) do
+    case clean(string) do
+      "" ->
+        {:ok, nil}
+
+      text ->
+        lines = Keyword.get(style, :lines, 1)
+        weight = Keyword.get(style, :weight, :normal)
+        color = Keyword.get(style, :color, @ink)
+
+        with {:ok, max_height} <- max_height(size, lines) do
+          fitted(text, width, max_height, size, weight, color)
+        end
+    end
+  end
+
+  # The post body: the largest of the `sizes` at which the whole opening fits
+  # `lines` lines, so a two-line post reads big and a long one still shows its
+  # first lines at the smallest size, cut there. `height` caps the block on
+  # top of that.
+  defp body_block(string, width, height, sizes \\ [44, 40, 36], lines \\ 6) do
+    case clean(string) do
+      "" -> {:ok, nil}
+      text -> body_block_at(text, width, height, sizes, lines)
+    end
+  end
+
+  defp body_block_at(string, width, height, sizes, lines) do
+    {larger, [floor]} = Enum.split(sizes, -1)
+
+    case cap(string, width, floor, lines) do
+      {:whole, string} ->
+        Enum.find_value(larger, &whole_block(string, width, height, &1, lines)) ||
+          floor_block(string, width, height, floor, lines)
+
+      {:cut, string} ->
+        floor_block(string, width, height, floor, lines)
+    end
+  end
+
+  # The whole text at `size`, or nil when it does not fit `lines` lines.
+  defp whole_block(string, width, height, size, lines) do
+    with {:ok, tallest} <- max_height(size, lines),
+         {:ok, img, false} <- measured(string, width, min(tallest, height), size) do
+      {:ok, img}
+    else
+      _ -> nil
+    end
+  end
+
+  defp floor_block(string, width, height, floor, lines) do
+    with {:ok, tallest} <- max_height(floor, lines) do
+      fitted(string, width, min(tallest, height), floor, :normal, @ink)
+    end
+  end
+
+  # More characters than could fill `lines` lines at `size` even in a narrow
+  # face are cut before anything is rendered: Pango lays the whole text out
+  # first, and a long body at the square card's 136 px runs past the largest
+  # surface Cairo allows — which came back as an error rather than a card.
+  # Generous (0.3 em per character), so nothing that could have fit is lost;
+  # a cut text takes the floor size, since it cannot fit whole at a larger one.
+  defp cap(string, width, size, lines) do
+    most = trunc(lines * width / (size * 0.3))
+
+    if String.length(string) > most,
+      do: {:cut, Regex.replace(~r/\s+\S*\z/u, String.slice(string, 0, most), "")},
+      else: {:whole, string}
+  end
+
+  # Renders `string` wrapped to `width`; if the block is taller than
+  # `max_height`, cuts it to about the share that fits and then a word at a
+  # time until it does, closing with "…". The first cut is by the overshoot
+  # (a 600-character opening at six lines' room is two or three renders, not
+  # forty), the rest by the word.
+  defp fitted(string, width, max_height, size, weight, color) do
+    case measured(string, width, max_height, size, weight, color) do
+      {:ok, img, false} ->
+        {:ok, img}
+
+      {:ok, img, true} ->
+        string
+        |> about(max_height / Image.height(img))
+        |> shorter()
+        |> fitted(width, max_height, size, weight, color)
+
+      error ->
+        error
+    end
+  end
+
+  # The leading share of `string` a block that overshoots by 1/`share` is
+  # likely to fit at, on a word boundary — a little over rather than under,
+  # because the word loop after it only ever shortens: a cut that lands short
+  # of the room costs a line of the card, one that lands long costs a render
+  # or two. The whole string when the overshoot is under two lines or so:
+  # lines wrap unevenly, and there a character share lands a whole line short
+  # where three or four word cuts land exactly.
+  defp about(string, share) when share > 0.6, do: string
+
+  defp about(string, share) do
+    keep = trunc(String.length(string) * share * 1.2)
+    Regex.replace(~r/\s+\S*\z/u, String.slice(string, 0, keep), "")
+  end
+
+  defp measured(string, width, max_height, size, weight \\ :normal, color \\ @ink) do
+    with {:ok, img} <- pango(string, width, size, weight, color) do
+      {:ok, img, Image.height(img) > max_height}
+    end
+  end
+
+  # Drops the last word (past the last space, the last character) and closes
+  # with an ellipsis. Line breaks in the rest of the text are kept. A string
+  # that cannot be shortened further keeps a single character, so the
+  # recursion always ends.
+  defp shorter(string) do
+    base = string |> String.trim_trailing("…") |> String.trim_trailing()
+
+    cut =
+      case Regex.replace(~r/\s+\S+\s*\z/u, base, "") do
+        "" -> String.slice(base, 0, max(String.length(base) - 1, 1))
+        rest -> rest
+      end
+
+    Regex.replace(~r/[\s,.;:–-]+\z/u, cut, "") <> "…"
+  end
+
+  # The text through Pango as an RGBA image with a consistent line box. Pango
+  # (via libvips) trims the picture to the ink, so "PHP" and "open source"
+  # come back with different heights and different tops, which no baseline
+  # can be aligned from. So the text is rendered between two lines of
+  # invisible glyphs — one reaching the ascender line, one the descender, at
+  # alpha 1/65535 — and those lines are cropped off again by the measured
+  # pitch: what is left spans the full line box of the first and last visible
+  # lines, whatever their letters, and the ink trim of the visible glyphs
+  # alone decides the width.
+  defp pango(string, width, size, weight, color) do
+    span = ~s(<span foreground="#{color}" weight="#{weight}">#{escape(string)}</span>)
+
+    with {:ok, {_single, pitch}} <- metrics(size),
+         {:ok, img} <- raw_text(@ghost_line <> "\n" <> span <> "\n" <> @ghost_line, width, size),
+         {:ok, alpha} <- Operation.extract_band(img, 3),
+         {:ok, {left, _top, ink_width, _h}} <-
+           Operation.find_trim(alpha, threshold: 0, background: [0.0]),
+         true <- ink_width > 0 and Image.height(img) > 2 * pitch do
+      Image.crop(img, left, pitch, ink_width, Image.height(img) - 2 * pitch)
+    else
+      false -> {:error, :blank}
+      error -> error
+    end
+  end
+
+  defp raw_text(markup, width, size) do
+    with {:ok, {img, _flags}} <-
+           Operation.text(markup,
+             font: "#{@font} #{size}",
+             dpi: 72,
+             rgba: true,
+             width: width,
+             wrap: :VIPS_TEXT_WRAP_WORD,
+             align: :VIPS_ALIGN_LOW
+           ) do
+      {:ok, img}
+    end
+  end
+
+  defp escape(string), do: string |> Plug.HTML.html_escape_to_iodata() |> IO.iodata_to_binary()
+
+  # One line's box and the pitch between two lines at this size, in the font
+  # fontconfig actually picked — measured, not assumed, and cached per size.
+  defp metrics(size) do
+    case :persistent_term.get({__MODULE__, :metrics, size}, nil) do
+      nil ->
+        with {:ok, one} <- raw_text(@ghost_line, 200, size),
+             {:ok, two} <- raw_text(@ghost_line <> "\n" <> @ghost_line, 200, size) do
+          single = Image.height(one)
+          metrics = {single, Image.height(two) - single}
+          :persistent_term.put({__MODULE__, :metrics, size}, metrics)
+          {:ok, metrics}
+        end
+
+      metrics ->
+        {:ok, metrics}
+    end
+  end
+
+  # The tallest `lines`-line block this size can produce, with a pixel of
+  # slack for rounding.
+  defp max_height(size, lines) do
+    with {:ok, {single, pitch}} <- metrics(size) do
+      {:ok, single + (lines - 1) * pitch + 1}
+    end
+  end
+
+  # Whitespace folded; emoji and other pictographs dropped, because Pango draws
+  # them from a monochrome fallback face as black silhouettes. nil is "".
+  defp clean(nil), do: ""
+
+  defp clean(string) do
+    string
+    |> String.replace(~r/[\p{So}\p{Sk}\p{Cs}\x{FE0F}\x{200D}]/u, "")
+    |> String.replace(~r/[ \t]+/, " ")
+    |> String.replace(~r/ *\n[ \n]*/, "\n")
+    |> String.trim()
+  end
+
+  # ---------------------------------------------------------------- pills
+
+  # Up to two rows of tag pills in brand-50 with brand-700 text, as many as
+  # fit, on a transparent layer the caller stacks like a text block. No tags,
+  # no block.
+  defp pill_row(tags, width) do
+    case tags |> Enum.map(&clean/1) |> Enum.reject(&(&1 == "")) do
+      [] -> {:ok, nil}
+      labels -> pill_row_of(labels, width)
+    end
+  end
+
+  @pill %{size: 24, pad_x: 18, height: 44, gap: 12, rows: 2}
+
+  defp pill_row_of(tags, width) do
+    %{height: height, gap: gap, rows: rows} = @pill
+
+    with {:ok, layer} <-
+           Image.new(width, rows * height + (rows - 1) * gap, color: [0, 0, 0, 0], bands: 4),
+         {:ok, layer, rows_used} when rows_used > 0 <- draw_pills(layer, tags, width) do
+      Image.crop(layer, 0, 0, width, rows_used * height + (rows_used - 1) * gap)
+    else
+      # Not one pill fit (a single tag wider than the column): no block.
+      {:ok, _layer, 0} -> {:ok, nil}
+      error -> error
+    end
+  end
+
+  # Pills left to right, row by row, until one no longer fits; answers the
+  # layer and how many rows it used — zero when even the first was refused.
+  defp draw_pills(layer, tags, width) do
+    Enum.reduce_while(tags, {:ok, layer, 0, 0}, fn tag, {:ok, layer, x, row} ->
+      case draw_pill(layer, tag, {x, row}, width) do
+        {:ok, layer, x, row} -> {:cont, {:ok, layer, x, row}}
+        :full -> {:halt, {:ok, layer, x, row}}
+        error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, _layer, 0, 0} -> {:ok, layer, 0}
+      {:ok, layer, _x, row} -> {:ok, layer, row + 1}
+      error -> error
+    end
+  end
+
+  # One pill at the next free slot from (x, row): the slot after it, or
+  # `:full` when neither this row nor the next has room.
+  defp draw_pill(layer, tag, {x, row}, width) do
+    %{size: size, pad_x: pad_x, height: height, gap: gap} = @pill
+
+    with {:ok, label} <- pango(tag, width, size, :normal, @brand_700),
+         pill_width = Image.width(label) + 2 * pad_x,
+         {:ok, x, row} <- pill_slot(x, row, pill_width, width),
+         y = row * (height + gap),
+         {:ok, pill} <- rounded_rect(pill_width, height, div(height, 2), @brand_50),
+         {:ok, layer} <- Image.compose(layer, pill, x: x, y: y),
+         {:ok, layer} <-
+           Image.compose(layer, label,
+             x: x + pad_x,
+             y: y + div(height - Image.height(label), 2)
+           ) do
+      {:ok, layer, x + pill_width + gap, row}
+    end
+  end
+
+  # Where the next pill goes: on this row if it fits, else at the start of the
+  # next, `:full` once the rows are spent.
+  defp pill_slot(x, row, pill_width, width) do
+    cond do
+      x + pill_width <= width -> {:ok, x, row}
+      row + 1 < @pill.rows and pill_width <= width -> {:ok, 0, row + 1}
+      true -> :full
+    end
+  end
+
+  # ---------------------------------------------------------------- pictures
+
+  # The round avatar at (x, y); a member without a picture gets a brand-50
+  # disc, so the card keeps its shape.
+  defp place_avatar(card, nil, size, x, y) do
+    with {:ok, disc} <- rounded_rect(size, size, div(size, 2), @brand_50) do
+      Image.compose(card, disc, x: x, y: y)
+    end
+  end
+
+  defp place_avatar(card, jpeg, size, x, y) when is_binary(jpeg) do
+    with {:ok, img} <- Image.open(jpeg),
+         {:ok, img} <- Image.thumbnail(img, size, crop: :center),
+         {:ok, img} <- Image.flatten(img),
+         {:ok, mask} <- cached({:circle, size}, fn -> circle_mask(size) end),
+         {:ok, round} <- Image.add_alpha(img, mask) do
+      Image.compose(card, round, x: x, y: y)
+    end
+  end
+
+  # ---------------------------------------------------------------- masks
+
+  # A filled rounded rectangle with an anti-aliased edge, as an RGBA image.
+  defp rounded_rect(width, height, radius, color) do
+    with {:ok, fill} <- Image.new(width, height, color: color),
+         {:ok, mask} <- rounded_mask(width, height, radius) do
+      Image.add_alpha(fill, mask)
+    end
+  end
+
+  defp circle_mask(size), do: rounded_mask(size, size, size / 2)
+
+  # The signed distance from each pixel centre to a rounded rectangle, turned
+  # into coverage: 255 inside, 0 outside, a one-pixel ramp on the edge. Pure
+  # pixel arithmetic — `Image.rounded/2` and `Image.avatar/2` rasterise an SVG
+  # for the same mask, which needs the librsvg loader.
+  defp rounded_mask(width, height, radius) do
+    cx = (width - 1) / 2
+    cy = (height - 1) / 2
+    inner_x = width / 2 - radius
+    inner_y = height / 2 - radius
+
+    with {:ok, xyz} <- Operation.xyz(width, height),
+         {:ok, x} <- Operation.extract_band(xyz, 0),
+         {:ok, y} <- Operation.extract_band(xyz, 1),
+         {:ok, dx} <- corner_distance(x, cx, inner_x),
+         {:ok, dy} <- corner_distance(y, cy, inner_y),
+         {:ok, dx2} <- Operation.multiply(dx, dx),
+         {:ok, dy2} <- Operation.multiply(dy, dy),
+         {:ok, d2} <- Operation.add(dx2, dy2),
+         {:ok, d} <- Operation.math2_const(d2, :VIPS_OPERATION_MATH2_POW, [0.5]),
+         # coverage = clip((radius + 0.5 - d) * 255, 0, 255); the cast clips.
+         {:ok, cov} <- Operation.linear(d, [-255.0], [(radius + 0.5) * 255]) do
+      Operation.cast(cov, :VIPS_FORMAT_UCHAR)
+    end
+  end
+
+  # max(|v - centre| - inner, 0), the distance past the straight part of the
+  # edge; zero along the flat sides. max(a, 0) = (a + |a|) / 2 keeps it to
+  # arithmetic libvips has.
+  defp corner_distance(band, centre, inner) do
+    with {:ok, shifted} <- Operation.linear(band, [1.0], [-centre]),
+         {:ok, abs} <- Operation.abs(shifted),
+         {:ok, past} <- Operation.linear(abs, [1.0], [-inner]),
+         {:ok, past_abs} <- Operation.abs(past),
+         {:ok, sum} <- Operation.add(past, past_abs) do
+      Operation.linear(sum, [0.5], [0.0])
+    end
+  end
+end

--- a/lib/vutuv_web/open_graph.ex
+++ b/lib/vutuv_web/open_graph.ex
@@ -7,9 +7,15 @@ defmodule VutuvWeb.OpenGraph do
 
     * a page about a member (`:user` — the profile, its sections, their
       posts): the member's name as title, their work info and follower
-      count as description, their avatar as image. The avatar is linked as `/:slug/avatar.jpg`
-      (`VutuvWeb.AvatarController`) because preview scrapers don't decode
-      the AVIF the site serves itself.
+      count as description, their **generated card** as image
+      (`/:slug/og.png`, `VutuvWeb.OgImage`: face, name, headline and tags in
+      one 1200×630 picture, the shape every platform draws large). The one
+      exception is LinkedIn's scraper, whose organic feed draws every link as
+      a small square cut from the middle of the picture (since 2024, whatever
+      the size): it gets the square avatar, `/:slug/avatar.jpg`
+      (`VutuvWeb.AvatarController`, a JPEG because preview scrapers don't
+      decode the AVIF the site serves itself), or the brand card when the
+      member has none.
     * a page about an organization (`:organization` — the page itself and
       the posts published in its name): its name as title, its own
       description as description, its logo as image. The logo is linked as
@@ -17,17 +23,22 @@ defmodule VutuvWeb.OpenGraph do
       (`VutuvWeb.OrganizationAvatarController`), the square JPEG twin of the
       member endpoint above, and only while the page is publicly visible —
       that endpoint refuses it otherwise.
-    * a visible, unrestricted post additionally previews its first line,
-      its publication date and — when it has images — its first image
-      (`/post_images/<token>/og.jpg`, the proxy's on-the-fly JPEG);
-      restricted posts and teasers never put the body or an image into
-      a tag. Whose post it is decides only the *fallback* picture (avatar
-      or logo), so a member's post and a page's post preview alike.
+    * a visible, unrestricted post titles as "Author: first line…" (on
+      LinkedIn and X the title is all the text a card carries), describes
+      itself with the opening of its body, carries its publication date and
+      previews — when it has images — its first image
+      (`/post_images/<token>/og.jpg`, the proxy's on-the-fly JPEG), else, for
+      a member's post, its own generated card (`<permalink>/og.png`: the
+      author and the opening lines in the picture itself), else the author's
+      picture as above; restricted posts and teasers never put the body or an
+      image into a tag. A page's post has no generated card yet and falls
+      back to the page's logo.
     * everything else: the site description and the generated brand card
       (`VutuvWeb.OgCard`).
 
   The plain `<meta name="description">` renders `description/1` too, so
-  the two can never disagree.
+  the two can never disagree. `creator/1` adds `fediverse:creator` for a
+  federating member, which Mastodon turns into a "More from …" follow line.
 
   **Who names the subject.** These assigns reach here two ways: a plug or a
   controller render assign (`:user` from `VutuvWeb.Plug.UserResolveSlug`,
@@ -49,6 +60,8 @@ defmodule VutuvWeb.OpenGraph do
   use Gettext, backend: VutuvWeb.Gettext
 
   alias Vutuv.Accounts.User
+  alias Vutuv.Fediverse
+  alias Vutuv.Moderation
   alias Vutuv.OrganizationImageStore
   alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
@@ -57,8 +70,11 @@ defmodule VutuvWeb.OpenGraph do
   alias Vutuv.Posts.PostImage
   alias Vutuv.Posts.PostVideo
   alias Vutuv.SiteName
+  alias Vutuv.SocialFeed
+  alias VutuvWeb.Fediverse.Docs
   alias VutuvWeb.Markdown
   alias VutuvWeb.OgCard
+  alias VutuvWeb.OgImage
   alias VutuvWeb.PostTeaser
   alias VutuvWeb.UI
   alias VutuvWeb.UserHelpers
@@ -70,10 +86,60 @@ defmodule VutuvWeb.OpenGraph do
     [
       {"og:site_name", SiteName.get()},
       {"og:type", type(ca)},
-      {"og:title", VutuvWeb.LayoutHTML.page_title(assigns) || SiteName.get()},
+      {"og:title", title(assigns)},
       {"og:description", description(assigns)},
       {"og:locale", og_locale(assigns)}
-    ] ++ url_tags(assigns) ++ article_tags(ca) ++ profile_tags(ca) ++ image_tags(image(ca))
+    ] ++
+      url_tags(assigns) ++ article_tags(ca) ++ profile_tags(ca) ++ image_tags(image(ca))
+  end
+
+  @doc """
+  The link-preview heading. A post page leads with its author and the post's
+  first line — "René Oelke: „… zunächst nur in den USA.“" — because on
+  LinkedIn and X the title is the only text a card carries at all, and the
+  page title ("René Oelke · 2026-09-09") told a reader nothing about the
+  post. Every other page shares its `<title>`.
+  """
+  def title(assigns) do
+    post_title(conn_assigns(assigns)) || VutuvWeb.LayoutHTML.page_title(assigns) ||
+      SiteName.get()
+  end
+
+  # The first line of a quotable post, cut on a word boundary at @title_excerpt
+  # characters, behind the author's name. A post with no words (a photograph)
+  # falls through to the page title.
+  @title_excerpt 90
+
+  defp post_title(%{post: %Post{} = post} = ca) do
+    with true <- quotable?(post),
+         line when line != "" <- PostTeaser.plain_line(post, length: @title_excerpt + 1),
+         name when is_binary(name) <- author_name(ca) do
+      "#{name}: #{SocialFeed.Post.truncate(line, @title_excerpt)}"
+    else
+      _ -> nil
+    end
+  end
+
+  defp post_title(_ca), do: nil
+
+  # The page's own subject, which for a post is its author (the controller
+  # and the embedding LiveViews name it beside the post; see the moduledoc).
+  defp author_name(%{user: %User{} = user}), do: UserHelpers.full_name(user)
+  defp author_name(%{organization: %Organization{name: name}}), do: name
+  defp author_name(_ca), do: nil
+
+  @doc """
+  The `fediverse:creator` value for this page — the member's Fediverse
+  address (`@handle@host`) on their profile and their posts — or nil.
+  Mastodon 4.3+ renders it as a "More from …" byline with a follow link on
+  the preview card, once the member's actor lists this host among its
+  `attributionDomains`. Only a federating member has an address to name.
+  """
+  def creator(assigns) do
+    case conn_assigns(assigns) do
+      %{user: %User{} = user} -> if Fediverse.federated?(user), do: "@" <> Docs.acct(user)
+      _ca -> nil
+    end
   end
 
   # The og:type=profile structured properties — the member behind the page,
@@ -281,9 +347,14 @@ defmodule VutuvWeb.OpenGraph do
   defp type(_ca), do: "website"
 
   # Only a post page names a `:post`; the teaser page names none at all, so it
-  # falls through to the author's info like any other page about them.
+  # falls through to the author's info like any other page about them. The
+  # opening of the whole body, not its first line alone: Bluesky, Mastodon,
+  # Slack and Facebook draw the description under the title, and after a
+  # one-line title the next 200 characters are what tease the post.
   defp post_excerpt(%{post: %Post{} = post}) do
-    if quotable?(post), do: PostTeaser.line(post)
+    if quotable?(post) do
+      post |> PostTeaser.opening() |> String.replace(~r/\s*\n\s*/u, " ")
+    end
   end
 
   defp post_excerpt(_ca), do: nil
@@ -336,14 +407,17 @@ defmodule VutuvWeb.OpenGraph do
 
   defp organization_info(_ca), do: nil
 
-  # The member's follower count as a localized, compacted phrase ("3 followers",
-  # "1.2K followers"), matching the count shown in the profile header. Empty
-  # when the count is absent (a non-profile page) or zero, so a profile with no
-  # followers and no work info falls through to the site pitch like before.
-  defp follower_detail(count) when is_integer(count) and count > 0,
+  @doc """
+  The member's follower count as a localized, compacted phrase ("3 followers",
+  "1.2K followers"), matching the count shown in the profile header. Empty
+  when the count is absent (a non-profile page) or zero, so a profile with no
+  followers and no work info falls through to the site pitch like before.
+  Shared with the generated profile card (`VutuvWeb.OgImageController`).
+  """
+  def follower_detail(count) when is_integer(count) and count > 0,
     do: "#{UI.compact_count(count)} #{ngettext("follower", "followers", count)}"
 
-  defp follower_detail(_count), do: ""
+  def follower_detail(_count), do: ""
 
   # Every locale this installation serves, not just German: `:locale` is already
   # one of `Languages.site_locales/0` by the time it reaches here, and the same
@@ -387,18 +461,42 @@ defmodule VutuvWeb.OpenGraph do
 
   defp article_tags(_ca), do: []
 
-  # Image priority: an unrestricted post's first image, else the member's
-  # avatar or the organization's logo, else the brand card. A restricted post's
-  # images must stay out of the tags like its body does.
+  # Image priority: an unrestricted post's first image, else its generated
+  # card (a member's post only, see `VutuvWeb.OgImageController`), else the
+  # member's card or the organization's logo, else the brand card. A
+  # restricted post's images must stay out of the tags like its body does.
   defp image(%{post: %Post{} = post} = ca) do
-    case quotable?(post) && (first_image(post) || post_video(post)) do
-      %PostImage{} = post_image -> post_image_entry(post_image, ca)
-      %PostVideo{} = video -> video_cover_entry(video, ca)
-      _no_image -> author_image(ca)
+    if quotable?(post) do
+      case first_image(post) || post_video(post) do
+        %PostImage{} = post_image -> post_image_entry(post_image, ca)
+        %PostVideo{} = video -> video_cover_entry(video, ca)
+        nil -> post_card(post, ca) || author_image(ca)
+      end
+    else
+      author_image(ca)
     end
   end
 
   defp image(ca), do: author_image(ca)
+
+  # A quotable member's post (`image/1` asked) previews as its own card: author,
+  # headline and the opening lines in the picture itself, which is all X shows
+  # of a link. The
+  # LinkedIn scraper (`:square_preview?`, `VutuvWeb.Plug.PreviewScraper`) gets
+  # the square post card instead — its feed cuts a square from the middle of
+  # whatever it is given, and a square drawn as one carries the face and the
+  # first lines where the middle of the wide card is a strip of headline.
+  defp post_card(%Post{organization_id: nil} = post, %{user: %User{} = user} = ca) do
+    if Moderation.profile_visible_to?(user, nil) do
+      name = UserHelpers.full_name(user)
+
+      if ca[:square_preview?],
+        do: square_card(abs_url(Posts.path(post) <> "/og-square.png"), name),
+        else: wide_card(abs_url(Posts.path(post) <> "/og.png"), name)
+    end
+  end
+
+  defp post_card(_post, _ca), do: nil
 
   # A post with a clip and no photo previews with the clip's cover (issue
   # #1906): the same JPEG the Fediverse attachment names as its icon.
@@ -425,7 +523,7 @@ defmodule VutuvWeb.OpenGraph do
 
   defp video_cover_dimensions(%PostVideo{width: width, height: height}), do: {width, height}
 
-  # Whoever the page is about, as a picture: the member's avatar, else the
+  # Whoever the page is about, as a picture: the member's card, else the
   # organization's logo, else the brand card.
   defp author_image(ca), do: member_image(ca) || organization_image(ca) || brand_card()
 
@@ -460,20 +558,58 @@ defmodule VutuvWeb.OpenGraph do
   defp image_alt(_post_image, %{organization: %Organization{name: name}}), do: name
   defp image_alt(_post_image, _ca), do: SiteName.get()
 
-  # Named only while `/:slug/avatar.jpg` actually answers — `Vutuv.Avatar.url/2`
-  # is nil for a member with no picture, one the AI gate still holds and one a
-  # copyright case froze — so a scraper is never sent to a 404.
-  defp member_image(%{user: %User{} = user}) do
-    if Vutuv.Avatar.url(user, :medium) do
-      square_image(
-        abs_url("/#{user.username}/avatar.jpg"),
-        Vutuv.Avatar.og_size(),
-        UserHelpers.full_name(user)
-      )
+  # A member's pages preview as their generated card (`/:slug/og.png`): name,
+  # headline, tags and face in one wide picture, for every member the public
+  # may see — with or without a picture of their own. The LinkedIn scraper
+  # (`:square_preview?`) keeps the square avatar, named only while
+  # `/:slug/avatar.jpg` actually answers — `Vutuv.Avatar.url/2` is nil for a
+  # member with no picture, one the AI gate still holds and one a copyright
+  # case froze — so a scraper is never sent to a 404; without a face it falls
+  # through to the brand card, whose middle is the wordmark.
+  defp member_image(%{user: %User{} = user} = ca) do
+    cond do
+      not Moderation.profile_visible_to?(user, nil) ->
+        nil
+
+      ca[:square_preview?] ->
+        if Vutuv.Avatar.url(user, :medium) do
+          square_image(
+            abs_url("/#{user.username}/avatar.jpg"),
+            Vutuv.Avatar.og_size(),
+            UserHelpers.full_name(user)
+          )
+        end
+
+      true ->
+        wide_card(abs_url("/#{user.username}/og.png"), UserHelpers.full_name(user))
     end
   end
 
   defp member_image(_ca), do: nil
+
+  # A generated card: the wide PNG, which every platform but LinkedIn draws
+  # large (`summary_large_image`).
+  defp wide_card(url, alt) do
+    %{
+      url: url,
+      width: OgImage.width(),
+      height: OgImage.height(),
+      type: "image/png",
+      alt: alt,
+      card: "summary_large_image"
+    }
+  end
+
+  # The square post card, for the one feed that cuts a square anyway.
+  defp square_card(url, alt),
+    do: %{
+      url: url,
+      width: OgImage.square(),
+      height: OgImage.square(),
+      type: "image/png",
+      alt: alt,
+      card: "summary"
+    }
 
   # The page's logo, through the same scraper-friendly JPEG endpoint the actor
   # document names (`VutuvWeb.OrganizationAvatarController`). That endpoint

--- a/lib/vutuv_web/plugs/preview_scraper.ex
+++ b/lib/vutuv_web/plugs/preview_scraper.ex
@@ -1,0 +1,56 @@
+defmodule VutuvWeb.Plug.PreviewScraper do
+  @moduledoc """
+  Names the one link-preview scraper whose feed wants a different picture, as
+  the assign `:square_preview?` that `VutuvWeb.OpenGraph` reads.
+
+  LinkedIn's organic feed has drawn every shared link as a small square cut
+  from the middle of the `og:image` since 2024, whatever the image's size —
+  the wide card every other platform draws large is a strip of headline to
+  it. So its scraper (`LinkedInBot`) is told a square picture where the page
+  has one (the author's face, or a square post card), and every other reader
+  of the same URL gets the wide card.
+
+  A page that answers differently by user agent has to say so, or a shared
+  cache hands X the LinkedIn tag set: `Vary: User-Agent` goes on every HTML
+  response this pipeline serves, whatever the agent, because the header
+  describes the URL, not the one response. Read from the request here rather
+  than inside the tag builder, the way `VutuvWeb.Plug.AgentFormat` settles
+  the format and `VutuvWeb.Plug.Locale` the language before any controller
+  runs, so `OpenGraph` stays a pure function of the assigns.
+  """
+
+  import Plug.Conn
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    conn
+    |> assign(:square_preview?, square_preview?(conn))
+    # At send time, not now: the agent-format answers write their own Vary
+    # (`accept`, `accept-language`) when they respond, which would replace one
+    # set here. Merging as the response leaves keeps both.
+    |> register_before_send(&merge_vary(&1, "user-agent"))
+  end
+
+  @doc "Whether this request comes from LinkedIn's link-preview scraper."
+  def square_preview?(%Plug.Conn{} = conn) do
+    conn
+    |> get_req_header("user-agent")
+    |> Enum.any?(&String.contains?(&1, "LinkedInBot"))
+  end
+
+  # Adds a name to the Vary header of an HTML response without dropping one
+  # another plug set. Only HTML: the agent-format siblings (`.md`, `.json`, …)
+  # carry no preview tags and answer every agent alike.
+  defp merge_vary(conn, name) do
+    case {html?(conn), get_resp_header(conn, "vary")} do
+      {false, _vary} -> conn
+      {true, []} -> put_resp_header(conn, "vary", name)
+      {true, [existing | _]} -> put_resp_header(conn, "vary", existing <> ", " <> name)
+    end
+  end
+
+  defp html?(conn) do
+    Enum.any?(get_resp_header(conn, "content-type"), &String.starts_with?(&1, "text/html"))
+  end
+end

--- a/lib/vutuv_web/post_teaser.ex
+++ b/lib/vutuv_web/post_teaser.ex
@@ -151,6 +151,34 @@ defmodule VutuvWeb.PostTeaser do
   def plain_line(post, opts), do: teaser(post, &fold/1, opts)
 
   @doc """
+  The opening of the **whole** body as plain text, paragraph breaks kept, at
+  most `:length` characters (200 by default) — for the surfaces that show
+  more than one line of a post: the link-preview description under a title
+  that already carries the first line, and the generated preview card, which
+  draws the first six lines. Where `line/2` picks one line and skips the
+  skippable ones, this keeps the order the author wrote; a post that opens
+  with a quoted URL or a hashtag line shows it, as the post itself does.
+
+  Sliced before the Markdown pipeline runs, like `teaser/3`: markup only ever
+  adds characters, so four times the cap of source always yields more plain
+  text than the cap keeps, and a 10k body is not parsed to throw 9,800 away.
+  """
+  def opening(post, opts \\ []) do
+    limit = Keyword.get(opts, :length, @length)
+
+    case Posts.text(post) do
+      body when is_binary(body) ->
+        body
+        |> String.slice(0, limit * 4)
+        |> Markdown.to_plain_text()
+        |> String.slice(0, limit)
+
+      _no_text ->
+        ""
+    end
+  end
+
+  @doc """
   What a post calls itself in a list of posts: the author's name and the
   publication date. The `<title>` of `/:slug/posts/:id` and of
   `/organizations/:slug/posts/:id`, the heading a shared link previews with

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -41,6 +41,9 @@ defmodule VutuvWeb.Router do
     # than trusted from the session.
     plug(Plugs.ActingAs)
     plug(Plugs.Locale)
+    # Which link-preview scraper is asking, for the one whose feed wants a
+    # square picture (VutuvWeb.OpenGraph).
+    plug(Plugs.PreviewScraper)
     # The one-time welcome questions, floating over the page a brand-new
     # member's registration PIN landed them on. Before the ad plug, which
     # stands down while they are open.
@@ -647,6 +650,12 @@ defmodule VutuvWeb.Router do
     # readability — the paths differ in length and cannot collide.
     get("/organizations/:slug/avatar.jpg", OrganizationAvatarController, :show)
     get("/:slug/avatar.jpg", AvatarController, :show)
+    # The generated 1200×630 cards a member's pages and posts name as their
+    # og:image (VutuvWeb.OgImage): the wide shape every platform renders
+    # large, where the square avatar got the thumbnail beside the title.
+    get("/:slug/og.png", OgImageController, :profile)
+    get("/:slug/posts/:id/og.png", OgImageController, :post)
+    get("/:slug/posts/:id/og-square.png", OgImageController, :post_square)
     # Agent-skills discovery (Cloudflare draft) + security.txt (RFC 9116).
     get("/.well-known/agent-skills/index.json", WellKnownController, :agent_skills_index)
     get("/.well-known/agent-skills/vutuv/SKILL.md", WellKnownController, :agent_skill)

--- a/lib/vutuv_web/templates/layout/root.html.heex
+++ b/lib/vutuv_web/templates/layout/root.html.heex
@@ -29,6 +29,11 @@
       content={content}
     />
     <meta name="twitter:card" content={OpenGraph.twitter_card(assigns)} />
+    <%!-- Mastodon 4.3+ draws a "More from …" byline with a follow link on the
+    card of a page whose author it can name (VutuvWeb.OpenGraph.creator/1). --%>
+    <%= if creator = OpenGraph.creator(assigns) do %>
+      <meta name="fediverse:creator" content={creator} />
+    <% end %>
     <%!-- Explicit canonical URL, shared one-for-one with og:url
     (VutuvWeb.OpenGraph.canonical_url/1): the request path without volatile
     query params (?lang, ?page), so search engines and AI crawlers index one

--- a/test/vutuv_web/agent_docs/agent_format_test.exs
+++ b/test/vutuv_web/agent_docs/agent_format_test.exs
@@ -481,7 +481,9 @@ defmodule VutuvWeb.AgentFormatTest do
       conn = get(build_conn(), "/agent_tester")
       html = html_response(conn, 200)
 
-      assert get_resp_header(conn, "vary") == ["accept"]
+      # `user-agent` beside it: the profile's link-preview picture differs
+      # for LinkedIn's scraper (VutuvWeb.Plug.PreviewScraper).
+      assert get_resp_header(conn, "vary") == ["accept, user-agent"]
       assert html =~ ~s(rel="alternate" type="text/markdown" href="/agent_tester.md")
       assert html =~ ~s(rel="alternate" type="application/json" href="/agent_tester.json")
       assert html =~ ~s(rel="alternate" type="application/xml" href="/agent_tester.xml")

--- a/test/vutuv_web/controllers/og_image_controller_test.exs
+++ b/test/vutuv_web/controllers/og_image_controller_test.exs
@@ -1,0 +1,124 @@
+defmodule VutuvWeb.OgImageControllerTest do
+  @moduledoc """
+  GET /:slug/og.png and /:slug/posts/:id/og.png — the generated link-preview
+  cards behind `og:image` on a member's pages (`VutuvWeb.OgImage`). Drawn
+  from the anonymous public view only, so a withheld profile and a post an
+  anonymous reader may not see answer the same plain 404.
+  """
+  # Not async: points the global :uploads_dir_prefix at a tmp dir for the
+  # member-with-avatar case.
+  use VutuvWeb.ConnCase, async: false
+
+  import Vutuv.PostsHelpers
+
+  alias Vutuv.ImageHelpers
+  alias Vutuv.Posts
+
+  setup %{conn: conn} do
+    tmp = Path.join(System.tmp_dir!(), "vutuv_og_image_#{System.unique_integer([:positive])}")
+    prev = Application.get_env(:vutuv, :uploads_dir_prefix)
+    Application.put_env(:vutuv, :uploads_dir_prefix, tmp)
+
+    on_exit(fn ->
+      File.rm_rf(tmp)
+
+      if prev,
+        do: Application.put_env(:vutuv, :uploads_dir_prefix, prev),
+        else: Application.delete_env(:vutuv, :uploads_dir_prefix)
+    end)
+
+    {:ok, conn: conn}
+  end
+
+  defp member_with_avatar(attrs) do
+    user = insert_activated_user(attrs)
+
+    src = Path.join(System.tmp_dir!(), "src_#{System.unique_integer([:positive])}.jpg")
+    {:ok, img} = Image.new(600, 400, color: [10, 120, 200])
+    {:ok, _} = Image.write(img, src)
+    on_exit(fn -> File.rm(src) end)
+
+    upload = %Plug.Upload{filename: "selfie.jpg", path: src, content_type: "image/jpeg"}
+    {:ok, stored, fingerprint, _moderation} = Vutuv.Avatar.store({upload, user})
+
+    user
+    |> Ecto.Changeset.change(avatar: stored, avatar_fingerprint: fingerprint)
+    |> Repo.update!()
+    |> ImageHelpers.with_image_rows()
+  end
+
+  defp png_size(conn) do
+    assert conn.status == 200
+    assert conn |> get_resp_header("content-type") |> hd() =~ "image/png"
+    assert conn |> get_resp_header("cache-control") |> hd() == "public, max-age=86400"
+    {:ok, img} = Image.open(conn.resp_body)
+    {Image.width(img), Image.height(img)}
+  end
+
+  describe "GET /:slug/og.png" do
+    test "draws the member's card, 1200×630, with their picture", %{conn: conn} do
+      user = member_with_avatar(first_name: "Ava", last_name: "Card", locale: "de")
+      insert(:work_experience, user: user, title: "Developer", organization: "Acme Corp")
+
+      assert conn |> get("/#{user.username}/og.png") |> png_size() == {1200, 630}
+    end
+
+    test "draws a card for a member without a picture too", %{conn: conn} do
+      user = insert_activated_user(first_name: "Bare")
+
+      assert conn |> get("/#{user.username}/og.png") |> png_size() == {1200, 630}
+    end
+
+    test "an unknown slug and a withheld profile are plain 404s", %{conn: conn} do
+      hidden =
+        insert_activated_user(first_name: "Hidden")
+        |> Ecto.Changeset.change(
+          suspended_until: NaiveDateTime.add(NaiveDateTime.utc_now(:second), 86_400)
+        )
+        |> Repo.update!()
+
+      assert conn |> get("/no-such-member/og.png") |> Map.fetch!(:status) == 404
+      assert conn |> get("/#{hidden.username}/og.png") |> Map.fetch!(:status) == 404
+    end
+  end
+
+  describe "GET /:slug/posts/:id/og.png" do
+    test "draws the post's card", %{conn: conn} do
+      author = insert_activated_user(first_name: "Paula")
+      post = create_post!(author, %{"body" => "Hello **preview** world.\n\nSecond paragraph."})
+
+      assert conn |> get(Posts.path(post) <> "/og.png") |> png_size() == {1200, 630}
+    end
+
+    test "draws the square card for LinkedIn's thumbnail", %{conn: conn} do
+      author = insert_activated_user(first_name: "Paula")
+      post = create_post!(author, %{"body" => "Hello preview world, and a few more words."})
+
+      assert conn |> get(Posts.path(post) <> "/og-square.png") |> png_size() == {1200, 1200}
+    end
+
+    test "resolves the post by its id, whatever handle stands beside it", %{conn: conn} do
+      author = insert_activated_user(first_name: "Paula")
+      post = create_post!(author, %{"body" => "Hello preview world."})
+
+      assert conn |> get("/somebody-else/posts/#{post.id}/og.png") |> png_size() == {1200, 630}
+    end
+
+    test "a restricted post has no card, and neither has an unknown id", %{conn: conn} do
+      author = insert_activated_user()
+
+      post =
+        create_post!(author, %{
+          "body" => "members only",
+          "denials" => [%{"wildcard" => "logged_out"}]
+        })
+
+      assert conn |> get(Posts.path(post) <> "/og.png") |> Map.fetch!(:status) == 404
+      assert conn |> get(Posts.path(post) <> "/og-square.png") |> Map.fetch!(:status) == 404
+
+      assert conn
+             |> get("/#{author.username}/posts/#{Vutuv.UUIDv7.generate()}/og.png")
+             |> Map.fetch!(:status) == 404
+    end
+  end
+end

--- a/test/vutuv_web/fediverse/docs_test.exs
+++ b/test/vutuv_web/fediverse/docs_test.exs
@@ -33,6 +33,10 @@ defmodule VutuvWeb.Fediverse.DocsTest do
       assert doc["summary"] =~ "&lt;Koblenz&gt;"
       # The avatar rides as the scraper-friendly square JPEG.
       assert doc["icon"]["url"] == "#{base()}/#{user.username}/avatar.jpg"
+      # This site may name the member as a page's author (`fediverse:creator`),
+      # in both spellings of the host, with the term declared in the context.
+      assert doc["attributionDomains"] == ["localhost", "www.localhost"]
+      assert %{"toot" => _, "attributionDomains" => _} = List.last(doc["@context"])
     end
 
     # It used to be named unconditionally, so every member without a picture

--- a/test/vutuv_web/og_image_test.exs
+++ b/test/vutuv_web/og_image_test.exs
@@ -1,0 +1,85 @@
+defmodule VutuvWeb.OgImageTest do
+  @moduledoc """
+  The generated link-preview cards (`VutuvWeb.OgImage`): both shapes come out
+  1200×630 whatever the data holds — no picture, markup in a name, a body
+  longer than the card, nothing but emoji — because a card that fails is a
+  page without a picture on every platform.
+  """
+  use ExUnit.Case, async: true
+
+  alias VutuvWeb.OgImage
+
+  defp size({:ok, png}) do
+    {:ok, img} = Image.open(png)
+    {Image.width(img), Image.height(img)}
+  end
+
+  defp jpeg do
+    {:ok, img} = Image.new(512, 512, color: [200, 90, 40])
+    {:ok, bytes} = Image.write(img, :memory, suffix: ".jpg")
+    bytes
+  end
+
+  test "the profile card, with and without a picture" do
+    data = %{
+      name: "Greta Tester",
+      headline: "Developer @ Acme Corp",
+      tags: ["Elixir", "Phoenix", "open source", "PostgreSQL", "Rust", "Kubernetes", "Go"],
+      meta: "12 followers · Member since 2016",
+      footer: "vutuv.de/greta"
+    }
+
+    assert size(OgImage.profile_png(Map.put(data, :avatar, jpeg()))) == {1200, 630}
+    assert size(OgImage.profile_png(data)) == {1200, 630}
+  end
+
+  test "the post card, short and far too long" do
+    base = %{
+      name: "Paula Post",
+      avatar: jpeg(),
+      meta: "September 9, 2026",
+      footer: "vutuv.de/paula"
+    }
+
+    assert size(OgImage.post_png(Map.put(base, :text, "Two words."))) == {1200, 630}
+
+    long = Enum.map_join(1..600, " ", &"word#{&1}")
+    assert size(OgImage.post_png(Map.put(base, :text, long))) == {1200, 630}
+  end
+
+  test "the square card, short and far too long" do
+    base = %{name: "Paula Post", avatar: jpeg()}
+
+    assert size(OgImage.square_png(Map.put(base, :text, "Two words."))) == {1200, 1200}
+
+    long = Enum.map_join(1..600, " ", &"word#{&1}")
+    assert size(OgImage.square_png(Map.put(base, :text, long))) == {1200, 1200}
+  end
+
+  test "markup in the words is drawn as text, not read as Pango markup" do
+    data = %{
+      name: "<b>Bold</b> & Co",
+      headline: "<span foreground=\"red\">x</span>",
+      text: "a & b < c"
+    }
+
+    assert size(OgImage.post_png(data)) == {1200, 630}
+    assert size(OgImage.profile_png(data)) == {1200, 630}
+    assert size(OgImage.square_png(data)) == {1200, 1200}
+  end
+
+  test "a body of nothing but emoji, and no body at all, still make a card" do
+    assert size(OgImage.post_png(%{name: "Emoji", text: "🎉🎉 💪 🇪🇺"})) == {1200, 630}
+    assert size(OgImage.post_png(%{name: "Silent", text: nil})) == {1200, 630}
+    assert size(OgImage.profile_png(%{name: "Only a name"})) == {1200, 630}
+    assert size(OgImage.square_png(%{name: "Silent", text: "🎉"})) == {1200, 1200}
+  end
+
+  test "a single tag wider than the column leaves no empty pill row" do
+    wide = %{name: "Wide", tags: [String.duplicate("tag", 60)]}
+    narrow = %{name: "Wide", tags: ["ok"]}
+
+    assert size(OgImage.profile_png(wide)) == {1200, 630}
+    assert size(OgImage.profile_png(narrow)) == {1200, 630}
+  end
+end

--- a/test/vutuv_web/open_graph_test.exs
+++ b/test/vutuv_web/open_graph_test.exs
@@ -132,7 +132,7 @@ defmodule VutuvWeb.OpenGraphTest do
   end
 
   describe "profile pages" do
-    test "a member previews with name, work info and avatar", %{conn: conn} do
+    test "a member previews with name, work info and their generated card", %{conn: conn} do
       user =
         insert_activated_user(
           first_name: "Greta",
@@ -152,14 +152,80 @@ defmodule VutuvWeb.OpenGraphTest do
       assert title(html) == "Greta Tester · Developer @ Acme Corp - vutuv"
       assert og(html, "og:description") =~ "Acme Corp"
       assert og(html, "og:url") == @base <> "/#{user.username}"
-      assert og(html, "og:image") == @base <> "/#{user.username}/avatar.jpg"
-      assert og(html, "og:image:width") == "512"
-      assert og(html, "og:image:type") == "image/jpeg"
-      assert html =~ ~s(<meta name="twitter:card" content="summary")
+      # The wide generated card (VutuvWeb.OgImage), the one shape every
+      # platform draws large — the square avatar got the thumbnail beside the
+      # title everywhere.
+      assert og(html, "og:image") == @base <> "/#{user.username}/og.png"
+      assert og(html, "og:image:width") == "1200"
+      assert og(html, "og:image:height") == "630"
+      assert og(html, "og:image:type") == "image/png"
+      assert og(html, "og:image:alt") == "Greta Tester"
+      assert html =~ ~s(<meta name="twitter:card" content="summary_large_image")
       # The og:type=profile structured properties, so scrapers get the parts.
       assert og(html, "profile:first_name") == "Greta"
       assert og(html, "profile:last_name") == "Tester"
       assert og(html, "profile:username") == user.username
+    end
+
+    # LinkedIn's organic feed has drawn every link as a small square cut from
+    # the middle of the picture since 2024, whatever its size — so for its
+    # scraper the face is the better thumbnail than a slice of the card.
+    test "LinkedIn's scraper gets the square avatar instead", %{conn: conn} do
+      user =
+        insert_activated_user(first_name: "Greta", avatar: "selfie.jpg")
+        |> ImageHelpers.with_image_rows()
+
+      html =
+        conn
+        |> put_req_header(
+          "user-agent",
+          "LinkedInBot/1.0 (compatible; Mozilla/5.0; Apache-HttpClient +http://www.linkedin.com)"
+        )
+        |> get(~p"/#{user}")
+        |> html_response(200)
+
+      assert og(html, "og:image") == @base <> "/#{user.username}/avatar.jpg"
+      assert og(html, "og:image:width") == "512"
+      assert html =~ ~s(<meta name="twitter:card" content="summary")
+    end
+
+    # The answer differs by user agent, so the URL has to say so to any cache
+    # between us and the scrapers — on every response, not only LinkedIn's.
+    test "every page declares that it varies by user agent", %{conn: conn} do
+      user = insert_activated_user(first_name: "Greta")
+
+      vary = conn |> get(~p"/#{user}") |> get_resp_header("vary")
+
+      assert Enum.any?(vary, &(&1 =~ ~r/user-agent/i))
+    end
+
+    test "a member without an avatar still gets their card (LinkedIn the brand card)",
+         %{conn: conn} do
+      user = insert_activated_user(first_name: "Bare")
+
+      html = conn |> get(~p"/#{user}") |> html_response(200)
+      assert og(html, "og:image") == @base <> "/#{user.username}/og.png"
+
+      linkedin =
+        conn
+        |> put_req_header("user-agent", "LinkedInBot/1.0")
+        |> get(~p"/#{user}")
+        |> html_response(200)
+
+      assert og(linkedin, "og:image") == @base <> "/og-card.png"
+    end
+
+    test "a federating member is named as the fediverse:creator, others are not",
+         %{conn: conn} do
+      federating = insert_activated_user(fediverse_followers?: true)
+      plain = insert_activated_user()
+
+      html = conn |> get(~p"/#{federating}") |> html_response(200)
+
+      assert html =~
+               ~s(<meta name="fediverse:creator" content="@#{federating.username}@localhost">)
+
+      refute conn |> get(~p"/#{plain}") |> html_response(200) =~ "fediverse:creator"
     end
 
     test "a member without work info titles with their headline instead", %{conn: conn} do
@@ -182,14 +248,6 @@ defmodule VutuvWeb.OpenGraphTest do
 
       assert og(html, "og:title") == "Bare Name"
       assert title(html) == "Bare Name - vutuv"
-    end
-
-    test "a member without an avatar falls back to the brand card", %{conn: conn} do
-      user = insert_activated_user(first_name: "Bare")
-
-      html = conn |> get(~p"/#{user}") |> html_response(200)
-
-      assert og(html, "og:image") == @base <> "/og-card.png"
     end
 
     test "a member without work info or tags gets the site description, never an empty one",
@@ -232,20 +290,70 @@ defmodule VutuvWeb.OpenGraphTest do
   end
 
   describe "post pages" do
-    test "a public post previews as an article with its first line", %{conn: conn} do
+    test "a public post previews as an article: author + first line, opening, its card",
+         %{conn: conn} do
       author =
-        insert_activated_user(first_name: "Paula", avatar: "selfie.jpg")
+        insert_activated_user(first_name: "Paula", last_name: "Post", avatar: "selfie.jpg")
         |> ImageHelpers.with_image_rows()
 
-      post = create_post!(author, %{"body" => "Hello preview world, this is the first line."})
+      post =
+        create_post!(author, %{
+          "body" => "Hello preview world, this is the first line.\n\nAnd a second paragraph."
+        })
 
       html = conn |> get(Posts.path(post)) |> html_response(200)
 
       assert og(html, "og:type") == "article"
-      assert og(html, "og:description") =~ "Hello preview world"
+      # LinkedIn and X show nothing but the title, so it names the author and
+      # the post's first line — the page title ("Paula Post · <date>") said
+      # nothing about the post. The <title> itself is unchanged.
+      assert og(html, "og:title") == "Paula Post: Hello preview world, this is the first line."
+      assert title(html) == "Paula Post · #{Date.to_iso8601(post.published_on)} - vutuv"
+      # The description carries the opening of the whole body, not the first
+      # line alone.
+      assert og(html, "og:description") =~ "first line. And a second paragraph."
       assert og(html, "article:published_time") == Date.to_iso8601(post.published_on)
-      # The author's avatar gives the preview a face.
-      assert og(html, "og:image") == @base <> "/#{author.username}/avatar.jpg"
+      # The post's own generated card: author, headline and the opening lines
+      # in the picture itself.
+      assert og(html, "og:image") == @base <> Posts.path(post) <> "/og.png"
+      assert og(html, "og:image:width") == "1200"
+      assert og(html, "og:image:type") == "image/png"
+      assert html =~ ~s(<meta name="twitter:card" content="summary_large_image")
+    end
+
+    test "a long first line is cut on a word boundary in the title", %{conn: conn} do
+      author = insert_activated_user(first_name: "Paula", last_name: "Post")
+      words = Enum.map_join(1..40, " ", &"word#{&1}")
+      post = create_post!(author, %{"body" => words})
+
+      title = conn |> get(Posts.path(post)) |> html_response(200) |> og("og:title")
+
+      assert String.starts_with?(title, "Paula Post: word1 word2")
+      assert String.ends_with?(title, "…")
+      refute title =~ "word40"
+      assert String.length(title) <= String.length("Paula Post: ") + 91
+    end
+
+    # LinkedIn's feed cuts a square from the middle of whatever it is given, so
+    # its scraper is handed a square drawn as one: face, name and the first
+    # lines in very large type (`VutuvWeb.OgImage.square_png/1`).
+    test "LinkedIn's scraper gets the square post card", %{conn: conn} do
+      author =
+        insert_activated_user(first_name: "Paula", avatar: "selfie.jpg")
+        |> ImageHelpers.with_image_rows()
+
+      post = create_post!(author, %{"body" => "Hello preview world."})
+
+      html =
+        conn
+        |> put_req_header("user-agent", "LinkedInBot/1.0")
+        |> get(Posts.path(post))
+        |> html_response(200)
+
+      assert og(html, "og:image") == @base <> Posts.path(post) <> "/og-square.png"
+      assert og(html, "og:image:width") == "1200"
+      assert og(html, "og:image:height") == "1200"
+      assert html =~ ~s(<meta name="twitter:card" content="summary")
     end
 
     test "a post with images previews its first image instead of the avatar", %{conn: conn} do
@@ -488,9 +596,10 @@ defmodule VutuvWeb.OpenGraphTest do
       assert og(html, "og:description") =~ "hiring three developers"
       refute og(html, "og:description") =~ "Verified organization pages"
       assert og(html, "article:published_time") == Date.to_iso8601(post.published_on)
-      # The title distinguishes the post from the page it was published on.
-      assert og(html, "og:title") == "Acme GmbH · #{Date.to_iso8601(post.published_on)}"
-      # No picture of its own, so the page behind it gives the card a face.
+      # The title names the page and the post's first line.
+      assert og(html, "og:title") == "Acme GmbH: We are hiring three developers."
+      # No picture of its own, so the page behind it gives the card a face —
+      # a page's post has no generated card yet.
       assert og(html, "og:image") ==
                @base <> "/organizations/#{organization.slug}/avatar.jpg"
 


### PR DESCRIPTION
A vutuv profile or post shared on LinkedIn, X, WhatsApp, Facebook, Bluesky or Mastodon showed the small card: a 512 px avatar as `og:image` and a title like "René Oelke · 2026-09-09". On X that was a face and a domain.

Every member page and member post now names a generated 1200×630 card as `og:image` (`/:slug/og.png`, `<permalink>/og.png`, `VutuvWeb.OgImage`, libvips only), the post title reads "Author: first line…", the description is the opening of the body, and federating members carry `fediverse:creator` plus `attributionDomains` on their actor. LinkedIn's scraper gets a square post card instead (`og-square.png`), because its organic feed cuts a square from the middle of any picture; `VutuvWeb.Plug.PreviewScraper` sets `Vary: User-Agent` for that.

To decide: nothing. Organization pages keep their logo for now.

Demo of every platform, before and after: https://claude.ai/code/artifact/5f5dccb3-59ed-458a-a002-ae5f328ffb83

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_014BgYGRNiKNDvskvV9azss1
