### PR TITLE
Wire the press-kit image kind into the AI scan, the pixelated stand-in and the takedown

### DIFF
--- a/docs/architecture/images.md
+++ b/docs/architecture/images.md
@@ -79,7 +79,7 @@ once — screenshots included, a few minutes after the traffic switch.
 
 The **pixelated preview** of a picture still being checked is the one thing
 the mode drops entirely rather than shrinks: `Pixelation.stands_in?/2` answers
-false for a viewer in the mode, so the three renderers that ask fall back to
+false for a viewer in the mode, so every renderer that asks falls back to
 the grey hourglass tile they already have for installations without previews.
 The preview is 64 blocks blown up to 960 px and costs about what the finished
 picture's lite does (13 kB against 12 kB on one photo), for the minutes a scan
@@ -755,8 +755,10 @@ pixelated window must take its time from the photo rather than the mirror's
 directory and `file` for the version segment, while **`cover_status` stays on
 the review row** — it says whether a fetch is due, not whether a picture
 exists, and `ReviewCovers.reconcile/1` and `refresh_all/1` both select on it.
-No kind's takedown is written yet: `@takedown` is still profile-only, so all
-four are refused by `takedown_ready?/1` until the release that wires them.
+None of the four has its takedown written yet: `@takedown` holds the two profile
+kinds and `press_kit` (which was born on the row and got its freeze with its
+scan, #2084), so all four mirrored kinds stay refused by `takedown_ready?/1`
+until the release that wires them.
 
 What **step 3** drops: `job_posting_images`, `post_images` and
 `organization_images` outright, and `post_reviews.cover` +
@@ -833,14 +835,43 @@ root segment permanently burns a handle, and this kind therefore needs no
 `send_file` rather than the X-Accel handoff (`:post_image_serving`), so a new
 kind of proxied picture costs no nginx change.
 
-**Born pending, and not yet scanned.** A fresh row starts at
+**Born pending, and how it gets out (issue #2084).** A fresh row starts at
 `Vutuv.Moderation.ImageScans.initial_state/0`, so with the AI gate on it is
 `"pending"` and `PressKit.visible_to?/2` shows it to its owner alone — for a
 page, to every member of its staff, since a colleague has to be able to see what
-is being checked. Nothing enqueues that scan yet and
-`Vutuv.Images.takedown_ready?/1` answers false for the kind, so a report may not
-name one: the scan, the pixelated stand-in and the freeze are #2084's, and the
-report gate #2089's.
+is being checked. `PressKit.create/4` queues the scan that clears it, and a
+stranger meanwhile gets the **pixelated stand-in** at
+`/system/press_kit/<token>/pixelated.avif` (`PressKit.pixelated_url/1`), whose
+window is measured from the row's own `inserted_at` — this kind is born on
+`images`, so that timestamp *is* the upload and no mirror can lie about it. Once
+released the stand-in URL redirects to `large` rather than 404ing, so a page
+drawn seconds before the verdict never shows a broken image. A rejection runs
+`PressKit.delete/1` (row, versions, original, stand-in, hold) and tells whoever
+uploaded it — `images.user_id` for a member's own kit, `uploader_user_id` for a
+page's, the same choice an organization logo's scan makes, because that is the
+member whose file was refused.
+
+Its scan clauses in `Vutuv.Moderation.ImageSubjects` are its own rather than an
+entry in the `@gallery_images` registry: those three kinds are still mirrors of
+a source table, so every generic step there (`Repo.get(schema, id)`,
+`Images.mirrored?/1`, the post's federation settle) either means nothing here or
+would reach a row of another kind. One trap the drift repair had to learn:
+`press_kit_stranded/0` skips a **frozen** row. Its files are in the hold, so
+`source/1` answers `:gone`, the scan cancels, the row stays `pending` and the
+next pass queues it again — for ever, at the front of an oldest-first queue.
+
+**The takedown is wired from the first release** (`@takedown`'s `:press_kit`
+strategy), so `takedown_ready?/1` answers true and a copyright case may name a
+press picture — a picture published *for redistribution* is the likeliest of all
+of them to draw a notice. A freeze stamps `frozen_at` and moves every file into
+the hold; `PressKit.visible_to?/2` then refuses the row to everybody, its owner
+and an admin included, and the download answers 404. One gap is left for the
+report sub-issue (#2089): `Vutuv.Moderation`'s `owner_id/1` reads `%Image{}`'s
+`user_id` only, so a **page's** press picture has no case owner and
+`can_report?/2` refuses it. The organization-*post* clause beside it already
+answers the same question with `organizations.created_by_user_id` (the member
+who carries the strike ladder), and that is the answer to copy — `Case.owner_id`
+is one `users` FK, which `Organizations.owners/1`'s list cannot fill.
 
 ### The takedown hold (issue #2012)
 
@@ -1248,7 +1279,10 @@ link screenshots and organization homepage captures
 (`screenshots/<id>/pixelated-<hash>.avif`, in the *served* tree
 while the thumb itself waits in quarantine) and pictures cached from other
 networks (`remote_media/posts/<id>/pixelated-<hash>.avif` — the fingerprinted
-name shape, for the two kinds whose directory outlives the picture in it). Not
+name shape, for the two kinds whose directory outlives the picture in it) and
+press pictures (`press_kit/<token>/pixelated.avif`, served at
+`/system/press_kit/<token>/pixelated.avif`, which redirects to `large` once
+released — a logo included, cut from the rasterisation the scan judges). Not
 avatars and covers, whose initials tile is the better placeholder at 36 pixels,
 and not organization or job-posting images, which no page shows to a stranger
 while they wait. The response is `ImageProxy.serve_pixelated/2`, the deliberate

--- a/lib/vutuv/images.ex
+++ b/lib/vutuv/images.ex
@@ -47,6 +47,7 @@ defmodule Vutuv.Images do
 
   alias Vutuv.Accounts.User
   alias Vutuv.Images.Image
+  alias Vutuv.PressKitStore
   alias Vutuv.Repo
   alias Vutuv.Uploads
 
@@ -963,13 +964,26 @@ defmodule Vutuv.Images do
   # differently. A kind arrives here in the same change as its strategy's
   # clauses (issue #2057).
   #
+  # It is also the "how every byte of this kind is deleted" registry, not only
+  # the copyright gate: `purge/1` is what an upheld case runs *and* what an
+  # owner's own "remove it" runs (`Vutuv.PressKit.delete/1`), so a kind without
+  # an entry has no delete path either.
+  #
   # The gate used to be derived from `@mirrored` instead, and the two agreed by
   # arithmetic rather than by meaning: that entry is what a **contract** release
   # deletes, so the gate would have opened on the deploy that retires a kind's
   # old table whether or not anything had wired that kind's freeze, and the
   # first report accepted on it would have raised in front of the admin who
   # upheld it.
-  @takedown Map.new(@profile_kinds, &{&1, :profile})
+  #
+  # `press_kit` (issue #2084) arrives with a strategy of its own rather than
+  # pointing at `:profile`: there is no member row to clear (a page's press
+  # picture has no member owner at all) and its files are keyed by the row's
+  # token rather than by a member scope. A picture published *for
+  # redistribution* is the likeliest of all of them to draw a copyright notice,
+  # which is why the kind gets its takedown in the same release as its scan
+  # rather than one later.
+  @takedown @profile_kinds |> Map.new(&{&1, :profile}) |> Map.put("press_kit", :press_kit)
 
   @doc """
   Whether a copyright case can act on this picture at all — what
@@ -1021,27 +1035,41 @@ defmodule Vutuv.Images do
   already invisible and a job `reconcile_holds/0` finishes. The other order
   would leave files in a hold that nothing knows to bring back.
   """
-  def freeze(%Image{kind: kind} = image) when is_map_key(@takedown, kind),
-    do: freeze_by(@takedown[kind], image)
+  def freeze(%Image{kind: kind} = image) when is_map_key(@takedown, kind) do
+    # The stamp is the same statement whatever the strategy is, so it is here
+    # rather than copied into each of them. `is_nil(frozen_at)` so a second pass
+    # — `reconcile_holds/0` finishing an interrupted move — re-asserts the
+    # freeze without moving the moment it happened, which is what the case and
+    # the statement of reasons quote.
+    {_count, _} =
+      Repo.update_all(from(i in Image, where: i.id == ^image.id and is_nil(i.frozen_at)),
+        set: [frozen_at: now(), updated_at: now()]
+      )
+
+    freeze_by(@takedown[kind], image)
+  end
 
   def freeze(%Image{} = image), do: no_takedown_path!(image, "freeze")
 
   # The profile strategy: the files are served straight off disk (`serving/1`
   # answers `:static`), so taking the picture offline means moving them.
   defp freeze_by(:profile, %Image{} = image) do
-    # `is_nil(frozen_at)` so a second pass — `reconcile_holds/0` finishing an
-    # interrupted move — re-asserts the freeze without moving the moment it
-    # happened, which is what the case and the statement of reasons quote.
-    {_count, _} =
-      Repo.update_all(from(i in Image, where: i.id == ^image.id and is_nil(i.frozen_at)),
-        set: [frozen_at: now(), updated_at: now()]
-      )
-
     hide_from_member_row(image)
 
     with %User{} = user <- owner(image),
          do: @profile_columns[image.kind].module.hold(image.id, user)
 
+    :ok
+  end
+
+  # The press-kit strategy. Every byte already goes through an authorizing
+  # proxy, so `frozen_at` alone takes the picture off every page and out of
+  # every download (`Vutuv.PressKit.visible_to?/2` refuses a stamped row to
+  # everybody, its owner and an admin included) — the file move is what makes
+  # the hold a *hold* rather than a flag, so an upheld case has the bytes to
+  # delete and a rejected one has them to put back.
+  defp freeze_by(:press_kit, %Image{} = image) do
+    PressKitStore.hold(image)
     :ok
   end
 
@@ -1061,17 +1089,26 @@ defmodule Vutuv.Images do
   only once the member row names the files again, so a half-finished restore is
   still a hold for `reconcile_holds/0` to find.
   """
-  def unfreeze(%Image{kind: kind} = image) when is_map_key(@takedown, kind),
-    do: unfreeze_by(@takedown[kind], image)
-
-  def unfreeze(%Image{} = image), do: no_takedown_path!(image, "unfreeze")
-
-  defp unfreeze_by(:profile, %Image{} = image) do
+  def unfreeze(%Image{kind: kind} = image) when is_map_key(@takedown, kind) do
+    # Cleared before the strategy runs, and the hold removed after it: an
+    # interruption in between then leaves a row that is no longer frozen beside
+    # a hold nothing has emptied, which `reconcile_holds/0` reads as an
+    # unfinished release and finishes. The other order would leave a frozen row
+    # with its files already back, which that same pass would dutifully freeze
+    # again.
     {_count, _} =
       Repo.update_all(from(i in Image, where: i.id == ^image.id),
         set: [frozen_at: nil, updated_at: now()]
       )
 
+    unfreeze_by(@takedown[kind], image)
+    Uploads.purge_hold(image.id)
+    :ok
+  end
+
+  def unfreeze(%Image{} = image), do: no_takedown_path!(image, "unfreeze")
+
+  defp unfreeze_by(:profile, %Image{} = image) do
     with %User{} = user <- owner(image) do
       config = @profile_columns[image.kind]
       config.module.release(image.id, user)
@@ -1080,7 +1117,11 @@ defmodule Vutuv.Images do
       config.module.regenerate(Repo.get!(User, user.id))
     end
 
-    Uploads.purge_hold(image.id)
+    :ok
+  end
+
+  defp unfreeze_by(:press_kit, %Image{} = image) do
+    PressKitStore.release(image)
     :ok
   end
 
@@ -1093,8 +1134,11 @@ defmodule Vutuv.Images do
   nothing points at (which `reconcile_holds/0` collects), never a member row
   naming files that are gone.
   """
-  def purge(%Image{kind: kind} = image) when is_map_key(@takedown, kind),
-    do: purge_by(@takedown[kind], image)
+  def purge(%Image{kind: kind} = image) when is_map_key(@takedown, kind) do
+    purge_by(@takedown[kind], image)
+    Uploads.purge_hold(image.id)
+    :ok
+  end
 
   def purge(%Image{} = image), do: no_takedown_path!(image, "purge")
 
@@ -1112,7 +1156,15 @@ defmodule Vutuv.Images do
         Repo.delete_all(from(i in Image, where: i.id == ^image.id))
     end
 
-    Uploads.purge_hold(image.id)
+    :ok
+  end
+
+  # The row first and the files after, which is the order an interruption can
+  # survive: it leaves files nothing points at (collected by
+  # `reconcile_holds/0`) rather than a row naming files that are gone.
+  defp purge_by(:press_kit, %Image{} = image) do
+    Repo.delete_all(from(i in Image, where: i.id == ^image.id))
+    PressKitStore.delete(image.token)
     :ok
   end
 

--- a/lib/vutuv/moderation/image_scan.ex
+++ b/lib/vutuv/moderation/image_scan.ex
@@ -29,10 +29,14 @@ defmodule Vutuv.Moderation.ImageScan do
   #
   # `post_video_frame` is one still of a post's clip (issue #1908): a clip is
   # judged frame by frame, and one refused frame refuses the whole clip.
+  #
+  # `press_kit` (issue #2084) is a press photo or a logo variant. Its owner may
+  # be a page rather than a member, so `owner_user_id` carries whoever uploaded
+  # it — the person whose file was refused, and the only one there is to tell.
   @kinds ~w(avatar cover post_image job_posting_image organization_image
             url_screenshot post_screenshot organization_screenshot review_cover
             qualification_document job_reference_document remote_post_image
-            remote_avatar post_video_frame)
+            remote_avatar post_video_frame press_kit)
   @statuses ~w(pending scanning approved rejected canceled)
   @open_statuses ~w(pending scanning)
 

--- a/lib/vutuv/moderation/image_scans.ex
+++ b/lib/vutuv/moderation/image_scans.ex
@@ -55,7 +55,8 @@ defmodule Vutuv.Moderation.ImageScans do
   # content, so they get the notice. Machine captures (link screenshots) are
   # our artifact of a third-party page — silently showing no preview is the
   # same UX as a failed capture, so no notice.
-  @notify_kinds ~w(avatar cover post_image job_posting_image organization_image post_video_frame)
+  @notify_kinds ~w(avatar cover post_image job_posting_image organization_image post_video_frame
+                   press_kit)
 
   ## Gate + lifecycle API (what the storing contexts use)
 

--- a/lib/vutuv/moderation/image_subjects.ex
+++ b/lib/vutuv/moderation/image_subjects.ex
@@ -39,6 +39,8 @@ defmodule Vutuv.Moderation.ImageSubjects do
   alias Vutuv.Posts.PostVideoFrame
   alias Vutuv.Posts.Screenshots
   alias Vutuv.PostVideoStore
+  alias Vutuv.PressKit
+  alias Vutuv.PressKitStore
   alias Vutuv.Profiles.Qualification
   alias Vutuv.Profiles.Url
   alias Vutuv.QualificationDocument
@@ -55,6 +57,8 @@ defmodule Vutuv.Moderation.ImageSubjects do
   # time here: the contract half of #2013 drops all four per kind, and a second
   # copy is a second place to remember.
   @profile_images Vutuv.Images.member_columns()
+
+  @press_kit "press_kit"
 
   @gallery_images %{
     # `pixelated: true` marks the one gallery kind a stranger meets while the
@@ -232,6 +236,31 @@ defmodule Vutuv.Moderation.ImageSubjects do
       first_existing([PostVideoStore.frame_path(video.token, frame.position)])
     else
       _ -> :gone
+    end
+  end
+
+  # A press photo or a logo variant (issue #2084). Its row lives on `images`
+  # itself rather than in a table of its own, so it is deliberately not in
+  # `@gallery_images` above — that map is a registry of *mirror* kinds, and every
+  # generic step it drives is a mirror step (`Repo.get(schema, id)` on a table
+  # holding one kind, `Images.mirrored?/1`, the post's federation settle), none
+  # of which means anything here. Immutable once stored (nothing edits the bytes, only the
+  # caption beside them), so no fingerprint guard: the row's own existence is
+  # the guard, and a re-upload is a new row with a new token.
+  #
+  # The original is what the model judges, which for a vector logo means the
+  # rasterisation `Vutuv.Uploads.Spec.open_rotated/1` makes — the same door the
+  # served versions came through, so nothing is released that was not looked at.
+  def source(%ImageScan{kind: @press_kit} = scan) do
+    case press_kit_row(scan.subject_id) do
+      nil ->
+        :gone
+
+      image ->
+        first_existing([
+          PressKitStore.original_path(image.token),
+          PressKitStore.version_path(image.token, "large")
+        ])
     end
   end
 
@@ -563,6 +592,20 @@ defmodule Vutuv.Moderation.ImageSubjects do
     end
   end
 
+  # A press picture that passed. Stand-in first, then the flip, for the reason
+  # the gallery branch above states: of the two orders only this one's leftover
+  # is harmless. `Vutuv.PressKit.release/1` owns the write, so the shared
+  # `images` table keeps one writer per kind, and it answers `:stale` for a row
+  # that is no longer the one that was waiting.
+  def apply_approved(%ImageScan{kind: @press_kit} = scan) do
+    drop_press_kit_pixelated(scan.subject_id)
+
+    with :ok <- PressKit.release(scan.subject_id) do
+      broadcast(scan, :approved)
+      :ok
+    end
+  end
+
   @doc """
   Deletes the rejected image on the spot: files (served, quarantined and the
   private original — nothing unsafe stays at rest) and the asset's
@@ -804,6 +847,22 @@ defmodule Vutuv.Moderation.ImageSubjects do
     end
   end
 
+  # A refused press picture: `Vutuv.PressKit.delete/1`, which is the owner's own
+  # "remove it" — row, every derived version, the private original, the
+  # stand-in and any hold. Nothing unsafe stays at rest, and the scan row is
+  # left as the only record of what was deleted.
+  def apply_rejected(%ImageScan{kind: @press_kit} = scan) do
+    case press_kit_row(scan.subject_id) do
+      nil ->
+        :stale
+
+      image ->
+        :ok = PressKit.delete(image)
+        broadcast(scan, :rejected)
+        :ok
+    end
+  end
+
   # The one write behind both remote-picture verdicts (issue #1163): flip the
   # moderation column, guarded on the fingerprint so a verdict can never touch
   # bytes that changed under it. `clear_file: true` also drops the reference, so
@@ -1041,6 +1100,7 @@ defmodule Vutuv.Moderation.ImageSubjects do
       gallery_stranded("post_image") ++
       gallery_stranded("job_posting_image") ++
       gallery_stranded("organization_image") ++
+      press_kit_stranded() ++
       post_screenshot_stranded() ++
       review_cover_stranded() ++
       video_frame_stranded() ++
@@ -1097,6 +1157,27 @@ defmodule Vutuv.Moderation.ImageSubjects do
     )
     |> Repo.all()
     |> Enum.map(fn {id, owner_id} -> {kind, id, owner_id, nil} end)
+  end
+
+  # A press picture waiting on a scan nobody queued. Its owner is whichever half
+  # of the member-or-page pair the row names — a page's row leaves `user_id`
+  # empty, so without the coalesce the re-enqueued scan would have nobody to
+  # tell about a rejection.
+  #
+  # **A frozen row is not stranded.** Its files are in the takedown hold, so
+  # `source/1` answers `:gone`, the scan cancels, the row stays `pending` and
+  # the next pass queues it again — for ever, on a picture that is offline by
+  # decision rather than by drift, and at the front of every batch because the
+  # queue is oldest-first.
+  defp press_kit_stranded do
+    from(i in Images.Image,
+      as: :subject,
+      where: i.kind == ^@press_kit and i.moderation == "pending" and is_nil(i.frozen_at),
+      where: not exists(open_scan_exists(@press_kit)),
+      select: {i.id, coalesce(i.user_id, i.uploader_user_id)}
+    )
+    |> Repo.all()
+    |> Enum.map(fn {id, owner_id} -> {@press_kit, id, owner_id, nil} end)
   end
 
   defp flat_stranded(kind) do
@@ -1167,6 +1248,21 @@ defmodule Vutuv.Moderation.ImageSubjects do
   end
 
   defp drop_pixelated(_config, _subject_id), do: :ok
+
+  # The press kit's twin of the above: the row is read by id because the flip
+  # below has none in hand, and a picture already gone (a delete that raced the
+  # verdict) simply has nothing to drop.
+  defp drop_press_kit_pixelated(subject_id) do
+    case press_kit_row(subject_id) do
+      nil -> :ok
+      image -> PressKitStore.delete_pixelated(image.token)
+    end
+  end
+
+  # Narrowed to the kind, so a scan can never read — or write over — a row of
+  # another one that happens to share the id.
+  defp press_kit_row(subject_id),
+    do: Repo.get_by(Images.Image, id: subject_id, kind: @press_kit)
 
   defp broadcast(%ImageScan{} = scan, verdict) do
     Vutuv.Activity.broadcast(

--- a/lib/vutuv/press_kit.ex
+++ b/lib/vutuv/press_kit.ex
@@ -38,13 +38,18 @@ defmodule Vutuv.PressKit do
   picture the page owns, which is why the database refuses it
   (`images_press_kit_has_one_owner`).
 
-  ## Born pending
+  ## Born pending, and how it gets out (issue #2084)
 
   A fresh row starts at `Vutuv.Moderation.ImageScans.initial_state/0`, so on an
-  installation with the AI gate on it is `"pending"` and `visible_to?/2` shows
-  it to its owner alone until a verdict releases it. Nothing here enqueues that
-  scan yet — #2084 wires the scan, the pixelated stand-in and the takedown, and
-  `Vutuv.Images.takedown_ready?/1` answers false for this kind until it does.
+  installation with the AI gate on it is `"pending"`, `visible_to?/2` shows it
+  to its owner alone, and `create/4` queues the scan that has to clear it. Until
+  a verdict lands a stranger gets the **pixelated stand-in** (`pixelated_url/1`)
+  rather than nothing, for the window `Vutuv.Moderation.Pixelation` measures
+  from the upload — this row *is* the upload, so `inserted_at` is the honest
+  clock and no mirror row can lie about it. A rejection wipes every byte and
+  tells whoever uploaded it; a copyright case can freeze one from the first day
+  it exists (`Vutuv.Images.freeze/1`), because a picture published for
+  redistribution is the likeliest of all of them to draw a notice.
   """
 
   import Ecto.Query, warn: false
@@ -56,6 +61,7 @@ defmodule Vutuv.PressKit do
   alias Vutuv.Images
   alias Vutuv.Images.Image
   alias Vutuv.Moderation.ImageScans
+  alias Vutuv.Moderation.Pixelation
   alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
   alias Vutuv.PressKitStore
@@ -150,7 +156,35 @@ defmodule Vutuv.PressKit do
 
   def visible_to?(_image, _viewer), do: false
 
-  defp public?(owner, image), do: not Identity.hidden?(owner) and Images.servable?(image)
+  @doc """
+  Whether the **pixelated stand-in** may be fetched — which is the mirror image
+  of `visible_to?/2`: it answers for exactly the picture that one refuses
+  because the AI gate has not released it yet.
+
+  No viewer argument, deliberately. A press kit is a public section of a public
+  profile, so there is no reader-specific question left once the owner is
+  visible; what there is, is a *frozen* picture, and a takedown has to read like
+  a picture that was never there — stand-in included.
+
+  The cheap half is asked first on purpose: a released picture — every picture,
+  a few seconds after it is uploaded — answers `false` here without touching the
+  database, so the proxy's `or` costs one owner lookup rather than two.
+  """
+  def pixelated_visible?(%Image{kind: @kind, frozen_at: nil} = image),
+    do: not ImageScans.released?(image.moderation) and owner_visible?(image)
+
+  def pixelated_visible?(_image), do: false
+
+  defp public?(owner, image), do: owner_visible?(owner) and Images.servable?(image)
+
+  defp owner_visible?(%Image{} = image) do
+    case owner(image) do
+      nil -> false
+      owner -> owner_visible?(owner)
+    end
+  end
+
+  defp owner_visible?(owner), do: not Identity.hidden?(owner)
 
   defp privileged?(_owner, %User{admin?: true}), do: true
   defp privileged?(%User{id: id}, %User{id: id}), do: true
@@ -186,13 +220,38 @@ defmodule Vutuv.PressKit do
   again — the remote-media proxy set that pattern and this follows it, which is
   also why this kind needs no `Vutuv.Accounts.ReservedSlugs` entry.
   """
-  def url(%Image{token: token}, version), do: "/system/press_kit/#{token}/#{version}.avif"
+  def url(%Image{} = image, version), do: address(image, "#{version}.avif")
 
   @doc "The URL the file itself is handed over at: the cleaned photo, or a logo's vector."
-  def download_url(%Image{token: token}), do: "/system/press_kit/#{token}/download.orig"
+  def download_url(%Image{} = image), do: address(image, "download.orig")
 
   @doc "The URL of a logo variant's PNG rendering, beside its vector."
-  def png_download_url(%Image{token: token}), do: "/system/press_kit/#{token}/download.png"
+  def png_download_url(%Image{} = image), do: address(image, "download.png")
+
+  @doc """
+  The URL of the pixelated stand-in, or `nil` when there is nothing standing in
+  right now: the picture is released or frozen, the window has run out, the file
+  was never written (an installation with the preview off) or the reader is in
+  data-saving mode. A caller that gets `nil` draws the "being checked" tile.
+
+  The window is measured from `inserted_at`, and this row **is** the upload —
+  the one thing the mirrored kinds cannot say, since their `images` row is
+  minted by the mirror and a backfilled one claims to be minutes old.
+
+  Once per rendered picture, so a page drawing a whole shelf should hand over
+  rows with `:user` or `:organization` preloaded — `owner/1` takes the preload
+  when it is there and looks the owner up per picture when it is not.
+  """
+  def pixelated_url(%Image{} = image) do
+    if pixelated_visible?(image) and
+         Pixelation.stands_in?(PressKitStore.pixelated_path(image.token), image.inserted_at),
+       do: address(image, Pixelation.filename())
+  end
+
+  # One owner of the proxy's path shape. Four addresses hang off it, and a
+  # hand-built copy at a call site is a place the next one has to be remembered
+  # again.
+  defp address(%Image{token: token}, file), do: "/system/press_kit/#{token}/#{file}"
 
   @doc """
   The name the downloaded file arrives under, e.g. `ada_king-press-1.jpg` or
@@ -260,15 +319,36 @@ defmodule Vutuv.PressKit do
   end
 
   @doc """
-  Removes a press picture: the row first, then every file. That order is the one
-  an interruption can survive — it leaves files nothing points at rather than a
-  row naming files that are gone.
+  Releases a press picture the AI gate cleared, and answers `:stale` when the row
+  is no longer the one that was waiting (deleted meanwhile, or already settled by
+  a verdict that got there first).
+
+  Here rather than in `Vutuv.Moderation.ImageSubjects` so that the shared
+  `images` table keeps one writer per kind — the refusal beside it already goes
+  through `delete/1`.
   """
-  def delete(%Image{kind: @kind} = image) do
-    Repo.delete_all(from(i in Image, where: i.id == ^image.id))
-    PressKitStore.delete(image.token)
-    :ok
+  def release(image_id) when is_binary(image_id) do
+    from(i in Image,
+      where: i.id == ^image_id and i.kind == ^@kind and i.moderation == "pending"
+    )
+    |> Repo.update_all(set: [moderation: "approved", updated_at: NaiveDateTime.utc_now(:second)])
+    |> case do
+      {1, _} -> :ok
+      _none -> :stale
+    end
   end
+
+  @doc """
+  Removes a press picture: the row first, then every file, then any takedown
+  hold. That order is the one an interruption can survive — it leaves files
+  nothing points at rather than a row naming files that are gone.
+
+  One path with the upheld copyright case, not two: `Vutuv.Images.purge/1`
+  gates on the same `@takedown` entry that lets a case name this kind at all,
+  and while the kind had no entry (#2083) this had to be its own copy. The
+  refused AI verdict takes it too, so "the files are gone" is one function.
+  """
+  def delete(%Image{kind: @kind} = image), do: Images.purge(image)
 
   @doc """
   Every press-kit token this **owner** holds — what `Vutuv.Accounts.delete_user/1`
@@ -307,6 +387,13 @@ defmodule Vutuv.PressKit do
   defp owner_columns(%Organization{} = owner, %User{id: uploader_id}),
     do: %{organization_id: Query.organization_side(owner), uploader_user_id: uploader_id}
 
+  # Who a rejection is told about. A member owns their own kit; a page's row
+  # leaves `user_id` empty by constraint, so the scan takes the **uploader** —
+  # the colleague whose file was refused, and the only member the row names at
+  # all. It is what an organization logo's scan already does.
+  defp scan_owner_id(%Image{user_id: id}) when is_binary(id), do: id
+  defp scan_owner_id(%Image{uploader_user_id: id}), do: id
+
   defp validate_form(changeset), do: if(changeset.valid?, do: :ok, else: {:error, changeset})
 
   defp validate_size(path) do
@@ -337,6 +424,7 @@ defmodule Vutuv.PressKit do
     |> Repo.insert()
     |> case do
       {:ok, image} ->
+        ImageScans.enqueue(@kind, image.id, scan_owner_id(image))
         {:ok, image}
 
       {:error, changeset} ->

--- a/lib/vutuv/uploaders/press_kit_store.ex
+++ b/lib/vutuv/uploaders/press_kit_store.ex
@@ -39,6 +39,7 @@ defmodule Vutuv.PressKitStore do
   """
 
   alias Vutuv.Images.Image, as: ImageRow
+  alias Vutuv.Moderation.Pixelation
   alias Vutuv.Uploads.Originals
   alias Vutuv.Uploads.Spec
 
@@ -103,6 +104,13 @@ defmodule Vutuv.PressKitStore do
   defp write_versions(path, ext, dir, token, logo?) do
     with {:ok, rotated} <- Spec.open_rotated(path),
          :ok <- write_derived_versions(rotated, dir, logo?) do
+      # The stand-in a stranger meets while the model looks at this picture
+      # (issue #1720). Deliberately outside `write_derived_versions/3`, which
+      # the Regenerator also drives: a mosaic is not a version of the picture,
+      # it is the temporary absence of one. A vector logo gets one too — it is
+      # cut from the rasterisation `open_rotated/1` already made, which is the
+      # same door the scan judges it through.
+      Pixelation.write_if_enabled(rotated, dir)
       :ok = Originals.store(storage_dir(token), path, ext)
 
       {:ok,
@@ -155,6 +163,32 @@ defmodule Vutuv.PressKitStore do
   end
 
   def version_path(_token, _version), do: nil
+
+  @doc """
+  Where this picture's stand-in lives (`Vutuv.Moderation.Pixelation`). The path
+  is built whether or not the file is there — `Pixelation.stands_in?/2` is what
+  asks that, because a missing stand-in is an ordinary state (a settled scan, a
+  swept leftover, an installation with the preview switched off). Same contract
+  as `Vutuv.PostImageStore.pixelated_path/1`, so the two cannot drift.
+  """
+  def pixelated_path(token) when is_binary(token), do: Pixelation.path(dir(token))
+
+  @doc """
+  Drops the stand-in once the scan has settled. Approval and rejection both end
+  the wait it stood in for; a rejection takes the whole directory anyway, which
+  makes this the approval's job.
+  """
+  def delete_pixelated(token) when is_binary(token), do: Pixelation.clear(dir(token))
+
+  @doc """
+  Moves every stored file of this picture into its takedown hold, and back
+  (`Vutuv.Images.freeze/1` and `unfreeze/1`, issue #2012). Keyed by the row's id
+  like every other hold, while the files themselves are keyed by the token —
+  which is why these take the row rather than a token.
+  """
+  def hold(%ImageRow{id: id, token: token}), do: Vutuv.Uploads.hold(id, storage_dir(token))
+
+  def release(%ImageRow{id: id, token: token}), do: Vutuv.Uploads.release(id, storage_dir(token))
 
   @doc "The X-Accel-Redirect target for a served version, for the mode that uses it."
   def accel_path(token, version) when is_binary(token) and version in @all_versions do

--- a/lib/vutuv/uploads.ex
+++ b/lib/vutuv/uploads.ex
@@ -153,9 +153,16 @@ defmodule Vutuv.Uploads do
     }
   end
 
+  @doc "The `{scope, config}` twin of `hold/2`, for an uploader keyed that way."
+  def hold(image_id, scope, config), do: hold(image_id, storage_dir(scope, config))
+
   @doc """
-  Moves every stored file of `scope` — derived versions, the private original
-  and anything still in AI quarantine — into the hold of `image_id`.
+  Moves every stored file under `storage_dir` — derived versions, the private
+  original and anything still in AI quarantine — into the hold of `image_id`.
+
+  The directory is the primitive, because the loop and `hold_slots/1` never
+  wanted anything else: a profile picture's tree is `<prefix>/<member id>` and a
+  press picture's is `press_kit/<token>`, with no scope to derive it from.
 
   **Restartable by construction.** Each file is moved on its own with an atomic
   rename, so an interruption leaves every file whole on one side or the other
@@ -164,24 +171,23 @@ defmodule Vutuv.Uploads do
   `frozen_at` *before* this runs: the stamp is the record of the intent, and
   the move is the part that may need a second attempt.
   """
-  def hold(image_id, scope, config) do
-    storage_dir = storage_dir(scope, config)
-
+  def hold(image_id, storage_dir) when is_binary(storage_dir) do
     for {slot, source} <- hold_slots(storage_dir),
         do: move_all(source, Path.join(hold_dir(image_id), slot))
 
     :ok
   end
 
+  @doc "The `{scope, config}` twin of `release/2`, for an uploader keyed that way."
+  def release(image_id, scope, config), do: release(image_id, storage_dir(scope, config))
+
   @doc """
   The other direction: every file in the hold of `image_id` goes back to the
   tree it came from, at the name it had. The (now empty) hold is left standing
-  — `Vutuv.Images.unfreeze/1` removes it only once the member row names the
-  files again, so an interruption is still visible as a hold to finish.
+  — `Vutuv.Images.unfreeze/1` removes it only once the picture is reachable
+  again, so an interruption is still visible as a hold to finish.
   """
-  def release(image_id, scope, config) do
-    storage_dir = storage_dir(scope, config)
-
+  def release(image_id, storage_dir) when is_binary(storage_dir) do
     for {slot, target} <- hold_slots(storage_dir),
         do: move_all(Path.join(hold_dir(image_id), slot), target)
 

--- a/lib/vutuv/uploads/spec.ex
+++ b/lib/vutuv/uploads/spec.ex
@@ -364,12 +364,18 @@ defmodule Vutuv.Uploads.Spec do
 
   # Whether SVG markup is something we are willing to hand to the renderer.
   #
-  # A rasterised SVG never reaches a browser here — every proxy serves the
-  # derived AVIF versions only — so this is not an XSS gate but a *renderer*
-  # gate: the XML parser runs on our server, on markup a member (or a remote
-  # server) chose, and left alone it will expand entities and follow references
-  # while rendering. So it has to be readable text, must carry none of
-  # `@svg_forbidden`, and may not point a reference at the network or the disk.
+  # No page here ever *renders* an SVG: every proxy shows the derived AVIF
+  # versions, and the one route by which a vector leaves at all — a press logo's
+  # `download.orig` (#2083) — hands it over as an `attachment` under `nosniff`,
+  # so the browser saves it rather than executing it on our origin. This is
+  # therefore not an XSS gate but a *renderer* gate: the XML parser runs on our
+  # server, on markup a member (or a remote server) chose, and left alone it
+  # will expand entities and follow references while rendering. So it has to be
+  # readable text, must carry none of `@svg_forbidden`, and may not point a
+  # reference at the network or the disk.
+  #
+  # That download is also why the vetting matters twice over: the markup a
+  # journalist saves is the markup this predicate cleared, unchanged.
   #
   # Deliberately narrower than "contains no URL". Every SVG an editor exports
   # names URLs that are never fetched — the `xmlns` namespaces, and the RDF /

--- a/lib/vutuv_web/controllers/press_kit_image_controller.ex
+++ b/lib/vutuv_web/controllers/press_kit_image_controller.ex
@@ -16,6 +16,11 @@ defmodule VutuvWeb.PressKitImageController do
       For a logo uploaded as SVG it is the vector itself.
     * `download.png` — a logo variant's PNG rendering, for whoever cannot use a
       vector. 404 on a photo, which has no such thing.
+    * `pixelated.avif` — the stand-in a stranger meets while the AI check is
+      looking at the picture (issue #2084). The one address here that answers a
+      reader `visible_to?/2` refuses, and the one that redirects rather than
+      sending bytes once the verdict has landed, so a page rendered before it
+      never draws a broken image.
 
   **The two downloads are `attachment`, and every response carries `nosniff`.**
   vutuv rasterises SVGs and never renders one, and an SVG rendered inline on our
@@ -31,6 +36,7 @@ defmodule VutuvWeb.PressKitImageController do
   use VutuvWeb, :controller
 
   alias Vutuv.Images.Image
+  alias Vutuv.Moderation.ImageScans
   alias Vutuv.PressKit
   alias Vutuv.PressKitStore
   alias VutuvWeb.ImageProxy
@@ -38,23 +44,45 @@ defmodule VutuvWeb.PressKitImageController do
   def show(conn, %{"token" => token, "version" => version_file}) do
     with image when not is_nil(image) <- PressKit.get_by_token(token),
          version when not is_nil(version) <- parse_version(version_file, image),
-         true <- PressKit.visible_to?(image, conn.assigns[:current_user]) do
+         true <- allowed?(image, conn.assigns[:current_user], version) do
       serve(conn, image, version)
     else
       _ -> ImageProxy.not_found(conn)
     end
   end
 
-  # The two file addresses are named rather than parsed as versions: neither is
-  # a size of the picture, and nothing that enumerates versions should offer
-  # them. Everything else goes through the shared whitelist parser, which never
-  # resolves a stored filename — and the whitelist is the shelf's, so a logo
-  # cannot be asked for the lightbox size it does not have.
+  # The stand-in is the mirror image of the picture: it answers for exactly the
+  # reader the picture refuses. Both are allowed, so a URL rendered before the
+  # verdict still resolves after it — the owner's own page is drawn from the
+  # picture and would otherwise 404 on a stale stand-in URL in a cache.
+  defp allowed?(image, viewer, :pixelated),
+    do: PressKit.pixelated_visible?(image) or PressKit.visible_to?(image, viewer)
+
+  defp allowed?(image, viewer, _version), do: PressKit.visible_to?(image, viewer)
+
+  # The three named addresses are named rather than parsed as versions: none of
+  # them is a size of the picture, and nothing that enumerates versions should
+  # offer them. Everything else goes through the shared whitelist parser, which
+  # never resolves a stored filename — and the whitelist is the shelf's, so a
+  # logo cannot be asked for the lightbox size it does not have.
   defp parse_version("download.orig", _image), do: :download
   defp parse_version("download.png", image), do: if(Image.logo?(image), do: :png)
+  defp parse_version("pixelated.avif", _image), do: :pixelated
 
   defp parse_version(version_file, image),
     do: ImageProxy.parse_version(version_file, PressKitStore.versions(image))
+
+  # A released picture hands its URL back to itself rather than 404ing on a
+  # stand-in that was deleted seconds ago: `large` is the size both shelves have.
+  defp serve(conn, image, :pixelated) do
+    if ImageScans.released?(image.moderation) do
+      conn
+      |> put_resp_header("cache-control", "private, no-store")
+      |> redirect(to: PressKit.url(image, "large"))
+    else
+      ImageProxy.serve_pixelated(conn, existing(PressKitStore.pixelated_path(image.token)))
+    end
+  end
 
   defp serve(conn, image, :download),
     do: hand_over(conn, PressKitStore.download_file(image), image)
@@ -76,4 +104,8 @@ defmodule VutuvWeb.PressKitImageController do
 
   defp hand_over(conn, {path, ext}, image),
     do: ImageProxy.hand_over(conn, path, PressKit.download_name(image, ext))
+
+  # A stand-in that is not on disk is the proxy's usual 404 rather than a crash
+  # in `send_file` — the same guard the post proxy keeps for the same reason.
+  defp existing(path), do: if(File.exists?(path), do: path)
 end

--- a/lib/vutuv_web/views/user_helpers.ex
+++ b/lib/vutuv_web/views/user_helpers.ex
@@ -937,6 +937,8 @@ defmodule VutuvWeb.UserHelpers do
 
   def image_kind_label("post_video_frame", "de"), do: "ein Video aus einem Ihrer Beiträge"
 
+  def image_kind_label("press_kit", "de"), do: "ein Bild aus Ihrem Pressebereich"
+
   def image_kind_label(_kind, "de"), do: "ein Bild"
   def image_kind_label("avatar", "it"), do: "la Sua immagine del profilo"
   def image_kind_label("cover", "it"), do: "la Sua immagine di copertina"
@@ -956,6 +958,8 @@ defmodule VutuvWeb.UserHelpers do
 
   def image_kind_label("post_video_frame", "it"), do: "un video di uno dei Suoi post"
 
+  def image_kind_label("press_kit", "it"), do: "un'immagine dalla Sua sezione stampa"
+
   def image_kind_label(_kind, "it"), do: "un'immagine"
   def image_kind_label("avatar", _locale), do: "your profile picture"
   def image_kind_label("cover", _locale), do: "your cover photo"
@@ -972,6 +976,8 @@ defmodule VutuvWeb.UserHelpers do
     do: "an uploaded employment reference"
 
   def image_kind_label("post_video_frame", _locale), do: "a video from one of your posts"
+
+  def image_kind_label("press_kit", _locale), do: "a picture from your press section"
 
   def image_kind_label(_kind, _locale), do: "an image"
 

--- a/test/vutuv/moderation_image_takedown_test.exs
+++ b/test/vutuv/moderation_image_takedown_test.exs
@@ -25,6 +25,7 @@ defmodule Vutuv.ModerationImageTakedownTest do
   alias Vutuv.Images.Image, as: ImageRow
   alias Vutuv.Moderation
   alias Vutuv.Moderation.Report
+  alias Vutuv.PressKit
   alias Vutuv.Repo
 
   setup do
@@ -57,6 +58,20 @@ defmodule Vutuv.ModerationImageTakedownTest do
   defp reload(user), do: Repo.get!(User, user.id)
 
   defp reload_row(%ImageRow{id: id}), do: Repo.get(ImageRow, id)
+
+  # A press picture (issue #2084): the third kind the gate admits, and the one
+  # whose files are keyed by the row's own token rather than by a member scope.
+  # `PressKit.create/4` takes the `{path, filename}` pair the socket upload hands
+  # over, so the shared fixture's `%Plug.Upload{}` is unwrapped rather than
+  # rebuilt.
+  defp press_picture(owner) do
+    %Plug.Upload{path: src} = jpeg_upload("press.jpg", [40, 90, 30])
+
+    {:ok, image} =
+      PressKit.create(owner, owner, {src, "press.jpg"}, %{"rights_confirmed" => "true"})
+
+    image
+  end
 
   defp notice(attrs \\ %{}) do
     Map.merge(
@@ -376,7 +391,10 @@ defmodule Vutuv.ModerationImageTakedownTest do
          %{owner: owner, ready: ready} do
       # Real pictures, because "the takedown can act on it" is a claim about
       # files moving, not about a clause existing.
-      real = Map.new(~w(avatar cover), &{&1, Images.profile_image(owner.id, &1)})
+      real =
+        ~w(avatar cover)
+        |> Map.new(&{&1, Images.profile_image(owner.id, &1)})
+        |> Map.put("press_kit", press_picture(owner))
 
       for kind <- ready do
         row = Map.get(real, kind)

--- a/test/vutuv/press_kit_moderation_test.exs
+++ b/test/vutuv/press_kit_moderation_test.exs
@@ -1,0 +1,220 @@
+defmodule Vutuv.PressKitModerationTest do
+  @moduledoc """
+  A press picture through the AI gate and the copyright freeze (issue #2084).
+
+  #2083 gave the kind a row and a proxy but no way out of limbo: nothing
+  enqueued a scan, so a row was born `"pending"` and stayed there for ever on
+  an installation with the gate on, and `Vutuv.Images.takedown_ready?/1`
+  answered false, so no copyright case could name one. What the tests below
+  hold is the whole life of such a row: it is queued at upload, a safe verdict
+  releases it, an unsafe one wipes every byte and tells whoever uploaded it,
+  the drift repair finds one nobody queued, and the freeze moves the files into
+  the hold and back without deleting one.
+
+  Not async: the upload path writes files and the AI gate is a global flag, and
+  the SQL sandbox rolls back neither.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Ecto.Query
+  import Vutuv.OrganizationsHelpers
+  import Vutuv.WebPushHelpers, only: [put_config: 2]
+
+  alias Vutuv.Activity
+  alias Vutuv.Images
+  alias Vutuv.Images.Image, as: ImageRow
+  alias Vutuv.Moderation.ImageScan
+  alias Vutuv.Moderation.ImageScans
+  alias Vutuv.Moderation.ImageSubjects
+  alias Vutuv.PressKit
+  alias Vutuv.PressKitStore
+  alias Vutuv.Repo
+  alias Vutuv.Uploads
+
+  @kind "press_kit"
+  @safe {:ok, %{safe?: true, category: "safe"}}
+  @unsafe {:ok, %{safe?: false, category: "nudity"}}
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "vutuv_press_mod_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    put_config(:uploads_dir_prefix, tmp)
+    put_config(:moderate_images, true)
+    put_config(:verify_organization_domains, true)
+    on_exit(fn -> File.rm_rf(tmp) end)
+
+    owner = insert(:activated_user)
+    # The rejection notice needs an address to land in.
+    insert(:email, user: owner)
+
+    {:ok, tmp: tmp, owner: owner}
+  end
+
+  defp photo!(owner, uploader, tmp) do
+    path = Path.join(tmp, "shot-#{System.unique_integer([:positive])}.jpg")
+    {:ok, img} = Image.new(600, 400, color: [10, 120, 200])
+    {:ok, _} = Image.write(img, path)
+
+    attrs = %{"rights_confirmed" => "true", "credit" => "Foto: Ada King"}
+    {:ok, image} = PressKit.create(owner, uploader, {path, "shot.jpg"}, attrs)
+    image
+  end
+
+  defp scan_of(%ImageRow{id: id}),
+    do: Repo.one(from(s in ImageScan, where: s.kind == @kind and s.subject_id == ^id))
+
+  defp served_files(token),
+    do: Path.wildcard(Path.join(Uploads.disk_dir("press_kit/#{token}"), "*"))
+
+  defp original_files(token),
+    do: Path.wildcard(Path.join(Uploads.disk_dir("originals/press_kit/#{token}"), "*"))
+
+  defp held_files(%ImageRow{id: id}), do: Path.wildcard(Path.join(Uploads.hold_dir(id), "*/*"))
+
+  describe "the scan" do
+    test "a fresh press picture is queued for the model that has to clear it", %{
+      owner: owner,
+      tmp: tmp
+    } do
+      photo = photo!(owner, owner, tmp)
+
+      assert photo.moderation == "pending"
+      assert scan = scan_of(photo)
+      assert scan.status == "pending"
+      assert scan.owner_user_id == owner.id
+    end
+
+    test "a page's picture is queued against the colleague who uploaded it", %{
+      owner: owner,
+      tmp: tmp
+    } do
+      # `images.user_id` is empty for a page's row (the member cascade would
+      # take the page's photo with the uploader's account), so the scan has to
+      # take its owner from `uploader_user_id` — otherwise nobody is told when
+      # the file they chose is refused.
+      organization = active_organization_for(owner)
+      photo = photo!(organization, owner, tmp)
+
+      assert photo.user_id == nil
+      assert scan_of(photo).owner_user_id == owner.id
+    end
+
+    test "a safe verdict releases the picture and drops its stand-in", %{owner: owner, tmp: tmp} do
+      photo = photo!(owner, owner, tmp)
+      stand_in = PressKitStore.pixelated_path(photo.token)
+      assert File.exists?(stand_in)
+
+      ImageScans.deliver_due(judge: fn _path -> @safe end)
+
+      assert Repo.get!(ImageRow, photo.id).moderation == "approved"
+      assert scan_of(photo).status == "approved"
+      # The stand-in stood in for a wait that is over; the picture itself stays.
+      refute File.exists?(stand_in)
+      assert PressKitStore.version_path(photo.token, "large")
+    end
+
+    test "an unsafe verdict wipes every byte and tells the uploader", %{owner: owner, tmp: tmp} do
+      photo = photo!(owner, owner, tmp)
+      flush_emails()
+
+      ImageScans.deliver_due(judge: fn _path -> @unsafe end)
+
+      assert Repo.get(ImageRow, photo.id) == nil
+      assert served_files(photo.token) == []
+      assert original_files(photo.token) == []
+
+      assert scan_of(photo).status == "rejected"
+
+      assert [email] = flush_emails()
+      assert email.subject =~ "An automated check removed an image"
+      assert email.text_body =~ "press"
+
+      %{entries: entries} = Activity.notifications_page(owner.id)
+      assert Enum.any?(entries, &(&1.kind == "image_rejected" and &1.image_kind == @kind))
+    end
+
+    test "the drift repair finds a press picture nobody queued", %{owner: owner, tmp: tmp} do
+      photo = photo!(owner, owner, tmp)
+      Repo.delete_all(from(s in ImageScan, where: s.subject_id == ^photo.id))
+
+      assert {@kind, photo.id, owner.id, nil} in ImageSubjects.stranded_pending()
+      assert ImageScans.repair_drift() >= 1
+      assert scan_of(photo).status == "pending"
+    end
+
+    test "a frozen picture is not queued again, whatever its moderation says", %{
+      owner: owner,
+      tmp: tmp
+    } do
+      # Its files are in the hold, so the scan would find nothing, cancel, and
+      # be re-enqueued on the next pass — for ever, on a row that is offline by
+      # decision rather than by drift.
+      photo = photo!(owner, owner, tmp)
+      Repo.delete_all(from(s in ImageScan, where: s.subject_id == ^photo.id))
+      :ok = Images.freeze(photo)
+
+      refute Enum.any?(ImageSubjects.stranded_pending(), &(elem(&1, 1) == photo.id))
+    end
+  end
+
+  describe "the takedown" do
+    test "a press picture can be frozen, and a freeze moves rather than deletes", %{
+      owner: owner,
+      tmp: tmp
+    } do
+      photo = photo!(owner, owner, tmp)
+      assert Images.takedown_ready?(photo)
+
+      :ok = Images.freeze(photo)
+
+      assert %NaiveDateTime{} = Repo.get!(ImageRow, photo.id).frozen_at
+      # Nothing a reader can reach is left, and every byte is still on disk.
+      assert served_files(photo.token) == []
+      assert original_files(photo.token) == []
+      assert length(held_files(photo)) > 1
+      assert PressKitStore.version_path(photo.token, "large") == nil
+      assert PressKitStore.download_file(photo) == nil
+    end
+
+    test "an unfreeze puts every file back at the URL it had", %{owner: owner, tmp: tmp} do
+      photo = photo!(owner, owner, tmp)
+      before = served_files(photo.token)
+
+      :ok = Images.freeze(photo)
+      :ok = Images.unfreeze(Repo.get!(ImageRow, photo.id))
+
+      assert Repo.get!(ImageRow, photo.id).frozen_at == nil
+      assert served_files(photo.token) == before
+      assert held_files(photo) == []
+      assert PressKitStore.version_path(photo.token, "large")
+    end
+
+    test "an upheld case deletes the row, the files and the hold", %{owner: owner, tmp: tmp} do
+      photo = photo!(owner, owner, tmp)
+      :ok = Images.freeze(photo)
+
+      :ok = Images.purge(Repo.get!(ImageRow, photo.id))
+
+      assert Repo.get(ImageRow, photo.id) == nil
+      assert served_files(photo.token) == []
+      assert original_files(photo.token) == []
+      assert held_files(photo) == []
+    end
+
+    test "an interrupted freeze is finished by the standing reconcile", %{owner: owner, tmp: tmp} do
+      # The stamp is the intent and the disk is the state: a slot that dies
+      # between the two leaves a picture already invisible and files still
+      # reachable, which is the half `reconcile_holds/0` finishes.
+      photo = photo!(owner, owner, tmp)
+
+      Repo.update_all(from(i in ImageRow, where: i.id == ^photo.id),
+        set: [frozen_at: NaiveDateTime.utc_now(:second)]
+      )
+
+      :ok = Images.reconcile_holds()
+
+      assert served_files(photo.token) == []
+      assert length(held_files(photo)) > 1
+    end
+  end
+end

--- a/test/vutuv/press_kit_test.exs
+++ b/test/vutuv/press_kit_test.exs
@@ -100,15 +100,16 @@ defmodule Vutuv.PressKitTest do
       assert File.exists?(Path.join(dir, "large.avif"))
     end
 
-    test "the kind is declared, proxied, and has no takedown yet", %{owner: owner, tmp: tmp} do
+    test "the kind is declared, proxied and takeable offline", %{owner: owner, tmp: tmp} do
       assert @kind in Images.kinds()
       assert Images.serving(@kind) == :proxy
       refute Images.mirrored?(@kind)
 
       {:ok, photo} = add_photo(owner, owner, tmp)
-      # #2084 wires the freeze; until then the report gate must refuse the kind
-      # rather than open a case whose uphold raises.
-      refute Images.takedown_ready?(photo)
+      # The report gate refuses a kind nothing can take offline, because such a
+      # case raises the moment an admin upholds it. #2084 gave this one its
+      # freeze in the same release as its scan.
+      assert Images.takedown_ready?(photo)
     end
 
     test "an upload without the rights confirmation is refused", %{owner: owner, tmp: tmp} do

--- a/test/vutuv_web/controllers/press_kit_image_controller_test.exs
+++ b/test/vutuv_web/controllers/press_kit_image_controller_test.exs
@@ -17,6 +17,7 @@ defmodule VutuvWeb.PressKitImageControllerTest do
 
   import Vutuv.WebPushHelpers, only: [put_config: 2]
 
+  alias Vutuv.Images
   alias Vutuv.PressKit
   alias Vutuv.Repo
 
@@ -178,6 +179,57 @@ defmodule VutuvWeb.PressKitImageControllerTest do
       Repo.update!(Ecto.Changeset.change(photo, kind: "post_image"))
 
       assert get(anonymous(), PressKit.url(photo, "large")).status == 404
+    end
+  end
+
+  describe "while the AI check is looking (issue #2084)" do
+    test "a stranger gets the stand-in and nothing else", %{owner: owner, tmp: tmp} do
+      photo = photo!(owner, tmp)
+
+      assert url = PressKit.pixelated_url(photo)
+      conn = get(anonymous(), url)
+
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-type") == ["image/avif"]
+      # The real picture takes this URL within seconds, so no cache may keep it.
+      assert get_resp_header(conn, "cache-control") == ["private, no-store"]
+
+      # And the picture itself stays shut until the verdict clears it.
+      assert get(anonymous(), PressKit.url(photo, "large")).status == 404
+    end
+
+    test "the stand-in hands the URL back once the picture is released",
+         %{owner: owner, tmp: tmp} do
+      photo = photo!(owner, tmp)
+      url = PressKit.pixelated_url(photo)
+      released = release!(photo)
+
+      # A page drawn before the verdict keeps a stand-in URL in it; it must land
+      # on the picture rather than on a 404 for a file that was just deleted.
+      conn = get(anonymous(), url)
+      assert redirected_to(conn) == PressKit.url(released, "large")
+      assert PressKit.pixelated_url(Repo.reload!(released)) == nil
+    end
+
+    test "a frozen picture has no stand-in either", %{owner: owner, tmp: tmp} do
+      # A takedown has to read exactly like a picture that was never there, and
+      # a mosaic of the picture is still the picture.
+      photo = photo!(owner, tmp)
+      url = PressKit.pixelated_url(photo)
+      :ok = Images.freeze(photo)
+
+      assert get(anonymous(), url).status == 404
+      assert PressKit.pixelated_url(Repo.reload!(photo)) == nil
+    end
+
+    test "a logo waits behind a stand-in cut from its rasterisation",
+         %{owner: owner, tmp: tmp} do
+      # The scan judges the raster an SVG is turned into, so the same door gives
+      # the stand-in its pixels — a vector logo is not exempt from the wait.
+      logo = svg_logo!(owner, tmp)
+
+      assert url = PressKit.pixelated_url(logo)
+      assert get(anonymous(), url).status == 200
     end
   end
 end


### PR DESCRIPTION
Since #2083 a press picture was born `"pending"` and stayed there: nothing enqueued an AI scan, and `Vutuv.Images.takedown_ready?/1` said no, so a copyright case could not name one.

`Vutuv.PressKit.create/4` now queues the scan, and until a verdict lands a stranger gets the pixelated stand-in at `/system/press_kit/<token>/pixelated.avif` — a logo too, cut from the rasterisation the scan judges. Once released that URL redirects to `large` instead of 404ing. A rejection wipes every byte and tells the uploader (`images.user_id`, or `uploader_user_id` for a page) with a label of its own. `press_kit` also gets its `@takedown` strategy now rather than a release later, so a freeze moves its files into the hold and every address answers 404. The shared stamp/clear/purge-hold steps moved up into `freeze/1`, `unfreeze/1` and `purge/1`.

To decide: for a **page's** press picture `Vutuv.Moderation`'s `owner_id/1` still reads `user_id` only, so no case owner and no report — I left that to #2089, and recommend the organization-post answer (`created_by_user_id`).

Closes #2084

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01WPMGFtmCZNip8EJiRrx6ch
