### PR TITLE
A square icon for the row beside Facebook and LinkedIn

### DIFF
--- a/lib/vutuv/profiles/link_badges.ex
+++ b/lib/vutuv/profiles/link_badges.ex
@@ -27,24 +27,30 @@ defmodule Vutuv.Profiles.LinkBadges do
   @handle_token "__HANDLE__"
   @handle_placeholder "your-handle"
 
-  @icon_path "/images/brand/vutuv-mark.svg"
-  @icon_size 28
-
   @doc "The stand-in handle an anonymous reader sees in every snippet."
   def handle_placeholder, do: @handle_placeholder
 
   @doc """
-  The badge images, each `%{name:, note:, path:, width:, height:, dark_plate?:}`.
+  The badge images, each
+  `%{name:, note:, path:, width:, height:, dark_plate?:, wordmark?:}`.
 
-  `dark_plate?` says whether a preview needs a dark surface behind it, and it is
-  a field rather than a guess at the filename because getting it wrong is
-  invisible in code and obvious on screen: a badge drawn on the very colour it
-  is made of has no edge, so it reads as loose glyphs rather than as a badge.
+  Both flags are **fields rather than guesses** at a filename or a shape, for
+  the same reason: getting either wrong is invisible in code and obvious on
+  screen. `dark_plate?` says a preview needs a dark surface, because a badge
+  drawn on the very colour it is made of has no edge and reads as loose glyphs.
+  `wordmark?` says the file spells "vutuv" across itself, which is what
+  `link_badges_test.exs` checks against the brand wordmark; reading that off
+  "wider than it is tall" would hold today by layout accident and drop a stacked
+  badge out of the check silently.
 
-  The icon mark is deliberately **not** in this list. It is already a brand
-  asset the media kit offers (`MediaKitDoc.assets/0`), and one file under two
-  names in two catalogs is two notes that drift; the icon snippet below points
-  at that same file.
+  The **icon** is the square one, for the row of brand icons a homepage usually
+  has. It is a file of its own rather than the mark plus a corner radius at the
+  call site, because the tile beside it offers a **download**: a member who
+  saves the file has nowhere to put a radius. What it duplicates is not
+  `vutuv-mark.svg` (a sharp square) but the rounded square already inside both
+  badge files, down to that square's own `rx` — three drawings of one logo in
+  one grid must round the same. It keeps the mark's proportions too: a link icon
+  drawn differently from the app icon is two logos, not one.
   """
   def badges do
     [
@@ -54,7 +60,8 @@ defmodule Vutuv.Profiles.LinkBadges do
         path: "/images/brand/vutuv-badge.svg",
         width: 130,
         height: 40,
-        dark_plate?: false
+        dark_plate?: false,
+        wordmark?: true
       },
       %{
         name: "Badge, dark",
@@ -62,7 +69,20 @@ defmodule Vutuv.Profiles.LinkBadges do
         path: "/images/brand/vutuv-badge-dark.svg",
         width: 130,
         height: 40,
-        dark_plate?: true
+        dark_plate?: true,
+        wordmark?: true
+      },
+      %{
+        name: "Icon, rounded",
+        note:
+          "Square, for a row of icons beside Facebook, LinkedIn and the rest. " <>
+            "For an avatar or a favicon take the sharp-cornered icon mark above.",
+        path: "/images/brand/vutuv-icon.svg",
+        # 40px: a touch target on a phone, and a common size for such a row.
+        width: 40,
+        height: 40,
+        dark_plate?: false,
+        wordmark?: false
       }
     ]
   end
@@ -110,6 +130,7 @@ defmodule Vutuv.Profiles.LinkBadges do
   defp raw_snippets do
     badge = badge("Badge")
     dark = badge("Badge, dark")
+    icon = badge("Icon, rounded")
 
     [
       %{
@@ -123,13 +144,15 @@ defmodule Vutuv.Profiles.LinkBadges do
       },
       %{
         key: "icon",
-        name: "An icon",
-        note: "For a row of social icons beside the others.",
+        name: "A square icon",
+        note:
+          "For the row of icons beside Facebook, LinkedIn and the rest. " <>
+            "The corners are rounded in the file, so it needs no CSS; add " <>
+            "border-radius:50% if your row is round.",
         language: "html",
         code: """
         <a href="#{profile_url()}" rel="me" title="vutuv">
-          <img src="#{asset_url(@icon_path)}" alt="vutuv"
-               width="#{@icon_size}" height="#{@icon_size}" style="border-radius:6px">
+          #{img(icon)}
         </a>\
         """
       },
@@ -168,8 +191,7 @@ defmodule Vutuv.Profiles.LinkBadges do
            style="display:inline-flex;align-items:center;gap:8px;padding:9px 14px;
                   border-radius:8px;background:#2563EB;color:#fff;text-decoration:none;
                   font:600 14px/1 system-ui,sans-serif">
-          <img src="#{asset_url(@icon_path)}" alt="" width="18" height="18"
-               style="border-radius:4px">
+          <img src="#{asset_url(icon.path)}" alt="" width="18" height="18">
           #{@handle_token} on vutuv
         </a>\
         """

--- a/lib/vutuv_web/templates/company/media_kit.html.heex
+++ b/lib/vutuv_web/templates/company/media_kit.html.heex
@@ -118,7 +118,7 @@ sibling hand a journalist the same words. --%>
       />
     </div>
 
-    <ul class="mt-5 grid gap-4 sm:grid-cols-2">
+    <ul class="mt-5 grid gap-4 sm:grid-cols-3">
       <.asset_tile
         :for={badge <- @badges}
         name={badge.name}

--- a/priv/static/images/brand/vutuv-icon.svg
+++ b/priv/static/images/brand/vutuv-icon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512" role="img" aria-label="vutuv">
+  <title>vutuv</title>
+  <defs>
+    <linearGradient id="vutuvIcon" x1="0" y1="0" x2="512" y2="512" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1e40af"/>
+      <stop offset="1" stop-color="#2563eb"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="118" fill="url(#vutuvIcon)"/>
+  <g fill="#ffffff" transform="translate(-444.223 -1633.924) scale(4.330425)">
+    <path d="M154.3,468c-4.1-8-8.3-17.4-12.5-28.1c-4.2-10.7-8.2-22.4-12-35h19c0.8,3.1,1.7,6.5,2.8,10.1c1.1,3.6,2.2,7.3,3.4,11 c1.2,3.7,2.3,7.3,3.5,10.9c1.2,3.5,2.3,6.7,3.4,9.6c1-2.9,2.2-6.1,3.4-9.6c1.2-3.5,2.4-7.1,3.6-10.9c1.2-3.7,2.3-7.4,3.4-11 c1.1-3.6,2-7,2.8-10.1h18.5c-3.8,12.6-7.8,24.3-12,35c-4.2,10.7-8.4,20.1-12.5,28.1H154.3z"/>
+  </g>
+</svg>

--- a/test/vutuv/profiles/link_badges_test.exs
+++ b/test/vutuv/profiles/link_badges_test.exs
@@ -1,13 +1,13 @@
 defmodule Vutuv.Profiles.LinkBadgesTest do
   @moduledoc """
-  The catalog a member links their own homepage from, and the two badge files it
+  The catalog a member links their own homepage from, and the badge files it
   hands out.
 
   The verification half — that every HTML snippet carries the exact `rel="me"`
   back-link `Vutuv.Profiles.LinkVerification` goes looking for — is asserted in
   `company_controller_test.exs`, where it reads them back through the real
-  parser. What is here is the half a rendering test cannot see: that the badge
-  files still draw the brand.
+  parser. What is here is the half a rendering test cannot see: that the three
+  badge files still draw the brand, at the shape their snippets claim.
   """
   use ExUnit.Case, async: true
 
@@ -33,14 +33,22 @@ defmodule Vutuv.Profiles.LinkBadgesTest do
     # inlines the wordmark's five letters and the mark's "v". That copy is
     # forced; what is not forced is that nothing notices when the brand is
     # redrawn and the badges keep the old shapes. This is that notice.
+    #
+    # Which files spell "vutuv" across themselves is the catalog's own
+    # `wordmark?`, not a guess from the shape: "wider than it is tall" holds for
+    # today's badges by layout accident, and a stacked badge would drop out of
+    # this check without a word.
     test "still draw the same wordmark the brand asset does" do
       wordmark = paths("vutuv-wordmark.svg")
       assert length(wordmark) == 5
 
-      for badge <- LinkBadges.badges() do
+      spelled = Enum.filter(LinkBadges.badges(), & &1.wordmark?)
+      assert spelled != []
+
+      for badge <- spelled do
         file = Path.basename(badge.path)
 
-        assert badge.path |> Path.basename() |> paths() |> Enum.take(-5) == wordmark,
+        assert file |> paths() |> Enum.take(-5) == wordmark,
                "#{file} no longer carries the wordmark from vutuv-wordmark.svg — " <>
                  "rebuild it from the brand files rather than editing it by hand"
       end
@@ -56,14 +64,21 @@ defmodule Vutuv.Profiles.LinkBadgesTest do
     end
 
     # The badge's own `width`/`height` are what the snippets write into their
-    # `<img>`, so a file redrawn at another size would hand out an `<img>` that
-    # stretches it on somebody else's page.
-    test "are drawn at the size the snippets claim" do
+    # `<img>`, so a file whose shape stops matching them is handed out stretched
+    # on somebody else's page. The **ratio** is what has to agree, not the
+    # numbers: a badge is drawn 1:1 with its box while the square icon is a 512
+    # px artboard shown at 40.
+    test "are drawn at the shape the snippets claim" do
       for badge <- LinkBadges.badges() do
         svg = File.read!(Path.join(@brand, Path.basename(badge.path)))
 
-        assert svg =~ ~s|viewBox="0 0 #{badge.width} #{badge.height}"|,
-               "#{badge.path} is not #{badge.width}x#{badge.height}, which its snippets claim"
+        assert [w, h] = Regex.run(~r/viewBox="0 0 (\d+) (\d+)"/, svg, capture: :all_but_first),
+               "#{badge.path} has no plain `viewBox=\"0 0 w h\"` to read its shape from"
+
+        # Cross-multiplied, so the comparison is exact and needs no tolerance.
+        assert String.to_integer(w) * badge.height == String.to_integer(h) * badge.width,
+               "#{badge.path} is drawn #{w}x#{h}, which the <img> at " <>
+                 "#{badge.width}x#{badge.height} would stretch"
       end
     end
   end


### PR DESCRIPTION
Homepages usually carry a row of square brand icons. vutuv only had the sharp-cornered brand mark, which the snippet rounded with inline CSS — no good for a member who **downloads** the file and drops it into an existing row, where there is no CSS left to reach. `/system/media-kit#link-to-your-profile` now offers `vutuv-icon.svg`, rounded in the picture itself, as a third tile beside the two badges.

It wears the same corner radius as the square inside both badge files (three drawings of one logo in one grid must round alike) and the app icon's proportions. Checked in a browser against stand-ins for the icons such a row holds, square and circular.

The catalog now says which file spells the wordmark (`wordmark?`) instead of inferring it from "wider than tall", and the shape test compares aspect ratios — the icon is a 512px artboard shown at 40.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_016PTm99JJ2ncLy6Wsro6tf9