### PR TITLE
An organization page offers the same press section, managed by its team

### DIFF
--- a/docs/architecture/images.md
+++ b/docs/architecture/images.md
@@ -936,6 +936,32 @@ siblings are `VutuvWeb.AgentDocs.PressKitDoc`, and the profile document carries
 the same entries under `press_kit`; both list the **released** pictures only,
 since a document that names a file must name one that can be fetched.
 
+**A page has the same section, kept by its team (issue #2087).** The card, the
+section page, the documents, the schema.org block and the sitemap entry are the
+same code with an organization as the owner — `PressKitComponents.press_card/1`
+(lifted out of the profile template when the page needed the second copy),
+`VutuvWeb.PressKitController.organization/2`, `PressKitDoc.build/2`. Three things
+are the page's own. **The URL is built from the slug**, `/organizations/:slug/press`
+(`PressKit.page_path/1`), not from a claimed root handle: that handle dispatches
+the bare `/:slug` alone, so `Identity.path/1 <> "/press"` answered an address that
+404ed. The **editor** is `/organizations/:slug/press/edit` — the same
+`VutuvWeb.PressKitLive`, embedded by `OrganizationController.press/2` instead of
+routed, so it resolves the viewer with `InitAssigns.assign_embedded/2` and
+re-asks `manageable_by?/2` on the socket (`OrganizationLive.ManageGate`) rather
+than trusting the signed `organization_id`; it is on the manage tab bar and in
+the page's own manage strip, for an owner or a publisher. And a page may take
+**its own logo** onto the logo shelf with one press (`PressKit.adopt_page_logo/3`)
+where that logo is a **vector** — `File.cp!` through the ordinary `create/4`, so
+the page's original stays where it is and the copy meets the same cap, whitelist,
+rights stamp and scan; a raster logo is not offered, since the file the page
+uploaded is already the screen-sized copy and would be a print promise it cannot
+keep.
+
+The sentences whose German addresses the reader as the owner ("Ihr Logo", "über
+Sie schreibt") get **their own msgids** for the page's editor rather than sharing
+the member's: `gettext.extract --merge` fuzzy-filled all three with exactly that
+member-voiced German, which is the trap `docs/architecture/i18n.md` records.
+
 ### The takedown hold (issue #2012)
 
 A copyright freeze **moves** a picture, it never deletes one, and the tree it

--- a/docs/architecture/organizations.md
+++ b/docs/architecture/organizations.md
@@ -650,6 +650,19 @@ column `user_id` empty for this kind, because it cascades. The whole move,
 including what the release that wires the takedown has to answer for a page
 that cannot be struck, is in [images.md](images.md).
 
+Beside the logo a page keeps a **press kit** (#2087): press photos and logo
+variants a journalist downloads, on a card below the open positions and on
+`/organizations/:slug/press`. Its editor is `/organizations/:slug/press/edit`,
+on the manage tab bar, and it is the one manage page a **publisher** reaches
+without holding an administrative role — the material a page hands the press is
+part of speaking for it (`Vutuv.PressKit.manageable_by?/2`, owners and
+publishers, deliberately not `can_manage?/2`, which also counts whoever claimed
+the page). The rows belong to the page: `organization_id` owns them and the
+colleague who uploaded one only rides in `uploader_user_id`, so a press photo
+outlives their account exactly as the logo does. Where the page's own logo is a
+vector it is one press away from being the first variant. The whole kind is in
+[images.md](images.md).
+
 ## The homepage screenshot
 
 The page shows a picture of the website it names — a "Website" card at the top

--- a/lib/vutuv/press_kit.ex
+++ b/lib/vutuv/press_kit.ex
@@ -66,6 +66,7 @@ defmodule Vutuv.PressKit do
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Moderation.Pixelation
   alias Vutuv.Ordering
+  alias Vutuv.OrganizationImageStore
   alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
   alias Vutuv.PressKitStore
@@ -116,6 +117,21 @@ defmodule Vutuv.PressKit do
 
   @doc "The owner's logo variants, in the order they are shown."
   def logos(owner), do: shelf_rows(owner, true)
+
+  @doc """
+  Both shelves of one owner's kit **whatever their moderation state** —
+  `%{photos:, logos:}`, each in the owner's own order. What the editor lists,
+  which is the one surface that shows a picture the AI gate is still holding as
+  itself rather than as a stand-in.
+
+  One query for both, for `public_shelves/2`'s reason: the caps are ten and five,
+  so the whole kit is at most fifteen rows and the split is cheaper in memory
+  than a second round trip — and the editor reloads them after every save,
+  delete, move, reorder and upload.
+  """
+  def shelves(owner) do
+    owner |> owned() |> Ordering.by_position() |> Repo.all() |> split()
+  end
 
   @doc "How many pictures the owner has on that shelf."
   def count(owner, logo?) when is_boolean(logo?),
@@ -254,12 +270,21 @@ defmodule Vutuv.PressKit do
   """
   def manageable_by?(%User{id: id}, %User{id: id}), do: true
 
-  def manageable_by?(%Organization{} = organization, %User{} = viewer) do
-    powers = Organizations.role_powers(organization, viewer)
-    powers.owner? or powers.publisher?
-  end
+  def manageable_by?(%Organization{} = organization, %User{} = viewer),
+    do: organization |> Organizations.role_powers(viewer) |> manageable_by_powers?()
 
   def manageable_by?(_owner, _viewer), do: false
+
+  @doc """
+  The same rule, read off a `Vutuv.Organizations.role_powers/2` answer somebody
+  already holds — for the page itself, which consolidated five permission reads
+  into that one and must not grow a sixth to ask this.
+
+  Public so the rule keeps one home: `manageable_by?/2` is this function plus
+  the read.
+  """
+  def manageable_by_powers?(%{owner?: owner?, publisher?: publisher?}),
+    do: owner? or publisher?
 
   @doc """
   Whether `viewer` may fetch this picture's bytes — the one statement of that
@@ -430,16 +455,35 @@ defmodule Vutuv.PressKit do
   defp address(%Image{token: token}, file), do: "/system/press_kit/#{token}/#{file}"
 
   @doc """
-  Where this owner's press kit is published: `/ada.king/press` for a member, the
-  page's canonical path plus `/press` for a page — `Vutuv.Identity.path/1` plus
-  one segment, so the next owner kind is remembered in the one place that
-  already knows about owner kinds.
+  Where this owner's press kit is published: `/ada.king/press` for a member,
+  `/organizations/acme/press` for a page.
 
   For everything holding an owner rather than a route: the doc's canonical URL,
-  the schema.org block, and #2087's page twin. The profile template keeps its
-  verified `~p` sigil, which is a compile-time check this cannot give it.
+  the schema.org block, the card's footer link and the sitemap entry.
+
+  **A page is addressed by its slug here, not by its root handle**, which is
+  where this deviates from `Vutuv.Identity.path/1`. A page that claimed a root
+  handle is canonical at `/acme`, but that handle dispatches the **bare**
+  `/:slug` page alone (`VutuvWeb.Plug.UserResolveSlug`, `dispatch_organization:
+  true` on that one route) — every sub-page of a page lives under
+  `/organizations/:slug/`, exactly as its post permalinks do, and #2086 shipped
+  `Identity.path/1 <> "/press"` here, which answered `/acme/press` for such a
+  page and 404ed.
   """
+  def page_path(%Organization{slug: slug}), do: "/organizations/#{slug}/press"
   def page_path(owner), do: Identity.path(owner) <> "/press"
+
+  @doc """
+  Where this kit is **edited**: `/settings/press` for a member (#2085), the
+  page's own editor for a page (#2087).
+
+  The second path this kind owns, and it needs one owner for the same reason the
+  first does — four surfaces link to it (the section page's "Manage" bridge, the
+  card's add tile, the page's manage menu and the editor's own trail), and a
+  member's editor carries no slug at all while a page's does.
+  """
+  def editor_path(%Organization{slug: slug}), do: "/organizations/#{slug}/press/edit"
+  def editor_path(%User{}), do: "/settings/press"
 
   @doc """
   The one sentence under which every press picture is offered.
@@ -520,6 +564,57 @@ defmodule Vutuv.PressKit do
   end
 
   @doc """
+  The page's own logo file, when it is one the logo shelf could take as a
+  variant: the absolute path of the stored original, or `nil` (#2087).
+
+  **A vector only, deliberately.** A press logo is offered for print, and what a
+  page uploaded as a raster is already the screen-sized copy
+  `Vutuv.OrganizationImageStore` derived from it — handing a journalist a 512 px
+  PNG under the word "logo" is worse than handing them nothing, and it is what
+  the page's own tile already shows. A vector is the one case where the file the
+  page uploaded **is** the printable one, which is why #2082 asked for the
+  one-click offer on exactly that case.
+
+  It asks the disk rather than the row's `content_type`, because the disk is
+  what `adopt_page_logo/3` will copy: an installation restored from a snapshot
+  carries no `originals/` tree, and a button offering a file that is not there
+  would fail on the press instead of never appearing.
+  """
+  def page_logo_source(%Organization{logo: token}) when is_binary(token) do
+    path = OrganizationImageStore.original_path(token)
+
+    if path && Path.extname(path) == ".svg", do: path
+  end
+
+  def page_logo_source(_owner), do: nil
+
+  @doc """
+  Copies that logo onto the page's logo shelf as one more variant — the
+  one-click adoption, which is `create/4` with the page's own file standing in
+  for the upload.
+
+  Through `create/4` and nothing else, so it inherits every rule a picked file
+  meets: the authorization, the shelf cap, the whitelist, the rights stamp and
+  the AI scan. `attrs` are the add form's, the rights tick included — the page
+  holds this file, but releasing it for editorial use with a credit is still a
+  decision somebody makes rather than one adoption may imply.
+  """
+  def adopt_page_logo(%Organization{} = organization, %User{} = viewer, attrs) do
+    case page_logo_source(organization) do
+      nil ->
+        {:error, :invalid_file}
+
+      path ->
+        create(organization, viewer, {path, Path.basename(path)}, Map.put(attrs, "logo", true))
+    end
+  end
+
+  # A member's kit has no page logo to adopt, and the editor offers the button
+  # on a page alone — but the event arrives from a client, so the clause that
+  # cannot happen answers rather than raising.
+  def adopt_page_logo(_owner, _viewer, _attrs), do: {:error, :forbidden}
+
+  @doc """
   Edits one stored picture's label, credit and caption — the only three columns
   a form may write once the file is on disk (`Image.press_kit_update_changeset/2`
   says which are missing and why).
@@ -591,6 +686,29 @@ defmodule Vutuv.PressKit do
       image -> image.credit
     end
   end
+
+  @doc """
+  What the editor's credit field is **offered** ready-filled with: the last
+  picture on that shelf where there is one (`last_credit/1`), and the owner's
+  own name where there is not.
+
+  The fallback is the whole point. A press picture with no credit is one a
+  journalist may not print, and until now a first-time member met an empty field
+  — the shelf they were filling had nothing to copy a line from. The name is
+  right far more often than blank is: most members are photographed by somebody
+  they can name, and the ones who took the picture themselves are named
+  correctly by it.
+
+  The **owner's** name, never the uploader's: a page's press kit belongs to the
+  page, and the colleague who uploads for it is not who the credit names.
+
+  A default, not a value. It is rendered into an ordinary editable input and
+  nothing writes it at save time, so a member who clears the field stores an
+  empty credit — the field says what will be stored, which is the only way a
+  prefill can be honest.
+  """
+  def credit_default(owner, images) when is_list(images),
+    do: last_credit(images) || Identity.display_name(owner)
 
   @doc """
   Releases a press picture the AI gate cleared, and answers `:stale` when the row

--- a/lib/vutuv/sitemap.ex
+++ b/lib/vutuv/sitemap.ex
@@ -76,7 +76,8 @@ defmodule Vutuv.Sitemap do
       organizations: chunks(Repo.aggregate(indexable_organizations(), :count)),
       organization_posts: chunks(Repo.aggregate(indexable_organization_posts(), :count)),
       jobs: chunks(Repo.aggregate(indexable_jobs(), :count)),
-      press: chunks(Repo.aggregate(indexable_press_users(), :count))
+      press: chunks(Repo.aggregate(indexable_press_users(), :count)),
+      organization_press: chunks(Repo.aggregate(indexable_press_organizations(), :count))
     }
   end
 
@@ -108,6 +109,27 @@ defmodule Vutuv.Sitemap do
     |> Repo.all()
     |> Enum.map(fn {slug, updated_at} ->
       {"/#{slug}/press", NaiveDateTime.to_date(updated_at)}
+    end)
+  end
+
+  @doc """
+  `{path, lastmod_date}` entries of one organization-press chunk (1-based): the
+  press page of every crawlable page that actually offers a picture (#2087).
+
+  Its own type rather than a widened `press_entries/1`, for the reason
+  `organization_post_entries/1` is its own: that one is scoped to
+  `indexable_users/0` and reads a member's handle for the URL, and a page has
+  neither — its URL is built from the slug and its indexability is its `seo?`
+  flag. `lastmod` is the page's own, matching its directory entry.
+  """
+  def organization_press_entries(chunk) do
+    indexable_press_organizations()
+    |> order_by([o], o.id)
+    |> window(chunk)
+    |> select([o], {o.slug, o.updated_at})
+    |> Repo.all()
+    |> Enum.map(fn {slug, updated_at} ->
+      {"/organizations/#{slug}/press", NaiveDateTime.to_date(updated_at)}
     end)
   end
 
@@ -217,6 +239,21 @@ defmodule Vutuv.Sitemap do
       from(i in PressKit.public_query(), where: not is_nil(i.user_id), select: i.user_id)
 
     where(indexable_users(), [u], u.id in subquery(owner_ids))
+  end
+
+  # The page twin (#2087), and the other half of that nullable pair: a picture
+  # whose `organization_id` is set names a page's press section. Same `IN` over
+  # owner ids for the same reason — one row per page, however many pictures it
+  # offers — and the same explicit `not is_nil`, which here keeps a *member's*
+  # rows out.
+  defp indexable_press_organizations do
+    owner_ids =
+      from(i in PressKit.public_query(),
+        where: not is_nil(i.organization_id),
+        select: i.organization_id
+      )
+
+    where(indexable_organizations(), [o], o.id in subquery(owner_ids))
   end
 
   # scope_visible(nil) already drops restricted posts, frozen posts and

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -283,7 +283,11 @@ defmodule VutuvWeb.AgentDocs.Markdown do
       |> Enum.filter(&is_binary/1)
       |> Enum.join("\n"),
       organization_people(doc),
-      organization_open_positions(doc)
+      organization_open_positions(doc),
+      # The page's press kit (#2087), written by the same line builder the
+      # profile document uses, so a press picture reads the same whoever offers
+      # it.
+      section(gettext("Press"), Enum.map(doc[:press_kit] || [], &press_picture_line/1))
     ]
     |> join_blocks()
   end

--- a/lib/vutuv_web/agent_docs/organization_doc.ex
+++ b/lib/vutuv_web/agent_docs/organization_doc.ex
@@ -17,8 +17,10 @@ defmodule VutuvWeb.AgentDocs.OrganizationDoc do
   alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
+  alias Vutuv.PressKit
   alias VutuvWeb.AgentDocs
   alias VutuvWeb.AgentDocs.JobPostingDoc
+  alias VutuvWeb.AgentDocs.PressKitDoc
   alias VutuvWeb.Fediverse.Docs
   alias VutuvWeb.UserHelpers
 
@@ -83,12 +85,25 @@ defmodule VutuvWeb.AgentDocs.OrganizationDoc do
       # asked with a nil viewer, so a post still held by moderation is absent
       # here even though the page's own publishers see it in the HTML.
       posts: Enum.map(posts, &post_entry/1),
+      # The page's press kit (issue #2087), the twin of the profile document's
+      # own `press_kit` list: the card is on the HTML page, so the document
+      # names the same pictures. The **released** ones only, like every press
+      # document — one that names a file must name one that can be fetched.
+      press_kit: press_kit_entries(organization),
       # The page's Fediverse address, the same fact its card shows (nil unless
       # it federates). It belongs in the doc for the reason the whole system
       # exists: an agent reading the `.md` should be able to say where to follow
       # this page, and it is the one address here that is not a vutuv URL.
       fediverse: fediverse_entry(organization)
     })
+  end
+
+  # A read rather than a preload: press pictures are rows on the shared `images`
+  # table with no association off `organizations` (see `Vutuv.PressKit`), and the
+  # two shelves are rejoined here because the card shows them as one set.
+  defp press_kit_entries(organization) do
+    shelves = PressKit.published_shelves(organization)
+    PressKitDoc.entries(shelves.photos ++ shelves.logos)
   end
 
   # No `moved_to` arm, unlike `ProfileDoc`: a page cannot move its account

--- a/lib/vutuv_web/agent_docs/text.ex
+++ b/lib/vutuv_web/agent_docs/text.ex
@@ -254,6 +254,7 @@ defmodule VutuvWeb.AgentDocs.Text do
       |> Enum.filter(&is_binary/1),
       organization_people(doc),
       organization_open_positions(doc),
+      section(gettext("Press"), Enum.map(doc[:press_kit] || [], &press_picture_lines/1)),
       footer(doc)
     ]
     |> join_blocks()

--- a/lib/vutuv_web/components/organization_components.ex
+++ b/lib/vutuv_web/components/organization_components.ex
@@ -20,6 +20,7 @@ defmodule VutuvWeb.OrganizationComponents do
   alias Vutuv.Countries
   alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
+  alias Vutuv.PressKit
 
   attr(:domain, :string, required: true)
 
@@ -251,6 +252,14 @@ defmodule VutuvWeb.OrganizationComponents do
         </.manage_tab>
         <.manage_tab active={@active == :exclusions} navigate={"/organizations/#{@organization.slug}/exclusions"}>
           {gettext("Job exclusions")}
+        </.manage_tab>
+        <%!-- The page's press kit (issue #2087). Owners and publishers, which is
+        `Vutuv.PressKit`'s own rule read off the powers this header already has:
+        the material a page hands the press out with is part of speaking for it,
+        and it is the one manage page a publisher reaches without holding an
+        administrative role. --%>
+        <.manage_tab :if={PressKit.manageable_by_powers?(@powers)} active={@active == :press} navigate={PressKit.editor_path(@organization)}>
+          {gettext("Press")}
         </.manage_tab>
         <%!-- What happened to the page (issue #1336). Open to the whole team,
         not only its publishers: this is news ABOUT the page rather than

--- a/lib/vutuv_web/components/press_kit_components.ex
+++ b/lib/vutuv_web/components/press_kit_components.ex
@@ -1,13 +1,14 @@
 defmodule VutuvWeb.PressKitComponents do
   @moduledoc """
-  What a member's or a page's press kit looks like on a **public** surface
-  (issue #2086): the card below Links on the profile, and the section page at
-  `/:slug/press` that hands the files out.
+  What a member's or a page's press kit looks like on a **public** surface: the
+  card below Links on the profile (#2086) and below the open positions on an
+  organization page (#2087), and the section page that hands the files out.
 
-  Its own module rather than more of `VutuvWeb.UI` because #2087 draws exactly
-  the same two shelves on an organization page, and the one thing that differs
-  there is the owner it is handed — so everything here takes pictures and a
-  viewer and nothing else.
+  Its own module rather than more of `VutuvWeb.UI` because both owner kinds draw
+  exactly the same two shelves, and the one thing that differs is the owner they
+  are handed — so everything here takes pictures and a viewer and nothing else.
+  The whole card is `press_card/1`, which #2087 lifted out of
+  `templates/user/show.html.heex` when the page needed the second copy.
 
   ## What the card shows and what opens
 
@@ -15,10 +16,13 @@ defmodule VutuvWeb.PressKitComponents do
   `VutuvWeb.PostComponents.mosaic_layout/2` answers the geometry — hero first, a
   frame chosen from the hero's own shape, at most five tiles and a `+N` on the
   last — so the arrangements themselves are stated once for both. The grid's
-  *markup* is still written twice, and knowingly: folding it into a shared
-  component with a cell slot is the right move once #2087 makes a third caller
-  and there is a second press surface to prove the shape against, and until then
-  it would be a refactor of the app's hottest markup for one new page.
+  *markup* is still written twice, and knowingly. #2086 expected #2087 to be the
+  third caller that pays for folding it into a shared component with a cell
+  slot; it is not one. A page's card is this module's own `press_photos/1` at a
+  second **call site**, not a third copy of the markup, so the count of copies
+  is still two and the refactor of the app's hottest markup still has one
+  surface to prove itself on. Leave it until a genuinely different grid needs
+  the same geometry.
 
   A tile **describes** its photo and the magnifier in the corner **opens** it —
   the split `assets/js/lightbox.js` reads, and the reason a tile can sit inside
@@ -64,6 +68,57 @@ defmodule VutuvWeb.PressKitComponents do
   alias Vutuv.PressKit
   alias VutuvWeb.Markdown
   alias VutuvWeb.PostComponents
+
+  @doc """
+  The whole **Press card**: the photo mosaic, the logo row, the rights line and
+  the footer link to the section page — on a member's profile below Links, and
+  on a page below its open positions.
+
+  `manage_href` is the editor (`Vutuv.PressKit.editor_path/1`) when this viewer
+  may write the kit and `nil` when they may not, which is the only thing the two
+  surfaces disagree about: it decides whether an empty kit shows the card at all
+  and what the dashed add tile links to. Every other difference lives in the
+  owner, and `page_path/1` answers it.
+  """
+  attr(:id, :string, required: true)
+  attr(:owner, :any, required: true, doc: "the member or the page whose kit this is")
+  attr(:press, :map, required: true, doc: "`Vutuv.PressKit.public_shelves/2`'s answer")
+  attr(:viewer, :any, default: nil)
+  attr(:manage_href, :any, default: nil)
+
+  def press_card(assigns) do
+    # `Map.put/3`, not `assign/3`: a card's owner cannot change without a fresh
+    # mount, so the key needs no change mark and the attributes reading it stay
+    # separately tracked.
+    assigns = Map.put(assigns, :href, PressKit.page_path(assigns.owner))
+
+    ~H"""
+    <.card :if={press_any?(@press) or @manage_href} id={@id}>
+      <.section_header title={gettext("Press")} />
+      <.empty_add :if={@manage_href && not press_any?(@press)} href={@manage_href}>
+        {gettext("Add press photos")}
+      </.empty_add>
+      <div :if={press_any?(@press)} class="space-y-4">
+        <.press_photos
+          :if={@press.photos != []}
+          photos={@press.photos}
+          viewer={@viewer}
+          href={@href}
+        />
+        <.press_logos :if={@press.logos != []} logos={@press.logos} viewer={@viewer} />
+        <.press_rights />
+      </div>
+      <%!-- Not `<.manage_footer>`: that one hides the "View All" link until a
+      card shows less than it holds, and here the section page is not a longer
+      list of the same thing — it is where the files are handed over, so every
+      visitor needs it whatever the count. The owner's bridge to the editor is
+      the "Manage" link in that page's own header. --%>
+      <.card_footer_link :if={press_any?(@press)} href={@href}>
+        {gettext("All press material")} ({compact_count(press_total(@press))})
+      </.card_footer_link>
+    </.card>
+    """
+  end
 
   @doc """
   How many press pictures this kit holds altogether — both shelves, since the

--- a/lib/vutuv_web/controllers/organization_controller.ex
+++ b/lib/vutuv_web/controllers/organization_controller.ex
@@ -20,6 +20,7 @@ defmodule VutuvWeb.OrganizationController do
   alias Vutuv.Pages
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
+  alias Vutuv.PressKit
   alias Vutuv.Repo
   alias VutuvWeb.AgentDocs
   alias VutuvWeb.AgentDocs.OrganizationDoc
@@ -176,6 +177,20 @@ defmodule VutuvWeb.OrganizationController do
   """
   def apps(conn, %{"slug" => slug}),
     do: manage(conn, slug, VutuvWeb.OrganizationLive.Apps, &Organizations.owner?/2)
+
+  @doc """
+  The page's press-kit editor (issue #2087): `VutuvWeb.PressKitLive`, the very
+  editor `/settings/press` is, mounted with the page as the owner and the
+  signed-in member as the one acting.
+
+  Gated on `Vutuv.PressKit.manageable_by?/2` — its **owners and publishers** —
+  and deliberately not on `Organizations.can_manage?/2` like the tabs beside it:
+  that one also counts the member who claimed the page whether or not they still
+  hold a role, and writing a press kit follows the roles. The LiveView re-asks
+  the same predicate on the socket (`VutuvWeb.OrganizationLive.ManageGate`).
+  """
+  def press(conn, %{"slug" => slug}),
+    do: manage(conn, slug, VutuvWeb.PressKitLive, &PressKit.manageable_by?/2)
 
   def exclusions(conn, %{"slug" => slug}),
     do: manage(conn, slug, VutuvWeb.OrganizationLive.Exclusions, &Organizations.can_manage?/2)

--- a/lib/vutuv_web/controllers/page_controller.ex
+++ b/lib/vutuv_web/controllers/page_controller.ex
@@ -426,6 +426,9 @@ defmodule VutuvWeb.PageController do
   - `/organizations` — the verified organization directory; one organization at `/organizations/<slug>`
   - `/organizations/<slug>/posts/<id>` — a post published in an organization's own
     name; the organization is the author, so there is no member behind it to look up
+  - `/organizations/<slug>/press` — the organization's press kit: the same press
+    photos and logo variants a member offers, kept by the page's team and offered
+    for editorial use with the credit shown
   - `/jobs` — the public job board: open positions, filterable, newest first
   - `/jobs/<slug>` — a job posting: role, location, pay range, tags and how to apply
   - `/system/media-kit` — press material: boilerplate in three lengths, logo files,

--- a/lib/vutuv_web/controllers/press_kit_controller.ex
+++ b/lib/vutuv_web/controllers/press_kit_controller.ex
@@ -1,19 +1,28 @@
 defmodule VutuvWeb.PressKitController do
   @moduledoc """
-  `/:slug/press` — the page that hands a journalist the files (issue #2086):
-  every press photo whole, with its caption, credit, dimensions, file size and a
-  download, and every logo variant with its vector and its PNG.
+  The page that hands a journalist the files — `/:slug/press` for a member
+  (issue #2086) and `/organizations/:slug/press` for a page (issue #2087):
+  every press photo whole, with its caption, credit, dimensions, file size and
+  a download, and every logo variant with its vector and its PNG.
+
+  **One action per owner kind, one page.** The two differ in nothing a reader
+  sees: the shelves, the components and the template are `Vutuv.PressKit`'s and
+  take an owner. What they cannot share is how the owner is resolved — a member
+  comes out of the handle namespace through three plugs, a page out of
+  `Vutuv.Organizations.fetch_visible_organization/2` — so that is all `index/2`
+  and `organization/2` do differently.
 
   **The one page under a member's slug that is not noindexed.** Every other
   section page (`/links`, `/phone_numbers`, …) goes through the router's
   `:user_pipe`, whose `Vutuv.Plug.NoIndex` keeps personal data out of search
   results — the right rule for a phone number and the exact opposite of what a
   press kit is for. So this action resolves the slug with the same three plugs
-  the profile itself uses, carries the member's *own* opt-outs
-  (`noindex?` / `noai?`) rather than a blanket refusal, is listed in the sitemap
-  (`Vutuv.Sitemap.press_entries/1`) and publishes schema.org `ImageObject`
-  markup with `license` and `acquireLicensePage` — what image search reads to
-  mark a picture licensable, and the whole reason the page exists.
+  the profile itself uses, carries the owner's *own* opt-outs
+  (`Vutuv.PressKit.robots_axes/1`, a member's `noindex?`/`noai?` and a page's
+  `seo?`), is listed in the sitemap (`Vutuv.Sitemap`) and publishes schema.org
+  `ImageObject` markup with `license` and `acquireLicensePage` — what image
+  search reads to mark a picture licensable, and the whole reason the page
+  exists.
 
   Its agent-format siblings are `VutuvWeb.AgentDocs.PressKitDoc`, and they
   render the **anonymous** view: the HTML page shows the owner a picture the AI
@@ -22,32 +31,81 @@ defmodule VutuvWeb.PressKitController do
 
   use VutuvWeb, :controller
 
+  alias Vutuv.Organizations
   alias Vutuv.PressKit
   alias VutuvWeb.AgentDocs
   alias VutuvWeb.AgentDocs.PressKitDoc
   alias VutuvWeb.ContentPolicy
-  alias VutuvWeb.UserHelpers
+  alias VutuvWeb.ControllerHelpers
+  alias VutuvWeb.PressKitHTML
 
-  plug(VutuvWeb.Plug.UserResolveSlug)
-  plug(VutuvWeb.Plug.EnsureActivated)
-  plug(VutuvWeb.Plug.AgentExportOptOut)
+  # The member action's own resolution. A page is resolved in `organization/2`
+  # instead, so these three never see it.
+  plug(VutuvWeb.Plug.UserResolveSlug when action == :index)
+  plug(VutuvWeb.Plug.EnsureActivated when action == :index)
+  plug(VutuvWeb.Plug.AgentExportOptOut when action == :index)
 
   def index(conn, _params) do
     user = conn.assigns[:user]
-    {noindex?, noai?} = PressKit.robots_axes(user)
 
     AgentDocs.respond(conn,
-      html: fn conn ->
-        conn
-        |> ContentPolicy.put_robots_header(noindex?, noai?)
-        |> render("index.html",
-          shelves: PressKit.public_shelves(user, conn.assigns[:current_user]),
-          page_title: UserHelpers.member_page_title(user, gettext("Press"))
-        )
-      end,
+      html: fn conn -> render_press(conn, user) end,
       # The released shelves, deliberately: a document that offers a file must
       # offer one that can be fetched, whoever asks.
       doc: fn -> PressKitDoc.build(user, PressKit.published_shelves(user)) end
+    )
+  end
+
+  @doc """
+  A page's press section (issue #2087). The page twin of `index/2`, and the same
+  page: the shelves, the template and the documents take an owner.
+
+  It negotiates by hand rather than through `AgentDocs.respond/2` because the
+  agent formats answer a **second** question here. `fetch_visible_organization/2`
+  hands an owner or an admin the page while it is still pending or frozen, which
+  is right for the HTML they are looking at and wrong for a document that is
+  cached publicly for five minutes — so the siblings ask
+  `Organizations.agent_visible?/1`, exactly as the page's own `.md`/`.json` do.
+  """
+  def organization(conn, %{"slug" => slug}) do
+    case Organizations.fetch_visible_organization(slug, conn.assigns[:current_user]) do
+      {:error, :not_found} ->
+        ControllerHelpers.render_error(conn, 404)
+
+      {:ok, organization} ->
+        case AgentDocs.negotiate(conn) do
+          :html ->
+            conn
+            |> AgentDocs.put_html_alternates()
+            |> render_press(organization)
+
+          format ->
+            send_organization_doc(conn, format, organization)
+        end
+    end
+  end
+
+  defp send_organization_doc(conn, format, organization) do
+    if Organizations.agent_visible?(organization) do
+      AgentDocs.send_doc(
+        conn,
+        format,
+        PressKitDoc.build(organization, PressKit.published_shelves(organization))
+      )
+    else
+      ControllerHelpers.render_error(conn, 404)
+    end
+  end
+
+  defp render_press(conn, owner) do
+    {noindex?, noai?} = PressKit.robots_axes(owner)
+
+    conn
+    |> ContentPolicy.put_robots_header(noindex?, noai?)
+    |> render("index.html",
+      owner: owner,
+      shelves: PressKit.public_shelves(owner, conn.assigns[:current_user]),
+      page_title: PressKitHTML.press_page_title(owner)
     )
   end
 end

--- a/lib/vutuv_web/controllers/sitemap_controller.ex
+++ b/lib/vutuv_web/controllers/sitemap_controller.ex
@@ -20,7 +20,8 @@ defmodule VutuvWeb.SitemapController do
     "organizations" => &Sitemap.organization_entries/1,
     "organization_posts" => &Sitemap.organization_post_entries/1,
     "jobs" => &Sitemap.job_entries/1,
-    "press" => &Sitemap.press_entries/1
+    "press" => &Sitemap.press_entries/1,
+    "organization_press" => &Sitemap.organization_press_entries/1
   }
 
   def index(conn, _params) do

--- a/lib/vutuv_web/live/organization_live/show.ex
+++ b/lib/vutuv_web/live/organization_live/show.ex
@@ -19,6 +19,7 @@ defmodule VutuvWeb.OrganizationLive.Show do
   import VutuvWeb.FediverseComponents, only: [follow_us_from_elsewhere: 1]
   import VutuvWeb.JobComponents, only: [job_card: 1]
   import VutuvWeb.PostComponents, only: [post_card: 1, post_list: 1, post_row_class: 0]
+  import VutuvWeb.PressKitComponents, only: [press_card: 1]
 
   alias Vutuv.Countries
   alias Vutuv.Fediverse
@@ -27,6 +28,7 @@ defmodule VutuvWeb.OrganizationLive.Show do
   alias Vutuv.Organizations.Organization
   alias Vutuv.Organizations.Screenshots
   alias Vutuv.Posts
+  alias Vutuv.PressKit
   alias Vutuv.Social
   alias VutuvWeb.Fediverse.Docs
   alias VutuvWeb.JsonLd
@@ -141,16 +143,30 @@ defmodule VutuvWeb.OrganizationLive.Show do
   # pasted blocks of markup, because the comment beside them asks for exactly
   # that: they are a hand-kept copy of the manage pages' tab bar, so adding the
   # fifth should be adding a row.
-  defp manage_links(organization, can_edit?, owner?) do
+  # Takes the whole `role_powers/2` answer rather than a boolean per row: the
+  # list grows a row per release, and three adjacent booleans at the call site
+  # are three that can be passed in the wrong order with nothing to warn — the
+  # hazard `<.manage_header>`'s own docstring records having retired.
+  defp manage_links(organization, powers) do
     slug = organization.slug
+    owner? = powers.owner?
 
     Enum.filter(
       [
         %{
-          show?: can_edit?,
+          show?: powers.can_edit?,
           id: nil,
           label: gettext("Edit"),
           path: ~p"/organizations/#{slug}/edit"
+        },
+        # Beside Team and Domains rather than behind Edit: a press kit is the
+        # page's own material, and it is the one manage page a **publisher**
+        # reaches without holding an administrative role at all (#2087).
+        %{
+          show?: PressKit.manageable_by_powers?(powers),
+          id: "organization-manage-press",
+          label: gettext("Press"),
+          path: PressKit.editor_path(organization)
         },
         %{show?: owner?, id: nil, label: gettext("Team"), path: ~p"/organizations/#{slug}/roles"},
         %{
@@ -206,6 +222,13 @@ defmodule VutuvWeb.OrganizationLive.Show do
     # its own grant, so `role_powers/2` reads it from the role list on its own
     # rather than deriving it from the two above.
     |> assign(:publisher?, powers.publisher?)
+    # Who may write the page's press kit (#2087): its owners and its publishers,
+    # read off the `role_powers/2` answer above rather than asked again — the
+    # rule itself stays `Vutuv.PressKit`'s, which is what the editor and the
+    # section page's Manage bridge ask.
+    |> assign(:powers, powers)
+    |> assign(:manage_press?, PressKit.manageable_by_powers?(powers))
+    |> assign(:press, PressKit.public_shelves(organization, viewer))
     # Following a page (issue #1336): a private subscription that pulls its
     # posts into your feed. No approval and no notification — a page has no
     # inbox to be told, the same way following a member needs no permission.
@@ -672,7 +695,7 @@ defmodule VutuvWeb.OrganizationLive.Show do
               label makes that gap louder, since a heading reads as an
               inventory where a trailing row of links did not. --%>
               <div
-                :if={@can_edit? or @owner?}
+                :if={@can_edit? or @owner? or @manage_press?}
                 class="mt-4 border-t border-slate-100 pt-3 dark:border-slate-800"
               >
                 <%!-- The label takes a line of its own rather than leading
@@ -684,7 +707,7 @@ defmodule VutuvWeb.OrganizationLive.Show do
                 <.section_title class="text-xs">{gettext("Page management")}</.section_title>
                 <div class="mt-2 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm">
                   <.link
-                    :for={link <- manage_links(@organization, @can_edit?, @owner?)}
+                    :for={link <- manage_links(@organization, @powers)}
                     id={link.id}
                     navigate={link.path}
                     class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
@@ -842,6 +865,20 @@ defmodule VutuvWeb.OrganizationLive.Show do
               </.button>
             </div>
           </section>
+
+          <%!-- Press (issue #2087): the page's own card, the same one a member's
+          profile carries — the photos as the bento mosaic, the logo variants
+          beside them, and the section page where the files are handed over. It
+          sits below the open positions and above Subscribe: a journalist looking
+          for a printable picture is not the visitor the page opens with, and
+          Subscribe stays the "take me with you" footer. --%>
+          <.press_card
+            id="organization-press"
+            owner={@organization}
+            press={@press}
+            viewer={@current_user}
+            manage_href={@manage_press? && PressKit.editor_path(@organization)}
+          />
 
           <%!-- Subscribe: the one card that answers "how do I follow this page
           without a vutuv account", with both ways to do it. Same card, same

--- a/lib/vutuv_web/live/press_kit_live.ex
+++ b/lib/vutuv_web/live/press_kit_live.ex
@@ -1,9 +1,27 @@
 defmodule VutuvWeb.PressKitLive do
   @moduledoc """
-  The member's press-kit editor (`GET /settings/press`, issue #2085): the two
-  shelves `Vutuv.PressKit` holds — up to ten press photos and a handful of logo
-  variants — with the upload, the credit, the caption, the order and the
-  delete.
+  The press-kit editor: the two shelves `Vutuv.PressKit` holds — up to ten press
+  photos and a handful of logo variants — with the upload, the credit, the
+  caption, the order and the delete.
+
+  ## Two hosts, one editor
+
+  A member's own kit is at `GET /settings/press` (issue #2085), routed inside the
+  `:default` live_session, where `VutuvWeb.Live.InitAssigns` has already resolved
+  the viewer and `:settings_pipe` has already turned an anonymous request away.
+  A **page's** kit is at `GET /organizations/:slug/press/edit` (issue #2087),
+  embedded by `VutuvWeb.OrganizationController` — off the router, so no
+  `on_mount` hook runs at all and `mount/3` resolves the viewer itself
+  (`InitAssigns.assign_embedded/2`) and re-asks the role on the socket
+  (`VutuvWeb.OrganizationLive.ManageGate`), because the `organization_id` in the
+  curated session map is signed, not encrypted, and outlives a withdrawn role.
+
+  What that split costs is exactly two things: the chrome (the settings shell
+  against the page's manage tab bar) and the handful of sentences whose German
+  addresses the reader as the owner — `Vutuv.PressKit` itself has taken an owner
+  since #2083, so the shelves, the events and the writes are the same code for
+  both. Two assigns keep it honest: `:owner` is whose kit this is, `:current_user`
+  the member acting, and every write passes both.
 
   ## The authorization, which is this page's real subject
 
@@ -22,9 +40,9 @@ defmodule VutuvWeb.PressKitLive do
   The signed-in member comes from `VutuvWeb.Live.InitAssigns`, i.e. from the
   cookie's `session_token`, never a bare `session["user_id"]` (#1034/#1036).
 
-  A **page's** press kit is not edited here — that is #2087's surface, on the
-  page's own manage menu — but the rule it needs is already written:
-  `manageable_by?/2` answers for an owner or a publisher of the page.
+  `manageable_by?/2` is what the page's editor is gated on as well — an owner or
+  a publisher — asked by the controller for the request, by `ManageGate` for the
+  socket, and by every write for the event.
 
   ## Why a LiveView, and why one editor at a time
 
@@ -55,27 +73,67 @@ defmodule VutuvWeb.PressKitLive do
 
   use VutuvWeb, :live_view
 
+  import VutuvWeb.OrganizationComponents, only: [manage_header: 1]
+
+  alias Vutuv.Accounts.User
   alias Vutuv.Images.Image
   alias Vutuv.Moderation.ImageScans
+  alias Vutuv.Organizations.Organization
   alias Vutuv.PressKit
   alias Vutuv.PressKitStore
   alias VutuvWeb.ErrorHelpers
-
-  on_mount({VutuvWeb.Live.InitAssigns, :require_login})
+  alias VutuvWeb.Live.InitAssigns
+  alias VutuvWeb.OrganizationLive.ManageGate
 
   @impl true
-  def mount(_params, _session, socket) do
-    # `:user` is the press kit's **owner** and `:current_user` the member acting
-    # — the same person on this page, and deliberately named apart, because
-    # #2087's editor differs from this one in exactly that: there the owner is
-    # the page and the viewer one of its staff. `store/3` already passes them as
-    # two arguments for that reason.
-    user = socket.assigns.current_user
+  def mount(_params, session, socket) do
+    if session["organization_id"],
+      do: mount_page(socket, session),
+      else: mount_member(socket)
+  end
 
+  # The routed half. `Live.InitAssigns` has already resolved the viewer from the
+  # session token, and `:settings_pipe` has already refused the anonymous
+  # request that produced this page — the redirect below is the socket's own
+  # copy of that refusal, which used to be the module's `:require_login`
+  # on_mount and cannot be one any more: a hook reading `current_user` raises on
+  # the embedded mount, where nothing has assigned it yet.
+  defp mount_member(socket) do
+    case socket.assigns[:current_user] do
+      %User{} = user ->
+        {:ok, editor(socket, user)}
+
+      _anonymous ->
+        {:ok,
+         socket
+         |> put_flash(:error, gettext("You must be logged in to access that page"))
+         |> redirect(to: ~p"/login")}
+    end
+  end
+
+  # The embedded half (#2087). The viewer comes from the cookie's session token
+  # like everywhere else, and the role is re-asked here rather than trusted from
+  # the controller's signed map — `ManageGate` says why, and takes the very
+  # predicate the controller passed.
+  defp mount_page(socket, session) do
+    socket = InitAssigns.assign_embedded(socket, session)
+
+    case ManageGate.allow(socket, session, &PressKit.manageable_by?/2) do
+      {:ok, organization} -> {:ok, editor(socket, organization)}
+      {:refused, socket} -> {:ok, socket}
+    end
+  end
+
+  # Everything below this line is the same editor for both owners: `:owner` is
+  # whose kit it is, `:current_user` the member acting. They are the same person
+  # on `/settings/press` and deliberately named apart, because on a page's
+  # editor they are not — `PressKit.create/4` has taken them as two arguments
+  # since #2083 for exactly that reason.
+  defp editor(socket, owner) do
     socket =
       socket
       |> assign(:page_title, gettext("Press photos & logos"))
-      |> assign(:user, user)
+      |> assign(:owner, owner)
       # Which tile's edit panel is open; nil = none, which is the whole page for
       # somebody who came here only to upload.
       |> assign(:open, nil)
@@ -91,32 +149,39 @@ defmodule VutuvWeb.PressKitLive do
       # background it was drawn for. A preview only — nothing about it is stored.
       |> assign(:logo_ground, "light")
       |> assign(:error, nil)
+      # Whether the page's own logo may be taken onto the logo shelf (#2087).
+      # Once, here, and not in the shelf's markup: the answer is a `Path.wildcard`
+      # on disk, it cannot change from this page (a page's logo is uploaded on
+      # its Edit form), and an attribute in a component call is rebuilt whenever
+      # any assign that call reads changes — which for the add form is every
+      # debounced keystroke in the credit field and every upload chunk.
+      |> assign(:adopt_logo?, PressKit.page_logo_source(owner) != nil)
       |> load_shelves()
 
-    {:ok,
-     socket
-     # The credit the next upload carries, offered ready-filled from the last
-     # picture on that shelf and editable before the file is picked. Read off
-     # the shelves `load_shelves/1` has just loaded rather than queried again.
-     |> assign(:credits, %{
-       false => PressKit.last_credit(socket.assigns.photos) || "",
-       true => PressKit.last_credit(socket.assigns.logos) || ""
-     })
-     |> allow_upload(:photo,
-       accept: PressKitStore.photo_extensions(),
-       max_entries: PressKit.max_photos(),
-       max_file_size: PressKit.max_filesize(),
-       auto_upload: true,
-       progress: &handle_progress/3
-     )
-     |> allow_upload(:logo,
-       accept: PressKitStore.logo_extensions(),
-       max_entries: PressKit.max_logos(),
-       max_file_size: PressKit.max_filesize(),
-       auto_upload: true,
-       progress: &handle_progress/3
-     )
-     |> load_shelves()}
+    socket
+    # The credit the next upload carries, offered ready-filled and editable
+    # before the file is picked: the last picture on that shelf, or the owner's
+    # own name where the shelf is empty (`PressKit.credit_default/2` says why).
+    # Read off the shelves `load_shelves/1` has just loaded rather than queried
+    # again.
+    |> assign(:credits, %{
+      false => PressKit.credit_default(owner, socket.assigns.photos),
+      true => PressKit.credit_default(owner, socket.assigns.logos)
+    })
+    |> allow_upload(:photo,
+      accept: PressKitStore.photo_extensions(),
+      max_entries: PressKit.max_photos(),
+      max_file_size: PressKit.max_filesize(),
+      auto_upload: true,
+      progress: &handle_progress/3
+    )
+    |> allow_upload(:logo,
+      accept: PressKitStore.logo_extensions(),
+      max_entries: PressKit.max_logos(),
+      max_file_size: PressKit.max_filesize(),
+      auto_upload: true,
+      progress: &handle_progress/3
+    )
   end
 
   ## Events
@@ -183,7 +248,7 @@ defmodule VutuvWeb.PressKitLive do
       image ->
         direction = if dir == "up", do: :up, else: :down
         viewer = socket.assigns.current_user
-        PressKit.move(socket.assigns.user, viewer, Image.logo?(image), id, direction)
+        PressKit.move(socket.assigns.owner, viewer, Image.logo?(image), id, direction)
         {:noreply, load_shelves(socket)}
     end
   end
@@ -201,6 +266,15 @@ defmodule VutuvWeb.PressKitLive do
   def handle_event("logo_ground", %{"ground" => ground}, socket) when ground in ~w(light dark),
     do: {:noreply, assign(socket, :logo_ground, ground)}
 
+  # The page's own logo onto its logo shelf (#2087). Nothing about it is a
+  # shortcut past `create/4`: the same authorization, cap, whitelist, rights
+  # stamp and AI scan, with the stored file standing in for the picked one.
+  def handle_event("adopt_logo", _params, socket) do
+    socket.assigns.owner
+    |> PressKit.adopt_page_logo(socket.assigns.current_user, shelf_attrs(socket, true))
+    |> then(&stored(socket, &1, true))
+  end
+
   # A form with a `phx-change` and no submit still submits on Return, and the
   # credit input is one Return away from the drop zone on a phone keyboard.
   # Named rather than a catch-all: a catch-all also swallows a renamed event,
@@ -210,7 +284,7 @@ defmodule VutuvWeb.PressKitLive do
   ## Writing
 
   defp reorder(socket, logo?, order) do
-    PressKit.reorder(socket.assigns.user, socket.assigns.current_user, logo?, order)
+    PressKit.reorder(socket.assigns.owner, socket.assigns.current_user, logo?, order)
     load_shelves(socket)
   end
 
@@ -222,12 +296,15 @@ defmodule VutuvWeb.PressKitLive do
     Enum.find(socket.assigns.photos ++ socket.assigns.logos, &(&1.id == id))
   end
 
+  # One query for both shelves, not one per shelf: this runs on mount and again
+  # after every save, delete, move, reorder and upload, and the whole kit is at
+  # most fifteen rows.
   defp load_shelves(socket) do
-    user = socket.assigns.user
+    shelves = PressKit.shelves(socket.assigns.owner)
 
     socket
-    |> assign(:photos, PressKit.photos(user))
-    |> assign(:logos, PressKit.logos(user))
+    |> assign(:photos, shelves.photos)
+    |> assign(:logos, shelves.logos)
   end
 
   # `auto_upload: true`, so this runs the moment the last chunk lands.
@@ -241,31 +318,38 @@ defmodule VutuvWeb.PressKitLive do
     # meets, and the changeset is what a crafted client meets. One rule, in the
     # place that already owns it, instead of a copy on this page that nothing
     # could reach to test.
-    attrs = %{
-      "logo" => logo?,
-      "credit" => credit(socket, logo?),
-      "rights_confirmed" => socket.assigns.armed[logo?]
-    }
+    attrs = shelf_attrs(socket, logo?)
 
     result =
       consume_uploaded_entry(socket, entry, fn %{path: path} ->
         {:ok,
          PressKit.create(
-           socket.assigns.user,
+           socket.assigns.owner,
            socket.assigns.current_user,
            {path, entry.client_name},
            attrs
          )}
       end)
 
-    case result do
-      {:ok, _image} ->
-        {:noreply, socket |> assign(:error, nil) |> load_shelves()}
-
-      {:error, reason} ->
-        {:noreply, assign(socket, :error, store_error(reason, logo?))}
-    end
+    stored(socket, result, logo?)
   end
+
+  # What the add form is holding for one shelf, as changeset attrs — the upload
+  # and the page-logo adoption write the same three.
+  defp shelf_attrs(socket, logo?) do
+    %{
+      "logo" => logo?,
+      "credit" => credit(socket, logo?),
+      "rights_confirmed" => socket.assigns.armed[logo?]
+    }
+  end
+
+  # What either way of adding a picture does with the answer.
+  defp stored(socket, {:ok, _image}, _logo?),
+    do: {:noreply, socket |> assign(:error, nil) |> load_shelves()}
+
+  defp stored(socket, {:error, reason}, logo?),
+    do: {:noreply, assign(socket, :error, store_error(reason, logo?))}
 
   defp store_error(:too_many, true),
     do: gettext("No more than %{max} logo variants.", max: compact_count(PressKit.max_logos()))
@@ -318,7 +402,67 @@ defmodule VutuvWeb.PressKitLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <.settings_shell user={@user} active={:press} title={gettext("Press photos & logos")}>
+    <.editor_chrome owner={@owner} viewer={@current_user} title={@page_title}>
+      <.error_banner :if={@error} id="press-error">{@error}</.error_banner>
+
+      <.shelf
+        owner={@owner}
+        viewer={@current_user}
+        logo?={false}
+        images={@photos}
+        upload={@uploads.photo}
+        armed?={@armed[false]}
+        credit={@credits[false]}
+        open={@open}
+      />
+
+      <.shelf
+        owner={@owner}
+        viewer={@current_user}
+        logo?={true}
+        images={@logos}
+        upload={@uploads.logo}
+        armed?={@armed[true]}
+        credit={@credits[true]}
+        open={@open}
+        logo_ground={@logo_ground}
+        adopt_logo?={@adopt_logo?}
+      />
+    </.editor_chrome>
+    """
+  end
+
+  # The one thing the two hosts do not share: where this editor sits, and the
+  # one sentence that says what the shelves are for — which cannot be shared,
+  # because the German of the member's version addresses the reader as the owner
+  # ("Ihr Logo") and a page's team is not the page.
+  attr(:owner, :any, required: true)
+  attr(:viewer, :any, required: true)
+  attr(:title, :string, required: true)
+  slot(:inner_block, required: true)
+
+  defp editor_chrome(%{owner: %Organization{}} = assigns) do
+    ~H"""
+    <div class="mx-auto max-w-2xl py-6">
+      <.manage_header organization={@owner} active={:press} viewer={@viewer} />
+
+      <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">{@title}</h1>
+      <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+        {gettext(
+          "What a journalist writing about this page may download: photos in print quality and its logo as a file. Everything here is public and free for editorial use as long as the credit is shown."
+        )}
+      </p>
+
+      <div class="mt-6 space-y-6">
+        {render_slot(@inner_block)}
+      </div>
+    </div>
+    """
+  end
+
+  defp editor_chrome(assigns) do
+    ~H"""
+    <.settings_shell user={@owner} active={:press} title={@title}>
       <div class="space-y-6">
         <.card>
           <p class="text-sm text-slate-600 dark:text-slate-400">
@@ -328,34 +472,14 @@ defmodule VutuvWeb.PressKitLive do
           </p>
         </.card>
 
-        <.error_banner :if={@error} id="press-error">{@error}</.error_banner>
-
-        <.shelf
-          user={@user}
-          logo?={false}
-          images={@photos}
-          upload={@uploads.photo}
-          armed?={@armed[false]}
-          credit={@credits[false]}
-          open={@open}
-        />
-
-        <.shelf
-          user={@user}
-          logo?={true}
-          images={@logos}
-          upload={@uploads.logo}
-          armed?={@armed[true]}
-          credit={@credits[true]}
-          open={@open}
-          logo_ground={@logo_ground}
-        />
+        {render_slot(@inner_block)}
       </div>
     </.settings_shell>
     """
   end
 
-  attr(:user, :any, required: true)
+  attr(:owner, :any, required: true)
+  attr(:viewer, :any, required: true)
   attr(:logo?, :boolean, required: true)
   attr(:images, :list, required: true)
   attr(:upload, :any, required: true)
@@ -367,6 +491,10 @@ defmodule VutuvWeb.PressKitLive do
   # tiles' comprehension — a comprehension tracks no per-entry change, so
   # pressing Light/Dark would otherwise re-send every photo tile's dynamics too.
   attr(:logo_ground, :string, default: "light")
+
+  # Likewise only the logo shelf can adopt anything, and the answer is read from
+  # disk once at mount (`editor/2`), never from this markup.
+  attr(:adopt_logo?, :boolean, default: false)
 
   defp shelf(assigns) do
     # `assign/3` and deliberately not `Map.put/3`: the count changes with every
@@ -396,15 +524,7 @@ defmodule VutuvWeb.PressKitLive do
       </div>
 
       <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
-        {if @logo?,
-          do:
-            gettext(
-              "Your logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
-            ),
-          else:
-            gettext(
-              "The first photo is the one shown first. Drag a tile, or use the arrows, to change the order."
-            )}
+        {if @logo?, do: logo_shelf_hint(@owner), else: photo_shelf_hint()}
       </p>
 
       <%!-- The light/dark switch, on the logo shelf alone: a white wordmark on
@@ -440,7 +560,8 @@ defmodule VutuvWeb.PressKitLive do
       >
         <.tile
           :for={{image, index} <- Enum.with_index(@images)}
-          user={@user}
+          owner={@owner}
+          viewer={@viewer}
           image={image}
           index={index}
           last?={index == @count - 1}
@@ -455,6 +576,7 @@ defmodule VutuvWeb.PressKitLive do
         upload={@upload}
         armed?={@armed?}
         credit={@credit}
+        adopt_logo?={@adopt_logo?}
       />
 
       <p
@@ -468,7 +590,8 @@ defmodule VutuvWeb.PressKitLive do
     """
   end
 
-  attr(:user, :any, required: true)
+  attr(:owner, :any, required: true)
+  attr(:viewer, :any, required: true)
   attr(:image, :any, required: true)
   attr(:index, :integer, required: true)
   attr(:last?, :boolean, required: true)
@@ -577,7 +700,7 @@ defmodule VutuvWeb.PressKitLive do
           variant="danger-ghost"
           phx-click="delete"
           phx-value-id={@image.id}
-          data-confirm={gettext("Remove this picture from your press kit?")}
+          data-confirm={remove_confirm(@owner)}
         >
           {gettext("Remove")}
         </.button>
@@ -639,7 +762,7 @@ defmodule VutuvWeb.PressKitLive do
             <.markdown_editor
               id={"press-caption-#{@image.id}"}
               name="picture[caption]"
-              user={@user}
+              user={@viewer}
               value={@image.caption || ""}
               label={gettext("Caption")}
               placeholder={gettext("Who took it, where, and what may be cropped.")}
@@ -665,6 +788,7 @@ defmodule VutuvWeb.PressKitLive do
   attr(:upload, :any, required: true)
   attr(:armed?, :boolean, required: true)
   attr(:credit, :string, required: true)
+  attr(:adopt_logo?, :boolean, default: false)
 
   defp add_form(assigns) do
     assigns = Map.put(assigns, :shelf, PressKit.shelf_name(assigns.logo?))
@@ -746,6 +870,28 @@ defmodule VutuvWeb.PressKitLive do
         <.live_file_input upload={@upload} disabled={not @armed?} class="sr-only" />
       </label>
 
+      <%!-- The page's own logo, taken onto the shelf with one press (#2087),
+      offered only where that file is a vector — a raster logo on this page is
+      already the screen-sized copy, and offering it for print would be a
+      promise the file cannot keep. It is armed by the very tick beside it
+      rather than skipping the gate: the page holds the file, but releasing it
+      for editorial use is still somebody's decision, and one rule beats a
+      second one that only this button knows about. --%>
+      <div :if={@adopt_logo?} class="space-y-1">
+        <.button
+          type="button"
+          id="press-adopt-logo"
+          variant="secondary"
+          phx-click="adopt_logo"
+          disabled={not @armed?}
+        >
+          {gettext("Use the page's own logo")}
+        </.button>
+        <p class="text-xs text-slate-600 dark:text-slate-400">
+          {gettext("Copies the vector file this page's logo was uploaded as onto this shelf.")}
+        </p>
+      </div>
+
       <.upload_problems upload={@upload} />
 
       <div
@@ -793,6 +939,36 @@ defmodule VutuvWeb.PressKitLive do
   end
 
   ## View helpers
+
+  # The three sentences that cannot be one msgid: their German addresses the
+  # reader as the owner of what it describes ("Ihr Logo", "Ihrem Pressebereich"),
+  # and a page's team is not the page. A msgid is a key rather than a phrase, so
+  # a different voice gets one of its own instead of a translation that fits
+  # neither.
+  defp logo_shelf_hint(%Organization{}) do
+    gettext(
+      "The page's logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
+    )
+  end
+
+  defp logo_shelf_hint(_owner) do
+    gettext(
+      "Your logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
+    )
+  end
+
+  # The photo shelf's is about the order rather than about whose pictures they
+  # are, so both hosts say it.
+  defp photo_shelf_hint do
+    gettext(
+      "The first photo is the one shown first. Drag a tile, or use the arrows, to change the order."
+    )
+  end
+
+  defp remove_confirm(%Organization{}),
+    do: gettext("Remove this picture from this page's press kit?")
+
+  defp remove_confirm(_owner), do: gettext("Remove this picture from your press kit?")
 
   defp shelf_max(true), do: PressKit.max_logos()
   defp shelf_max(false), do: PressKit.max_photos()

--- a/lib/vutuv_web/live/press_kit_live.ex
+++ b/lib/vutuv_web/live/press_kit_live.ex
@@ -217,26 +217,40 @@ defmodule VutuvWeb.PressKitLive do
           {:ok, _image} ->
             {:noreply, socket |> assign(:open, nil) |> assign(:error, nil) |> load_shelves()}
 
-          {:error, changeset} ->
-            {:noreply, assign(socket, :error, first_error(changeset))}
+          # Every reason this write can be refused, not the changeset alone:
+          # `update/3` asks the same `manageable_by?/2` every other write asks,
+          # and answers `{:error, :forbidden}` — which is not a changeset, and
+          # took the socket down with a `FunctionClauseError` when it reached
+          # `first_error/1`. `write_error/2` is the one vocabulary all three
+          # writers share.
+          {:error, reason} ->
+            {:noreply, assign(socket, :error, write_error(reason, Image.logo?(image)))}
         end
     end
   end
 
   def handle_event("delete", %{"id" => id}, socket) do
-    case owned(socket, id) do
-      nil ->
-        {:noreply, socket}
+    # Re-asked here, per event, because `PressKit.delete/1` cannot ask: #2084's
+    # AI rejection calls it with no viewer at all. While a kit's owner *was* its
+    # viewer, resolving the row out of `owned/2` was the check; on a page's kit
+    # it is not, and this is the irreversible write — `Images.purge/1` drops the
+    # row, every served version and the private original, and nothing derives a
+    # print file back. A withdrawn role therefore bites on the next press rather
+    # than at the next mount.
+    with %Image{} = image <- owned(socket, id),
+         true <- PressKit.manageable_by?(socket.assigns.owner, socket.assigns.current_user) do
+      :ok = PressKit.delete(image)
 
-      image ->
-        :ok = PressKit.delete(image)
-
-        {:noreply,
-         socket
-         |> assign(:open, nil)
-         |> assign(:error, nil)
-         |> load_shelves()
-         |> put_flash(:info, gettext("Picture removed."))}
+      {:noreply,
+       socket
+       |> assign(:open, nil)
+       |> assign(:error, nil)
+       |> load_shelves()
+       |> put_flash(:info, gettext("Picture removed."))}
+    else
+      # Silent and unchanged, the way a refused `move` or `reorder` already
+      # answers: the shelf is reloaded, so the page shows what is really there.
+      _refused -> {:noreply, load_shelves(socket)}
     end
   end
 
@@ -349,33 +363,36 @@ defmodule VutuvWeb.PressKitLive do
     do: {:noreply, socket |> assign(:error, nil) |> load_shelves()}
 
   defp stored(socket, {:error, reason}, logo?),
-    do: {:noreply, assign(socket, :error, store_error(reason, logo?))}
+    do: {:noreply, assign(socket, :error, write_error(reason, logo?))}
 
-  defp store_error(:too_many, true),
+  # The one error vocabulary of this page's three writers — the upload, the
+  # page-logo adoption and the caption edit. Named for the write rather than for
+  # the upload since #2087, when a refused edit found its way here.
+  defp write_error(:too_many, true),
     do: gettext("No more than %{max} logo variants.", max: compact_count(PressKit.max_logos()))
 
-  defp store_error(:too_many, false),
+  defp write_error(:too_many, false),
     do: gettext("No more than %{max} press photos.", max: compact_count(PressKit.max_photos()))
 
   # Defensive: `allow_upload/3` is configured with the same cap, so LiveView
   # refuses an oversized file before this can see it. The wording is the shared
   # one either way, so the two gates cannot answer differently.
-  defp store_error(:too_large, _logo?),
+  defp write_error(:too_large, _logo?),
     do:
       gettext("That file is larger than %{limit}. Please upload a smaller one.",
         limit: megabyte_label(PressKit.max_filesize())
       )
 
-  defp store_error(:forbidden, _logo?),
+  defp write_error(:forbidden, _logo?),
     do: gettext("You cannot add a picture to this press kit.")
 
-  defp store_error(%Ecto.Changeset{errors: errors} = changeset, _logo?) do
+  defp write_error(%Ecto.Changeset{errors: errors} = changeset, _logo?) do
     if Keyword.has_key?(errors, :rights_confirmed),
       do: gettext("Please confirm the rights first, then choose the file."),
       else: first_error(changeset)
   end
 
-  defp store_error(_reason, _logo?), do: gettext("That file could not be processed.")
+  defp write_error(_reason, _logo?), do: gettext("That file could not be processed.")
 
   # `ErrorHelpers.changeset_messages/1` rather than a traverse of our own: it
   # translates and interpolates, where a bare `{message, _opts}` hands the

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -798,6 +798,16 @@ defmodule VutuvWeb.Router do
     # /:slug agent-format catch-all.
     get("/organizations/:slug/roles", OrganizationController, :roles)
     get("/organizations/:slug/domains", OrganizationController, :domains)
+    # The page's press section (issue #2087), the twin of a member's
+    # `/:slug/press`: the public page that hands the files over, and the editor
+    # its owners and publishers reach from the manage menu. Under the page's
+    # **slug** rather than its root handle, like every other sub-page of a page
+    # — the handle dispatches the bare `/:slug` only (`Vutuv.PressKit.page_path/1`
+    # says so once, for every caller that holds an owner rather than a route).
+    # The public one is a `PressKitController` action so the press page has one
+    # home for both owner kinds, agent-format siblings included.
+    get("/organizations/:slug/press", PressKitController, :organization)
+    get("/organizations/:slug/press/edit", OrganizationController, :press)
     # The role-holder standing job-exclusion default (issue #939), live_render
     # like roles/domains. Inherited by every posting attributed to the organization.
     get("/organizations/:slug/exclusions", OrganizationController, :exclusions)

--- a/lib/vutuv_web/templates/press_kit/index.html.heex
+++ b/lib/vutuv_web/templates/press_kit/index.html.heex
@@ -1,16 +1,15 @@
-<%!-- The public press page: every picture whole, with the two facts a
-journalist checks before downloading and a finger-sized download beside them.
-Unlike the other section pages this one is crawlable on purpose — see
-`VutuvWeb.PressKitController` — so it carries schema.org ImageObject markup with
-the licensing properties image search reads. --%>
+<%!-- The public press page of a member (#2086) or a page (#2087): every picture
+whole, with the two facts a journalist checks before downloading and a
+finger-sized download beside them. Nothing here asks which kind of owner it is
+drawing — the shelves, the components and the paths all take one — so the two
+surfaces cannot drift apart. Unlike the other section pages this one is
+crawlable on purpose (see `VutuvWeb.PressKitController`), so it carries
+schema.org ImageObject markup with the licensing properties image search
+reads. --%>
 <.page_header
-  title={gettext("Press photos and logos of %{name}", name: full_name(@user))}
-  manage_to={same_user?(@user, @current_user) && ~p"/settings/press"}
-  crumbs={[
-    gettext("Users"),
-    {full_name(@user), ~p"/#{@user}"},
-    gettext("Press")
-  ]}
+  title={press_heading(@owner)}
+  manage_to={press_manage_to(@owner, @current_user)}
+  crumbs={press_crumbs(@owner)}
 />
 
 <% photos = views(@shelves.photos, @current_user) %>
@@ -20,11 +19,11 @@ the licensing properties image search reads. --%>
 a picture the AI gate still holds, and naming its `contentUrl` here would
 publish an address that answers 404 to everybody else. Only for an owner search
 engines may index at all (`Vutuv.Identity.indexable?/1`, the one answer to that
-question). --%>
+question for a member and for a page alike). --%>
 <% pictures = public_pictures(views(@shelves.photos ++ @shelves.logos, nil)) %>
 <JsonLd.script
-  :if={Vutuv.Identity.indexable?(@user) and pictures != []}
-  data={JsonLd.press_kit_page(@user, pictures, Vutuv.PressKit.rights_line())}
+  :if={Vutuv.Identity.indexable?(@owner) and pictures != []}
+  data={JsonLd.press_kit_page(@owner, pictures, Vutuv.PressKit.rights_line())}
 />
 
 <.card_section empty={@shelves.photos == [] and @shelves.logos == []}>

--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -983,30 +983,13 @@ the resulting ~200px rail width. --%>
     tree (press_card_class_availability_test.exs holds it to that), because this
     card is streamed by a LiveView into documents still holding the previous
     release's stylesheet after a deploy. --%>
-    <.card :if={press_any?(@press) or @as_owner?} id="profile-press">
-      <.section_header title={gettext("Press")} />
-      <.empty_add :if={@as_owner? and not press_any?(@press)} href={~p"/settings/press"}>
-        {gettext("Add press photos")}
-      </.empty_add>
-      <div :if={press_any?(@press)} class="space-y-4">
-        <.press_photos
-          :if={@press.photos != []}
-          photos={@press.photos}
-          viewer={@current_user}
-          href={~p"/#{@user}/press"}
-        />
-        <.press_logos :if={@press.logos != []} logos={@press.logos} viewer={@current_user} />
-        <.press_rights />
-      </div>
-      <%!-- Not `<.manage_footer>`: that one hides the "View All" link until a
-      card shows less than it holds, and here the section page is not a longer
-      list of the same thing — it is where the files are handed over, so every
-      visitor needs it whatever the count. The owner's bridge to /settings/press
-      is the "Manage" link in that page's own header. --%>
-      <.card_footer_link :if={press_any?(@press)} href={~p"/#{@user}/press"}>
-        {gettext("All press material")} ({compact_count(press_total(@press))})
-      </.card_footer_link>
-    </.card>
+    <.press_card
+      id="profile-press"
+      owner={@user}
+      press={@press}
+      viewer={@current_user}
+      manage_href={@as_owner? && Vutuv.PressKit.editor_path(@user)}
+    />
 
     <%!-- Follower / following previews (latest 3 each, full lists behind "View All").
     Side by side in two columns on sm+, stacked on mobile. `order-1` drops the

--- a/lib/vutuv_web/views/press_kit_html.ex
+++ b/lib/vutuv_web/views/press_kit_html.ex
@@ -1,13 +1,66 @@
 defmodule VutuvWeb.PressKitHTML do
   @moduledoc """
-  The public press page (`/:slug/press`, issue #2086). Everything it draws is
-  `VutuvWeb.PressKitComponents`, shared with the profile card and with #2087's
-  page twin; this module is the template's home and nothing else.
+  The public press page — `/:slug/press` for a member (issue #2086) and
+  `/organizations/:slug/press` for a page (issue #2087). Everything it draws is
+  `VutuvWeb.PressKitComponents`, shared with the profile card and the page's
+  card; what lives here is the one template and the three things about it that
+  differ per owner kind — its title, its breadcrumb trail and where its owner
+  goes to edit it.
+
+  Those three are functions rather than assigns the controller passes, so the
+  page keeps one template and the controller keeps no view knowledge.
   """
   use VutuvWeb, :html
 
   import VutuvWeb.PressKitComponents
-  import VutuvWeb.UserHelpers, only: [full_name: 1, same_user?: 2]
+
+  alias Vutuv.Identity
+  alias Vutuv.Organizations.Organization
+  alias Vutuv.PressKit
+  alias VutuvWeb.UserHelpers
 
   embed_templates("../templates/press_kit/*")
+
+  @doc """
+  The page's `<title>`: the owner's name and the section, in the one shape
+  every other public sub-page wears.
+  """
+  def press_page_title(owner), do: UserHelpers.member_page_title(owner, gettext("Press"))
+
+  @doc "The page's heading, which names its owner rather than a bare category."
+  def press_heading(owner),
+    do: gettext("Press photos and logos of %{name}", name: Identity.display_name(owner))
+
+  @doc """
+  The breadcrumb trail: the owner's own listing, the owner, this page.
+
+  The middle crumb asks the identity rather than matching the owner kind a
+  second time (`Identity.path/1` for a page *is*
+  `Organizations.canonical_path/1`), so only the first word branches — the
+  listing each kind belongs to, in the msgid that listing already uses.
+  """
+  def press_crumbs(owner),
+    do: [
+      owner_listing(owner),
+      {Identity.display_name(owner), Identity.path(owner)},
+      gettext("Press")
+    ]
+
+  defp owner_listing(%Organization{}), do: gettext("Organizations")
+  defp owner_listing(_owner), do: gettext("Users")
+
+  @doc """
+  Where this viewer edits this kit, or `false` — `<.page_header>`'s quiet
+  "Manage ›" bridge, the same one every profile section page carries.
+
+  One question for both owner kinds, `Vutuv.PressKit.manageable_by?/2`: a
+  member their own, a page's **owner or publisher**. Deliberately not
+  `Organizations.can_manage?/2`, the manage menu's usual gate — that one also
+  counts the member who claimed the page whether or not they still hold a role,
+  and writing a press kit follows the roles. It costs a role read only for a
+  signed-in viewer, since that predicate answers an anonymous one from its
+  catch-all clause without touching the database.
+  """
+  def press_manage_to(owner, viewer),
+    do: PressKit.manageable_by?(owner, viewer) and PressKit.editor_path(owner)
 end

--- a/lib/vutuv_web/views/user_helpers.ex
+++ b/lib/vutuv_web/views/user_helpers.ex
@@ -531,8 +531,13 @@ defmodule VutuvWeb.UserHelpers do
   pages all fell back to the member's name, so a member's own subpages
   competed with `/:slug` for the same title in search results
   (profile_subpage_titles_test.exs).
+
+  It names the owner through `Vutuv.Identity.display_name/1` (which is all
+  `full_name/1` does), so a page's sub-page can wear the same shape — the press
+  page is served for both owner kinds (#2087) and there must not be a second
+  spelling of this separator.
   """
-  def member_page_title(user, label), do: "#{full_name(user)} · #{label}"
+  def member_page_title(owner, label), do: "#{Vutuv.Identity.display_name(owner)} · #{label}"
 
   def work_information_string(user, len \\ 256)
 

--- a/lib/vutuv_web/views/user_html.ex
+++ b/lib/vutuv_web/views/user_html.ex
@@ -17,14 +17,7 @@ defmodule VutuvWeb.UserHTML do
       remote_post_card: 1
     ]
 
-  import VutuvWeb.PressKitComponents,
-    only: [
-      press_any?: 1,
-      press_logos: 1,
-      press_photos: 1,
-      press_rights: 1,
-      press_total: 1
-    ]
+  import VutuvWeb.PressKitComponents, only: [press_card: 1]
 
   import VutuvWeb.UserHelpers
 

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -33,12 +33,12 @@ msgstr "Eintrag hinzufügen"
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:169
 #: lib/vutuv_web/live/organization_live/fediverse.ex:123
-#: lib/vutuv_web/live/organization_live/show.ex:920
+#: lib/vutuv_web/live/organization_live/show.ex:957
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1543
+#: lib/vutuv_web/templates/user/show.html.heex:1526
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -100,11 +100,11 @@ msgstr "Avatar"
 msgid "Birthdate"
 msgstr "Geburtstag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:703
-#: lib/vutuv_web/agent_docs/markdown.ex:704
-#: lib/vutuv_web/agent_docs/text.ex:653
+#: lib/vutuv_web/agent_docs/markdown.ex:707
+#: lib/vutuv_web/agent_docs/markdown.ex:708
 #: lib/vutuv_web/agent_docs/text.ex:654
-#: lib/vutuv_web/templates/user/show.html.heex:1174
+#: lib/vutuv_web/agent_docs/text.ex:655
+#: lib/vutuv_web/templates/user/show.html.heex:1157
 #, elixir-autogen
 msgid "Birthday"
 msgstr "Geburtstag"
@@ -119,7 +119,7 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
 #: lib/vutuv_web/live/post_live/composer.ex:1917
-#: lib/vutuv_web/live/press_kit_live.ex:656
+#: lib/vutuv_web/live/press_kit_live.ex:796
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -155,7 +155,7 @@ msgstr "Wählen Sie einen Typ aus"
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1212
+#: lib/vutuv_web/templates/user/show.html.heex:1195
 #, elixir-autogen
 msgid "Contact"
 msgstr "Kontakt"
@@ -164,7 +164,7 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
-#: lib/vutuv_web/components/post_components.ex:4392
+#: lib/vutuv_web/components/post_components.ex:4435
 #: lib/vutuv_web/components/ui.ex:4864
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
@@ -212,14 +212,14 @@ msgstr "Inaktivieren"
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:4357
+#: lib/vutuv_web/components/post_components.ex:4400
 #: lib/vutuv_web/components/ui.ex:4855
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
 #: lib/vutuv_web/live/job_posting_live/show.ex:201
-#: lib/vutuv_web/live/organization_live/show.ex:152
-#: lib/vutuv_web/live/press_kit_live.ex:573
+#: lib/vutuv_web/live/organization_live/show.ex:159
+#: lib/vutuv_web/live/press_kit_live.ex:713
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:19
@@ -227,7 +227,7 @@ msgstr "Download"
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:113
-#: lib/vutuv_web/templates/user/show.html.heex:1197
+#: lib/vutuv_web/templates/user/show.html.heex:1180
 #, elixir-autogen
 msgid "Edit"
 msgstr "Ändern"
@@ -308,14 +308,14 @@ msgstr "Lebenslauf"
 msgid "Fax"
 msgstr "Fax"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:689
+#: lib/vutuv_web/agent_docs/markdown.ex:693
 #: lib/vutuv_web/templates/user/edit.html.heex:170
 #, elixir-autogen
 msgid "First Name"
 msgstr "Vorname"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:724
-#: lib/vutuv_web/agent_docs/text.ex:674
+#: lib/vutuv_web/agent_docs/markdown.ex:728
+#: lib/vutuv_web/agent_docs/text.ex:675
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
@@ -325,18 +325,18 @@ msgstr "Vorname"
 msgid "Followers"
 msgstr "Follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:725
-#: lib/vutuv_web/agent_docs/text.ex:675
+#: lib/vutuv_web/agent_docs/markdown.ex:729
+#: lib/vutuv_web/agent_docs/text.ex:676
 #: lib/vutuv_web/components/fediverse_components.ex:468
 #: lib/vutuv_web/components/ui.ex:3087
 #: lib/vutuv_web/components/ui.ex:3122
 #: lib/vutuv_web/controllers/followee_controller.ex:29
 #: lib/vutuv_web/live/import_connections_live.ex:469
-#: lib/vutuv_web/live/organization_live/show.ex:618
+#: lib/vutuv_web/live/organization_live/show.ex:641
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:1042
-#: lib/vutuv_web/views/user_html.ex:649
+#: lib/vutuv_web/templates/user/show.html.heex:1025
+#: lib/vutuv_web/views/user_html.ex:642
 #, elixir-autogen
 msgid "Following"
 msgstr "Folge ich"
@@ -385,7 +385,7 @@ msgstr "Stellenbezeichnung"
 msgid "Language"
 msgstr "Sprache"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:691
+#: lib/vutuv_web/agent_docs/markdown.ex:695
 #: lib/vutuv_web/templates/user/edit.html.heex:175
 #, elixir-autogen
 msgid "Last Name"
@@ -452,7 +452,7 @@ msgstr "Ausloggen"
 msgid "Log in"
 msgstr "Einloggen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:690
+#: lib/vutuv_web/agent_docs/markdown.ex:694
 #: lib/vutuv_web/templates/user/edit.html.heex:180
 #, elixir-autogen
 msgid "Middle Name"
@@ -477,7 +477,7 @@ msgstr "Mehr"
 msgid "Name"
 msgstr "Name"
 
-#: lib/vutuv_web/components/post_components.ex:807
+#: lib/vutuv_web/components/post_components.ex:808
 #: lib/vutuv_web/live/notification_live/index.ex:776
 #: lib/vutuv_web/live/organization_live/activity.ex:136
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
@@ -489,7 +489,7 @@ msgstr "Name"
 msgid "New"
 msgstr "Neu"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:693
+#: lib/vutuv_web/agent_docs/markdown.ex:697
 #: lib/vutuv_web/templates/user/edit.html.heex:185
 #, elixir-autogen
 msgid "Nickname"
@@ -570,7 +570,7 @@ msgstr "Telefonnummer wurde gelöscht."
 msgid "Phone number updated successfully."
 msgstr "Telefonnummer wurde geändert."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:688
+#: lib/vutuv_web/agent_docs/markdown.ex:692
 #: lib/vutuv_web/templates/user/edit.html.heex:190
 #, elixir-autogen
 msgid "Prefix"
@@ -620,7 +620,7 @@ msgstr "Öffentlich"
 #: lib/vutuv_web/components/ui.ex:4756
 #: lib/vutuv_web/live/organization_live/edit.ex:376
 #: lib/vutuv_web/live/post_live/composer.ex:2201
-#: lib/vutuv_web/live/press_kit_live.ex:655
+#: lib/vutuv_web/live/press_kit_live.ex:795
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
@@ -662,7 +662,7 @@ msgstr "Speichern"
 msgid "Search"
 msgstr "Suche"
 
-#: lib/vutuv_web/components/post_components.ex:1866
+#: lib/vutuv_web/components/post_components.ex:1867
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -696,13 +696,13 @@ msgstr "Slug"
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1326
+#: lib/vutuv_web/templates/user/show.html.heex:1309
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profile"
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1328
+#: lib/vutuv_web/templates/user/show.html.heex:1311
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr "Profil hinzufügen"
@@ -727,12 +727,12 @@ msgstr "Profil wurde geändert."
 msgid "Profile deleted successfully."
 msgstr "Profil wurde gelöscht."
 
-#: lib/vutuv_web/views/user_html.ex:1057
+#: lib/vutuv_web/views/user_html.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Social networks"
 msgstr "Soziale Netzwerke"
 
-#: lib/vutuv_web/views/user_html.ex:1064
+#: lib/vutuv_web/views/user_html.ex:1057
 #, elixir-autogen, elixir-format
 msgid "Code & repositories"
 msgstr "Code & Repositorys"
@@ -750,7 +750,7 @@ msgstr "Etwas ist schiefgelaufen"
 msgid "Submit a bugreport or a feature request."
 msgstr "Fehler auf der Seite melden."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:692
+#: lib/vutuv_web/agent_docs/markdown.ex:696
 #: lib/vutuv_web/templates/user/edit.html.heex:195
 #, elixir-autogen
 msgid "Suffix"
@@ -832,7 +832,6 @@ msgstr "Benutzername"
 #: lib/vutuv_web/templates/messenger/show.html.heex:4
 #: lib/vutuv_web/templates/phone_number/index.html.heex:8
 #: lib/vutuv_web/templates/phone_number/show.html.heex:4
-#: lib/vutuv_web/templates/press_kit/index.html.heex:10
 #: lib/vutuv_web/templates/qualification/index.html.heex:9
 #: lib/vutuv_web/templates/qualification/show.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/index.html.heex:8
@@ -844,21 +843,22 @@ msgstr "Benutzername"
 #: lib/vutuv_web/templates/user_tag/show.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:8
 #: lib/vutuv_web/templates/work_experience/show.html.heex:4
+#: lib/vutuv_web/views/press_kit_html.ex:50
 #, elixir-autogen
 msgid "Users"
 msgstr "Benutzer"
 
 #: lib/vutuv_web/components/ui.ex:1597
-#: lib/vutuv_web/views/user_html.ex:594
-#: lib/vutuv_web/views/user_html.ex:595
-#: lib/vutuv_web/views/user_html.ex:609
+#: lib/vutuv_web/views/user_html.ex:587
+#: lib/vutuv_web/views/user_html.ex:588
+#: lib/vutuv_web/views/user_html.ex:602
 #, elixir-autogen
 msgid "vCard"
 msgstr "vCard"
 
 #: lib/vutuv_web/components/ui.ex:4925
-#: lib/vutuv_web/templates/user/show.html.heex:1036
-#: lib/vutuv_web/templates/user/show.html.heex:1059
+#: lib/vutuv_web/templates/user/show.html.heex:1019
+#: lib/vutuv_web/templates/user/show.html.heex:1042
 #, elixir-autogen
 msgid "View All"
 msgstr "Alle anzeigen"
@@ -940,6 +940,7 @@ msgstr "Sie folgen %{name} jetzt zurück."
 
 #: lib/vutuv_web/live/init_assigns.ex:54
 #: lib/vutuv_web/live/post_live/feed.ex:169
+#: lib/vutuv_web/live/press_kit_live.ex:109
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1061,7 +1062,7 @@ msgstr "Diese Seite ist für Sie gesperrt."
 msgid "An error occurred"
 msgstr "Es gab einen Fehler."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1163
+#: lib/vutuv_web/templates/user/show.html.heex:1146
 #, elixir-autogen
 msgid "General Info"
 msgstr "Allgemeines"
@@ -1144,7 +1145,7 @@ msgstr "Wählen Sie einen Social-Media-Anbieter aus"
 msgid "Add Localization"
 msgstr "Lokalisierung hinzufügen"
 
-#: lib/vutuv_web/components/organization_components.ex:315
+#: lib/vutuv_web/components/organization_components.ex:324
 #: lib/vutuv_web/live/admin/activity_live.ex:153
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
@@ -1202,7 +1203,7 @@ msgstr "Alle Tag-Synonyme"
 msgid "All tag urls"
 msgstr "Alle Tag-URLs"
 
-#: lib/vutuv_web/components/post_components.ex:5006
+#: lib/vutuv_web/components/post_components.ex:5049
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:643
@@ -1372,11 +1373,11 @@ msgid "Tag urls"
 msgstr "Tag-URLs"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:34
-#: lib/vutuv_web/agent_docs/markdown.ex:596
-#: lib/vutuv_web/agent_docs/markdown.ex:1237
+#: lib/vutuv_web/agent_docs/markdown.ex:600
+#: lib/vutuv_web/agent_docs/markdown.ex:1241
 #: lib/vutuv_web/agent_docs/text.ex:31
-#: lib/vutuv_web/agent_docs/text.ex:601
-#: lib/vutuv_web/agent_docs/text.ex:867
+#: lib/vutuv_web/agent_docs/text.ex:602
+#: lib/vutuv_web/agent_docs/text.ex:868
 #: lib/vutuv_web/components/ui.ex:5305
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
@@ -1703,12 +1704,12 @@ msgstr "Empfehlen"
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:320
 #: lib/vutuv_web/live/organization_live/following.ex:340
 #: lib/vutuv_web/live/organization_live/following.ex:421
-#: lib/vutuv_web/live/organization_live/show.ex:579
-#: lib/vutuv_web/live/organization_live/show.ex:616
+#: lib/vutuv_web/live/organization_live/show.ex:602
+#: lib/vutuv_web/live/organization_live/show.ex:639
 #: lib/vutuv_web/live/post_live/feed.ex:902
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
-#: lib/vutuv_web/templates/user/show.html.heex:1367
-#: lib/vutuv_web/views/user_html.ex:660
+#: lib/vutuv_web/templates/user/show.html.heex:1350
+#: lib/vutuv_web/views/user_html.ex:653
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr "Folgen"
@@ -1727,7 +1728,7 @@ msgstr ""
 msgid "Log out"
 msgstr "Ausloggen"
 
-#: lib/vutuv_web/components/organization_components.ex:321
+#: lib/vutuv_web/components/organization_components.ex:330
 #: lib/vutuv_web/live/admin/activity_live.ex:143
 #: lib/vutuv_web/live/admin/activity_live.ex:175
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
@@ -1742,10 +1743,10 @@ msgstr "Ausloggen"
 msgid "Member"
 msgstr "Mitglied"
 
-#: lib/vutuv_web/live/organization_live/show.ex:638
-#: lib/vutuv_web/views/user_html.ex:687
-#: lib/vutuv_web/views/user_html.ex:688
-#: lib/vutuv_web/views/user_html.ex:698
+#: lib/vutuv_web/live/organization_live/show.ex:661
+#: lib/vutuv_web/views/user_html.ex:680
+#: lib/vutuv_web/views/user_html.ex:681
+#: lib/vutuv_web/views/user_html.ex:691
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr "Nachricht"
@@ -1765,7 +1766,7 @@ msgstr "Nachrichten"
 msgid "Network"
 msgstr "Netzwerk"
 
-#: lib/vutuv_web/components/post_components.ex:486
+#: lib/vutuv_web/components/post_components.ex:487
 #: lib/vutuv_web/components/ui.ex:4974
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
@@ -1855,7 +1856,7 @@ msgstr "Zu viele Versuche. Bitte versuchen Sie es später erneut."
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:27
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:18
 #: lib/vutuv_web/templates/user/show.html.heex:232
-#: lib/vutuv_web/views/user_html.ex:1109
+#: lib/vutuv_web/views/user_html.ex:1102
 #, elixir-autogen, elixir-format
 msgid "Verified profile"
 msgstr "Verifiziertes Profil"
@@ -1881,7 +1882,7 @@ msgstr ""
 "Wir haben eine PIN an Ihre neue E-Mail-Adresse geschickt. Geben Sie sie "
 "unten ein, um die Adresse zu bestätigen."
 
-#: lib/vutuv_web/views/user_html.ex:247
+#: lib/vutuv_web/views/user_html.ex:240
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr "Vorgeschlagene Profile"
@@ -1900,14 +1901,14 @@ msgstr "Ihre Anmeldung ist abgelaufen. Bitte versuchen Sie es erneut."
 
 #: lib/vutuv_web/open_graph.ex:418
 #: lib/vutuv_web/templates/tag/show.html.heex:32
-#: lib/vutuv_web/views/user_html.ex:531
+#: lib/vutuv_web/views/user_html.ex:524
 #, elixir-autogen, elixir-format
 msgid "follower"
 msgid_plural "followers"
 msgstr[0] "Follower"
 msgstr[1] "Follower"
 
-#: lib/vutuv_web/views/user_html.ex:535
+#: lib/vutuv_web/views/user_html.ex:528
 #, elixir-autogen, elixir-format
 msgid "following"
 msgstr "folgt"
@@ -1937,7 +1938,7 @@ msgstr "Seitennavigation"
 #: lib/vutuv_web/components/ui.ex:4999
 #: lib/vutuv_web/live/organization_live/activity.ex:159
 #: lib/vutuv_web/live/organization_live/feed.ex:258
-#: lib/vutuv_web/live/organization_live/show.ex:787
+#: lib/vutuv_web/live/organization_live/show.ex:810
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr "Mehr laden"
@@ -2060,12 +2061,12 @@ msgstr "März"
 msgid "May"
 msgstr "Mai"
 
-#: lib/vutuv_web/views/user_html.ex:299
+#: lib/vutuv_web/views/user_html.ex:292
 #, elixir-autogen, elixir-format
 msgid "Member since %{month} %{year}"
 msgstr "Mitglied seit %{month} %{year}"
 
-#: lib/vutuv_web/views/user_html.ex:304
+#: lib/vutuv_web/views/user_html.ex:297
 #, elixir-autogen, elixir-format
 msgid "Member since %{year}"
 msgstr "Mitglied seit %{year}"
@@ -2110,7 +2111,7 @@ msgstr "Zurück zum Beitrag"
 
 #: lib/vutuv_web/live/post_live/composer.ex:2015
 #: lib/vutuv_web/live/post_live/composer.ex:2038
-#: lib/vutuv_web/live/press_kit_live.ex:786
+#: lib/vutuv_web/live/press_kit_live.ex:949
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr "Upload abbrechen"
@@ -2120,7 +2121,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:4389
+#: lib/vutuv_web/components/post_components.ex:4432
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2132,11 +2133,11 @@ msgstr "Diesen Beitrag endgültig löschen?"
 msgid "Edit post"
 msgstr "Beitrag bearbeiten"
 
-#: lib/vutuv_web/components/organization_components.ex:265
+#: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:203
 #: lib/vutuv_web/live/post_live/feed.ex:331
-#: lib/vutuv_web/live/post_live/feed.ex:3254
+#: lib/vutuv_web/live/post_live/feed.ex:3265
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1341
 #: lib/vutuv_web/live/shell_live.ex:1686
@@ -2165,8 +2166,8 @@ msgstr "Vor einer bestimmten Person verbergen…"
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:4343
-#: lib/vutuv_web/components/post_components.ex:4345
+#: lib/vutuv_web/components/post_components.ex:4386
+#: lib/vutuv_web/components/post_components.ex:4388
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
@@ -2182,7 +2183,7 @@ msgstr "Nicht eingeloggte Besucher"
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3583
+#: lib/vutuv_web/live/post_live/feed.ex:3594
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2222,7 +2223,7 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/gettext_extraction_anchors.ex:113
 #: lib/vutuv_web/live/admin/dashboard_live.ex:270
 #: lib/vutuv_web/live/fediverse_account_live.ex:446
-#: lib/vutuv_web/live/organization_live/show.ex:710
+#: lib/vutuv_web/live/organization_live/show.ex:733
 #: lib/vutuv_web/live/post_live/saved.ex:536
 #: lib/vutuv_web/live/search_live.ex:348
 #: lib/vutuv_web/live/search_live.ex:832
@@ -2232,13 +2233,13 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:4879
-#: lib/vutuv_web/components/post_components.ex:4883
+#: lib/vutuv_web/components/post_components.ex:4922
+#: lib/vutuv_web/components/post_components.ex:4926
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:4880
+#: lib/vutuv_web/components/post_components.ex:4923
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2248,7 +2249,7 @@ msgstr "Weniger anzeigen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:497
 #: lib/vutuv_web/components/job_exclusion_components.ex:189
-#: lib/vutuv_web/components/post_components.ex:1448
+#: lib/vutuv_web/components/post_components.ex:1449
 #: lib/vutuv_web/live/admin/screenshot_live.ex:352
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:229
@@ -2260,7 +2261,7 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/live/post_live/saved.ex:666
 #: lib/vutuv_web/live/post_live/saved.ex:694
 #: lib/vutuv_web/live/post_rewrites_live.ex:376
-#: lib/vutuv_web/live/press_kit_live.ex:582
+#: lib/vutuv_web/live/press_kit_live.ex:722
 #: lib/vutuv_web/templates/connection/index.html.heex:45
 #: lib/vutuv_web/views/settings_html.ex:386
 #, elixir-autogen, elixir-format
@@ -2279,7 +2280,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2454
+#: lib/vutuv_web/live/post_live/feed.ex:2465
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2293,7 +2294,7 @@ msgstr "Diese Seite konnte leider nicht gefunden werden."
 
 #: lib/vutuv_web/live/post_live/composer.ex:1520
 #: lib/vutuv_web/live/post_live/composer.ex:1588
-#: lib/vutuv_web/live/press_kit_live.ex:294
+#: lib/vutuv_web/live/press_kit_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr "Diese Datei konnte nicht verarbeitet werden."
@@ -2337,27 +2338,27 @@ msgstr "Was gibt's Neues?"
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:4340
+#: lib/vutuv_web/components/post_components.ex:4383
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:6646
+#: lib/vutuv_web/components/post_components.ex:6689
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:6650
+#: lib/vutuv_web/components/post_components.ex:6693
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:6648
+#: lib/vutuv_web/components/post_components.ex:6691
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:6649
+#: lib/vutuv_web/components/post_components.ex:6692
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2401,15 +2402,15 @@ msgstr "Alle %{count} Beiträge ansehen"
 msgid "All posts"
 msgstr "Alle Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:2180
-#: lib/vutuv_web/components/post_components.ex:6749
+#: lib/vutuv_web/components/post_components.ex:2181
+#: lib/vutuv_web/components/post_components.ex:6792
 #: lib/vutuv_web/components/ui.ex:4298
-#: lib/vutuv_web/views/user_html.ex:493
+#: lib/vutuv_web/views/user_html.ex:486
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr "Lesezeichen setzen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1291
+#: lib/vutuv_web/agent_docs/markdown.ex:1295
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:529
 #: lib/vutuv_web/live/shell_live.ex:1499
@@ -2420,17 +2421,17 @@ msgstr "Lesezeichen setzen"
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/vutuv_web/components/post_components.ex:2124
-#: lib/vutuv_web/components/post_components.ex:6990
+#: lib/vutuv_web/components/post_components.ex:2125
+#: lib/vutuv_web/components/post_components.ex:7033
 #: lib/vutuv_web/components/ui.ex:4284
 #: lib/vutuv_web/notification_line.ex:317
-#: lib/vutuv_web/views/user_html.ex:503
+#: lib/vutuv_web/views/user_html.ex:496
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr "Gefällt mir"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1290
-#: lib/vutuv_web/components/post_components.ex:7000
+#: lib/vutuv_web/agent_docs/markdown.ex:1294
+#: lib/vutuv_web/components/post_components.ex:7043
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
 #: lib/vutuv_web/live/shell_live.ex:1590
@@ -2451,58 +2452,58 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:6737
+#: lib/vutuv_web/components/post_components.ex:6780
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
-#: lib/vutuv_web/components/post_components.ex:2179
-#: lib/vutuv_web/components/post_components.ex:6748
+#: lib/vutuv_web/components/post_components.ex:2180
+#: lib/vutuv_web/components/post_components.ex:6791
 #: lib/vutuv_web/live/post_live/saved.ex:822
-#: lib/vutuv_web/views/user_html.ex:493
+#: lib/vutuv_web/views/user_html.ex:486
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
-#: lib/vutuv_web/components/post_components.ex:2160
-#: lib/vutuv_web/components/post_components.ex:6733
+#: lib/vutuv_web/components/post_components.ex:2161
+#: lib/vutuv_web/components/post_components.ex:6776
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
-#: lib/vutuv_web/components/post_components.ex:2753
-#: lib/vutuv_web/components/post_components.ex:5752
+#: lib/vutuv_web/components/post_components.ex:2754
+#: lib/vutuv_web/components/post_components.ex:5795
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:2159
-#: lib/vutuv_web/components/post_components.ex:6732
+#: lib/vutuv_web/components/post_components.ex:2160
+#: lib/vutuv_web/components/post_components.ex:6775
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:2123
-#: lib/vutuv_web/components/post_components.ex:6989
+#: lib/vutuv_web/components/post_components.ex:2124
+#: lib/vutuv_web/components/post_components.ex:7032
 #: lib/vutuv_web/live/post_live/saved.ex:821
-#: lib/vutuv_web/views/user_html.ex:503
+#: lib/vutuv_web/views/user_html.ex:496
 #, elixir-autogen, elixir-format
 msgid "Unlike"
 msgstr "Gefällt mir entfernen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:498
-#: lib/vutuv_web/components/post_components.ex:3351
+#: lib/vutuv_web/components/post_components.ex:3394
 #: lib/vutuv_web/components/ui.ex:3047
 #: lib/vutuv_web/components/ui.ex:3047
 #: lib/vutuv_web/components/ui.ex:3123
 #: lib/vutuv_web/live/organization_live/following.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:476
-#: lib/vutuv_web/live/organization_live/show.ex:621
+#: lib/vutuv_web/live/organization_live/show.ex:644
 #: lib/vutuv_web/live/post_live/feed.ex:889
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:42
-#: lib/vutuv_web/views/user_html.ex:650
+#: lib/vutuv_web/views/user_html.ex:643
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr "Entfolgen"
@@ -2512,20 +2513,20 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:7044
+#: lib/vutuv_web/components/post_components.ex:7087
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
 
-#: lib/vutuv_web/components/post_components.ex:444
+#: lib/vutuv_web/components/post_components.ex:445
 #: lib/vutuv_web/live/notification_live/index.ex:1331
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:2369
-#: lib/vutuv_web/components/post_components.ex:7027
-#: lib/vutuv_web/components/post_components.ex:7028
+#: lib/vutuv_web/components/post_components.ex:2370
+#: lib/vutuv_web/components/post_components.ex:7070
+#: lib/vutuv_web/components/post_components.ex:7071
 #: lib/vutuv_web/live/notification_live/index.ex:993
 #: lib/vutuv_web/live/post_live/reply.ex:49
 #: lib/vutuv_web/notification_line.ex:314
@@ -2533,7 +2534,7 @@ msgstr "Antworten"
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:4299
+#: lib/vutuv_web/components/post_components.ex:4342
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
@@ -2554,7 +2555,7 @@ msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beitr
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
 
-#: lib/vutuv_web/components/post_components.ex:3817
+#: lib/vutuv_web/components/post_components.ex:3860
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:63
 #: lib/vutuv_web/live/post_live/remote_reply.ex:61
 #: lib/vutuv_web/live/post_live/reply.ex:63
@@ -2562,14 +2563,14 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:4271
+#: lib/vutuv_web/components/post_components.ex:4314
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:4262
-#: lib/vutuv_web/components/post_components.ex:4291
-#: lib/vutuv_web/components/post_components.ex:4294
+#: lib/vutuv_web/components/post_components.ex:4305
+#: lib/vutuv_web/components/post_components.ex:4334
+#: lib/vutuv_web/components/post_components.ex:4337
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
@@ -2744,26 +2745,26 @@ msgstr "Link hinzufügen"
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1286
+#: lib/vutuv_web/templates/user/show.html.heex:1269
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr "Telefonnummer hinzufügen"
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1545
+#: lib/vutuv_web/templates/user/show.html.heex:1528
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr "Adresse hinzufügen"
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1214
+#: lib/vutuv_web/templates/user/show.html.heex:1197
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr "E-Mail-Adresse hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1165
+#: lib/vutuv_web/templates/user/show.html.heex:1148
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr "Persönliche Angaben hinzufügen"
@@ -2794,7 +2795,7 @@ msgstr "Ersten Beitrag schreiben"
 msgid "Manage"
 msgstr "Verwalten"
 
-#: lib/vutuv_web/components/post_components.ex:884
+#: lib/vutuv_web/components/post_components.ex:885
 #: lib/vutuv_web/controllers/page_controller.ex:211
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2824,8 +2825,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] "+1 weiteres Tag"
 msgstr[1] "+%{formatted} weitere Tags"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:726
-#: lib/vutuv_web/agent_docs/text.ex:676
+#: lib/vutuv_web/agent_docs/markdown.ex:730
+#: lib/vutuv_web/agent_docs/text.ex:677
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -2863,14 +2864,14 @@ msgid "This post is for the connections of %{name}"
 msgstr "Dieser Beitrag ist für die Vernetzungen von %{name}"
 
 #: lib/vutuv_web/views/admin/moderation_html.ex:127
-#: lib/vutuv_web/views/user_html.ex:545
+#: lib/vutuv_web/views/user_html.ex:538
 #, elixir-autogen, elixir-format
 msgid "connection"
 msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:6647
+#: lib/vutuv_web/components/post_components.ex:6690
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -2880,7 +2881,7 @@ msgstr "Personen, mit denen Sie nicht vernetzt sind"
 msgid "Open someone's profile to message them."
 msgstr "Öffnen Sie ein Profil, um jemandem zu schreiben."
 
-#: lib/vutuv_web/components/organization_components.ex:259
+#: lib/vutuv_web/components/organization_components.ex:268
 #: lib/vutuv_web/live/organization_live/activity.ex:112
 #: lib/vutuv_web/notification_line.ex:331
 #, elixir-autogen, elixir-format
@@ -2898,7 +2899,7 @@ msgid "Endorsement"
 msgstr "Empfehlung"
 
 #: lib/vutuv_web/notification_line.ex:312
-#: lib/vutuv_web/templates/user/show.html.heex:1020
+#: lib/vutuv_web/templates/user/show.html.heex:1003
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -2967,8 +2968,8 @@ msgstr "Gibt es etwas, das unsere Admins wissen sollten? (optional)"
 msgid "Bullying or harassment"
 msgstr "Mobbing oder Belästigung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:400
-#: lib/vutuv_web/agent_docs/text.ex:366
+#: lib/vutuv_web/agent_docs/markdown.ex:404
+#: lib/vutuv_web/agent_docs/text.ex:367
 #: lib/vutuv_web/controllers/page_controller.ex:76
 #: lib/vutuv_web/templates/layout/app.html.heex:126
 #: lib/vutuv_web/templates/page/community.html.heex:4
@@ -3130,13 +3131,13 @@ msgstr "Nichts zu sehen, keiner Ihrer Inhalte ist derzeit gemeldet."
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1254
-#: lib/vutuv_web/templates/user/show.html.heex:1255
+#: lib/vutuv_web/templates/user/show.html.heex:1237
+#: lib/vutuv_web/templates/user/show.html.heex:1238
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:4238
+#: lib/vutuv_web/components/post_components.ex:4281
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solange eine Meldung zu diesem Beitrag bearbeitet wird, sehen nur Sie ihn."
@@ -3164,7 +3165,7 @@ msgstr "Warteschlange öffnen"
 msgid "Opened"
 msgstr "Eröffnet"
 
-#: lib/vutuv_web/components/organization_components.ex:314
+#: lib/vutuv_web/components/organization_components.ex:323
 #: lib/vutuv_web/live/admin/api_app_live.ex:72
 #: lib/vutuv_web/live/admin/deliverability_live.ex:171
 #: lib/vutuv_web/live/admin/moderation_live.ex:56
@@ -3196,10 +3197,10 @@ msgstr "Abgelehnt"
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
-#: lib/vutuv_web/components/post_components.ex:1461
-#: lib/vutuv_web/components/post_components.ex:3371
-#: lib/vutuv_web/components/post_components.ex:4456
-#: lib/vutuv_web/live/organization_live/show.ex:661
+#: lib/vutuv_web/components/post_components.ex:1462
+#: lib/vutuv_web/components/post_components.ex:3414
+#: lib/vutuv_web/components/post_components.ex:4499
+#: lib/vutuv_web/live/organization_live/show.ex:684
 #: lib/vutuv_web/templates/user/show.html.heex:252
 #, elixir-autogen, elixir-format
 msgid "Report"
@@ -3882,12 +3883,12 @@ msgstr "gemeldete Nachricht"
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr "Im Rahmen scrollen oder klicken, um das ganze Bild zu öffnen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:833
+#: lib/vutuv_web/agent_docs/markdown.ex:837
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr "%{count} Empfehlungen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1412
+#: lib/vutuv_web/agent_docs/markdown.ex:1416
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr "%{count} auf dieser Seite, weitere mit ?page=N"
@@ -3901,11 +3902,11 @@ msgstr "%{count} Beiträge von %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:92
 #: lib/vutuv_web/agent_docs/markdown.ex:219
 #: lib/vutuv_web/agent_docs/markdown.ex:233
-#: lib/vutuv_web/agent_docs/markdown.ex:1237
+#: lib/vutuv_web/agent_docs/markdown.ex:1241
 #: lib/vutuv_web/agent_docs/text.ex:87
 #: lib/vutuv_web/agent_docs/text.ex:188
 #: lib/vutuv_web/agent_docs/text.ex:202
-#: lib/vutuv_web/agent_docs/text.ex:867
+#: lib/vutuv_web/agent_docs/text.ex:868
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr "%{count} insgesamt"
@@ -3924,28 +3925,28 @@ msgstr "Follower von %{name}"
 msgid "Images"
 msgstr "Bilder"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1255
-#: lib/vutuv_web/agent_docs/text.ex:878
+#: lib/vutuv_web/agent_docs/markdown.ex:1259
+#: lib/vutuv_web/agent_docs/text.ex:879
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr "Antwort auf einen gelöschten Beitrag von %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1252
-#: lib/vutuv_web/agent_docs/text.ex:875
+#: lib/vutuv_web/agent_docs/markdown.ex:1256
+#: lib/vutuv_web/agent_docs/text.ex:876
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr "Antwort auf einen gelöschten Beitrag."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1259
-#: lib/vutuv_web/agent_docs/markdown.ex:1505
-#: lib/vutuv_web/agent_docs/text.ex:882
-#: lib/vutuv_web/agent_docs/text.ex:951
+#: lib/vutuv_web/agent_docs/markdown.ex:1263
+#: lib/vutuv_web/agent_docs/markdown.ex:1509
+#: lib/vutuv_web/agent_docs/text.ex:883
+#: lib/vutuv_web/agent_docs/text.ex:952
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr "Antwort auf einen Beitrag von %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:661
-#: lib/vutuv_web/agent_docs/text.ex:639
+#: lib/vutuv_web/agent_docs/markdown.ex:665
+#: lib/vutuv_web/agent_docs/text.ex:640
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr "Mitglied seit"
@@ -3984,23 +3985,23 @@ msgstr "Beitrag von %{name}"
 msgid "Posts (%{count} total)"
 msgstr "Beiträge (insgesamt %{count})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:655
-#: lib/vutuv_web/agent_docs/text.ex:633
+#: lib/vutuv_web/agent_docs/markdown.ex:659
+#: lib/vutuv_web/agent_docs/text.ex:634
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr "Verifiziertes Profil: ja"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1183
+#: lib/vutuv_web/agent_docs/markdown.ex:1187
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr "repostet von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1045
+#: lib/vutuv_web/agent_docs/markdown.ex:1049
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr "heute"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1046
+#: lib/vutuv_web/agent_docs/markdown.ex:1050
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr "bis %{date}"
@@ -4078,8 +4079,8 @@ msgstr ""
 msgid "Billing name"
 msgstr "Name für die Rechnung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:414
-#: lib/vutuv_web/agent_docs/text.ex:374
+#: lib/vutuv_web/agent_docs/markdown.ex:418
+#: lib/vutuv_web/agent_docs/text.ex:375
 #, elixir-autogen, elixir-format
 msgid "Book online (login required): %{url}"
 msgstr "Online buchen (Login erforderlich): %{url}"
@@ -4131,8 +4132,8 @@ msgstr "Tag"
 msgid "Markdown is supported. At most %{max} characters."
 msgstr "Markdown wird unterstützt. Höchstens %{max} Zeichen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:404
-#: lib/vutuv_web/agent_docs/text.ex:370
+#: lib/vutuv_web/agent_docs/markdown.ex:408
+#: lib/vutuv_web/agent_docs/text.ex:371
 #: lib/vutuv_web/templates/ad/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Next available day"
@@ -4148,8 +4149,8 @@ msgstr "Ein Tag. Eine Anzeige. Alle Besucher."
 msgid "One text-only ad per calendar day, seen by every visitor."
 msgstr "Eine reine Textanzeige pro Kalendertag, gesehen von allen Besuchern."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:401
-#: lib/vutuv_web/agent_docs/text.ex:367
+#: lib/vutuv_web/agent_docs/markdown.ex:405
+#: lib/vutuv_web/agent_docs/text.ex:368
 #: lib/vutuv_web/templates/ad/index.html.heex:35
 #: lib/vutuv_web/templates/ad/preview.html.heex:32
 #: lib/vutuv_web/views/admin/ad_html.ex:59
@@ -4383,14 +4384,14 @@ msgstr "gebucht am"
 msgid "deleted account"
 msgstr "gelöschtes Konto"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:406
-#: lib/vutuv_web/agent_docs/text.ex:372
+#: lib/vutuv_web/agent_docs/markdown.ex:410
+#: lib/vutuv_web/agent_docs/text.ex:373
 #, elixir-autogen, elixir-format
 msgid "Already booked"
 msgstr "Bereits gebucht"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:402
-#: lib/vutuv_web/agent_docs/text.ex:368
+#: lib/vutuv_web/agent_docs/markdown.ex:406
+#: lib/vutuv_web/agent_docs/text.ex:369
 #, elixir-autogen, elixir-format
 msgid "Booking window"
 msgstr "Buchungszeitraum"
@@ -4635,7 +4636,7 @@ msgstr "Sie haben niemanden blockiert."
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3588
+#: lib/vutuv_web/live/post_live/feed.ex:3599
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
@@ -4645,11 +4646,11 @@ msgstr "Entdecken Sie Mitglieder zum Folgen"
 msgid "Find members"
 msgstr "Mitglieder finden"
 
-#: lib/vutuv_web/components/organization_components.ex:271
+#: lib/vutuv_web/components/organization_components.ex:280
 #: lib/vutuv_web/live/organization_live/following.ex:313
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:1042
+#: lib/vutuv_web/templates/user/show.html.heex:1025
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr "Folgt"
@@ -4692,12 +4693,12 @@ msgid "Not an exact match, but sounds like your search."
 msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 
 #: lib/vutuv_web/agent_docs/investors_doc.ex:212
-#: lib/vutuv_web/agent_docs/markdown.ex:537
-#: lib/vutuv_web/agent_docs/text.ex:542
+#: lib/vutuv_web/agent_docs/markdown.ex:541
+#: lib/vutuv_web/agent_docs/text.ex:543
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/live/notification_live/index.ex:640
 #: lib/vutuv_web/live/notification_live/index.ex:1333
-#: lib/vutuv_web/live/organization_live/show.ex:797
+#: lib/vutuv_web/live/organization_live/show.ex:820
 #: lib/vutuv_web/live/post_live/saved.ex:539
 #: lib/vutuv_web/live/search_live.ex:346
 #: lib/vutuv_web/live/search_live.ex:774
@@ -4717,8 +4718,8 @@ msgstr ""
 msgid "Similar names"
 msgstr "Ähnliche Namen"
 
-#: lib/vutuv_web/components/post_components.ex:441
-#: lib/vutuv_web/components/post_components.ex:460
+#: lib/vutuv_web/components/post_components.ex:442
+#: lib/vutuv_web/components/post_components.ex:461
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
@@ -4818,8 +4819,8 @@ msgstr "Entwickler"
 msgid "Edit your profile and its sections"
 msgstr "Ihr Profil und seine Bereiche bearbeiten"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:303
-#: lib/vutuv_web/agent_docs/text.ex:273
+#: lib/vutuv_web/agent_docs/markdown.ex:307
+#: lib/vutuv_web/agent_docs/text.ex:274
 #: lib/vutuv_web/live/admin/job_live.ex:389
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:140
 #: lib/vutuv_web/live/job_posting_live/show.ex:159
@@ -5566,11 +5567,11 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:4536
-#: lib/vutuv_web/components/post_components.ex:5145
-#: lib/vutuv_web/components/post_components.ex:5483
+#: lib/vutuv_web/components/post_components.ex:4579
+#: lib/vutuv_web/components/post_components.ex:5188
+#: lib/vutuv_web/components/post_components.ex:5526
 #: lib/vutuv_web/live/notification_live/index.ex:1069
-#: lib/vutuv_web/views/user_html.ex:140
+#: lib/vutuv_web/views/user_html.ex:133
 #, elixir-autogen, elixir-format
 msgid "View post"
 msgstr "Beitrag ansehen"
@@ -5594,7 +5595,7 @@ msgstr "Andere"
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:33
 #: lib/vutuv_web/views/email_html.ex:12
-#: lib/vutuv_web/views/user_html.ex:1234
+#: lib/vutuv_web/views/user_html.ex:1227
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr "Privat"
@@ -5779,7 +5780,7 @@ msgstr "@%{slug} hat Sie auf vutuv empfohlen"
 msgid "@%{slug} started following you on vutuv"
 msgstr "@%{slug} folgt Ihnen jetzt auf vutuv"
 
-#: lib/vutuv_web/components/organization_components.ex:284
+#: lib/vutuv_web/components/organization_components.ex:293
 #: lib/vutuv_web/live/organization_live/apps.ex:167
 #: lib/vutuv_web/templates/settings/apps.html.heex:12
 #, elixir-autogen, elixir-format
@@ -6253,7 +6254,7 @@ msgstr[1] "Beiträge"
 msgid "After choosing a file you can reposition and zoom it."
 msgstr "Nach der Auswahl einer Datei können Sie sie verschieben und zoomen."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1595
+#: lib/vutuv_web/templates/user/show.html.heex:1578
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr "Auch auf"
@@ -6299,16 +6300,16 @@ msgstr "Foto verwenden"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1180
-#: lib/vutuv_web/templates/user/show.html.heex:1190
+#: lib/vutuv_web/templates/user/show.html.heex:1163
+#: lib/vutuv_web/templates/user/show.html.heex:1173
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
 msgstr[0] "%{count} Jahr"
 msgstr[1] "%{count} Jahre"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:705
-#: lib/vutuv_web/agent_docs/text.ex:655
+#: lib/vutuv_web/agent_docs/markdown.ex:709
+#: lib/vutuv_web/agent_docs/text.ex:656
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr "Alter"
@@ -6342,12 +6343,12 @@ msgstr "Tagesbericht für %{day}"
 msgid "Jump to a day"
 msgstr "Zu einem Tag springen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1302
+#: lib/vutuv_web/templates/user/show.html.heex:1285
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr "E-Mails verwalten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1313
+#: lib/vutuv_web/templates/user/show.html.heex:1296
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr "Telefon verwalten"
@@ -6382,21 +6383,21 @@ msgstr "Tagesbericht öffnen"
 msgid "Previous day"
 msgstr "Vorheriger Tag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1290
-#: lib/vutuv_web/components/post_components.ex:443
+#: lib/vutuv_web/agent_docs/markdown.ex:1294
+#: lib/vutuv_web/components/post_components.ex:444
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reposts"
 msgstr "Reposts"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1311
+#: lib/vutuv_web/templates/user/show.html.heex:1294
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr "Alle Telefonnummern anzeigen"
 
 #: lib/vutuv_web/live/feed_languages_live.ex:235
-#: lib/vutuv_web/live/press_kit_live.ex:496
+#: lib/vutuv_web/live/press_kit_live.ex:636
 #: lib/vutuv_web/live/section_reorder_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder"
@@ -6411,7 +6412,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/feed_languages_live.ex:267
 #: lib/vutuv_web/live/post_rewrites_live.ex:364
-#: lib/vutuv_web/live/press_kit_live.ex:558
+#: lib/vutuv_web/live/press_kit_live.ex:698
 #: lib/vutuv_web/live/section_reorder_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Move down"
@@ -6419,7 +6420,7 @@ msgstr "Nach unten"
 
 #: lib/vutuv_web/live/feed_languages_live.ex:256
 #: lib/vutuv_web/live/post_rewrites_live.ex:352
-#: lib/vutuv_web/live/press_kit_live.ex:547
+#: lib/vutuv_web/live/press_kit_live.ex:687
 #: lib/vutuv_web/live/section_reorder_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -6454,9 +6455,9 @@ msgstr "Anzuzeigende Kartendienste"
 msgid "Maps"
 msgstr "Karten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1585
-#: lib/vutuv_web/templates/user/show.html.heex:1589
-#: lib/vutuv_web/templates/user/show.html.heex:1601
+#: lib/vutuv_web/templates/user/show.html.heex:1568
+#: lib/vutuv_web/templates/user/show.html.heex:1572
+#: lib/vutuv_web/templates/user/show.html.heex:1584
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr "In %{name} öffnen"
@@ -6501,7 +6502,7 @@ msgstr "Noch keine Empfehlungen."
 msgid "and %{count} more"
 msgstr "und %{count} weitere"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1250
+#: lib/vutuv_web/agent_docs/markdown.ex:1254
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr "empfohlen am %{date}"
@@ -6812,9 +6813,9 @@ msgstr ""
 "Schalten Sie einen Schalter aus, geht der passende Opt-out auf den Seiten "
 "und Antworten über Sie mit. Mit beiden aus zum Beispiel:"
 
-#: lib/vutuv_web/components/post_components.ex:3298
-#: lib/vutuv_web/components/post_components.ex:4409
-#: lib/vutuv_web/components/post_components.ex:4423
+#: lib/vutuv_web/components/post_components.ex:3341
+#: lib/vutuv_web/components/post_components.ex:4452
+#: lib/vutuv_web/components/post_components.ex:4466
 #: lib/vutuv_web/components/ui.ex:3195
 #: lib/vutuv_web/live/fediverse_account_live.ex:437
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6842,7 +6843,7 @@ msgstr "Neue Nachrichten und neue Vernetzungen"
 msgid "Remove this connection? You will stop following them."
 msgstr "Diese Vernetzung entfernen? Sie folgen der Person dann nicht mehr."
 
-#: lib/vutuv_web/components/post_components.ex:4409
+#: lib/vutuv_web/components/post_components.ex:4452
 #: lib/vutuv_web/components/ui.ex:3194
 #: lib/vutuv_web/live/fediverse_account_live.ex:435
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6872,12 +6873,12 @@ msgstr "Folgen Sie einander, um mit %{name} vernetzt zu sein und ihn zu lesen."
 msgid "Go to profile to follow"
 msgstr "Zum Profil, um zu folgen"
 
-#: lib/vutuv_web/views/user_html.ex:1233
+#: lib/vutuv_web/views/user_html.ex:1226
 #, elixir-autogen, elixir-format
 msgid "Professional"
 msgstr "Beruflich"
 
-#: lib/vutuv_web/views/user_html.ex:786
+#: lib/vutuv_web/views/user_html.ex:779
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr "Folgt Ihnen"
@@ -7416,7 +7417,7 @@ msgid "open the dev email inbox"
 msgstr "Dev-Postfach öffnen"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:45
-#: lib/vutuv_web/views/user_html.ex:785
+#: lib/vutuv_web/views/user_html.ex:778
 #, elixir-autogen, elixir-format
 msgid "Connected"
 msgstr "Vernetzt"
@@ -7560,7 +7561,7 @@ msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:6900
+#: lib/vutuv_web/components/post_components.ex:6943
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #: lib/vutuv_web/live/shell_live.ex:1817
 #, elixir-autogen, elixir-format
@@ -7672,9 +7673,9 @@ msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3877
+#: lib/vutuv_web/live/post_live/feed.ex:3888
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
-#: lib/vutuv_web/live/press_kit_live.ex:573
+#: lib/vutuv_web/live/press_kit_live.ex:713
 #, elixir-autogen
 msgid "Done"
 msgstr "Fertig"
@@ -7754,17 +7755,17 @@ msgstr "Feed von %{name}"
 msgid "The vutuv newsfeed of %{name}"
 msgstr "Der vutuv-Newsfeed von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1417
+#: lib/vutuv_web/agent_docs/markdown.ex:1421
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr "Ihr Feed ist leer."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1420
+#: lib/vutuv_web/agent_docs/markdown.ex:1424
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr "%{count} Beiträge auf dieser Seite"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1427
+#: lib/vutuv_web/agent_docs/markdown.ex:1431
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr "weitere Beiträge verfügbar, ?cursor=%{cursor} anhängen"
@@ -8617,13 +8618,13 @@ msgstr "Zu viele Importe. Bitte versuchen Sie es in Kürze erneut."
 msgid "Please check the fields marked in red."
 msgstr "Bitte prüfen Sie die rot markierten Felder."
 
-#: lib/vutuv_web/views/user_html.ex:1118
+#: lib/vutuv_web/views/user_html.ex:1111
 #, elixir-autogen, elixir-format
 msgid "Loading posts"
 msgstr "Beiträge werden geladen"
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:140
-#: lib/vutuv_web/templates/user/show.html.heex:1449
+#: lib/vutuv_web/templates/user/show.html.heex:1432
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr "Social-Media-Beiträge"
@@ -8923,7 +8924,7 @@ msgstr ""
 msgid "Not written yet"
 msgstr "Noch nicht verfasst"
 
-#: lib/vutuv_web/components/organization_components.ex:244
+#: lib/vutuv_web/components/organization_components.ex:245
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "Page"
@@ -8956,11 +8957,11 @@ msgstr "Die Seite wurde veröffentlicht."
 msgid "Write it under Admin › Legal pages"
 msgstr "Unter Admin › Rechtstexte verfassen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:715
 #: lib/vutuv_web/agent_docs/markdown.ex:719
-#: lib/vutuv_web/agent_docs/text.ex:665
-#: lib/vutuv_web/agent_docs/text.ex:669
-#: lib/vutuv_web/components/organization_components.ex:276
+#: lib/vutuv_web/agent_docs/markdown.ex:723
+#: lib/vutuv_web/agent_docs/text.ex:666
+#: lib/vutuv_web/agent_docs/text.ex:670
+#: lib/vutuv_web/components/organization_components.ex:285
 #: lib/vutuv_web/components/ui.ex:1807
 #: lib/vutuv_web/components/ui.ex:5459
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
@@ -8969,13 +8970,13 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:277
 #: lib/vutuv_web/live/organization_live/fediverse.ex:84
-#: lib/vutuv_web/live/organization_live/show.ex:165
+#: lib/vutuv_web/live/organization_live/show.ex:181
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:329
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:5
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:1354
+#: lib/vutuv_web/templates/user/show.html.heex:1337
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr "Fediverse"
@@ -9094,13 +9095,13 @@ msgstr "Ihr Profil als Lebenslauf"
 msgid "Higher Education"
 msgstr "Studium"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:923
+#: lib/vutuv_web/agent_docs/markdown.ex:927
 #: lib/vutuv_web/views/education_html.ex:54
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr "Schulbildung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:922
+#: lib/vutuv_web/agent_docs/markdown.ex:926
 #: lib/vutuv_web/views/education_html.ex:53
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -9129,14 +9130,14 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:5755
+#: lib/vutuv_web/components/post_components.ex:5798
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] "Repostet von %{name} und %{formatted} weiteren"
 msgstr[1] "Repostet von %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1186
+#: lib/vutuv_web/agent_docs/markdown.ex:1190
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr "repostet von %{name} und %{count} weiteren"
@@ -9388,8 +9389,8 @@ msgstr "Ehren-Tag"
 msgid "Honor tag (only site admins can assign it)"
 msgstr "Ehren-Tag (nur Admins können es vergeben)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:735
-#: lib/vutuv_web/agent_docs/text.ex:683
+#: lib/vutuv_web/agent_docs/markdown.ex:739
+#: lib/vutuv_web/agent_docs/text.ex:684
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr "Ehren-Tag"
@@ -9813,8 +9814,8 @@ msgstr "Walisisch"
 msgid "Yoruba"
 msgstr "Yoruba"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:657
-#: lib/vutuv_web/agent_docs/text.ex:635
+#: lib/vutuv_web/agent_docs/markdown.ex:661
+#: lib/vutuv_web/agent_docs/text.ex:636
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr "Beschäftigungsstatus"
@@ -9928,7 +9929,7 @@ msgstr[1] "%{count} Zertifikate oder Lizenzen"
 msgid "Add a certificate or license"
 msgstr "Zertifikat oder Lizenz hinzufügen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1039
+#: lib/vutuv_web/agent_docs/markdown.ex:1043
 #: lib/vutuv_web/views/qualification_html.ex:14
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -10008,7 +10009,7 @@ msgstr "Läuft nicht ab"
 msgid "Expired"
 msgstr "Abgelaufen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1014
+#: lib/vutuv_web/agent_docs/markdown.ex:1018
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr "ID: %{id}"
@@ -10025,7 +10026,7 @@ msgstr "Ausgestellt"
 msgid "Issuer"
 msgstr "Aussteller"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1038
+#: lib/vutuv_web/agent_docs/markdown.ex:1042
 #: lib/vutuv_web/views/qualification_html.ex:15
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -10055,7 +10056,7 @@ msgstr "Nachweis"
 msgid "Verification link"
 msgstr "Nachweislink"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1012
+#: lib/vutuv_web/agent_docs/markdown.ex:1016
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr "ausgestellt %{date}"
@@ -10070,7 +10071,7 @@ msgstr "z. B. AWS Solutions Architect – Associate"
 msgid "e.g. Amazon Web Services"
 msgstr "z. B. Amazon Web Services"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1013
+#: lib/vutuv_web/agent_docs/markdown.ex:1017
 #: lib/vutuv_web/views/qualification_html.ex:91
 #, elixir-autogen, elixir-format
 msgid "valid until %{date}"
@@ -10088,15 +10089,15 @@ msgstr ""
 msgid "Preferred"
 msgstr "Bevorzugt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:850
+#: lib/vutuv_web/agent_docs/markdown.ex:854
 #: lib/vutuv_web/live/section_reorder_live.ex:289
 #: lib/vutuv_web/views/language_html.ex:114
 #, elixir-autogen, elixir-format
 msgid "Preferred contact language"
 msgstr "Bevorzugte Kontaktsprache"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1276
-#: lib/vutuv_web/templates/user/show.html.heex:1277
+#: lib/vutuv_web/templates/user/show.html.heex:1259
+#: lib/vutuv_web/templates/user/show.html.heex:1260
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr "+%{code} ist die Ländervorwahl von %{region}"
@@ -10586,21 +10587,21 @@ msgstr ""
 " von einer gedruckten Kennwortliste an, eingegeben im normalen PIN-Feld. "
 "Ihre PIN per E-Mail funktioniert immer weiter."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:810
+#: lib/vutuv_web/agent_docs/markdown.ex:814
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] "%{count} Follower"
 msgstr[1] "%{count} Follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:808
+#: lib/vutuv_web/agent_docs/markdown.ex:812
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] "%{count} Repository"
 msgstr[1] "%{count} Repositories"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:806
+#: lib/vutuv_web/agent_docs/markdown.ex:810
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10608,16 +10609,16 @@ msgstr[0] "%{count} Stern"
 msgstr[1] "%{count} Sterne"
 
 #: lib/vutuv_web/live/notification_live/index.ex:1416
-#: lib/vutuv_web/live/organization_live/show.ex:648
-#: lib/vutuv_web/views/user_html.ex:982
-#: lib/vutuv_web/views/user_html.ex:1158
+#: lib/vutuv_web/live/organization_live/show.ex:671
+#: lib/vutuv_web/views/user_html.ex:975
+#: lib/vutuv_web/views/user_html.ex:1151
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower"
 msgid_plural "%{formatted} followers"
 msgstr[0] "%{formatted} Follower"
 msgstr[1] "%{formatted} Follower"
 
-#: lib/vutuv_web/views/user_html.ex:975
+#: lib/vutuv_web/views/user_html.ex:968
 #, elixir-autogen, elixir-format
 msgid "%{formatted} star"
 msgid_plural "%{formatted} stars"
@@ -10626,7 +10627,7 @@ msgstr[1] "%{formatted} Sterne"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:72
 #: lib/vutuv_web/agent_docs/text.ex:67
-#: lib/vutuv_web/templates/user/show.html.heex:1423
+#: lib/vutuv_web/templates/user/show.html.heex:1406
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr "Code"
@@ -10645,7 +10646,7 @@ msgstr ""
 "dessen öffentliche Statistiken zeigen: Sterne, Repositories, Follower, "
 "Sprachen und letzte Aktivität."
 
-#: lib/vutuv_web/views/user_html.ex:989
+#: lib/vutuv_web/views/user_html.ex:982
 #, elixir-autogen, elixir-format
 msgid "Last active %{date}"
 msgstr "Zuletzt aktiv %{date}"
@@ -10662,17 +10663,17 @@ msgstr ""
 "Wenn deaktiviert, zeigt die Social-Media-Karte Ihre Konten nur als einfache "
 "Links."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:824
+#: lib/vutuv_web/agent_docs/markdown.ex:828
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr "zuletzt aktiv %{date}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:811
+#: lib/vutuv_web/agent_docs/markdown.ex:815
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr "seit %{date}"
 
-#: lib/vutuv_web/views/user_html.ex:905
+#: lib/vutuv_web/views/user_html.ex:898
 #, elixir-autogen, elixir-format
 msgid "since %{year}"
 msgstr "seit %{year}"
@@ -11484,7 +11485,7 @@ msgstr "Ihre Liste ist leer. Es ist noch niemand ausgeschlossen."
 msgid "AI agents"
 msgstr "KI-Agenten"
 
-#: lib/vutuv_web/live/organization_live/show.ex:700
+#: lib/vutuv_web/live/organization_live/show.ex:723
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "Über die Organisation"
@@ -11497,7 +11498,7 @@ msgstr "Weiter zur Verifizierung"
 #: lib/vutuv_web/live/organization_live/domains.ex:284
 #: lib/vutuv_web/live/organization_live/domains.ex:319
 #: lib/vutuv_web/live/organization_live/new.ex:161
-#: lib/vutuv_web/live/organization_live/show.ex:1043
+#: lib/vutuv_web/live/organization_live/show.ex:1080
 #: lib/vutuv_web/templates/url/verify.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
@@ -11505,8 +11506,8 @@ msgstr "DNS-TXT-Eintrag"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:204
 #: lib/vutuv_web/live/organization_live/domains.ex:359
-#: lib/vutuv_web/live/organization_live/show.ex:1108
-#: lib/vutuv_web/live/organization_live/show.ex:1116
+#: lib/vutuv_web/live/organization_live/show.ex:1145
+#: lib/vutuv_web/live/organization_live/show.ex:1153
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr "Die Domain-Verifizierung ist auf dieser Installation deaktiviert."
@@ -11535,13 +11536,13 @@ msgstr ""
 "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) anbieten und für KI-"
 "Agenten auflisten."
 
-#: lib/vutuv_web/controllers/organization_controller.ex:290
+#: lib/vutuv_web/controllers/organization_controller.ex:305
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:31
 #, elixir-autogen, elixir-format
 msgid "Please log in first."
 msgstr "Bitte loggen Sie sich zuerst ein."
 
-#: lib/vutuv_web/live/organization_live/show.ex:1016
+#: lib/vutuv_web/live/organization_live/show.ex:1053
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr "Weisen Sie nach, dass Ihnen %{domain} gehört, um diese Seite zu veröffentlichen."
@@ -11562,13 +11563,13 @@ msgstr "Nach Name oder Stadt suchen"
 msgid "Search engines"
 msgstr "Suchmaschinen"
 
-#: lib/vutuv_web/components/organization_components.ex:142
+#: lib/vutuv_web/components/organization_components.ex:143
 #, elixir-autogen, elixir-format
 msgid "Select a country"
 msgstr "Land auswählen"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:338
-#: lib/vutuv_web/live/organization_live/show.ex:1078
+#: lib/vutuv_web/live/organization_live/show.ex:1115
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr "Stellen Sie diese Datei bereit unter:"
@@ -11590,12 +11591,12 @@ msgid "The upload failed."
 msgstr "Der Upload ist fehlgeschlagen."
 
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:1031
+#: lib/vutuv_web/live/organization_live/show.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr "Verifizierungsmethode"
 
-#: lib/vutuv_web/live/organization_live/show.ex:942
+#: lib/vutuv_web/live/organization_live/show.ex:979
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr "Verifizierte Domains"
@@ -11606,18 +11607,18 @@ msgstr "Verifizierte Domains"
 msgid "Verified via"
 msgstr "Verifiziert über"
 
-#: lib/vutuv_web/live/organization_live/show.ex:1002
+#: lib/vutuv_web/live/organization_live/show.ex:1039
 #, elixir-autogen, elixir-format
 msgid "Verified via %{domain}"
 msgstr "Verifiziert über %{domain}"
 
-#: lib/vutuv_web/live/organization_live/show.ex:1013
+#: lib/vutuv_web/live/organization_live/show.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr "%{name} verifizieren"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:353
-#: lib/vutuv_web/live/organization_live/show.ex:1102
+#: lib/vutuv_web/live/organization_live/show.ex:1139
 #, elixir-autogen, elixir-format
 msgid "Verify now"
 msgstr "Jetzt verifizieren"
@@ -11632,7 +11633,7 @@ msgstr "Website"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:285
 #: lib/vutuv_web/live/organization_live/domains.ex:329
-#: lib/vutuv_web/live/organization_live/show.ex:1054
+#: lib/vutuv_web/live/organization_live/show.ex:1091
 #: lib/vutuv_web/templates/url/verify.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11651,7 +11652,7 @@ msgstr ""
 "die Kontrolle über die Domain nachzuweisen."
 
 #: lib/vutuv_web/live/organization_live/domains.ex:340
-#: lib/vutuv_web/live/organization_live/show.ex:1084
+#: lib/vutuv_web/live/organization_live/show.ex:1121
 #: lib/vutuv_web/templates/url/verify.html.heex:109
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
@@ -11662,7 +11663,7 @@ msgstr "mit genau diesem Inhalt:"
 msgid "@handle or email"
 msgstr "@handle oder E-Mail"
 
-#: lib/vutuv_web/components/organization_components.ex:333
+#: lib/vutuv_web/components/organization_components.ex:342
 #: lib/vutuv_web/live/organization_live/edit.ex:421
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
@@ -11683,7 +11684,7 @@ msgstr "Mitglied hinzufügen"
 msgid "Added @%{handle} to the team."
 msgstr "@%{handle} zum Team hinzugefügt."
 
-#: lib/vutuv_web/components/organization_components.ex:334
+#: lib/vutuv_web/components/organization_components.ex:343
 #: lib/vutuv_web/live/organization_live/edit.ex:419
 #, elixir-autogen, elixir-format
 msgid "Alias"
@@ -11699,10 +11700,10 @@ msgstr "Alias hinzugefügt."
 msgid "Alias removed."
 msgstr "Alias entfernt."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:529
-#: lib/vutuv_web/agent_docs/text.ex:535
+#: lib/vutuv_web/agent_docs/markdown.ex:533
+#: lib/vutuv_web/agent_docs/text.ex:536
 #: lib/vutuv_web/live/organization_live/edit.ex:384
-#: lib/vutuv_web/live/organization_live/show.ex:930
+#: lib/vutuv_web/live/organization_live/show.ex:967
 #: lib/vutuv_web/templates/tag/single_card.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Also known as"
@@ -11729,7 +11730,7 @@ msgstr "Diese Seite archivieren?"
 msgid "Archived"
 msgstr "Archiviert"
 
-#: lib/vutuv_web/components/organization_components.ex:332
+#: lib/vutuv_web/components/organization_components.ex:341
 #: lib/vutuv_web/live/organization_live/edit.ex:420
 #, elixir-autogen, elixir-format
 msgid "Brand"
@@ -11769,10 +11770,10 @@ msgstr "Domain entfernt."
 msgid "Domain verified."
 msgstr "Domain verifiziert."
 
-#: lib/vutuv_web/components/organization_components.ex:250
+#: lib/vutuv_web/components/organization_components.ex:251
 #: lib/vutuv_web/live/admin/organization_live.ex:302
 #: lib/vutuv_web/live/organization_live/domains.ex:198
-#: lib/vutuv_web/live/organization_live/show.ex:159
+#: lib/vutuv_web/live/organization_live/show.ex:175
 #, elixir-autogen, elixir-format
 msgid "Domains"
 msgstr "Domains"
@@ -11782,7 +11783,7 @@ msgstr "Domains"
 msgid "Domains – %{name}"
 msgstr "Domains – %{name}"
 
-#: lib/vutuv_web/components/organization_components.ex:331
+#: lib/vutuv_web/components/organization_components.ex:340
 #, elixir-autogen, elixir-format
 msgid "Former name"
 msgstr "Früherer Name"
@@ -11862,7 +11863,7 @@ msgstr "Primär"
 msgid "Primary domain updated."
 msgstr "Primäre Domain aktualisiert."
 
-#: lib/vutuv_web/components/organization_components.ex:320
+#: lib/vutuv_web/components/organization_components.ex:329
 #, elixir-autogen, elixir-format
 msgid "Recruiter"
 msgstr "Recruiter"
@@ -11887,10 +11888,10 @@ msgstr "Diesen Namen entfernen?"
 msgid "Search name, alias or domain"
 msgstr "Name, Alias oder Domain suchen"
 
-#: lib/vutuv_web/components/organization_components.ex:247
+#: lib/vutuv_web/components/organization_components.ex:248
 #: lib/vutuv_web/live/admin/organization_live.ex:318
 #: lib/vutuv_web/live/organization_live/roles.ex:184
-#: lib/vutuv_web/live/organization_live/show.ex:155
+#: lib/vutuv_web/live/organization_live/show.ex:171
 #, elixir-autogen, elixir-format
 msgid "Team"
 msgstr "Team"
@@ -11927,8 +11928,8 @@ msgstr "ausstehend"
 msgid "primary"
 msgstr "primär"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:550
-#: lib/vutuv_web/agent_docs/text.ex:555
+#: lib/vutuv_web/agent_docs/markdown.ex:554
+#: lib/vutuv_web/agent_docs/text.ex:556
 #: lib/vutuv_web/live/admin/organization_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "verified"
@@ -12057,8 +12058,8 @@ msgstr "Per Rück-Link verifizieren"
 msgid "Verify via file"
 msgstr "Per Datei verifizieren"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1059
-#: lib/vutuv_web/agent_docs/text.ex:811
+#: lib/vutuv_web/agent_docs/markdown.ex:1063
+#: lib/vutuv_web/agent_docs/text.ex:812
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr "verifizierte Webseite"
@@ -12068,7 +12069,7 @@ msgstr "verifizierte Webseite"
 msgid "%{min} to %{max} characters: letters (a-z), numbers (0-9) and underscores."
 msgstr "%{min} bis %{max} Zeichen: Buchstaben (a-z), Zahlen (0-9) und Unterstriche."
 
-#: lib/vutuv_web/live/organization_live/show.ex:819
+#: lib/vutuv_web/live/organization_live/show.ex:842
 #, elixir-autogen, elixir-format
 msgid "Former"
 msgstr "Ehemalig"
@@ -12094,8 +12095,8 @@ msgstr "Verknüpft mit {name}"
 msgid "Remove link"
 msgstr "Verknüpfung entfernen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:541
-#: lib/vutuv_web/agent_docs/text.ex:546
+#: lib/vutuv_web/agent_docs/markdown.ex:545
+#: lib/vutuv_web/agent_docs/text.ex:547
 #, elixir-autogen, elixir-format
 msgid "former"
 msgstr "ehemalig"
@@ -12195,7 +12196,7 @@ msgstr "Vielleicht brauchen Sie Hilfe von Ihrer IT"
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr "Der Nachweis ist eine kleine technische Änderung an Ihrer Domain: ein DNS-Eintrag oder eine Datei auf Ihrer Website. Wenn Sie die Website nicht selbst verwalten, fragen Sie die Person oder das Team, das dies tut. Das ist meist Ihre IT-Abteilung oder die Firma, die Ihre Website betreut. Die genaue Anleitung zeigen wir Ihnen im nächsten Schritt, Sie können sie einfach weitergeben."
 
-#: lib/vutuv_web/live/organization_live/show.ex:1025
+#: lib/vutuv_web/live/organization_live/show.ex:1062
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr "Diese Schritte sind technisch. Wenn Sie %{domain} nicht selbst verwalten, kopieren Sie den unten gezeigten Eintrag oder die Datei und senden Sie ihn an Ihre IT-Abteilung oder die Firma, die Ihre Website betreut. Sobald sie ihn hinzugefügt hat, kommen Sie hierher zurück und klicken auf „Jetzt verifizieren“."
@@ -12301,9 +12302,9 @@ msgstr "Organisationsrolle"
 msgid "Organization unfrozen."
 msgstr "Organisation wieder freigegeben."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:520
-#: lib/vutuv_web/agent_docs/organization_doc.ex:123
-#: lib/vutuv_web/agent_docs/text.ex:479
+#: lib/vutuv_web/agent_docs/markdown.ex:524
+#: lib/vutuv_web/agent_docs/organization_doc.ex:138
+#: lib/vutuv_web/agent_docs/text.ex:480
 #: lib/vutuv_web/components/ui.ex:5486
 #: lib/vutuv_web/controllers/settings_controller.ex:222
 #: lib/vutuv_web/live/organization_live/index.ex:32
@@ -12314,24 +12315,25 @@ msgstr "Organisation wieder freigegeben."
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:80
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
+#: lib/vutuv_web/views/press_kit_html.ex:49
 #, elixir-autogen, elixir-format
 msgid "Organizations"
 msgstr "Organisationen"
 
-#: lib/vutuv_web/components/organization_components.ex:169
+#: lib/vutuv_web/components/organization_components.ex:170
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:90
 #, elixir-autogen, elixir-format
 msgid "Please choose"
 msgstr "Bitte wählen"
 
-#: lib/vutuv_web/controllers/organization_controller.ex:128
+#: lib/vutuv_web/controllers/organization_controller.ex:129
 #, elixir-autogen, elixir-format
 msgid "Please confirm your email address before claiming an organization page."
 msgstr ""
 "Bitte bestätigen Sie Ihre E-Mail-Adresse, bevor Sie eine Organisationsseite "
 "beanspruchen."
 
-#: lib/vutuv_web/controllers/organization_controller.ex:134
+#: lib/vutuv_web/controllers/organization_controller.ex:135
 #, elixir-autogen, elixir-format
 msgid "Please log in to claim an organization page."
 msgstr "Bitte loggen Sie sich ein, um eine Organisationsseite zu beanspruchen."
@@ -12361,7 +12363,7 @@ msgstr "Dieser Name ist für diese Organisation bereits eingetragen."
 msgid "The organization page was deleted."
 msgstr "Die Organisationsseite wurde gelöscht."
 
-#: lib/vutuv_web/live/organization_live/show.ex:470
+#: lib/vutuv_web/live/organization_live/show.ex:493
 #, elixir-autogen, elixir-format
 msgid "This organization page was reported and is hidden while it is reviewed. Only you and the moderators can see it."
 msgstr ""
@@ -12375,7 +12377,7 @@ msgstr ""
 "Verifizierte Organisationsseiten auf vutuv, jede mit einer nachgewiesenen Web-"
 "Domain."
 
-#: lib/vutuv_web/agent_docs/organization_doc.ex:124
+#: lib/vutuv_web/agent_docs/organization_doc.ex:139
 #, elixir-autogen, elixir-format
 msgid "Verified organization pages on vutuv."
 msgstr "Verifizierte Organisationsseiten auf vutuv."
@@ -12397,8 +12399,8 @@ msgstr "Sie dürfen diese Organisation nicht löschen."
 msgid "Your organization handle is set."
 msgstr "Ihr Organisations-Handle ist gesetzt."
 
-#: lib/vutuv_web/live/organization_live/show.ex:356
-#: lib/vutuv_web/live/organization_live/show.ex:409
+#: lib/vutuv_web/live/organization_live/show.ex:379
+#: lib/vutuv_web/live/organization_live/show.ex:432
 #, elixir-autogen, elixir-format
 msgid "Your organization page is verified and now live."
 msgstr "Ihre Organisationsseite ist verifiziert und jetzt live."
@@ -12572,10 +12574,10 @@ msgstr "Entwürfe"
 msgid "Edit posting"
 msgstr "Anzeige bearbeiten"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:297
-#: lib/vutuv_web/agent_docs/markdown.ex:581
-#: lib/vutuv_web/agent_docs/text.ex:267
-#: lib/vutuv_web/agent_docs/text.ex:586
+#: lib/vutuv_web/agent_docs/markdown.ex:301
+#: lib/vutuv_web/agent_docs/markdown.ex:585
+#: lib/vutuv_web/agent_docs/text.ex:268
+#: lib/vutuv_web/agent_docs/text.ex:587
 #: lib/vutuv_web/live/admin/job_live.ex:340
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:17
 #: lib/vutuv_web/views/account_event_text.ex:225
@@ -12588,10 +12590,10 @@ msgstr "Arbeitgeber"
 msgid "Employer name (optional)"
 msgstr "Name des Arbeitgebers (optional)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:298
-#: lib/vutuv_web/agent_docs/markdown.ex:582
-#: lib/vutuv_web/agent_docs/text.ex:268
-#: lib/vutuv_web/agent_docs/text.ex:587
+#: lib/vutuv_web/agent_docs/markdown.ex:302
+#: lib/vutuv_web/agent_docs/markdown.ex:586
+#: lib/vutuv_web/agent_docs/text.ex:269
+#: lib/vutuv_web/agent_docs/text.ex:588
 #: lib/vutuv_web/live/job_board_live.ex:526
 #: lib/vutuv_web/live/job_posting_live/form.ex:499
 #, elixir-autogen, elixir-format
@@ -12663,12 +12665,12 @@ msgstr "Jobs"
 msgid "Let search engines index this posting."
 msgstr "Suchmaschinen dürfen diese Anzeige indexieren."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:556
-#: lib/vutuv_web/agent_docs/markdown.ex:559
-#: lib/vutuv_web/agent_docs/markdown.ex:561
-#: lib/vutuv_web/agent_docs/text.ex:561
-#: lib/vutuv_web/agent_docs/text.ex:564
-#: lib/vutuv_web/agent_docs/text.ex:566
+#: lib/vutuv_web/agent_docs/markdown.ex:560
+#: lib/vutuv_web/agent_docs/markdown.ex:563
+#: lib/vutuv_web/agent_docs/markdown.ex:565
+#: lib/vutuv_web/agent_docs/text.ex:562
+#: lib/vutuv_web/agent_docs/text.ex:565
+#: lib/vutuv_web/agent_docs/text.ex:567
 #: lib/vutuv_web/live/job_posting_live/form.ex:549
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -12717,8 +12719,8 @@ msgstr "Neue Konten können nach einigen Tagen veröffentlichen."
 msgid "New posting"
 msgstr "Neue Anzeige"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:309
-#: lib/vutuv_web/agent_docs/text.ex:278
+#: lib/vutuv_web/agent_docs/markdown.ex:313
+#: lib/vutuv_web/agent_docs/text.ex:279
 #: lib/vutuv_web/live/job_posting_live/form.ex:756
 #: lib/vutuv_web/live/job_posting_live/show.ex:177
 #, elixir-autogen, elixir-format
@@ -12802,10 +12804,10 @@ msgstr "Veröffentlichen als"
 msgid "Postal code"
 msgstr "Postleitzahl"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:302
-#: lib/vutuv_web/agent_docs/markdown.ex:586
-#: lib/vutuv_web/agent_docs/text.ex:272
-#: lib/vutuv_web/agent_docs/text.ex:591
+#: lib/vutuv_web/agent_docs/markdown.ex:306
+#: lib/vutuv_web/agent_docs/markdown.ex:590
+#: lib/vutuv_web/agent_docs/text.ex:273
+#: lib/vutuv_web/agent_docs/text.ex:592
 #: lib/vutuv_web/live/job_posting_live/show.ex:156
 #, elixir-autogen, elixir-format
 msgid "Posted"
@@ -12830,10 +12832,10 @@ msgstr "Veröffentlichen"
 #: lib/vutuv/accounts/user.ex:1291
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:590
-#: lib/vutuv_web/agent_docs/markdown.ex:559
-#: lib/vutuv_web/agent_docs/markdown.ex:561
-#: lib/vutuv_web/agent_docs/text.ex:564
-#: lib/vutuv_web/agent_docs/text.ex:566
+#: lib/vutuv_web/agent_docs/markdown.ex:563
+#: lib/vutuv_web/agent_docs/markdown.ex:565
+#: lib/vutuv_web/agent_docs/text.ex:565
+#: lib/vutuv_web/agent_docs/text.ex:567
 #: lib/vutuv_web/components/job_components.ex:140
 #: lib/vutuv_web/components/job_components.ex:141
 #, elixir-autogen, elixir-format
@@ -12845,18 +12847,18 @@ msgstr "Remote"
 msgid "Report this posting"
 msgstr "Diese Anzeige melden"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:308
-#: lib/vutuv_web/agent_docs/text.ex:277
+#: lib/vutuv_web/agent_docs/markdown.ex:312
+#: lib/vutuv_web/agent_docs/text.ex:278
 #: lib/vutuv_web/live/job_posting_live/form.ex:746
 #: lib/vutuv_web/live/job_posting_live/show.ex:172
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr "Erforderlich"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:301
-#: lib/vutuv_web/agent_docs/markdown.ex:585
-#: lib/vutuv_web/agent_docs/text.ex:271
-#: lib/vutuv_web/agent_docs/text.ex:590
+#: lib/vutuv_web/agent_docs/markdown.ex:305
+#: lib/vutuv_web/agent_docs/markdown.ex:589
+#: lib/vutuv_web/agent_docs/text.ex:272
+#: lib/vutuv_web/agent_docs/text.ex:591
 #, elixir-autogen, elixir-format
 msgid "Salary"
 msgstr "Gehalt"
@@ -12950,10 +12952,10 @@ msgstr "Wer kann sie sehen"
 msgid "Working student"
 msgstr "Werkstudent:in"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:299
-#: lib/vutuv_web/agent_docs/markdown.ex:583
-#: lib/vutuv_web/agent_docs/text.ex:269
-#: lib/vutuv_web/agent_docs/text.ex:588
+#: lib/vutuv_web/agent_docs/markdown.ex:303
+#: lib/vutuv_web/agent_docs/markdown.ex:587
+#: lib/vutuv_web/agent_docs/text.ex:270
+#: lib/vutuv_web/agent_docs/text.ex:589
 #: lib/vutuv_web/live/job_posting_live/form.ex:514
 #, elixir-autogen, elixir-format
 msgid "Workplace"
@@ -13098,13 +13100,13 @@ msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT
 msgstr "Bekommen Sie einen Fehler, oder ist %{host} ein CNAME / Alias auf eine andere Adresse? Ein TXT-Eintrag kann nicht denselben Namen wie ein CNAME haben. Verwenden Sie stattdessen diesen Namen, mit exakt demselben Wert wie oben:"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:336
-#: lib/vutuv_web/live/organization_live/show.ex:1071
+#: lib/vutuv_web/live/organization_live/show.ex:1108
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr "Ist %{domain} ein CNAME / Alias (ein TXT-Eintrag kann nicht denselben Namen wie ein CNAME haben), legen Sie den Eintrag stattdessen auf %{name} an, mit demselben Wert."
 
 #: lib/vutuv_web/live/organization_live/domains.ex:334
-#: lib/vutuv_web/live/organization_live/show.ex:1062
+#: lib/vutuv_web/live/organization_live/show.ex:1099
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr "Legen Sie in Ihren DNS-Einstellungen einen TXT-Eintrag auf dem Namen %{domain} mit diesem Wert an:"
@@ -13153,13 +13155,13 @@ msgstr "%{km} km"
 msgid "All countries"
 msgstr "Alle Länder"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:604
+#: lib/vutuv_web/agent_docs/markdown.ex:608
 #: lib/vutuv_web/templates/tag/show.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr "Alle Stellen mit diesem Tag"
 
-#: lib/vutuv_web/agent_docs/text.ex:608
+#: lib/vutuv_web/agent_docs/text.ex:609
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr "Alle Stellen mit diesem Tag: %{url}"
@@ -13200,17 +13202,17 @@ msgid "Minimum yearly salary"
 msgstr "Mindestgehalt pro Jahr"
 
 #: lib/vutuv_web/live/job_board_live.ex:383
-#: lib/vutuv_web/live/organization_live/show.ex:841
+#: lib/vutuv_web/live/organization_live/show.ex:864
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr "Weitere Stellen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:323
+#: lib/vutuv_web/agent_docs/markdown.ex:327
 #, elixir-autogen, elixir-format
 msgid "Next page"
 msgstr "Nächste Seite"
 
-#: lib/vutuv_web/agent_docs/text.ex:292
+#: lib/vutuv_web/agent_docs/text.ex:293
 #, elixir-autogen, elixir-format
 msgid "Next page: %{url}"
 msgstr "Nächste Seite: %{url}"
@@ -13225,11 +13227,11 @@ msgstr "Noch keine Stellenanzeigen."
 msgid "No matching positions. Try adjusting the filters."
 msgstr "Keine passenden Stellen. Passen Sie die Filter an."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:602
-#: lib/vutuv_web/agent_docs/markdown.ex:614
-#: lib/vutuv_web/agent_docs/text.ex:606
-#: lib/vutuv_web/agent_docs/text.ex:618
-#: lib/vutuv_web/live/organization_live/show.ex:833
+#: lib/vutuv_web/agent_docs/markdown.ex:606
+#: lib/vutuv_web/agent_docs/markdown.ex:618
+#: lib/vutuv_web/agent_docs/text.ex:607
+#: lib/vutuv_web/agent_docs/text.ex:619
+#: lib/vutuv_web/live/organization_live/show.ex:856
 #: lib/vutuv_web/templates/tag/show.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Open positions"
@@ -13550,7 +13552,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "E-Mail-Benachrichtigungen für Ihre gespeicherte Suche „%{label}“ stoppen?"
 
-#: lib/vutuv_web/components/post_components.ex:3776
+#: lib/vutuv_web/components/post_components.ex:3819
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:788
 #: lib/vutuv_web/controllers/settings_controller.ex:806
@@ -13695,7 +13697,7 @@ msgstr "Vor bestimmten Personen verbergen (Wettbewerber, eigene Belegschaft, Ein
 msgid "Inherited from the organization"
 msgstr "Von der Organisation geerbt"
 
-#: lib/vutuv_web/components/organization_components.ex:253
+#: lib/vutuv_web/components/organization_components.ex:254
 #: lib/vutuv_web/live/organization_live/exclusions.ex:113
 #, elixir-autogen, elixir-format
 msgid "Job exclusions"
@@ -13974,22 +13976,22 @@ msgstr "Mobil (privat)"
 msgid "Work mobile"
 msgstr "Mobil (Arbeit)"
 
-#: lib/vutuv_web/components/post_components.ex:483
+#: lib/vutuv_web/components/post_components.ex:484
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr "Noch keine Beiträge."
 
-#: lib/vutuv_web/components/post_components.ex:485
+#: lib/vutuv_web/components/post_components.ex:486
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr "Noch keine Antworten."
 
-#: lib/vutuv_web/components/post_components.ex:484
+#: lib/vutuv_web/components/post_components.ex:485
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr "Noch keine Reposts."
 
-#: lib/vutuv_web/components/post_components.ex:442
+#: lib/vutuv_web/components/post_components.ex:443
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr "Eigene Beiträge"
@@ -14050,7 +14052,7 @@ msgstr "Signal und WhatsApp akzeptieren eine Telefonnummer oder einen Benutzerna
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1389
+#: lib/vutuv_web/templates/user/show.html.heex:1372
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr "Messenger hinzufügen"
@@ -14087,7 +14089,7 @@ msgstr "Messenger wurde geändert."
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1387
+#: lib/vutuv_web/templates/user/show.html.heex:1370
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr "Messenger"
@@ -14164,34 +14166,34 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:6443
+#: lib/vutuv_web/components/post_components.ex:6486
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1379
-#: lib/vutuv_web/components/post_components.ex:6400
+#: lib/vutuv_web/agent_docs/markdown.ex:1383
+#: lib/vutuv_web/components/post_components.ex:6443
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:6444
+#: lib/vutuv_web/components/post_components.ex:6487
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:6446
+#: lib/vutuv_web/components/post_components.ex:6489
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:6442
+#: lib/vutuv_web/components/post_components.ex:6485
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1379
-#: lib/vutuv_web/components/post_components.ex:6399
+#: lib/vutuv_web/agent_docs/markdown.ex:1383
+#: lib/vutuv_web/components/post_components.ex:6442
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
@@ -14202,12 +14204,12 @@ msgstr "Filmbesprechung"
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/components/post_components.ex:6441
+#: lib/vutuv_web/components/post_components.ex:6484
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/components/post_components.ex:6445
+#: lib/vutuv_web/components/post_components.ex:6488
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14227,7 +14229,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:6482
+#: lib/vutuv_web/components/post_components.ex:6525
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14235,27 +14237,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:6512
+#: lib/vutuv_web/components/post_components.ex:6555
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:6513
+#: lib/vutuv_web/components/post_components.ex:6556
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:6511
+#: lib/vutuv_web/components/post_components.ex:6554
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:6471
+#: lib/vutuv_web/components/post_components.ex:6514
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:6518
+#: lib/vutuv_web/components/post_components.ex:6561
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14280,12 +14282,12 @@ msgstr "Qualifikation"
 msgid "With qualification:"
 msgstr "Mit Qualifikation:"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:879
+#: lib/vutuv_web/agent_docs/markdown.ex:883
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:6285
+#: lib/vutuv_web/components/post_components.ex:6328
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14328,7 +14330,7 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:6276
+#: lib/vutuv_web/components/post_components.ex:6319
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -14369,19 +14371,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] "Für %{formatted} Job genutzt"
 msgstr[1] "Für %{formatted} Jobs genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1028
+#: lib/vutuv_web/agent_docs/markdown.ex:1032
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr "aktuell genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1027
+#: lib/vutuv_web/agent_docs/markdown.ex:1031
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] "für %{count} Job genutzt"
 msgstr[1] "für %{count} Jobs genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1033
+#: lib/vutuv_web/agent_docs/markdown.ex:1037
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -14461,8 +14463,8 @@ msgstr "Hochgeladener Nachweis für %{name}"
 msgid "View the uploaded proof (%{label})"
 msgstr "Hochgeladenen Nachweis ansehen (%{label})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:965
-#: lib/vutuv_web/agent_docs/text.ex:790
+#: lib/vutuv_web/agent_docs/markdown.ex:969
+#: lib/vutuv_web/agent_docs/text.ex:791
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr "Nachweis"
@@ -14526,8 +14528,8 @@ msgstr "Wie möchten Sie arbeiten?"
 msgid "Skip for now"
 msgstr "Erstmal überspringen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:659
-#: lib/vutuv_web/agent_docs/text.ex:637
+#: lib/vutuv_web/agent_docs/markdown.ex:663
+#: lib/vutuv_web/agent_docs/text.ex:638
 #, elixir-autogen, elixir-format
 msgid "Preferred workplace"
 msgstr "Bevorzugte Arbeitsform"
@@ -14691,14 +14693,14 @@ msgstr "Konto zum Einfrieren suchen"
 msgid "See all frozen accounts"
 msgstr "Alle eingefrorenen Konten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:4065
+#: lib/vutuv_web/components/post_components.ex:4108
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "%{formatted} früheren Beitrag anzeigen"
 msgstr[1] "%{formatted} frühere Beiträge anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:4088
+#: lib/vutuv_web/components/post_components.ex:4131
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14725,7 +14727,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:6999
+#: lib/vutuv_web/components/post_components.ex:7042
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -15129,7 +15131,7 @@ msgstr "%{blocked} Server blockiert, am aktivsten eingehend: %{host}."
 msgid "none yet"
 msgstr "noch keiner"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1326
+#: lib/vutuv_web/agent_docs/markdown.ex:1330
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr "Reaktionen aus anderen Netzwerken"
@@ -15463,7 +15465,7 @@ msgstr "Anwendung bearbeiten"
 msgid "Book an ad"
 msgstr "Anzeige buchen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1096
+#: lib/vutuv_web/templates/user/show.html.heex:1079
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr "%{name} hat dieses Fediverse-Konto umgezogen. Folgen Sie stattdessen der neuen Adresse:"
@@ -15513,8 +15515,8 @@ msgstr "%{server} hat nicht geantwortet. Kopieren Sie stattdessen die Adresse ob
 msgid "Your server"
 msgstr "Ihr Server"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:716
-#: lib/vutuv_web/agent_docs/text.ex:666
+#: lib/vutuv_web/agent_docs/markdown.ex:720
+#: lib/vutuv_web/agent_docs/text.ex:667
 #, elixir-autogen, elixir-format
 msgid "moved to %{address}"
 msgstr "umgezogen nach %{address}"
@@ -15886,7 +15888,7 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:6945
+#: lib/vutuv_web/components/post_components.ex:6988
 #: lib/vutuv_web/live/notification_live/index.ex:1592
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -15894,7 +15896,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:6949
+#: lib/vutuv_web/components/post_components.ex:6992
 #: lib/vutuv_web/live/notification_live/index.ex:1586
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15902,15 +15904,15 @@ msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Like"
 msgstr[1] "%{formatted} Likes"
 
-#: lib/vutuv_web/components/post_components.ex:6953
+#: lib/vutuv_web/components/post_components.ex:6996
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
 msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1328
-#: lib/vutuv_web/components/post_components.ex:6904
+#: lib/vutuv_web/agent_docs/markdown.ex:1332
+#: lib/vutuv_web/components/post_components.ex:6947
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Bereits in den Zahlen oben enthalten."
@@ -15920,22 +15922,22 @@ msgstr "Bereits in den Zahlen oben enthalten."
 msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
 msgstr "Antworten, die dort draußen geschrieben werden, erscheinen unter Ihrem Beitrag, gekennzeichnet als aus einem anderen Netzwerk. Wir speichern eine Kopie für bis zu sechs Monate und prüfen ab und zu, ob sie dort noch veröffentlicht ist; löscht sie die Autorin oder der Autor, verschwindet auch unsere. Sie können jede einzelne Antwort entfernen, und wenn Sie das hier ausschalten, werden alle gelöscht."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1268
-#: lib/vutuv_web/agent_docs/markdown.ex:1526
-#: lib/vutuv_web/agent_docs/text.ex:888
-#: lib/vutuv_web/agent_docs/text.ex:965
+#: lib/vutuv_web/agent_docs/markdown.ex:1272
+#: lib/vutuv_web/agent_docs/markdown.ex:1530
+#: lib/vutuv_web/agent_docs/text.ex:889
+#: lib/vutuv_web/agent_docs/text.ex:966
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr "Inhaltswarnung"
 
-#: lib/vutuv_web/components/post_components.ex:1582
-#: lib/vutuv_web/components/post_components.ex:2682
+#: lib/vutuv_web/components/post_components.ex:1583
+#: lib/vutuv_web/components/post_components.ex:2683
 #: lib/vutuv_web/live/fediverse_account_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr "Aus einem anderen Netzwerk"
 
-#: lib/vutuv_web/components/post_components.ex:1446
+#: lib/vutuv_web/components/post_components.ex:1447
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr "Diese Antwort aus Ihrem Beitrag entfernen?"
@@ -15947,7 +15949,7 @@ msgstr "Vom Mitglied entfernt"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:150
 #: lib/vutuv_web/agent_docs/markdown.ex:182
-#: lib/vutuv_web/agent_docs/markdown.ex:1327
+#: lib/vutuv_web/agent_docs/markdown.ex:1331
 #: lib/vutuv_web/agent_docs/text.ex:125
 #: lib/vutuv_web/agent_docs/text.ex:154
 #, elixir-autogen, elixir-format
@@ -15964,7 +15966,7 @@ msgstr "Antwort aus einem anderen Netzwerk"
 msgid "Reply removed."
 msgstr "Antwort entfernt."
 
-#: lib/vutuv_web/components/post_components.ex:1458
+#: lib/vutuv_web/components/post_components.ex:1459
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
@@ -15974,7 +15976,7 @@ msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
 msgid "Reported as not appropriate"
 msgstr "Als unangemessen gemeldet"
 
-#: lib/vutuv_web/components/post_components.ex:1472
+#: lib/vutuv_web/components/post_components.ex:1473
 #: lib/vutuv_web/live/notification_live/index.ex:1117
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -16005,10 +16007,10 @@ msgstr "Danke. Die Antwort wurde sofort gelöscht."
 msgid "That reply is not yours to remove."
 msgstr "Diese Antwort können Sie nicht entfernen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1528
-#: lib/vutuv_web/components/post_components.ex:1497
-#: lib/vutuv_web/components/post_components.ex:1728
-#: lib/vutuv_web/components/post_components.ex:3634
+#: lib/vutuv_web/agent_docs/markdown.ex:1532
+#: lib/vutuv_web/components/post_components.ex:1498
+#: lib/vutuv_web/components/post_components.ex:1729
+#: lib/vutuv_web/components/post_components.ex:3677
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "View the original"
@@ -16674,22 +16676,22 @@ msgstr "Was sich an welchem Konto geändert hat, wann, von welchem Gerät und wi
 msgid "device or detail"
 msgstr "Gerät oder Detail"
 
-#: lib/vutuv_web/components/post_components.ex:4250
+#: lib/vutuv_web/components/post_components.ex:4293
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Angehefteter Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:4376
+#: lib/vutuv_web/components/post_components.ex:4419
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "An Profil anheften"
 
-#: lib/vutuv_web/components/post_components.ex:4384
+#: lib/vutuv_web/components/post_components.ex:4427
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Vom Profil lösen"
 
-#: lib/vutuv_web/components/post_components.ex:4370
+#: lib/vutuv_web/components/post_components.ex:4413
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr "Es lässt sich nur ein Beitrag an Ihr Profil anheften. Diesen anheften und den anderen lösen?"
@@ -16711,13 +16713,13 @@ msgstr ""
 msgid "Unpinned. The post is a normal post again."
 msgstr "Nicht mehr angeheftet. Der Beitrag ist wieder ein normaler Beitrag."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1169
+#: lib/vutuv_web/agent_docs/markdown.ex:1173
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr "angehefteter Beitrag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:653
-#: lib/vutuv_web/agent_docs/text.ex:628
+#: lib/vutuv_web/agent_docs/markdown.ex:657
+#: lib/vutuv_web/agent_docs/text.ex:629
 #: lib/vutuv_web/templates/user/edit.html.heex:225
 #: lib/vutuv_web/templates/user/show.html.heex:291
 #: lib/vutuv_web/views/account_event_text.ex:213
@@ -16769,8 +16771,8 @@ msgstr "CC BY-SA 4.0 (Namensnennung, gleiche Bedingungen)"
 msgid "CC0 1.0 (no rights reserved)"
 msgstr "CC0 1.0 (keine Rechte vorbehalten)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1445
-#: lib/vutuv_web/agent_docs/text.ex:919
+#: lib/vutuv_web/agent_docs/markdown.ex:1449
+#: lib/vutuv_web/agent_docs/text.ex:920
 #: lib/vutuv_web/live/post_live/composer.ex:2661
 #, elixir-autogen, elixir-format
 msgid "Cover"
@@ -16781,8 +16783,8 @@ msgstr "Titelbild"
 msgid "Describe the photo for people who can't see it"
 msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1456
-#: lib/vutuv_web/agent_docs/text.ex:932
+#: lib/vutuv_web/agent_docs/markdown.ex:1460
+#: lib/vutuv_web/agent_docs/text.ex:933
 #: lib/vutuv_web/components/ui.ex:3249
 #, elixir-autogen, elixir-format
 msgid "Download the original"
@@ -16818,19 +16820,19 @@ msgstr "Nächstes Foto"
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
 
-#: lib/vutuv_web/components/post_components.ex:3829
+#: lib/vutuv_web/components/post_components.ex:3872
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Fediverse-Einstellungen öffnen"
 
-#: lib/vutuv_web/components/post_components.ex:5321
-#: lib/vutuv_web/components/press_kit_components.ex:344
+#: lib/vutuv_web/components/post_components.ex:5364
+#: lib/vutuv_web/components/press_kit_components.ex:399
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:5549
-#: lib/vutuv_web/components/press_kit_components.ex:414
+#: lib/vutuv_web/components/post_components.ex:5592
+#: lib/vutuv_web/components/press_kit_components.ex:469
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
@@ -16841,9 +16843,9 @@ msgstr "Foto wird geprüft"
 msgid "Photo options"
 msgstr "Foto-Einstellungen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1489
-#: lib/vutuv_web/agent_docs/text.ex:907
-#: lib/vutuv_web/components/post_components.ex:5631
+#: lib/vutuv_web/agent_docs/markdown.ex:1493
+#: lib/vutuv_web/agent_docs/text.ex:908
+#: lib/vutuv_web/components/post_components.ex:5674
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Fotos:"
@@ -16869,7 +16871,7 @@ msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qual
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:3882
+#: lib/vutuv_web/components/post_components.ex:3925
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
@@ -16889,7 +16891,7 @@ msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen S
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
 
-#: lib/vutuv_web/components/post_components.ex:3873
+#: lib/vutuv_web/components/post_components.ex:3916
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht öffentlich beantworten."
@@ -16899,12 +16901,12 @@ msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht �
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr "Diese Antwort wurde in einem anderen Netzwerk geschrieben. Sie zu beantworten heißt, Ihre Worte in dieses Netzwerk zu senden, und das tut vutuv nur für Mitglieder, die die Fediverse-Teilnahme eingeschaltet haben."
 
-#: lib/vutuv_web/components/post_components.ex:3891
+#: lib/vutuv_web/components/post_components.ex:3934
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Diese Seite nimmt nicht am Fediverse teil."
 
-#: lib/vutuv_web/components/post_components.ex:3825
+#: lib/vutuv_web/components/post_components.ex:3868
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Fediverse-Teilnahme einschalten, um zu antworten"
@@ -16919,7 +16921,7 @@ msgstr "Wer diese Fotos weiterverwenden darf"
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:3886
+#: lib/vutuv_web/components/post_components.ex:3929
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshalb werden von hier aus keine Antworten mehr gesendet."
@@ -16929,7 +16931,7 @@ msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshal
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
 
-#: lib/vutuv_web/components/post_components.ex:3839
+#: lib/vutuv_web/components/post_components.ex:3882
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fediverse-Follower. Auf vutuv ist sie ebenfalls ein öffentlicher Beitrag."
@@ -17003,14 +17005,14 @@ msgid_plural "Some of these photos carry the location they were taken at, and th
 msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exakte Datei gibt ihn weiter."
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1346
-#: lib/vutuv_web/components/post_components.ex:6942
+#: lib/vutuv_web/agent_docs/markdown.ex:1350
+#: lib/vutuv_web/components/post_components.ex:6985
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1344
-#: lib/vutuv_web/components/post_components.ex:6939
+#: lib/vutuv_web/agent_docs/markdown.ex:1348
+#: lib/vutuv_web/components/post_components.ex:6982
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17020,7 +17022,7 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:6826
+#: lib/vutuv_web/components/post_components.ex:6869
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
@@ -17370,7 +17372,7 @@ msgstr "Von hier aus wird %{follows} Konten in anderen Netzwerken gefolgt, davon
 msgid "Cached posts"
 msgstr "Zwischengespeicherte Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:3393
+#: lib/vutuv_web/components/post_components.ex:3436
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr "Nur für die Follower dieses Kontos"
@@ -17380,7 +17382,7 @@ msgstr "Nur für die Follower dieses Kontos"
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Danke. Unsere Kopie wurde sofort gelöscht."
 
-#: lib/vutuv_web/components/post_components.ex:3633
+#: lib/vutuv_web/components/post_components.ex:3676
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Beim Original abstimmen"
@@ -17400,12 +17402,12 @@ msgstr "Zwischengespeicherter Beitrag gemeldet, hier für alle entfernt"
 msgid "Content from other networks taken down by members"
 msgstr "Von Mitgliedern entfernte Inhalte aus anderen Netzwerken"
 
-#: lib/vutuv_web/components/post_components.ex:1869
+#: lib/vutuv_web/components/post_components.ex:1870
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Verbergen"
 
-#: lib/vutuv_web/components/post_components.ex:3574
+#: lib/vutuv_web/components/post_components.ex:3617
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Von der verfassenden Person als sensibel markiert"
@@ -17420,7 +17422,7 @@ msgstr "Stummgeschaltet. Sie folgen dem Konto weiterhin; die Beiträge verschwin
 msgid "Nobody has removed or reported anything yet."
 msgstr "Bisher hat niemand etwas entfernt oder gemeldet."
 
-#: lib/vutuv_web/components/post_components.ex:3366
+#: lib/vutuv_web/components/post_components.ex:3409
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr "Diesen Beitrag als unangemessen melden? Unsere Kopie wird sofort für alle auf diesem vutuv gelöscht."
@@ -17513,34 +17515,34 @@ msgstr "Ihr Kontoumzug"
 msgid "“LinkedIn is annoying. vutuv is not.”"
 msgstr "„LinkedIn nervt. vutuv nicht.“"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1146
+#: lib/vutuv_web/agent_docs/markdown.ex:1150
 #, elixir-autogen, elixir-format
 msgid "(a picture)"
 msgid_plural "(%{count} pictures)"
 msgstr[0] "(ein Bild)"
 msgstr[1] "(%{count} Bilder)"
 
-#: lib/vutuv_web/components/post_components.ex:3016
+#: lib/vutuv_web/components/post_components.ex:3026
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr "Bild wird geprüft"
 
-#: lib/vutuv_web/components/post_components.ex:2886
+#: lib/vutuv_web/components/post_components.ex:2887
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr "Wieder verdecken"
 
-#: lib/vutuv_web/components/post_components.ex:2881
+#: lib/vutuv_web/components/post_components.ex:2882
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr "Heikles Motiv. Bild anzeigen."
 
-#: lib/vutuv_web/components/post_components.ex:3732
+#: lib/vutuv_web/components/post_components.ex:3775
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Das sind viele Likes in einer Stunde. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:3738
+#: lib/vutuv_web/components/post_components.ex:3781
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Diesen Beitrag gibt es hier nicht mehr."
@@ -17550,7 +17552,7 @@ msgstr "Diesen Beitrag gibt es hier nicht mehr."
 msgid "Back to the feed"
 msgstr "Zurück zum Feed"
 
-#: lib/vutuv_web/components/post_components.ex:3877
+#: lib/vutuv_web/components/post_components.ex:3920
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17601,7 +17603,7 @@ msgstr ""
 "Dieser Link zeigt auf einen einzelnen Beitrag. Von hier aus können Sie dem "
 "Konto dahinter folgen: %{account}."
 
-#: lib/vutuv_web/views/user_html.ex:249
+#: lib/vutuv_web/views/user_html.ex:242
 #, elixir-autogen, elixir-format
 msgid "Your feed shows the posts of members you follow. Follow a few to fill it."
 msgstr ""
@@ -17670,8 +17672,8 @@ msgstr "Profil verifizieren"
 msgid "We could not reach the network just now. Please try again in a moment."
 msgstr "Wir konnten das Netzwerk gerade nicht erreichen. Bitte versuchen Sie es gleich noch einmal."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1073
-#: lib/vutuv_web/agent_docs/text.ex:712
+#: lib/vutuv_web/agent_docs/markdown.ex:1077
+#: lib/vutuv_web/agent_docs/text.ex:713
 #, elixir-autogen, elixir-format
 msgid "verified profile"
 msgstr "verifiziertes Profil"
@@ -18176,14 +18178,14 @@ msgstr "Seiten, von denen nie ein Screenshot entsteht, weil ein Browser ohne Anz
 msgid "Screenshot blocklist"
 msgstr "Screenshot-Blockliste"
 
-#: lib/vutuv_web/components/post_components.ex:475
+#: lib/vutuv_web/components/post_components.ex:476
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 "Noch nichts aus dem Fediverse. Folgen Sie Konten dort draußen, um diesen Tab "
 "zu füllen."
 
-#: lib/vutuv_web/components/post_components.ex:472
+#: lib/vutuv_web/components/post_components.ex:473
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
@@ -18227,7 +18229,7 @@ msgstr "Auf vutuv gibt es zu diesem Tag noch keine Beiträge."
 msgid "word in a post"
 msgstr "Wort in einem Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:3735
+#: lib/vutuv_web/components/post_components.ex:3778
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Diese Antwort gibt es hier nicht mehr."
@@ -18294,24 +18296,24 @@ msgstr "Höchstens %{max} Tags. Entfernen Sie eines, um ein anderes hinzuzufüge
 msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr "Auf der Seite eines Beitrags stehen direkt unter der Zahl die Mitglieder, denen er gefällt. Hier legen Sie fest, ob Sie zu diesen Gesichtern gehören."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1314
+#: lib/vutuv_web/agent_docs/markdown.ex:1318
 #, elixir-autogen, elixir-format
 msgid "Liked by"
 msgstr "Gefällt diesen Mitgliedern"
 
-#: lib/vutuv_web/components/post_components.ex:5925
+#: lib/vutuv_web/components/post_components.ex:5968
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Gefällt %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:5927
+#: lib/vutuv_web/components/post_components.ex:5970
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Gefällt %{name} und %{formatted} weiteren"
 msgstr[1] "Gefällt %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/components/post_components.ex:5938
+#: lib/vutuv_web/components/post_components.ex:5981
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr "Nur Sie sehen hier alle: Einige dieser Mitglieder werden anderen Lesern nicht genannt."
@@ -18336,12 +18338,12 @@ msgstr "Wenn aus, sehen andere Mitglieder Sie nicht mehr bei den Likes eines Bei
 msgid "Your likes follow the site default again."
 msgstr "Ihre Likes folgen wieder dem Standardwert der Website."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1369
+#: lib/vutuv_web/agent_docs/markdown.ex:1373
 #, elixir-autogen, elixir-format
 msgid "%{address} (this page only)"
 msgstr "%{address} (nur diese Seite)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1366
+#: lib/vutuv_web/agent_docs/markdown.ex:1370
 #, elixir-autogen, elixir-format
 msgid "%{address} (whole website)"
 msgstr "%{address} (ganze Website)"
@@ -18351,7 +18353,7 @@ msgstr "%{address} (ganze Website)"
 msgid "Verified webpage of the author (%{address})"
 msgstr "Verifizierte Webseite der Autorin oder des Autors (%{address})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1358
+#: lib/vutuv_web/agent_docs/markdown.ex:1362
 #, elixir-autogen, elixir-format
 msgid "Verified webpages of the author linked here: %{addresses}"
 msgstr ""
@@ -18485,7 +18487,7 @@ msgstr "Ausstellungsdatum"
 msgid "Label"
 msgstr "Bezeichnung"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3606
+#: lib/vutuv_web/live/post_live/feed.ex:3617
 #: lib/vutuv_web/live/reference_check_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -18686,7 +18688,7 @@ msgstr "Weder den Prompt noch das Modell haben wir geschrieben."
 msgid "Employment references of %{name}"
 msgstr "Arbeitszeugnisse von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:947
+#: lib/vutuv_web/agent_docs/markdown.ex:951
 #, elixir-autogen, elixir-format
 msgid "document"
 msgstr "Dokument"
@@ -18902,7 +18904,7 @@ msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr "PDF, JPG, PNG oder WebP, bis %{limit}"
 
 #: lib/vutuv_web/components/ui.ex:4582
-#: lib/vutuv_web/live/press_kit_live.ex:281
+#: lib/vutuv_web/live/press_kit_live.ex:382
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "That file is larger than %{limit}. Please upload a smaller one."
@@ -19908,17 +19910,17 @@ msgstr "Suchen Sie so oft Sie möchten und nehmen Sie dazu, was gehört. Abkürz
 msgid "Start over"
 msgstr "Von vorn beginnen"
 
-#: lib/vutuv_web/components/post_components.ex:3765
+#: lib/vutuv_web/components/post_components.ex:3808
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr "Ein Herz oder ein Repost geht zurück in das Netzwerk, aus dem dieser Beitrag stammt. Ihr Konto nimmt derzeit nicht am Fediverse teil. Einschalten können Sie das in den {settings}."
 
-#: lib/vutuv_web/components/organization_components.ex:319
+#: lib/vutuv_web/components/organization_components.ex:328
 #, elixir-autogen, elixir-format
 msgid "Editorial"
 msgstr "Redaktion"
 
-#: lib/vutuv_web/components/organization_components.ex:325
+#: lib/vutuv_web/components/organization_components.ex:334
 #, elixir-autogen, elixir-format
 msgid "Edits the page and posts jobs."
 msgstr "Bearbeitet die Seite und schreibt Stellen aus."
@@ -19928,7 +19930,7 @@ msgstr "Bearbeitet die Seite und schreibt Stellen aus."
 msgid "Give members their roles on this page. Someone can hold several at once, and every role is granted on its own."
 msgstr "Geben Sie Mitgliedern ihre Rollen auf dieser Seite. Jemand kann mehrere gleichzeitig haben, und jede Rolle wird einzeln vergeben."
 
-#: lib/vutuv_web/components/organization_components.ex:324
+#: lib/vutuv_web/components/organization_components.ex:333
 #, elixir-autogen, elixir-format
 msgid "Manages the team and the domains, and edits the page."
 msgstr "Verwaltet Team und Domains und bearbeitet die Seite."
@@ -19938,7 +19940,7 @@ msgstr "Verwaltet Team und Domains und bearbeitet die Seite."
 msgid "Pick at least one role."
 msgstr "Wählen Sie mindestens eine Rolle."
 
-#: lib/vutuv_web/components/organization_components.ex:327
+#: lib/vutuv_web/components/organization_components.ex:336
 #, elixir-autogen, elixir-format
 msgid "Posts jobs."
 msgstr "Schreibt Stellen aus."
@@ -19953,7 +19955,7 @@ msgstr "Rollen"
 msgid "Roles updated."
 msgstr "Rollen aktualisiert."
 
-#: lib/vutuv_web/components/organization_components.ex:326
+#: lib/vutuv_web/components/organization_components.ex:335
 #, elixir-autogen, elixir-format
 msgid "Writes posts in the organization's name."
 msgstr "Schreibt Beiträge im Namen der Organisation."
@@ -19963,7 +19965,7 @@ msgstr "Schreibt Beiträge im Namen der Organisation."
 msgid "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
 msgstr "Der Besitzer vergibt die Rollen der anderen Mitglieder auf der Seite und kann den Besitz jederzeit an jemand anderen übergeben. Jemand kann mehrere Rollen haben, und das Schreiben im Namen der Organisation wird immer einzeln vergeben."
 
-#: lib/vutuv_web/live/organization_live/show.ex:782
+#: lib/vutuv_web/live/organization_live/show.ex:805
 #, elixir-autogen, elixir-format
 msgid "Nothing published yet."
 msgstr "Noch nichts veröffentlicht."
@@ -19998,7 +20000,7 @@ msgstr "Begonnen, im Namen einer Organisation zu schreiben"
 msgid "Stopped writing as an organization"
 msgstr "Beendet, im Namen einer Organisation zu schreiben"
 
-#: lib/vutuv_web/live/organization_live/show.ex:746
+#: lib/vutuv_web/live/organization_live/show.ex:769
 #, elixir-autogen, elixir-format
 msgid "Write as %{name} for now"
 msgstr "Vorerst als %{name} schreiben"
@@ -20220,12 +20222,12 @@ msgstr "Andere Netzwerke sprechen diese Seite als @name@%{host} an, so wie sie e
 
 #: lib/vutuv_web/live/organization_live/fediverse.ex:92
 #: lib/vutuv_web/live/organization_live/new.ex:211
-#: lib/vutuv_web/live/organization_live/show.ex:897
+#: lib/vutuv_web/live/organization_live/show.ex:934
 #, elixir-autogen, elixir-format
 msgid "People who have no vutuv account can follow this page and read its posts, in networks like Mastodon."
 msgstr "Auch Menschen ohne vutuv-Konto können dieser Seite folgen und ihre Beiträge lesen, in Netzwerken wie Mastodon."
 
-#: lib/vutuv_web/live/organization_live/show.ex:911
+#: lib/vutuv_web/live/organization_live/show.ex:948
 #, elixir-autogen, elixir-format
 msgid "Set this page up for other networks"
 msgstr "Seite für andere Netzwerke einrichten"
@@ -20240,7 +20242,7 @@ msgstr "Ausschalten"
 msgid "Switch it on"
 msgstr "Einschalten"
 
-#: lib/vutuv_web/live/organization_live/show.ex:902
+#: lib/vutuv_web/live/organization_live/show.ex:939
 #, elixir-autogen, elixir-format
 msgid "The page gets an address of its own for that, written like an email address."
 msgstr "Die Seite bekommt dafür eine eigene Adresse, die wie eine E-Mail-Adresse aussieht."
@@ -20485,13 +20487,13 @@ msgstr "Nur wenn Sie hier klicken: Wir fragen bei gravatar.com nach, ob es zu Ih
 msgid "The gravatar.com lookup is switched off on this installation."
 msgstr "Die Abfrage bei gravatar.com ist auf dieser Installation abgeschaltet."
 
-#: lib/vutuv_web/components/organization_components.ex:35
+#: lib/vutuv_web/components/organization_components.ex:36
 #, elixir-autogen, elixir-format
 msgid "A new entry can take a while to reach everyone. We keep checking %{domain} by ourselves and send you an email as soon as it works, so you can close this page."
 msgstr "Ein neuer Eintrag braucht manchmal eine Weile, bis er überall ankommt. Wir prüfen %{domain} von selbst weiter und schicken Ihnen eine E-Mail, sobald es klappt. Sie können diese Seite also schließen."
 
 #: lib/vutuv_web/live/organization_live/domains.ex:351
-#: lib/vutuv_web/live/organization_live/show.ex:1100
+#: lib/vutuv_web/live/organization_live/show.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Checking …"
 msgstr "Wird geprüft …"
@@ -20795,27 +20797,27 @@ msgstr "Sprache"
 msgid "The language this post is written in"
 msgstr "Die Sprache, in der dieser Beitrag geschrieben ist"
 
-#: lib/vutuv_web/components/post_components.ex:5819
+#: lib/vutuv_web/components/post_components.ex:5862
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Original anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:5855
+#: lib/vutuv_web/components/post_components.ex:5898
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Übersetzen"
 
-#: lib/vutuv_web/components/post_components.ex:5864
+#: lib/vutuv_web/components/post_components.ex:5907
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Übersetzt"
 
-#: lib/vutuv_web/components/post_components.ex:5867
+#: lib/vutuv_web/components/post_components.ex:5910
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Übersetzt aus %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:5844
+#: lib/vutuv_web/components/post_components.ex:5887
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Wird übersetzt …"
@@ -20825,7 +20827,7 @@ msgstr "Wird übersetzt …"
 msgid "Feed language settings reset to the site defaults."
 msgstr "Feed-Spracheinstellungen auf die Website-Vorgaben zurückgesetzt."
 
-#: lib/vutuv_web/components/post_components.ex:5834
+#: lib/vutuv_web/components/post_components.ex:5877
 #: lib/vutuv_web/components/ui.ex:5371
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -20954,20 +20956,20 @@ msgstr "Wir haben den Link in Ihrem Profil noch nicht gefunden. Bitte versuchen 
 msgid "Your username, or paste the address of your profile page."
 msgstr "Ihr Benutzername – oder fügen Sie die Adresse Ihrer Profilseite ein."
 
-#: lib/vutuv_web/components/post_components.ex:5597
+#: lib/vutuv_web/components/post_components.ex:5640
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] "Unsere KI prüft es gerade. Sobald die Prüfung durch ist, erscheint das Foto von selbst."
 msgstr[1] "Unsere KI prüft sie gerade, %{done} von %{total} sind durch. Sobald die letzte durch ist, erscheinen die Fotos von selbst."
 
-#: lib/vutuv_web/components/post_components.ex:5594
+#: lib/vutuv_web/components/post_components.ex:5637
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Ihr Beitrag ist veröffentlicht, das Foto noch nicht."
 
-#: lib/vutuv_web/components/post_components.ex:2907
-#: lib/vutuv_web/components/post_components.ex:4663
+#: lib/vutuv_web/components/post_components.ex:2908
+#: lib/vutuv_web/components/post_components.ex:4706
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -20986,12 +20988,12 @@ msgstr "Empfohlen: quadratisch, mindestens %{width} × %{height} Pixel."
 
 #: lib/vutuv_web/live/job_board_live.ex:431
 #: lib/vutuv_web/live/post_live/feed.ex:964
-#: lib/vutuv_web/views/user_html.ex:372
+#: lib/vutuv_web/views/user_html.ex:365
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
 msgstr "Profilbild von %{name}"
 
-#: lib/vutuv_web/views/user_html.ex:375
+#: lib/vutuv_web/views/user_html.ex:368
 #, elixir-autogen, elixir-format
 msgid "Show the profile picture larger"
 msgstr "Profilbild größer anzeigen"
@@ -21108,7 +21110,7 @@ msgstr "Andere Datei auswerten"
 msgid "Find my contacts"
 msgstr "Kontakte finden"
 
-#: lib/vutuv_web/views/user_html.ex:271
+#: lib/vutuv_web/views/user_html.ex:264
 #, elixir-autogen, elixir-format
 msgid "Find people you know from LinkedIn"
 msgstr "Bekannte aus LinkedIn finden"
@@ -21480,7 +21482,7 @@ msgstr "Land suchen"
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr "Diese Seite folgt bereits so vielen Konten, wie hier erlaubt sind (%{max})."
 
-#: lib/vutuv_web/components/post_components.ex:3346
+#: lib/vutuv_web/components/post_components.ex:3389
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr "%{handle} nicht mehr folgen? Die Beiträge verschwinden aus Ihrem Feed."
@@ -21606,7 +21608,7 @@ msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public po
 msgstr ""
 "Folgen Sie #%{tag} von Mastodon oder einer anderen Fediverse-App aus, dann landen die öffentlichen Beiträge in Ihrer Timeline. Ein vutuv-Konto brauchen Sie dafür nicht."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3771
+#: lib/vutuv_web/live/post_live/feed.ex:3782
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Andere Mitglieder begrüßen"
@@ -22104,13 +22106,13 @@ msgid "Hide a word or a whole phrase …"
 msgstr "Wort oder ganzen Satz ausblenden …"
 
 #: lib/vutuv_web/live/post_live/feed.ex:709
-#: lib/vutuv_web/live/post_live/feed.ex:3934
+#: lib/vutuv_web/live/post_live/feed.ex:3945
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Tags ausblenden"
 
 #: lib/vutuv_web/live/post_live/feed.ex:708
-#: lib/vutuv_web/live/post_live/feed.ex:3923
+#: lib/vutuv_web/live/post_live/feed.ex:3934
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Wörter ausblenden"
@@ -22177,7 +22179,7 @@ msgstr "Beiträge mit einem dieser Tags werden genauso zugeklappt."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Beiträge mit einem dieser Wörter werden auf eine Zeile zugeklappt — nicht gelöscht, und mit einem Weg, sie doch zu lesen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3797
+#: lib/vutuv_web/live/post_live/feed.ex:3808
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Weggelegt:"
@@ -22216,7 +22218,7 @@ msgid "Show posts by %{name}"
 msgstr "Beiträge von %{name} anzeigen"
 
 #: lib/vutuv_web/live/post_live/feed.ex:707
-#: lib/vutuv_web/live/post_live/feed.ex:3889
+#: lib/vutuv_web/live/post_live/feed.ex:3900
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr "Quellen"
@@ -22255,8 +22257,8 @@ msgid_plural "and %{formatted} more"
 msgstr[0] "und 1 weiterer"
 msgstr[1] "und %{formatted} weitere"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3371
-#: lib/vutuv_web/live/post_live/feed.ex:3398
+#: lib/vutuv_web/live/post_live/feed.ex:3382
+#: lib/vutuv_web/live/post_live/feed.ex:3409
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -22288,7 +22290,7 @@ msgstr ""
 "erscheint, sobald die Prüfung durch ist."
 
 #: lib/vutuv_web/live/organization_live/edit.ex:290
-#: lib/vutuv_web/live/press_kit_live.ex:741
+#: lib/vutuv_web/live/press_kit_live.ex:882
 #, elixir-autogen, elixir-format
 msgid "%{formats}, up to %{limit}"
 msgstr "%{formats}, bis %{limit}"
@@ -22321,7 +22323,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} Beitrag am %{day}"
 msgstr[1] "%{count} Beiträge am %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3563
+#: lib/vutuv_web/live/post_live/feed.ex:3574
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Zurück zu jetzt"
@@ -22331,7 +22333,7 @@ msgstr "Zurück zu jetzt"
 msgid "Busy month: the shading counts at least this much."
 msgstr "Voller Monat: die Färbung zählt mindestens so viel."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3609
+#: lib/vutuv_web/live/post_live/feed.ex:3620
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -22353,7 +22355,7 @@ msgstr "Nächster Monat"
 msgid "Next year"
 msgstr "Nächstes Jahr"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3559
+#: lib/vutuv_web/live/post_live/feed.ex:3570
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Am %{day} ist nichts in Ihrem Feed angekommen."
@@ -22380,7 +22382,7 @@ msgctxt "heatmap scale"
 msgid "More"
 msgstr "Mehr"
 
-#: lib/vutuv_web/live/organization_live/show.ex:549
+#: lib/vutuv_web/live/organization_live/show.ex:572
 #, elixir-autogen, elixir-format
 msgid "The website of %{name}"
 msgstr "Die Website von %{name}"
@@ -22435,29 +22437,29 @@ msgstr "Mit dem Gerät scannen, auf dem die App läuft"
 msgid "A new version is ready."
 msgstr "Neue Version bereit."
 
-#: lib/vutuv_web/live/organization_live/show.ex:684
+#: lib/vutuv_web/live/organization_live/show.ex:707
 #, elixir-autogen, elixir-format
 msgid "Page management"
 msgstr "Verwaltung"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2448
+#: lib/vutuv_web/live/post_live/feed.ex:2459
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
 msgstr[0] "Neu:"
 msgstr[1] "Neu (%{formatted}):"
 
-#: lib/vutuv_web/components/post_components.ex:3501
+#: lib/vutuv_web/components/post_components.ex:3544
 #, elixir-autogen, elixir-format
 msgid "Quoted post"
 msgstr "Zitierter Beitrag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1162
+#: lib/vutuv_web/agent_docs/markdown.ex:1166
 #, elixir-autogen, elixir-format
 msgid "Quotes %{name}: %{url}"
 msgstr "Zitiert %{name}: %{url}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1159
+#: lib/vutuv_web/agent_docs/markdown.ex:1163
 #, elixir-autogen, elixir-format
 msgid "Quotes %{url}"
 msgstr "Zitiert %{url}"
@@ -22472,7 +22474,7 @@ msgstr "Ein Konto erwähnen"
 msgid "{used} of {max} mentions"
 msgstr "{used} von {max} Erwähnungen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2560
+#: lib/vutuv_web/live/post_live/feed.ex:2571
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr "Bis hier neu"
@@ -22503,7 +22505,7 @@ msgstr "Nur diese Accounts (leer = alle) …"
 msgid "only %{account}"
 msgstr "nur %{account}"
 
-#: lib/vutuv_web/components/post_components.ex:7285
+#: lib/vutuv_web/components/post_components.ex:7330
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -22687,7 +22689,7 @@ msgctxt "phone tab bar"
 msgid "Write"
 msgstr "Schreiben"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3697
+#: lib/vutuv_web/live/post_live/feed.ex:3708
 #: lib/vutuv_web/live/post_rewrites_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "%{formatted} rule"
@@ -22755,9 +22757,9 @@ msgstr "Regeln für %{account}"
 msgid "Rules that rewrite the text of one account's posts before you read them: a footer under every post, a signature, a wall of hashtags. Only you see the difference. Open the ⋯ menu on any post to write rules for its author."
 msgstr "Regeln, die den Text der Beiträge eines Kontos umschreiben, bevor Sie ihn lesen: eine Fußzeile unter jedem Beitrag, eine Signatur, eine Wand aus Hashtags. Nur Sie sehen den Unterschied. Öffnen Sie das ⋯-Menü an einem Beitrag, um Regeln für dessen Autor zu schreiben."
 
-#: lib/vutuv_web/components/post_components.ex:1451
-#: lib/vutuv_web/components/post_components.ex:3359
-#: lib/vutuv_web/components/post_components.ex:4453
+#: lib/vutuv_web/components/post_components.ex:1452
+#: lib/vutuv_web/components/post_components.ex:3402
+#: lib/vutuv_web/components/post_components.ex:4496
 #: lib/vutuv_web/components/ui.ex:5363
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
@@ -22943,11 +22945,11 @@ msgstr "Dieser Beitrag wartet noch auf Sie"
 msgid "This video could not be converted."
 msgstr "Dieses Video konnte nicht umgewandelt werden."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1441
-#: lib/vutuv_web/agent_docs/markdown.ex:1444
-#: lib/vutuv_web/agent_docs/text.ex:916
+#: lib/vutuv_web/agent_docs/markdown.ex:1445
+#: lib/vutuv_web/agent_docs/markdown.ex:1448
 #: lib/vutuv_web/agent_docs/text.ex:917
-#: lib/vutuv_web/components/post_components.ex:2967
+#: lib/vutuv_web/agent_docs/text.ex:918
+#: lib/vutuv_web/components/post_components.ex:2977
 #: lib/vutuv_web/components/video_components.ex:127
 #: lib/vutuv_web/live/post_live/composer.ex:2458
 #, elixir-autogen, elixir-format
@@ -23010,7 +23012,7 @@ msgstr[1] "%{formatted} neue Follower"
 msgid "Last 30 days: %{parts}"
 msgstr "Letzte 30 Tage: %{parts}"
 
-#: lib/vutuv_web/components/post_components.ex:5015
+#: lib/vutuv_web/components/post_components.ex:5058
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Less"
@@ -23071,22 +23073,22 @@ msgstr "Mitglieder mit diesen Tags:"
 msgid "The fields the most members carry, and how many of them do."
 msgstr "Die Fachgebiete mit den meisten Mitgliedern, und wie viele es jeweils sind."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1212
-#: lib/vutuv_web/agent_docs/text.ex:840
+#: lib/vutuv_web/agent_docs/markdown.ex:1216
+#: lib/vutuv_web/agent_docs/text.ex:841
 #: lib/vutuv_web/live/job_board_live.ex:474
 #, elixir-autogen, elixir-format
 msgid "What members here work on"
 msgstr "Woran die Mitglieder hier arbeiten"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1204
-#: lib/vutuv_web/agent_docs/text.ex:832
+#: lib/vutuv_web/agent_docs/markdown.ex:1208
+#: lib/vutuv_web/agent_docs/text.ex:833
 #: lib/vutuv_web/live/job_board_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "Who you would reach"
 msgstr "Wen Sie hier erreichen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1205
-#: lib/vutuv_web/agent_docs/text.ex:833
+#: lib/vutuv_web/agent_docs/markdown.ex:1209
+#: lib/vutuv_web/agent_docs/text.ex:834
 #: lib/vutuv_web/live/job_board_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "One random vutuv account that is open to offers."
@@ -23194,8 +23196,8 @@ msgstr "In diesen %{days} Tagen sind %{total} Menschen dazugekommen, davon %{mem
 msgid "People here per day over the last %{days} days"
 msgstr "Menschen hier pro Tag über die letzten %{days} Tage"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:445
-#: lib/vutuv_web/agent_docs/text.ex:400
+#: lib/vutuv_web/agent_docs/markdown.ex:449
+#: lib/vutuv_web/agent_docs/text.ex:401
 #, elixir-autogen, elixir-format
 msgid "Press material: %{url}"
 msgstr "Pressematerial: %{url}"
@@ -23210,28 +23212,28 @@ msgstr "Ohne Konto lesbar"
 msgid "Send a message"
 msgstr "Nachricht schreiben"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:428
-#: lib/vutuv_web/agent_docs/text.ex:387
+#: lib/vutuv_web/agent_docs/markdown.ex:432
+#: lib/vutuv_web/agent_docs/text.ex:388
 #: lib/vutuv_web/templates/company/investors.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "Where we are"
 msgstr "Wo wir stehen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:435
-#: lib/vutuv_web/agent_docs/text.ex:394
+#: lib/vutuv_web/agent_docs/markdown.ex:439
+#: lib/vutuv_web/agent_docs/text.ex:395
 #: lib/vutuv_web/templates/company/investors.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Why this is worth building"
 msgstr "Warum sich das lohnt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:444
-#: lib/vutuv_web/agent_docs/text.ex:399
+#: lib/vutuv_web/agent_docs/markdown.ex:448
+#: lib/vutuv_web/agent_docs/text.ex:400
 #, elixir-autogen, elixir-format
 msgid "Write here: %{url}"
 msgstr "Schreiben Sie hier: %{url}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:441
-#: lib/vutuv_web/agent_docs/text.ex:396
+#: lib/vutuv_web/agent_docs/markdown.ex:445
+#: lib/vutuv_web/agent_docs/text.ex:397
 #: lib/vutuv_web/templates/company/investors.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Write to me"
@@ -23247,8 +23249,8 @@ msgstr "Schreiben Sie mir hier, auf vutuv. Ein Konto anzulegen dauert eine Minut
 msgid "My profile:"
 msgstr "Mein Profil:"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:443
-#: lib/vutuv_web/agent_docs/text.ex:398
+#: lib/vutuv_web/agent_docs/markdown.ex:447
+#: lib/vutuv_web/agent_docs/text.ex:399
 #, elixir-autogen, elixir-format
 msgid "My profile: %{url}"
 msgstr "Mein Profil: %{url}"
@@ -23268,8 +23270,8 @@ msgstr "Schnelle Seiten gewinnen"
 msgid "Source:"
 msgstr "Quelle:"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:512
-#: lib/vutuv_web/agent_docs/text.ex:469
+#: lib/vutuv_web/agent_docs/markdown.ex:516
+#: lib/vutuv_web/agent_docs/text.ex:470
 #, elixir-autogen, elixir-format
 msgid "Source: %{source}"
 msgstr "Quelle: %{source}"
@@ -23324,8 +23326,8 @@ msgstr "Konten, die Sie stummgeschaltet haben, und deren Reposts Sie ausblenden"
 msgid "Hidden. What they pass on stays out of your feed; their own posts do not."
 msgstr "Ausgeblendet. Was dieses Konto weiterreicht, erscheint nicht mehr in Ihrem Feed, die eigenen Beiträge schon."
 
-#: lib/vutuv_web/components/post_components.ex:3331
-#: lib/vutuv_web/components/post_components.ex:4447
+#: lib/vutuv_web/components/post_components.ex:3374
+#: lib/vutuv_web/components/post_components.ex:4490
 #, elixir-autogen, elixir-format
 msgid "Hide reposts"
 msgstr "Reposts ausblenden"
@@ -23506,8 +23508,8 @@ msgstr "Beiträge in Ihrem Feed"
 msgid "Posts loaded at once"
 msgstr "Beiträge auf einmal"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3633
-#: lib/vutuv_web/live/post_live/feed.ex:3637
+#: lib/vutuv_web/live/post_live/feed.ex:3644
+#: lib/vutuv_web/live/post_live/feed.ex:3648
 #, elixir-autogen, elixir-format
 msgid "Posts per page"
 msgstr "Beiträge pro Seite"
@@ -23522,60 +23524,60 @@ msgstr "Sie können das auch direkt im Feed ändern, gleich unter „Mehr laden�
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr "feed länge seitengröße beiträge anzahl menge mehr laden scrollen blättern seite umfang page size posts number load more"
 
-#: lib/vutuv_web/components/post_components.ex:7276
-#: lib/vutuv_web/components/post_components.ex:7277
+#: lib/vutuv_web/components/post_components.ex:7321
+#: lib/vutuv_web/components/post_components.ex:7322
 #, elixir-autogen, elixir-format
 msgid "A word or phrase …"
 msgstr "Ein Wort oder eine Wortgruppe …"
 
-#: lib/vutuv_web/components/post_components.ex:7304
+#: lib/vutuv_web/components/post_components.ex:7349
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr "Für wen %{thing} ausgeblendet wird"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3694
-#: lib/vutuv_web/live/post_live/feed.ex:3853
-#: lib/vutuv_web/live/post_live/feed.ex:3862
+#: lib/vutuv_web/live/post_live/feed.ex:3705
+#: lib/vutuv_web/live/post_live/feed.ex:3864
+#: lib/vutuv_web/live/post_live/feed.ex:3873
 #, elixir-autogen, elixir-format
 msgid "Hidden"
 msgstr "Ausgeblendet"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3827
+#: lib/vutuv_web/live/post_live/feed.ex:3838
 #, elixir-autogen, elixir-format
 msgid "Hide something from your feed"
 msgstr "Etwas aus dem Feed ausblenden"
 
-#: lib/vutuv_web/components/post_components.ex:7224
+#: lib/vutuv_web/components/post_components.ex:7267
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr "Nicht mehr zeigen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3868
+#: lib/vutuv_web/live/post_live/feed.ex:3879
 #, elixir-autogen, elixir-format
 msgid "Whatever these match is folded to a single line in your feed."
 msgstr "Was hiervon getroffen wird, klappt im Feed auf eine Zeile zu."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3888
+#: lib/vutuv_web/live/post_live/feed.ex:3899
 #, elixir-autogen, elixir-format
 msgid "Words & tags"
 msgstr "Wörter & Tags"
 
-#: lib/vutuv_web/components/post_components.ex:7308
+#: lib/vutuv_web/components/post_components.ex:7353
 #, elixir-autogen, elixir-format
 msgid "everyone"
 msgstr "bei allen"
 
-#: lib/vutuv_web/components/post_components.ex:7311
+#: lib/vutuv_web/components/post_components.ex:7356
 #, elixir-autogen, elixir-format
 msgid "only %{handle}"
 msgstr "nur %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:7280
+#: lib/vutuv_web/components/post_components.ex:7325
 #, elixir-autogen, elixir-format
 msgid "this word"
 msgstr "dieses Wort"
 
-#: lib/vutuv_web/components/post_components.ex:7321
+#: lib/vutuv_web/components/post_components.ex:7366
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr "nur %{server}"
@@ -23627,7 +23629,7 @@ msgstr "Diese Website ist gerade offline."
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr "Die Website läuft, nur diese Adresse gibt es hier nicht. Wahrscheinlich ist der Link alt oder enthält einen Tippfehler."
 
-#: lib/vutuv_web/components/post_components.ex:6628
+#: lib/vutuv_web/components/post_components.ex:6671
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr "Screenshot vergrößern"
@@ -23717,8 +23719,8 @@ msgstr "Ihr Inhalt wurde nach einer Meldung automatisch verborgen. Auf der Falls
 msgid "Hidden. What other people pass on of them stays out of your feed; their own posts do not."
 msgstr "Ausgeblendet. Was andere von diesem Konto weiterreichen, erscheint nicht mehr in Ihrem Feed, die eigenen Beiträge schon."
 
-#: lib/vutuv_web/components/post_components.ex:3317
-#: lib/vutuv_web/components/post_components.ex:4435
+#: lib/vutuv_web/components/post_components.ex:3360
+#: lib/vutuv_web/components/post_components.ex:4478
 #, elixir-autogen, elixir-format
 msgid "Hide when others repost them"
 msgstr "Ausblenden, wenn andere reposten"
@@ -23976,7 +23978,7 @@ msgstr "Ihr Titelbild wurde nicht ersetzt: Eine Meldung dazu ist noch offen. Öf
 msgid "Your profile picture was not replaced: a report about it is still open. Open the case to remove the picture or to say that it is yours."
 msgstr "Ihr Profilbild wurde nicht ersetzt: Eine Meldung dazu ist noch offen. Öffnen Sie den Fall, um das Bild zu entfernen oder zu sagen, dass es Ihres ist."
 
-#: lib/vutuv_web/components/post_components.ex:2478
+#: lib/vutuv_web/components/post_components.ex:2479
 #, elixir-autogen, elixir-format
 msgid "Fetching the answers from the servers that hold them…"
 msgstr "Die Antworten werden von den Servern geholt, auf denen sie liegen …"
@@ -23991,13 +23993,13 @@ msgstr "Nicht jede Antwort ließ sich holen. Der Rest steht auf dem Ursprungsser
 msgid "Nothing here we are allowed to show you."
 msgstr "Hier ist nichts, was wir Ihnen zeigen dürfen."
 
-#: lib/vutuv_web/components/post_components.ex:2497
+#: lib/vutuv_web/components/post_components.ex:2498
 #, elixir-autogen, elixir-format
 msgid "Show more answers"
 msgstr "Weitere Antworten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2386
-#: lib/vutuv_web/components/post_components.ex:2388
+#: lib/vutuv_web/components/post_components.ex:2387
+#: lib/vutuv_web/components/post_components.ex:2389
 #, elixir-autogen, elixir-format
 msgid "Show the one answer"
 msgid_plural "Show the %{count} answers"
@@ -24481,13 +24483,13 @@ msgstr "das Meldeformular"
 msgid "“%{note}”"
 msgstr "„%{note}“"
 
-#: lib/vutuv_web/components/post_components.ex:5193
-#: lib/vutuv_web/components/press_kit_components.ex:152
+#: lib/vutuv_web/components/post_components.ex:5236
+#: lib/vutuv_web/components/press_kit_components.ex:207
 #, elixir-autogen, elixir-format
 msgid "Show these photos larger"
 msgstr "Fotos vergrößern"
 
-#: lib/vutuv_web/components/post_components.ex:5379
+#: lib/vutuv_web/components/post_components.ex:5422
 #, elixir-autogen, elixir-format
 msgid "Show this photo larger"
 msgstr "Foto vergrößern"
@@ -24506,48 +24508,48 @@ msgid_plural "%{formatted} more entries (%{years})"
 msgstr[0] "Ein weiterer Eintrag (%{years})"
 msgstr[1] "%{formatted} weitere Einträge (%{years})"
 
-#: lib/vutuv_web/live/press_kit_live.ex:778
+#: lib/vutuv_web/live/press_kit_live.ex:941
 #, elixir-autogen, elixir-format
 msgid "%{percent}%"
 msgstr "%{percent} %"
 
-#: lib/vutuv_web/live/press_kit_live.ex:391
+#: lib/vutuv_web/live/press_kit_live.ex:536
 #, elixir-autogen, elixir-format
 msgid "%{used} of %{max}"
 msgstr "%{used} von %{max}"
 
-#: lib/vutuv_web/live/press_kit_live.ex:650
+#: lib/vutuv_web/live/press_kit_live.ex:790
 #, elixir-autogen, elixir-format
 msgid "A photographer's @handle links to their profile and notifies nobody."
 msgstr "Ein @handle verlinkt auf das Profil des Fotografen und benachrichtigt niemanden."
 
-#: lib/vutuv_web/live/press_kit_live.ex:734
+#: lib/vutuv_web/live/press_kit_live.ex:875
 #, elixir-autogen, elixir-format
 msgid "Add a logo variant"
 msgstr "Logo-Variante hinzufügen"
 
-#: lib/vutuv_web/live/press_kit_live.ex:735
+#: lib/vutuv_web/live/press_kit_live.ex:876
 #, elixir-autogen, elixir-format
 msgid "Add a press photo"
 msgstr "Pressefoto hinzufügen"
 
-#: lib/vutuv_web/live/press_kit_live.ex:612
+#: lib/vutuv_web/live/press_kit_live.ex:752
 #, elixir-autogen, elixir-format
 msgid "At the desk in the Bonn office"
 msgstr "Am Schreibtisch im Bonner Büro"
 
-#: lib/vutuv_web/live/press_kit_live.ex:644
+#: lib/vutuv_web/live/press_kit_live.ex:784
 #, elixir-autogen, elixir-format
 msgid "Caption"
 msgstr "Bildunterschrift"
 
-#: lib/vutuv_web/live/press_kit_live.ex:622
-#: lib/vutuv_web/live/press_kit_live.ex:686
+#: lib/vutuv_web/live/press_kit_live.ex:762
+#: lib/vutuv_web/live/press_kit_live.ex:827
 #, elixir-autogen, elixir-format
 msgid "Credit"
 msgstr "Bildnachweis"
 
-#: lib/vutuv_web/live/press_kit_live.ex:416
+#: lib/vutuv_web/live/press_kit_live.ex:553
 #, elixir-autogen, elixir-format
 msgid "Dark"
 msgstr "Dunkel"
@@ -24557,156 +24559,155 @@ msgstr "Dunkel"
 msgid "Files a journalist may download and print"
 msgstr "Dateien, die eine Redaktion herunterladen und drucken darf"
 
-#: lib/vutuv_web/live/press_kit_live.ex:533
+#: lib/vutuv_web/live/press_kit_live.ex:673
 #, elixir-autogen, elixir-format
 msgid "First: the main photo"
 msgstr "An erster Stelle: das Hauptfoto"
 
-#: lib/vutuv_web/live/press_kit_live.ex:532
+#: lib/vutuv_web/live/press_kit_live.ex:672
 #, elixir-autogen, elixir-format
 msgid "First: the main variant"
 msgstr "An erster Stelle: die Hauptvariante"
 
-#: lib/vutuv_web/live/press_kit_live.ex:709
+#: lib/vutuv_web/live/press_kit_live.ex:850
 #, elixir-autogen, elixir-format
 msgid "I hold the rights to this file and release it for editorial use, as long as the credit above is shown."
 msgstr "Ich habe die Rechte an dieser Datei und gebe sie zur redaktionellen Nutzung frei, solange der Bildnachweis oben genannt wird."
 
-#: lib/vutuv_web/live/press_kit_live.ex:416
+#: lib/vutuv_web/live/press_kit_live.ex:553
 #, elixir-autogen, elixir-format
 msgid "Light"
 msgstr "Hell"
 
-#: lib/vutuv_web/live/press_kit_live.ex:813
+#: lib/vutuv_web/live/press_kit_live.ex:1006
 #, elixir-autogen, elixir-format
 msgid "Logo variant"
 msgstr "Logo-Variante"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:116
-#: lib/vutuv_web/agent_docs/text.ex:412
-#: lib/vutuv_web/live/press_kit_live.ex:382
-#: lib/vutuv_web/templates/press_kit/index.html.heex:47
+#: lib/vutuv_web/agent_docs/text.ex:413
+#: lib/vutuv_web/live/press_kit_live.ex:527
+#: lib/vutuv_web/templates/press_kit/index.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "Logo variants"
 msgstr "Logo-Varianten"
 
-#: lib/vutuv_web/live/press_kit_live.ex:430
+#: lib/vutuv_web/live/press_kit_live.ex:567
 #, elixir-autogen, elixir-format
 msgid "No logo here yet."
 msgstr "Hier ist noch kein Logo."
 
-#: lib/vutuv_web/live/press_kit_live.ex:271
+#: lib/vutuv_web/live/press_kit_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} logo variants."
 msgstr "Höchstens %{max} Logo-Varianten."
 
-#: lib/vutuv_web/live/press_kit_live.ex:274
+#: lib/vutuv_web/live/press_kit_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} press photos."
 msgstr "Höchstens %{max} Pressefotos."
 
-#: lib/vutuv_web/live/press_kit_live.ex:431
+#: lib/vutuv_web/live/press_kit_live.ex:568
 #, elixir-autogen, elixir-format
 msgid "No press photo here yet."
 msgstr "Hier ist noch kein Pressefoto."
 
-#: lib/vutuv_web/live/press_kit_live.ex:631
-#: lib/vutuv_web/live/press_kit_live.ex:696
+#: lib/vutuv_web/live/press_kit_live.ex:771
+#: lib/vutuv_web/live/press_kit_live.ex:837
 #, elixir-autogen, elixir-format
 msgid "Photo: Ada King"
 msgstr "Foto: Ada King"
 
-#: lib/vutuv_web/live/press_kit_live.ex:174
+#: lib/vutuv_web/live/press_kit_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "Picture removed."
 msgstr "Bild entfernt."
 
-#: lib/vutuv_web/live/press_kit_live.ex:290
+#: lib/vutuv_web/live/press_kit_live.ex:391
 #, elixir-autogen, elixir-format
 msgid "Please confirm the rights first, then choose the file."
 msgstr "Bitte bestätigen Sie zuerst die Rechte und wählen Sie dann die Datei."
 
-#: lib/vutuv_web/live/press_kit_live.ex:813
+#: lib/vutuv_web/live/press_kit_live.ex:1006
 #, elixir-autogen, elixir-format
 msgid "Press photo"
 msgstr "Pressefoto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:115
-#: lib/vutuv_web/agent_docs/text.ex:411
-#: lib/vutuv_web/live/press_kit_live.ex:382
-#: lib/vutuv_web/templates/press_kit/index.html.heex:38
+#: lib/vutuv_web/agent_docs/text.ex:412
+#: lib/vutuv_web/live/press_kit_live.ex:527
+#: lib/vutuv_web/templates/press_kit/index.html.heex:37
 #, elixir-autogen, elixir-format
 msgid "Press photos"
 msgstr "Pressefotos"
 
 #: lib/vutuv_web/components/ui.ex:5277
-#: lib/vutuv_web/live/press_kit_live.ex:77
-#: lib/vutuv_web/live/press_kit_live.ex:321
+#: lib/vutuv_web/live/press_kit_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Press photos & logos"
 msgstr "Pressefotos & Logos"
 
-#: lib/vutuv_web/live/press_kit_live.ex:580
+#: lib/vutuv_web/live/press_kit_live.ex:988
 #, elixir-autogen, elixir-format
 msgid "Remove this picture from your press kit?"
 msgstr "Dieses Bild aus Ihrer Pressemappe entfernen?"
 
-#: lib/vutuv_web/live/press_kit_live.ex:414
+#: lib/vutuv_web/live/press_kit_live.ex:551
 #, elixir-autogen, elixir-format
 msgid "Show tiles on:"
 msgstr "Kacheln zeigen auf:"
 
-#: lib/vutuv_web/live/press_kit_live.ex:634
+#: lib/vutuv_web/live/press_kit_live.ex:774
 #, elixir-autogen, elixir-format
 msgid "Shown beside the picture and asked for with every download."
 msgstr "Steht neben dem Bild und wird bei jedem Download genannt."
 
-#: lib/vutuv_web/live/press_kit_live.ex:303
+#: lib/vutuv_web/live/press_kit_live.ex:404
 #, elixir-autogen, elixir-format
 msgid "That could not be saved."
 msgstr "Das konnte nicht gespeichert werden."
 
-#: lib/vutuv_web/live/press_kit_live.ex:405
+#: lib/vutuv_web/live/press_kit_live.ex:980
 #, elixir-autogen, elixir-format
 msgid "The first photo is the one shown first. Drag a tile, or use the arrows, to change the order."
 msgstr "Das erste Foto wird zuerst gezeigt. Ziehen Sie eine Kachel oder nutzen Sie die Pfeile, um die Reihenfolge zu ändern."
 
-#: lib/vutuv_web/live/press_kit_live.ex:465
+#: lib/vutuv_web/live/press_kit_live.ex:604
 #, elixir-autogen, elixir-format
 msgid "This shelf is full. Remove one picture to add another."
 msgstr "Hier ist kein Platz mehr. Entfernen Sie ein Bild, um ein weiteres hinzuzufügen."
 
-#: lib/vutuv_web/live/press_kit_live.ex:325
+#: lib/vutuv_web/live/press_kit_live.ex:486
 #, elixir-autogen, elixir-format
 msgid "What a journalist writing about you may download: photos in print quality and your logo as a file. Everything here is public and free for editorial use as long as your credit is shown."
 msgstr "Was eine Redaktion, die über Sie schreibt, herunterladen darf: Fotos in Druckqualität und Ihr Logo als Datei. Alles hier ist öffentlich und zur redaktionellen Nutzung frei, solange Ihr Bildnachweis genannt wird."
 
-#: lib/vutuv_web/live/press_kit_live.ex:600
+#: lib/vutuv_web/live/press_kit_live.ex:740
 #, elixir-autogen, elixir-format
 msgid "What the picture shows"
 msgstr "Was das Bild zeigt"
 
-#: lib/vutuv_web/live/press_kit_live.ex:599
+#: lib/vutuv_web/live/press_kit_live.ex:739
 #, elixir-autogen, elixir-format
 msgid "Which variant this is"
 msgstr "Um welche Variante es sich handelt"
 
-#: lib/vutuv_web/live/press_kit_live.ex:611
+#: lib/vutuv_web/live/press_kit_live.ex:751
 #, elixir-autogen, elixir-format
 msgid "White on a dark background"
 msgstr "Weiß auf dunklem Grund"
 
-#: lib/vutuv_web/live/press_kit_live.ex:645
+#: lib/vutuv_web/live/press_kit_live.ex:785
 #, elixir-autogen, elixir-format
 msgid "Who took it, where, and what may be cropped."
 msgstr "Wer es aufgenommen hat, wo, und was beschnitten werden darf."
 
-#: lib/vutuv_web/live/press_kit_live.ex:286
+#: lib/vutuv_web/live/press_kit_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "You cannot add a picture to this press kit."
 msgstr "Sie können dieser Pressemappe kein Bild hinzufügen."
 
-#: lib/vutuv_web/live/press_kit_live.ex:401
+#: lib/vutuv_web/live/press_kit_live.ex:972
 #, elixir-autogen, elixir-format
 msgid "Your logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
 msgstr "Ihr Logo als Datei, eine Kachel je Variante. Eine Druckerei fragt nach einem Vektor (SVG), alle anderen können ein PNG öffnen."
@@ -24728,65 +24729,69 @@ msgid_plural "%{count} bytes"
 msgstr[0] "%{count} Byte"
 msgstr[1] "%{count} Bytes"
 
-#: lib/vutuv_web/templates/user/show.html.heex:989
+#: lib/vutuv_web/components/press_kit_components.ex:99
 #, elixir-autogen, elixir-format
 msgid "Add press photos"
 msgstr "Pressefotos hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1007
+#: lib/vutuv_web/components/press_kit_components.ex:117
 #, elixir-autogen, elixir-format
 msgid "All press material"
 msgstr "Alle Pressematerialien"
 
-#: lib/vutuv_web/components/press_kit_components.ex:118
+#: lib/vutuv_web/components/press_kit_components.ex:173
 #, elixir-autogen, elixir-format
 msgid "All press photos"
 msgstr "Alle Pressefotos"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1543
-#: lib/vutuv_web/agent_docs/text.ex:986
+#: lib/vutuv_web/agent_docs/markdown.ex:1547
+#: lib/vutuv_web/agent_docs/text.ex:987
 #, elixir-autogen, elixir-format
 msgid "Credit: %{credit}"
 msgstr "Bildnachweis: %{credit}"
 
-#: lib/vutuv_web/components/press_kit_components.ex:265
-#: lib/vutuv_web/components/press_kit_components.ex:268
+#: lib/vutuv_web/components/press_kit_components.ex:320
+#: lib/vutuv_web/components/press_kit_components.ex:323
 #, elixir-autogen, elixir-format
 msgid "Download %{format}"
 msgstr "%{format} herunterladen"
 
-#: lib/vutuv_web/components/press_kit_components.ex:221
+#: lib/vutuv_web/components/press_kit_components.ex:276
 #, elixir-autogen, elixir-format
 msgid "Download photo"
 msgstr "Foto herunterladen"
 
-#: lib/vutuv/press_kit.ex:452
+#: lib/vutuv/press_kit.ex:496
 #, elixir-autogen, elixir-format
 msgid "Free for editorial use with credit."
 msgstr "Zur freien redaktionellen Verwendung mit Bildnachweis."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1546
+#: lib/vutuv_web/agent_docs/markdown.ex:1550
 #, elixir-autogen, elixir-format
 msgid "PNG version"
 msgstr "PNG-Fassung"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
+#: lib/vutuv_web/agent_docs/markdown.ex:290
 #: lib/vutuv_web/agent_docs/text.ex:57
-#: lib/vutuv_web/controllers/press_kit_controller.ex:45
-#: lib/vutuv_web/templates/press_kit/index.html.heex:12
-#: lib/vutuv_web/templates/user/show.html.heex:987
+#: lib/vutuv_web/agent_docs/text.ex:257
+#: lib/vutuv_web/components/organization_components.ex:262
+#: lib/vutuv_web/components/press_kit_components.ex:97
+#: lib/vutuv_web/live/organization_live/show.ex:168
+#: lib/vutuv_web/views/press_kit_html.ex:28
+#: lib/vutuv_web/views/press_kit_html.ex:46
 #, elixir-autogen, elixir-format
 msgid "Press"
 msgstr "Presse"
 
 #: lib/vutuv_web/agent_docs/press_kit_doc.ex:48
-#: lib/vutuv_web/templates/press_kit/index.html.heex:7
+#: lib/vutuv_web/views/press_kit_html.ex:32
 #, elixir-autogen, elixir-format
 msgid "Press photos and logos of %{name}"
 msgstr "Pressefotos und Logos von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1542
-#: lib/vutuv_web/agent_docs/text.ex:983
+#: lib/vutuv_web/agent_docs/markdown.ex:1546
+#: lib/vutuv_web/agent_docs/text.ex:984
 #, elixir-autogen, elixir-format
 msgid "Press picture"
 msgstr "Pressebild"
@@ -24796,12 +24801,37 @@ msgstr "Pressebild"
 msgid "Press pictures %{name} offers for download, free for editorial use with credit."
 msgstr "Pressebilder, die %{name} zum Herunterladen anbietet, zur freien redaktionellen Verwendung mit Bildnachweis."
 
-#: lib/vutuv_web/templates/press_kit/index.html.heex:32
+#: lib/vutuv_web/templates/press_kit/index.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "These pictures are offered for editorial use. Use them freely in reporting, and print the credit shown with each one."
 msgstr "Diese Bilder stehen für die redaktionelle Verwendung bereit. Nutzen Sie sie frei in Ihrer Berichterstattung und drucken Sie den jeweils angegebenen Bildnachweis mit ab."
 
-#: lib/vutuv_web/components/post_components.ex:3015
+#: lib/vutuv_web/components/post_components.ex:3025
 #, elixir-autogen, elixir-format
 msgid "Video is being checked"
 msgstr "Video wird geprüft"
+
+#: lib/vutuv_web/live/press_kit_live.ex:908
+#, elixir-autogen, elixir-format
+msgid "Copies the vector file this page's logo was uploaded as onto this shelf."
+msgstr "Kopiert die Vektordatei, als die das Logo dieser Seite hochgeladen wurde, hierher."
+
+#: lib/vutuv_web/live/press_kit_live.ex:986
+#, elixir-autogen, elixir-format
+msgid "Remove this picture from this page's press kit?"
+msgstr "Dieses Bild aus der Pressemappe dieser Seite entfernen?"
+
+#: lib/vutuv_web/live/press_kit_live.ex:966
+#, elixir-autogen, elixir-format
+msgid "The page's logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
+msgstr "Das Logo dieser Seite als Datei, eine Kachel je Variante. Eine Druckerei fragt nach einem Vektor (SVG), alle anderen können ein PNG öffnen."
+
+#: lib/vutuv_web/live/press_kit_live.ex:905
+#, elixir-autogen, elixir-format
+msgid "Use the page's own logo"
+msgstr "Logo dieser Seite verwenden"
+
+#: lib/vutuv_web/live/press_kit_live.ex:468
+#, elixir-autogen, elixir-format
+msgid "What a journalist writing about this page may download: photos in print quality and its logo as a file. Everything here is public and free for editorial use as long as the credit is shown."
+msgstr "Was eine Redaktion, die über diese Seite schreibt, herunterladen darf: Fotos in Druckqualität und das Logo als Datei. Alles hier ist öffentlich und zur redaktionellen Nutzung frei, solange der Bildnachweis genannt wird."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -35,12 +35,12 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:169
 #: lib/vutuv_web/live/organization_live/fediverse.ex:123
-#: lib/vutuv_web/live/organization_live/show.ex:920
+#: lib/vutuv_web/live/organization_live/show.ex:957
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1543
+#: lib/vutuv_web/templates/user/show.html.heex:1526
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -102,11 +102,11 @@ msgstr ""
 msgid "Birthdate"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:703
-#: lib/vutuv_web/agent_docs/markdown.ex:704
-#: lib/vutuv_web/agent_docs/text.ex:653
+#: lib/vutuv_web/agent_docs/markdown.ex:707
+#: lib/vutuv_web/agent_docs/markdown.ex:708
 #: lib/vutuv_web/agent_docs/text.ex:654
-#: lib/vutuv_web/templates/user/show.html.heex:1174
+#: lib/vutuv_web/agent_docs/text.ex:655
+#: lib/vutuv_web/templates/user/show.html.heex:1157
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
@@ -121,7 +121,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
 #: lib/vutuv_web/live/post_live/composer.ex:1917
-#: lib/vutuv_web/live/press_kit_live.ex:656
+#: lib/vutuv_web/live/press_kit_live.ex:796
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -155,7 +155,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1212
+#: lib/vutuv_web/templates/user/show.html.heex:1195
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -164,7 +164,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4392
+#: lib/vutuv_web/components/post_components.ex:4435
 #: lib/vutuv_web/components/ui.ex:4864
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
@@ -212,14 +212,14 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4357
+#: lib/vutuv_web/components/post_components.ex:4400
 #: lib/vutuv_web/components/ui.ex:4855
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
 #: lib/vutuv_web/live/job_posting_live/show.ex:201
-#: lib/vutuv_web/live/organization_live/show.ex:152
-#: lib/vutuv_web/live/press_kit_live.ex:573
+#: lib/vutuv_web/live/organization_live/show.ex:159
+#: lib/vutuv_web/live/press_kit_live.ex:713
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:19
@@ -227,7 +227,7 @@ msgstr ""
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:113
-#: lib/vutuv_web/templates/user/show.html.heex:1197
+#: lib/vutuv_web/templates/user/show.html.heex:1180
 #, elixir-autogen
 msgid "Edit"
 msgstr ""
@@ -308,14 +308,14 @@ msgstr ""
 msgid "Fax"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:689
+#: lib/vutuv_web/agent_docs/markdown.ex:693
 #: lib/vutuv_web/templates/user/edit.html.heex:170
 #, elixir-autogen
 msgid "First Name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:724
-#: lib/vutuv_web/agent_docs/text.ex:674
+#: lib/vutuv_web/agent_docs/markdown.ex:728
+#: lib/vutuv_web/agent_docs/text.ex:675
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
@@ -325,18 +325,18 @@ msgstr ""
 msgid "Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:725
-#: lib/vutuv_web/agent_docs/text.ex:675
+#: lib/vutuv_web/agent_docs/markdown.ex:729
+#: lib/vutuv_web/agent_docs/text.ex:676
 #: lib/vutuv_web/components/fediverse_components.ex:468
 #: lib/vutuv_web/components/ui.ex:3087
 #: lib/vutuv_web/components/ui.ex:3122
 #: lib/vutuv_web/controllers/followee_controller.ex:29
 #: lib/vutuv_web/live/import_connections_live.ex:469
-#: lib/vutuv_web/live/organization_live/show.ex:618
+#: lib/vutuv_web/live/organization_live/show.ex:641
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:1042
-#: lib/vutuv_web/views/user_html.ex:649
+#: lib/vutuv_web/templates/user/show.html.heex:1025
+#: lib/vutuv_web/views/user_html.ex:642
 #, elixir-autogen
 msgid "Following"
 msgstr ""
@@ -385,7 +385,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:691
+#: lib/vutuv_web/agent_docs/markdown.ex:695
 #: lib/vutuv_web/templates/user/edit.html.heex:175
 #, elixir-autogen
 msgid "Last Name"
@@ -452,7 +452,7 @@ msgstr ""
 msgid "Log in"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:690
+#: lib/vutuv_web/agent_docs/markdown.ex:694
 #: lib/vutuv_web/templates/user/edit.html.heex:180
 #, elixir-autogen
 msgid "Middle Name"
@@ -477,7 +477,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:807
+#: lib/vutuv_web/components/post_components.ex:808
 #: lib/vutuv_web/live/notification_live/index.ex:776
 #: lib/vutuv_web/live/organization_live/activity.ex:136
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
@@ -489,7 +489,7 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:693
+#: lib/vutuv_web/agent_docs/markdown.ex:697
 #: lib/vutuv_web/templates/user/edit.html.heex:185
 #, elixir-autogen
 msgid "Nickname"
@@ -570,7 +570,7 @@ msgstr ""
 msgid "Phone number updated successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:688
+#: lib/vutuv_web/agent_docs/markdown.ex:692
 #: lib/vutuv_web/templates/user/edit.html.heex:190
 #, elixir-autogen
 msgid "Prefix"
@@ -620,7 +620,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:4756
 #: lib/vutuv_web/live/organization_live/edit.ex:376
 #: lib/vutuv_web/live/post_live/composer.ex:2201
-#: lib/vutuv_web/live/press_kit_live.ex:655
+#: lib/vutuv_web/live/press_kit_live.ex:795
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
@@ -662,7 +662,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1866
+#: lib/vutuv_web/components/post_components.ex:1867
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -696,13 +696,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1326
+#: lib/vutuv_web/templates/user/show.html.heex:1309
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1328
+#: lib/vutuv_web/templates/user/show.html.heex:1311
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -727,12 +727,12 @@ msgstr ""
 msgid "Profile deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:1057
+#: lib/vutuv_web/views/user_html.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Social networks"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:1064
+#: lib/vutuv_web/views/user_html.ex:1057
 #, elixir-autogen, elixir-format
 msgid "Code & repositories"
 msgstr ""
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Submit a bugreport or a feature request."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:692
+#: lib/vutuv_web/agent_docs/markdown.ex:696
 #: lib/vutuv_web/templates/user/edit.html.heex:195
 #, elixir-autogen
 msgid "Suffix"
@@ -830,7 +830,6 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/show.html.heex:4
 #: lib/vutuv_web/templates/phone_number/index.html.heex:8
 #: lib/vutuv_web/templates/phone_number/show.html.heex:4
-#: lib/vutuv_web/templates/press_kit/index.html.heex:10
 #: lib/vutuv_web/templates/qualification/index.html.heex:9
 #: lib/vutuv_web/templates/qualification/show.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/index.html.heex:8
@@ -842,21 +841,22 @@ msgstr ""
 #: lib/vutuv_web/templates/user_tag/show.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:8
 #: lib/vutuv_web/templates/work_experience/show.html.heex:4
+#: lib/vutuv_web/views/press_kit_html.ex:50
 #, elixir-autogen
 msgid "Users"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1597
-#: lib/vutuv_web/views/user_html.ex:594
-#: lib/vutuv_web/views/user_html.ex:595
-#: lib/vutuv_web/views/user_html.ex:609
+#: lib/vutuv_web/views/user_html.ex:587
+#: lib/vutuv_web/views/user_html.ex:588
+#: lib/vutuv_web/views/user_html.ex:602
 #, elixir-autogen
 msgid "vCard"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4925
-#: lib/vutuv_web/templates/user/show.html.heex:1036
-#: lib/vutuv_web/templates/user/show.html.heex:1059
+#: lib/vutuv_web/templates/user/show.html.heex:1019
+#: lib/vutuv_web/templates/user/show.html.heex:1042
 #, elixir-autogen
 msgid "View All"
 msgstr ""
@@ -932,6 +932,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/init_assigns.ex:54
 #: lib/vutuv_web/live/post_live/feed.ex:169
+#: lib/vutuv_web/live/press_kit_live.ex:109
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1042,7 +1043,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1163
+#: lib/vutuv_web/templates/user/show.html.heex:1146
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1125,7 +1126,7 @@ msgstr ""
 msgid "Add Localization"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:315
+#: lib/vutuv_web/components/organization_components.ex:324
 #: lib/vutuv_web/live/admin/activity_live.ex:153
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
@@ -1183,7 +1184,7 @@ msgstr ""
 msgid "All tag urls"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5006
+#: lib/vutuv_web/components/post_components.ex:5049
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:643
@@ -1350,11 +1351,11 @@ msgid "Tag urls"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:34
-#: lib/vutuv_web/agent_docs/markdown.ex:596
-#: lib/vutuv_web/agent_docs/markdown.ex:1237
+#: lib/vutuv_web/agent_docs/markdown.ex:600
+#: lib/vutuv_web/agent_docs/markdown.ex:1241
 #: lib/vutuv_web/agent_docs/text.ex:31
-#: lib/vutuv_web/agent_docs/text.ex:601
-#: lib/vutuv_web/agent_docs/text.ex:867
+#: lib/vutuv_web/agent_docs/text.ex:602
+#: lib/vutuv_web/agent_docs/text.ex:868
 #: lib/vutuv_web/components/ui.ex:5305
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
@@ -1676,12 +1677,12 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:320
 #: lib/vutuv_web/live/organization_live/following.ex:340
 #: lib/vutuv_web/live/organization_live/following.ex:421
-#: lib/vutuv_web/live/organization_live/show.ex:579
-#: lib/vutuv_web/live/organization_live/show.ex:616
+#: lib/vutuv_web/live/organization_live/show.ex:602
+#: lib/vutuv_web/live/organization_live/show.ex:639
 #: lib/vutuv_web/live/post_live/feed.ex:902
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
-#: lib/vutuv_web/templates/user/show.html.heex:1367
-#: lib/vutuv_web/views/user_html.ex:660
+#: lib/vutuv_web/templates/user/show.html.heex:1350
+#: lib/vutuv_web/views/user_html.ex:653
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
@@ -1697,7 +1698,7 @@ msgstr ""
 msgid "Log out"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:321
+#: lib/vutuv_web/components/organization_components.ex:330
 #: lib/vutuv_web/live/admin/activity_live.ex:143
 #: lib/vutuv_web/live/admin/activity_live.ex:175
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
@@ -1712,10 +1713,10 @@ msgstr ""
 msgid "Member"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:638
-#: lib/vutuv_web/views/user_html.ex:687
-#: lib/vutuv_web/views/user_html.ex:688
-#: lib/vutuv_web/views/user_html.ex:698
+#: lib/vutuv_web/live/organization_live/show.ex:661
+#: lib/vutuv_web/views/user_html.ex:680
+#: lib/vutuv_web/views/user_html.ex:681
+#: lib/vutuv_web/views/user_html.ex:691
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
@@ -1735,7 +1736,7 @@ msgstr ""
 msgid "Network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:486
+#: lib/vutuv_web/components/post_components.ex:487
 #: lib/vutuv_web/components/ui.ex:4974
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
@@ -1825,7 +1826,7 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:27
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:18
 #: lib/vutuv_web/templates/user/show.html.heex:232
-#: lib/vutuv_web/views/user_html.ex:1109
+#: lib/vutuv_web/views/user_html.ex:1102
 #, elixir-autogen, elixir-format
 msgid "Verified profile"
 msgstr ""
@@ -1845,7 +1846,7 @@ msgstr ""
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:247
+#: lib/vutuv_web/views/user_html.ex:240
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr ""
@@ -1864,14 +1865,14 @@ msgstr ""
 
 #: lib/vutuv_web/open_graph.ex:418
 #: lib/vutuv_web/templates/tag/show.html.heex:32
-#: lib/vutuv_web/views/user_html.ex:531
+#: lib/vutuv_web/views/user_html.ex:524
 #, elixir-autogen, elixir-format
 msgid "follower"
 msgid_plural "followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_html.ex:535
+#: lib/vutuv_web/views/user_html.ex:528
 #, elixir-autogen, elixir-format
 msgid "following"
 msgstr ""
@@ -1901,7 +1902,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:4999
 #: lib/vutuv_web/live/organization_live/activity.ex:159
 #: lib/vutuv_web/live/organization_live/feed.ex:258
-#: lib/vutuv_web/live/organization_live/show.ex:787
+#: lib/vutuv_web/live/organization_live/show.ex:810
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr ""
@@ -2022,12 +2023,12 @@ msgstr ""
 msgid "May"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:299
+#: lib/vutuv_web/views/user_html.ex:292
 #, elixir-autogen, elixir-format
 msgid "Member since %{month} %{year}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:304
+#: lib/vutuv_web/views/user_html.ex:297
 #, elixir-autogen, elixir-format
 msgid "Member since %{year}"
 msgstr ""
@@ -2072,7 +2073,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/post_live/composer.ex:2015
 #: lib/vutuv_web/live/post_live/composer.ex:2038
-#: lib/vutuv_web/live/press_kit_live.ex:786
+#: lib/vutuv_web/live/press_kit_live.ex:949
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2082,7 +2083,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4389
+#: lib/vutuv_web/components/post_components.ex:4432
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2094,11 +2095,11 @@ msgstr ""
 msgid "Edit post"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:265
+#: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:203
 #: lib/vutuv_web/live/post_live/feed.ex:331
-#: lib/vutuv_web/live/post_live/feed.ex:3254
+#: lib/vutuv_web/live/post_live/feed.ex:3265
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1341
 #: lib/vutuv_web/live/shell_live.ex:1686
@@ -2127,8 +2128,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4343
-#: lib/vutuv_web/components/post_components.ex:4345
+#: lib/vutuv_web/components/post_components.ex:4386
+#: lib/vutuv_web/components/post_components.ex:4388
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2144,7 +2145,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3583
+#: lib/vutuv_web/live/post_live/feed.ex:3594
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2182,7 +2183,7 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:113
 #: lib/vutuv_web/live/admin/dashboard_live.ex:270
 #: lib/vutuv_web/live/fediverse_account_live.ex:446
-#: lib/vutuv_web/live/organization_live/show.ex:710
+#: lib/vutuv_web/live/organization_live/show.ex:733
 #: lib/vutuv_web/live/post_live/saved.ex:536
 #: lib/vutuv_web/live/search_live.ex:348
 #: lib/vutuv_web/live/search_live.ex:832
@@ -2192,13 +2193,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4879
-#: lib/vutuv_web/components/post_components.ex:4883
+#: lib/vutuv_web/components/post_components.ex:4922
+#: lib/vutuv_web/components/post_components.ex:4926
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4880
+#: lib/vutuv_web/components/post_components.ex:4923
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2208,7 +2209,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:497
 #: lib/vutuv_web/components/job_exclusion_components.ex:189
-#: lib/vutuv_web/components/post_components.ex:1448
+#: lib/vutuv_web/components/post_components.ex:1449
 #: lib/vutuv_web/live/admin/screenshot_live.ex:352
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:229
@@ -2220,7 +2221,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:666
 #: lib/vutuv_web/live/post_live/saved.ex:694
 #: lib/vutuv_web/live/post_rewrites_live.ex:376
-#: lib/vutuv_web/live/press_kit_live.ex:582
+#: lib/vutuv_web/live/press_kit_live.ex:722
 #: lib/vutuv_web/templates/connection/index.html.heex:45
 #: lib/vutuv_web/views/settings_html.ex:386
 #, elixir-autogen, elixir-format
@@ -2237,7 +2238,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2454
+#: lib/vutuv_web/live/post_live/feed.ex:2465
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2251,7 +2252,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/post_live/composer.ex:1520
 #: lib/vutuv_web/live/post_live/composer.ex:1588
-#: lib/vutuv_web/live/press_kit_live.ex:294
+#: lib/vutuv_web/live/press_kit_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
@@ -2295,27 +2296,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4340
+#: lib/vutuv_web/components/post_components.ex:4383
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6646
+#: lib/vutuv_web/components/post_components.ex:6689
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6650
+#: lib/vutuv_web/components/post_components.ex:6693
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6648
+#: lib/vutuv_web/components/post_components.ex:6691
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6649
+#: lib/vutuv_web/components/post_components.ex:6692
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2359,15 +2360,15 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2180
-#: lib/vutuv_web/components/post_components.ex:6749
+#: lib/vutuv_web/components/post_components.ex:2181
+#: lib/vutuv_web/components/post_components.ex:6792
 #: lib/vutuv_web/components/ui.ex:4298
-#: lib/vutuv_web/views/user_html.ex:493
+#: lib/vutuv_web/views/user_html.ex:486
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1291
+#: lib/vutuv_web/agent_docs/markdown.ex:1295
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:529
 #: lib/vutuv_web/live/shell_live.ex:1499
@@ -2378,17 +2379,17 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2124
-#: lib/vutuv_web/components/post_components.ex:6990
+#: lib/vutuv_web/components/post_components.ex:2125
+#: lib/vutuv_web/components/post_components.ex:7033
 #: lib/vutuv_web/components/ui.ex:4284
 #: lib/vutuv_web/notification_line.ex:317
-#: lib/vutuv_web/views/user_html.ex:503
+#: lib/vutuv_web/views/user_html.ex:496
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1290
-#: lib/vutuv_web/components/post_components.ex:7000
+#: lib/vutuv_web/agent_docs/markdown.ex:1294
+#: lib/vutuv_web/components/post_components.ex:7043
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
 #: lib/vutuv_web/live/shell_live.ex:1590
@@ -2409,58 +2410,58 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6737
+#: lib/vutuv_web/components/post_components.ex:6780
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2179
-#: lib/vutuv_web/components/post_components.ex:6748
+#: lib/vutuv_web/components/post_components.ex:2180
+#: lib/vutuv_web/components/post_components.ex:6791
 #: lib/vutuv_web/live/post_live/saved.ex:822
-#: lib/vutuv_web/views/user_html.ex:493
+#: lib/vutuv_web/views/user_html.ex:486
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2160
-#: lib/vutuv_web/components/post_components.ex:6733
+#: lib/vutuv_web/components/post_components.ex:2161
+#: lib/vutuv_web/components/post_components.ex:6776
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2753
-#: lib/vutuv_web/components/post_components.ex:5752
+#: lib/vutuv_web/components/post_components.ex:2754
+#: lib/vutuv_web/components/post_components.ex:5795
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2159
-#: lib/vutuv_web/components/post_components.ex:6732
+#: lib/vutuv_web/components/post_components.ex:2160
+#: lib/vutuv_web/components/post_components.ex:6775
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2123
-#: lib/vutuv_web/components/post_components.ex:6989
+#: lib/vutuv_web/components/post_components.ex:2124
+#: lib/vutuv_web/components/post_components.ex:7032
 #: lib/vutuv_web/live/post_live/saved.ex:821
-#: lib/vutuv_web/views/user_html.ex:503
+#: lib/vutuv_web/views/user_html.ex:496
 #, elixir-autogen, elixir-format
 msgid "Unlike"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:498
-#: lib/vutuv_web/components/post_components.ex:3351
+#: lib/vutuv_web/components/post_components.ex:3394
 #: lib/vutuv_web/components/ui.ex:3047
 #: lib/vutuv_web/components/ui.ex:3047
 #: lib/vutuv_web/components/ui.ex:3123
 #: lib/vutuv_web/live/organization_live/following.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:476
-#: lib/vutuv_web/live/organization_live/show.ex:621
+#: lib/vutuv_web/live/organization_live/show.ex:644
 #: lib/vutuv_web/live/post_live/feed.ex:889
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:42
-#: lib/vutuv_web/views/user_html.ex:650
+#: lib/vutuv_web/views/user_html.ex:643
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr ""
@@ -2470,20 +2471,20 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7044
+#: lib/vutuv_web/components/post_components.ex:7087
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:444
+#: lib/vutuv_web/components/post_components.ex:445
 #: lib/vutuv_web/live/notification_live/index.ex:1331
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2369
-#: lib/vutuv_web/components/post_components.ex:7027
-#: lib/vutuv_web/components/post_components.ex:7028
+#: lib/vutuv_web/components/post_components.ex:2370
+#: lib/vutuv_web/components/post_components.ex:7070
+#: lib/vutuv_web/components/post_components.ex:7071
 #: lib/vutuv_web/live/notification_live/index.ex:993
 #: lib/vutuv_web/live/post_live/reply.ex:49
 #: lib/vutuv_web/notification_line.ex:314
@@ -2491,7 +2492,7 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4299
+#: lib/vutuv_web/components/post_components.ex:4342
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2512,7 +2513,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3817
+#: lib/vutuv_web/components/post_components.ex:3860
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:63
 #: lib/vutuv_web/live/post_live/remote_reply.ex:61
 #: lib/vutuv_web/live/post_live/reply.ex:63
@@ -2520,14 +2521,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4271
+#: lib/vutuv_web/components/post_components.ex:4314
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4262
-#: lib/vutuv_web/components/post_components.ex:4291
-#: lib/vutuv_web/components/post_components.ex:4294
+#: lib/vutuv_web/components/post_components.ex:4305
+#: lib/vutuv_web/components/post_components.ex:4334
+#: lib/vutuv_web/components/post_components.ex:4337
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2700,26 +2701,26 @@ msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1286
+#: lib/vutuv_web/templates/user/show.html.heex:1269
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1545
+#: lib/vutuv_web/templates/user/show.html.heex:1528
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1214
+#: lib/vutuv_web/templates/user/show.html.heex:1197
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1165
+#: lib/vutuv_web/templates/user/show.html.heex:1148
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
@@ -2750,7 +2751,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:884
+#: lib/vutuv_web/components/post_components.ex:885
 #: lib/vutuv_web/controllers/page_controller.ex:211
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2780,8 +2781,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:726
-#: lib/vutuv_web/agent_docs/text.ex:676
+#: lib/vutuv_web/agent_docs/markdown.ex:730
+#: lib/vutuv_web/agent_docs/text.ex:677
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -2819,14 +2820,14 @@ msgid "This post is for the connections of %{name}"
 msgstr ""
 
 #: lib/vutuv_web/views/admin/moderation_html.ex:127
-#: lib/vutuv_web/views/user_html.ex:545
+#: lib/vutuv_web/views/user_html.ex:538
 #, elixir-autogen, elixir-format
 msgid "connection"
 msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6647
+#: lib/vutuv_web/components/post_components.ex:6690
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2836,7 +2837,7 @@ msgstr ""
 msgid "Open someone's profile to message them."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:259
+#: lib/vutuv_web/components/organization_components.ex:268
 #: lib/vutuv_web/live/organization_live/activity.ex:112
 #: lib/vutuv_web/notification_line.ex:331
 #, elixir-autogen, elixir-format
@@ -2854,7 +2855,7 @@ msgid "Endorsement"
 msgstr ""
 
 #: lib/vutuv_web/notification_line.ex:312
-#: lib/vutuv_web/templates/user/show.html.heex:1020
+#: lib/vutuv_web/templates/user/show.html.heex:1003
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -2923,8 +2924,8 @@ msgstr ""
 msgid "Bullying or harassment"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:400
-#: lib/vutuv_web/agent_docs/text.ex:366
+#: lib/vutuv_web/agent_docs/markdown.ex:404
+#: lib/vutuv_web/agent_docs/text.ex:367
 #: lib/vutuv_web/controllers/page_controller.ex:76
 #: lib/vutuv_web/templates/layout/app.html.heex:126
 #: lib/vutuv_web/templates/page/community.html.heex:4
@@ -3070,13 +3071,13 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1254
-#: lib/vutuv_web/templates/user/show.html.heex:1255
+#: lib/vutuv_web/templates/user/show.html.heex:1237
+#: lib/vutuv_web/templates/user/show.html.heex:1238
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4238
+#: lib/vutuv_web/components/post_components.ex:4281
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3102,7 +3103,7 @@ msgstr ""
 msgid "Opened"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:314
+#: lib/vutuv_web/components/organization_components.ex:323
 #: lib/vutuv_web/live/admin/api_app_live.ex:72
 #: lib/vutuv_web/live/admin/deliverability_live.ex:171
 #: lib/vutuv_web/live/admin/moderation_live.ex:56
@@ -3134,10 +3135,10 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1461
-#: lib/vutuv_web/components/post_components.ex:3371
-#: lib/vutuv_web/components/post_components.ex:4456
-#: lib/vutuv_web/live/organization_live/show.ex:661
+#: lib/vutuv_web/components/post_components.ex:1462
+#: lib/vutuv_web/components/post_components.ex:3414
+#: lib/vutuv_web/components/post_components.ex:4499
+#: lib/vutuv_web/live/organization_live/show.ex:684
 #: lib/vutuv_web/templates/user/show.html.heex:252
 #, elixir-autogen, elixir-format
 msgid "Report"
@@ -3767,12 +3768,12 @@ msgstr ""
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:833
+#: lib/vutuv_web/agent_docs/markdown.ex:837
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1412
+#: lib/vutuv_web/agent_docs/markdown.ex:1416
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3786,11 +3787,11 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:92
 #: lib/vutuv_web/agent_docs/markdown.ex:219
 #: lib/vutuv_web/agent_docs/markdown.ex:233
-#: lib/vutuv_web/agent_docs/markdown.ex:1237
+#: lib/vutuv_web/agent_docs/markdown.ex:1241
 #: lib/vutuv_web/agent_docs/text.ex:87
 #: lib/vutuv_web/agent_docs/text.ex:188
 #: lib/vutuv_web/agent_docs/text.ex:202
-#: lib/vutuv_web/agent_docs/text.ex:867
+#: lib/vutuv_web/agent_docs/text.ex:868
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
@@ -3809,28 +3810,28 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1255
-#: lib/vutuv_web/agent_docs/text.ex:878
+#: lib/vutuv_web/agent_docs/markdown.ex:1259
+#: lib/vutuv_web/agent_docs/text.ex:879
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1252
-#: lib/vutuv_web/agent_docs/text.ex:875
+#: lib/vutuv_web/agent_docs/markdown.ex:1256
+#: lib/vutuv_web/agent_docs/text.ex:876
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1259
-#: lib/vutuv_web/agent_docs/markdown.ex:1505
-#: lib/vutuv_web/agent_docs/text.ex:882
-#: lib/vutuv_web/agent_docs/text.ex:951
+#: lib/vutuv_web/agent_docs/markdown.ex:1263
+#: lib/vutuv_web/agent_docs/markdown.ex:1509
+#: lib/vutuv_web/agent_docs/text.ex:883
+#: lib/vutuv_web/agent_docs/text.ex:952
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:661
-#: lib/vutuv_web/agent_docs/text.ex:639
+#: lib/vutuv_web/agent_docs/markdown.ex:665
+#: lib/vutuv_web/agent_docs/text.ex:640
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr ""
@@ -3869,23 +3870,23 @@ msgstr ""
 msgid "Posts (%{count} total)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:655
-#: lib/vutuv_web/agent_docs/text.ex:633
+#: lib/vutuv_web/agent_docs/markdown.ex:659
+#: lib/vutuv_web/agent_docs/text.ex:634
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1183
+#: lib/vutuv_web/agent_docs/markdown.ex:1187
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1045
+#: lib/vutuv_web/agent_docs/markdown.ex:1049
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1046
+#: lib/vutuv_web/agent_docs/markdown.ex:1050
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -3961,8 +3962,8 @@ msgstr ""
 msgid "Billing name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:414
-#: lib/vutuv_web/agent_docs/text.ex:374
+#: lib/vutuv_web/agent_docs/markdown.ex:418
+#: lib/vutuv_web/agent_docs/text.ex:375
 #, elixir-autogen, elixir-format
 msgid "Book online (login required): %{url}"
 msgstr ""
@@ -4014,8 +4015,8 @@ msgstr ""
 msgid "Markdown is supported. At most %{max} characters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:404
-#: lib/vutuv_web/agent_docs/text.ex:370
+#: lib/vutuv_web/agent_docs/markdown.ex:408
+#: lib/vutuv_web/agent_docs/text.ex:371
 #: lib/vutuv_web/templates/ad/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Next available day"
@@ -4031,8 +4032,8 @@ msgstr ""
 msgid "One text-only ad per calendar day, seen by every visitor."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:401
-#: lib/vutuv_web/agent_docs/text.ex:367
+#: lib/vutuv_web/agent_docs/markdown.ex:405
+#: lib/vutuv_web/agent_docs/text.ex:368
 #: lib/vutuv_web/templates/ad/index.html.heex:35
 #: lib/vutuv_web/templates/ad/preview.html.heex:32
 #: lib/vutuv_web/views/admin/ad_html.ex:59
@@ -4246,14 +4247,14 @@ msgstr ""
 msgid "deleted account"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:406
-#: lib/vutuv_web/agent_docs/text.ex:372
+#: lib/vutuv_web/agent_docs/markdown.ex:410
+#: lib/vutuv_web/agent_docs/text.ex:373
 #, elixir-autogen, elixir-format
 msgid "Already booked"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:402
-#: lib/vutuv_web/agent_docs/text.ex:368
+#: lib/vutuv_web/agent_docs/markdown.ex:406
+#: lib/vutuv_web/agent_docs/text.ex:369
 #, elixir-autogen, elixir-format
 msgid "Booking window"
 msgstr ""
@@ -4477,7 +4478,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3588
+#: lib/vutuv_web/live/post_live/feed.ex:3599
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4487,11 +4488,11 @@ msgstr ""
 msgid "Find members"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:271
+#: lib/vutuv_web/components/organization_components.ex:280
 #: lib/vutuv_web/live/organization_live/following.ex:313
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:1042
+#: lib/vutuv_web/templates/user/show.html.heex:1025
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -4532,12 +4533,12 @@ msgid "Not an exact match, but sounds like your search."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/investors_doc.ex:212
-#: lib/vutuv_web/agent_docs/markdown.ex:537
-#: lib/vutuv_web/agent_docs/text.ex:542
+#: lib/vutuv_web/agent_docs/markdown.ex:541
+#: lib/vutuv_web/agent_docs/text.ex:543
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/live/notification_live/index.ex:640
 #: lib/vutuv_web/live/notification_live/index.ex:1333
-#: lib/vutuv_web/live/organization_live/show.ex:797
+#: lib/vutuv_web/live/organization_live/show.ex:820
 #: lib/vutuv_web/live/post_live/saved.ex:539
 #: lib/vutuv_web/live/search_live.ex:346
 #: lib/vutuv_web/live/search_live.ex:774
@@ -4555,8 +4556,8 @@ msgstr ""
 msgid "Similar names"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:441
-#: lib/vutuv_web/components/post_components.ex:460
+#: lib/vutuv_web/components/post_components.ex:442
+#: lib/vutuv_web/components/post_components.ex:461
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
@@ -4654,8 +4655,8 @@ msgstr ""
 msgid "Edit your profile and its sections"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:303
-#: lib/vutuv_web/agent_docs/text.ex:273
+#: lib/vutuv_web/agent_docs/markdown.ex:307
+#: lib/vutuv_web/agent_docs/text.ex:274
 #: lib/vutuv_web/live/admin/job_live.ex:389
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:140
 #: lib/vutuv_web/live/job_posting_live/show.ex:159
@@ -5354,11 +5355,11 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4536
-#: lib/vutuv_web/components/post_components.ex:5145
-#: lib/vutuv_web/components/post_components.ex:5483
+#: lib/vutuv_web/components/post_components.ex:4579
+#: lib/vutuv_web/components/post_components.ex:5188
+#: lib/vutuv_web/components/post_components.ex:5526
 #: lib/vutuv_web/live/notification_live/index.ex:1069
-#: lib/vutuv_web/views/user_html.ex:140
+#: lib/vutuv_web/views/user_html.ex:133
 #, elixir-autogen, elixir-format
 msgid "View post"
 msgstr ""
@@ -5382,7 +5383,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:33
 #: lib/vutuv_web/views/email_html.ex:12
-#: lib/vutuv_web/views/user_html.ex:1234
+#: lib/vutuv_web/views/user_html.ex:1227
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr ""
@@ -5564,7 +5565,7 @@ msgstr ""
 msgid "@%{slug} started following you on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:284
+#: lib/vutuv_web/components/organization_components.ex:293
 #: lib/vutuv_web/live/organization_live/apps.ex:167
 #: lib/vutuv_web/templates/settings/apps.html.heex:12
 #, elixir-autogen, elixir-format
@@ -6022,7 +6023,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1595
+#: lib/vutuv_web/templates/user/show.html.heex:1578
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6066,16 +6067,16 @@ msgstr ""
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1180
-#: lib/vutuv_web/templates/user/show.html.heex:1190
+#: lib/vutuv_web/templates/user/show.html.heex:1163
+#: lib/vutuv_web/templates/user/show.html.heex:1173
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:705
-#: lib/vutuv_web/agent_docs/text.ex:655
+#: lib/vutuv_web/agent_docs/markdown.ex:709
+#: lib/vutuv_web/agent_docs/text.ex:656
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr ""
@@ -6107,12 +6108,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1302
+#: lib/vutuv_web/templates/user/show.html.heex:1285
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1313
+#: lib/vutuv_web/templates/user/show.html.heex:1296
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6147,21 +6148,21 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1290
-#: lib/vutuv_web/components/post_components.ex:443
+#: lib/vutuv_web/agent_docs/markdown.ex:1294
+#: lib/vutuv_web/components/post_components.ex:444
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1311
+#: lib/vutuv_web/templates/user/show.html.heex:1294
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
 
 #: lib/vutuv_web/live/feed_languages_live.ex:235
-#: lib/vutuv_web/live/press_kit_live.ex:496
+#: lib/vutuv_web/live/press_kit_live.ex:636
 #: lib/vutuv_web/live/section_reorder_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder"
@@ -6174,7 +6175,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/feed_languages_live.ex:267
 #: lib/vutuv_web/live/post_rewrites_live.ex:364
-#: lib/vutuv_web/live/press_kit_live.ex:558
+#: lib/vutuv_web/live/press_kit_live.ex:698
 #: lib/vutuv_web/live/section_reorder_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Move down"
@@ -6182,7 +6183,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/feed_languages_live.ex:256
 #: lib/vutuv_web/live/post_rewrites_live.ex:352
-#: lib/vutuv_web/live/press_kit_live.ex:547
+#: lib/vutuv_web/live/press_kit_live.ex:687
 #: lib/vutuv_web/live/section_reorder_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -6217,9 +6218,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1585
-#: lib/vutuv_web/templates/user/show.html.heex:1589
-#: lib/vutuv_web/templates/user/show.html.heex:1601
+#: lib/vutuv_web/templates/user/show.html.heex:1568
+#: lib/vutuv_web/templates/user/show.html.heex:1572
+#: lib/vutuv_web/templates/user/show.html.heex:1584
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6260,7 +6261,7 @@ msgstr ""
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1250
+#: lib/vutuv_web/agent_docs/markdown.ex:1254
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -6546,9 +6547,9 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3298
-#: lib/vutuv_web/components/post_components.ex:4409
-#: lib/vutuv_web/components/post_components.ex:4423
+#: lib/vutuv_web/components/post_components.ex:3341
+#: lib/vutuv_web/components/post_components.ex:4452
+#: lib/vutuv_web/components/post_components.ex:4466
 #: lib/vutuv_web/components/ui.ex:3195
 #: lib/vutuv_web/live/fediverse_account_live.ex:437
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6576,7 +6577,7 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4409
+#: lib/vutuv_web/components/post_components.ex:4452
 #: lib/vutuv_web/components/ui.ex:3194
 #: lib/vutuv_web/live/fediverse_account_live.ex:435
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6605,12 +6606,12 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:1233
+#: lib/vutuv_web/views/user_html.ex:1226
 #, elixir-autogen, elixir-format
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:786
+#: lib/vutuv_web/views/user_html.ex:779
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr ""
@@ -7131,7 +7132,7 @@ msgid "open the dev email inbox"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:45
-#: lib/vutuv_web/views/user_html.ex:785
+#: lib/vutuv_web/views/user_html.ex:778
 #, elixir-autogen, elixir-format
 msgid "Connected"
 msgstr ""
@@ -7269,7 +7270,7 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:6900
+#: lib/vutuv_web/components/post_components.ex:6943
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #: lib/vutuv_web/live/shell_live.ex:1817
 #, elixir-autogen, elixir-format
@@ -7373,9 +7374,9 @@ msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3877
+#: lib/vutuv_web/live/post_live/feed.ex:3888
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
-#: lib/vutuv_web/live/press_kit_live.ex:573
+#: lib/vutuv_web/live/press_kit_live.ex:713
 #, elixir-autogen
 msgid "Done"
 msgstr ""
@@ -7449,17 +7450,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1417
+#: lib/vutuv_web/agent_docs/markdown.ex:1421
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1420
+#: lib/vutuv_web/agent_docs/markdown.ex:1424
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1427
+#: lib/vutuv_web/agent_docs/markdown.ex:1431
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -8256,13 +8257,13 @@ msgstr ""
 msgid "Please check the fields marked in red."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:1118
+#: lib/vutuv_web/views/user_html.ex:1111
 #, elixir-autogen, elixir-format
 msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:140
-#: lib/vutuv_web/templates/user/show.html.heex:1449
+#: lib/vutuv_web/templates/user/show.html.heex:1432
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8519,7 +8520,7 @@ msgstr ""
 msgid "Not written yet"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:244
+#: lib/vutuv_web/components/organization_components.ex:245
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "Page"
@@ -8551,11 +8552,11 @@ msgstr ""
 msgid "Write it under Admin › Legal pages"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:715
 #: lib/vutuv_web/agent_docs/markdown.ex:719
-#: lib/vutuv_web/agent_docs/text.ex:665
-#: lib/vutuv_web/agent_docs/text.ex:669
-#: lib/vutuv_web/components/organization_components.ex:276
+#: lib/vutuv_web/agent_docs/markdown.ex:723
+#: lib/vutuv_web/agent_docs/text.ex:666
+#: lib/vutuv_web/agent_docs/text.ex:670
+#: lib/vutuv_web/components/organization_components.ex:285
 #: lib/vutuv_web/components/ui.ex:1807
 #: lib/vutuv_web/components/ui.ex:5459
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
@@ -8564,13 +8565,13 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:277
 #: lib/vutuv_web/live/organization_live/fediverse.ex:84
-#: lib/vutuv_web/live/organization_live/show.ex:165
+#: lib/vutuv_web/live/organization_live/show.ex:181
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:329
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:5
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:1354
+#: lib/vutuv_web/templates/user/show.html.heex:1337
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr ""
@@ -8680,13 +8681,13 @@ msgstr ""
 msgid "Higher Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:923
+#: lib/vutuv_web/agent_docs/markdown.ex:927
 #: lib/vutuv_web/views/education_html.ex:54
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:922
+#: lib/vutuv_web/agent_docs/markdown.ex:926
 #: lib/vutuv_web/views/education_html.ex:53
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -8712,14 +8713,14 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5755
+#: lib/vutuv_web/components/post_components.ex:5798
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1186
+#: lib/vutuv_web/agent_docs/markdown.ex:1190
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -8944,8 +8945,8 @@ msgstr ""
 msgid "Honor tag (only site admins can assign it)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:735
-#: lib/vutuv_web/agent_docs/text.ex:683
+#: lib/vutuv_web/agent_docs/markdown.ex:739
+#: lib/vutuv_web/agent_docs/text.ex:684
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr ""
@@ -9369,8 +9370,8 @@ msgstr ""
 msgid "Yoruba"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:657
-#: lib/vutuv_web/agent_docs/text.ex:635
+#: lib/vutuv_web/agent_docs/markdown.ex:661
+#: lib/vutuv_web/agent_docs/text.ex:636
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr ""
@@ -9473,7 +9474,7 @@ msgstr[1] ""
 msgid "Add a certificate or license"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1039
+#: lib/vutuv_web/agent_docs/markdown.ex:1043
 #: lib/vutuv_web/views/qualification_html.ex:14
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -9553,7 +9554,7 @@ msgstr ""
 msgid "Expired"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1014
+#: lib/vutuv_web/agent_docs/markdown.ex:1018
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr ""
@@ -9570,7 +9571,7 @@ msgstr ""
 msgid "Issuer"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1038
+#: lib/vutuv_web/agent_docs/markdown.ex:1042
 #: lib/vutuv_web/views/qualification_html.ex:15
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -9597,7 +9598,7 @@ msgstr ""
 msgid "Verification link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1012
+#: lib/vutuv_web/agent_docs/markdown.ex:1016
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr ""
@@ -9612,7 +9613,7 @@ msgstr ""
 msgid "e.g. Amazon Web Services"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1013
+#: lib/vutuv_web/agent_docs/markdown.ex:1017
 #: lib/vutuv_web/views/qualification_html.ex:91
 #, elixir-autogen, elixir-format
 msgid "valid until %{date}"
@@ -9628,15 +9629,15 @@ msgstr ""
 msgid "Preferred"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:850
+#: lib/vutuv_web/agent_docs/markdown.ex:854
 #: lib/vutuv_web/live/section_reorder_live.ex:289
 #: lib/vutuv_web/views/language_html.ex:114
 #, elixir-autogen, elixir-format
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1276
-#: lib/vutuv_web/templates/user/show.html.heex:1277
+#: lib/vutuv_web/templates/user/show.html.heex:1259
+#: lib/vutuv_web/templates/user/show.html.heex:1260
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -10083,21 +10084,21 @@ msgstr ""
 msgid "Sign in with a one-time code (OTP) from an authenticator app or from a printed code list, typed into the normal PIN field. Your emailed PIN always keeps working."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:810
+#: lib/vutuv_web/agent_docs/markdown.ex:814
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:808
+#: lib/vutuv_web/agent_docs/markdown.ex:812
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:806
+#: lib/vutuv_web/agent_docs/markdown.ex:810
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10105,16 +10106,16 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:1416
-#: lib/vutuv_web/live/organization_live/show.ex:648
-#: lib/vutuv_web/views/user_html.ex:982
-#: lib/vutuv_web/views/user_html.ex:1158
+#: lib/vutuv_web/live/organization_live/show.ex:671
+#: lib/vutuv_web/views/user_html.ex:975
+#: lib/vutuv_web/views/user_html.ex:1151
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower"
 msgid_plural "%{formatted} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_html.ex:975
+#: lib/vutuv_web/views/user_html.ex:968
 #, elixir-autogen, elixir-format
 msgid "%{formatted} star"
 msgid_plural "%{formatted} stars"
@@ -10123,7 +10124,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:72
 #: lib/vutuv_web/agent_docs/text.ex:67
-#: lib/vutuv_web/templates/user/show.html.heex:1423
+#: lib/vutuv_web/templates/user/show.html.heex:1406
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -10139,7 +10140,7 @@ msgstr ""
 msgid "If you list a GitHub, GitLab or Codeberg account, your profile can show its public statistics: stars, repositories, followers, languages and recent activity."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:989
+#: lib/vutuv_web/views/user_html.ex:982
 #, elixir-autogen, elixir-format
 msgid "Last active %{date}"
 msgstr ""
@@ -10154,17 +10155,17 @@ msgstr ""
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:824
+#: lib/vutuv_web/agent_docs/markdown.ex:828
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:811
+#: lib/vutuv_web/agent_docs/markdown.ex:815
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:905
+#: lib/vutuv_web/views/user_html.ex:898
 #, elixir-autogen, elixir-format
 msgid "since %{year}"
 msgstr ""
@@ -10905,7 +10906,7 @@ msgstr ""
 msgid "AI agents"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:700
+#: lib/vutuv_web/live/organization_live/show.ex:723
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
@@ -10918,7 +10919,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:284
 #: lib/vutuv_web/live/organization_live/domains.ex:319
 #: lib/vutuv_web/live/organization_live/new.ex:161
-#: lib/vutuv_web/live/organization_live/show.ex:1043
+#: lib/vutuv_web/live/organization_live/show.ex:1080
 #: lib/vutuv_web/templates/url/verify.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
@@ -10926,8 +10927,8 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:204
 #: lib/vutuv_web/live/organization_live/domains.ex:359
-#: lib/vutuv_web/live/organization_live/show.ex:1108
-#: lib/vutuv_web/live/organization_live/show.ex:1116
+#: lib/vutuv_web/live/organization_live/show.ex:1145
+#: lib/vutuv_web/live/organization_live/show.ex:1153
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr ""
@@ -10953,13 +10954,13 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
 
-#: lib/vutuv_web/controllers/organization_controller.ex:290
+#: lib/vutuv_web/controllers/organization_controller.ex:305
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:31
 #, elixir-autogen, elixir-format
 msgid "Please log in first."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:1016
+#: lib/vutuv_web/live/organization_live/show.ex:1053
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr ""
@@ -10980,13 +10981,13 @@ msgstr ""
 msgid "Search engines"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:142
+#: lib/vutuv_web/components/organization_components.ex:143
 #, elixir-autogen, elixir-format
 msgid "Select a country"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:338
-#: lib/vutuv_web/live/organization_live/show.ex:1078
+#: lib/vutuv_web/live/organization_live/show.ex:1115
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr ""
@@ -11008,12 +11009,12 @@ msgid "The upload failed."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:1031
+#: lib/vutuv_web/live/organization_live/show.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:942
+#: lib/vutuv_web/live/organization_live/show.ex:979
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr ""
@@ -11024,18 +11025,18 @@ msgstr ""
 msgid "Verified via"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:1002
+#: lib/vutuv_web/live/organization_live/show.ex:1039
 #, elixir-autogen, elixir-format
 msgid "Verified via %{domain}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:1013
+#: lib/vutuv_web/live/organization_live/show.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:353
-#: lib/vutuv_web/live/organization_live/show.ex:1102
+#: lib/vutuv_web/live/organization_live/show.ex:1139
 #, elixir-autogen, elixir-format
 msgid "Verify now"
 msgstr ""
@@ -11050,7 +11051,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:285
 #: lib/vutuv_web/live/organization_live/domains.ex:329
-#: lib/vutuv_web/live/organization_live/show.ex:1054
+#: lib/vutuv_web/live/organization_live/show.ex:1091
 #: lib/vutuv_web/templates/url/verify.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11067,7 +11068,7 @@ msgid "You will publish a record or file to prove control of the domain on the n
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:340
-#: lib/vutuv_web/live/organization_live/show.ex:1084
+#: lib/vutuv_web/live/organization_live/show.ex:1121
 #: lib/vutuv_web/templates/url/verify.html.heex:109
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
@@ -11078,7 +11079,7 @@ msgstr ""
 msgid "@handle or email"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:333
+#: lib/vutuv_web/components/organization_components.ex:342
 #: lib/vutuv_web/live/organization_live/edit.ex:421
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
@@ -11099,7 +11100,7 @@ msgstr ""
 msgid "Added @%{handle} to the team."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:334
+#: lib/vutuv_web/components/organization_components.ex:343
 #: lib/vutuv_web/live/organization_live/edit.ex:419
 #, elixir-autogen, elixir-format
 msgid "Alias"
@@ -11115,10 +11116,10 @@ msgstr ""
 msgid "Alias removed."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:529
-#: lib/vutuv_web/agent_docs/text.ex:535
+#: lib/vutuv_web/agent_docs/markdown.ex:533
+#: lib/vutuv_web/agent_docs/text.ex:536
 #: lib/vutuv_web/live/organization_live/edit.ex:384
-#: lib/vutuv_web/live/organization_live/show.ex:930
+#: lib/vutuv_web/live/organization_live/show.ex:967
 #: lib/vutuv_web/templates/tag/single_card.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Also known as"
@@ -11145,7 +11146,7 @@ msgstr ""
 msgid "Archived"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:332
+#: lib/vutuv_web/components/organization_components.ex:341
 #: lib/vutuv_web/live/organization_live/edit.ex:420
 #, elixir-autogen, elixir-format
 msgid "Brand"
@@ -11181,10 +11182,10 @@ msgstr ""
 msgid "Domain verified."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:250
+#: lib/vutuv_web/components/organization_components.ex:251
 #: lib/vutuv_web/live/admin/organization_live.ex:302
 #: lib/vutuv_web/live/organization_live/domains.ex:198
-#: lib/vutuv_web/live/organization_live/show.ex:159
+#: lib/vutuv_web/live/organization_live/show.ex:175
 #, elixir-autogen, elixir-format
 msgid "Domains"
 msgstr ""
@@ -11194,7 +11195,7 @@ msgstr ""
 msgid "Domains – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:331
+#: lib/vutuv_web/components/organization_components.ex:340
 #, elixir-autogen, elixir-format
 msgid "Former name"
 msgstr ""
@@ -11272,7 +11273,7 @@ msgstr ""
 msgid "Primary domain updated."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:320
+#: lib/vutuv_web/components/organization_components.ex:329
 #, elixir-autogen, elixir-format
 msgid "Recruiter"
 msgstr ""
@@ -11297,10 +11298,10 @@ msgstr ""
 msgid "Search name, alias or domain"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:247
+#: lib/vutuv_web/components/organization_components.ex:248
 #: lib/vutuv_web/live/admin/organization_live.ex:318
 #: lib/vutuv_web/live/organization_live/roles.ex:184
-#: lib/vutuv_web/live/organization_live/show.ex:155
+#: lib/vutuv_web/live/organization_live/show.ex:171
 #, elixir-autogen, elixir-format
 msgid "Team"
 msgstr ""
@@ -11337,8 +11338,8 @@ msgstr ""
 msgid "primary"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:550
-#: lib/vutuv_web/agent_docs/text.ex:555
+#: lib/vutuv_web/agent_docs/markdown.ex:554
+#: lib/vutuv_web/agent_docs/text.ex:556
 #: lib/vutuv_web/live/admin/organization_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "verified"
@@ -11461,8 +11462,8 @@ msgstr ""
 msgid "Verify via file"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1059
-#: lib/vutuv_web/agent_docs/text.ex:811
+#: lib/vutuv_web/agent_docs/markdown.ex:1063
+#: lib/vutuv_web/agent_docs/text.ex:812
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -11472,7 +11473,7 @@ msgstr ""
 msgid "%{min} to %{max} characters: letters (a-z), numbers (0-9) and underscores."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:819
+#: lib/vutuv_web/live/organization_live/show.ex:842
 #, elixir-autogen, elixir-format
 msgid "Former"
 msgstr ""
@@ -11498,8 +11499,8 @@ msgstr ""
 msgid "Remove link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:541
-#: lib/vutuv_web/agent_docs/text.ex:546
+#: lib/vutuv_web/agent_docs/markdown.ex:545
+#: lib/vutuv_web/agent_docs/text.ex:547
 #, elixir-autogen, elixir-format
 msgid "former"
 msgstr ""
@@ -11577,7 +11578,7 @@ msgstr ""
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:1025
+#: lib/vutuv_web/live/organization_live/show.ex:1062
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr ""
@@ -11682,9 +11683,9 @@ msgstr ""
 msgid "Organization unfrozen."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:520
-#: lib/vutuv_web/agent_docs/organization_doc.ex:123
-#: lib/vutuv_web/agent_docs/text.ex:479
+#: lib/vutuv_web/agent_docs/markdown.ex:524
+#: lib/vutuv_web/agent_docs/organization_doc.ex:138
+#: lib/vutuv_web/agent_docs/text.ex:480
 #: lib/vutuv_web/components/ui.ex:5486
 #: lib/vutuv_web/controllers/settings_controller.ex:222
 #: lib/vutuv_web/live/organization_live/index.ex:32
@@ -11695,22 +11696,23 @@ msgstr ""
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:80
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
+#: lib/vutuv_web/views/press_kit_html.ex:49
 #, elixir-autogen, elixir-format
 msgid "Organizations"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:169
+#: lib/vutuv_web/components/organization_components.ex:170
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:90
 #, elixir-autogen, elixir-format
 msgid "Please choose"
 msgstr ""
 
-#: lib/vutuv_web/controllers/organization_controller.ex:128
+#: lib/vutuv_web/controllers/organization_controller.ex:129
 #, elixir-autogen, elixir-format
 msgid "Please confirm your email address before claiming an organization page."
 msgstr ""
 
-#: lib/vutuv_web/controllers/organization_controller.ex:134
+#: lib/vutuv_web/controllers/organization_controller.ex:135
 #, elixir-autogen, elixir-format
 msgid "Please log in to claim an organization page."
 msgstr ""
@@ -11740,7 +11742,7 @@ msgstr ""
 msgid "The organization page was deleted."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:470
+#: lib/vutuv_web/live/organization_live/show.ex:493
 #, elixir-autogen, elixir-format
 msgid "This organization page was reported and is hidden while it is reviewed. Only you and the moderators can see it."
 msgstr ""
@@ -11750,7 +11752,7 @@ msgstr ""
 msgid "Verified organization pages on vutuv, each with a proven web domain."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/organization_doc.ex:124
+#: lib/vutuv_web/agent_docs/organization_doc.ex:139
 #, elixir-autogen, elixir-format
 msgid "Verified organization pages on vutuv."
 msgstr ""
@@ -11770,8 +11772,8 @@ msgstr ""
 msgid "Your organization handle is set."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:356
-#: lib/vutuv_web/live/organization_live/show.ex:409
+#: lib/vutuv_web/live/organization_live/show.ex:379
+#: lib/vutuv_web/live/organization_live/show.ex:432
 #, elixir-autogen, elixir-format
 msgid "Your organization page is verified and now live."
 msgstr ""
@@ -11940,10 +11942,10 @@ msgstr ""
 msgid "Edit posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:297
-#: lib/vutuv_web/agent_docs/markdown.ex:581
-#: lib/vutuv_web/agent_docs/text.ex:267
-#: lib/vutuv_web/agent_docs/text.ex:586
+#: lib/vutuv_web/agent_docs/markdown.ex:301
+#: lib/vutuv_web/agent_docs/markdown.ex:585
+#: lib/vutuv_web/agent_docs/text.ex:268
+#: lib/vutuv_web/agent_docs/text.ex:587
 #: lib/vutuv_web/live/admin/job_live.ex:340
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:17
 #: lib/vutuv_web/views/account_event_text.ex:225
@@ -11956,10 +11958,10 @@ msgstr ""
 msgid "Employer name (optional)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:298
-#: lib/vutuv_web/agent_docs/markdown.ex:582
-#: lib/vutuv_web/agent_docs/text.ex:268
-#: lib/vutuv_web/agent_docs/text.ex:587
+#: lib/vutuv_web/agent_docs/markdown.ex:302
+#: lib/vutuv_web/agent_docs/markdown.ex:586
+#: lib/vutuv_web/agent_docs/text.ex:269
+#: lib/vutuv_web/agent_docs/text.ex:588
 #: lib/vutuv_web/live/job_board_live.ex:526
 #: lib/vutuv_web/live/job_posting_live/form.ex:499
 #, elixir-autogen, elixir-format
@@ -12031,12 +12033,12 @@ msgstr ""
 msgid "Let search engines index this posting."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:556
-#: lib/vutuv_web/agent_docs/markdown.ex:559
-#: lib/vutuv_web/agent_docs/markdown.ex:561
-#: lib/vutuv_web/agent_docs/text.ex:561
-#: lib/vutuv_web/agent_docs/text.ex:564
-#: lib/vutuv_web/agent_docs/text.ex:566
+#: lib/vutuv_web/agent_docs/markdown.ex:560
+#: lib/vutuv_web/agent_docs/markdown.ex:563
+#: lib/vutuv_web/agent_docs/markdown.ex:565
+#: lib/vutuv_web/agent_docs/text.ex:562
+#: lib/vutuv_web/agent_docs/text.ex:565
+#: lib/vutuv_web/agent_docs/text.ex:567
 #: lib/vutuv_web/live/job_posting_live/form.ex:549
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -12085,8 +12087,8 @@ msgstr ""
 msgid "New posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:309
-#: lib/vutuv_web/agent_docs/text.ex:278
+#: lib/vutuv_web/agent_docs/markdown.ex:313
+#: lib/vutuv_web/agent_docs/text.ex:279
 #: lib/vutuv_web/live/job_posting_live/form.ex:756
 #: lib/vutuv_web/live/job_posting_live/show.ex:177
 #, elixir-autogen, elixir-format
@@ -12170,10 +12172,10 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:302
-#: lib/vutuv_web/agent_docs/markdown.ex:586
-#: lib/vutuv_web/agent_docs/text.ex:272
-#: lib/vutuv_web/agent_docs/text.ex:591
+#: lib/vutuv_web/agent_docs/markdown.ex:306
+#: lib/vutuv_web/agent_docs/markdown.ex:590
+#: lib/vutuv_web/agent_docs/text.ex:273
+#: lib/vutuv_web/agent_docs/text.ex:592
 #: lib/vutuv_web/live/job_posting_live/show.ex:156
 #, elixir-autogen, elixir-format
 msgid "Posted"
@@ -12198,10 +12200,10 @@ msgstr ""
 #: lib/vutuv/accounts/user.ex:1291
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:590
-#: lib/vutuv_web/agent_docs/markdown.ex:559
-#: lib/vutuv_web/agent_docs/markdown.ex:561
-#: lib/vutuv_web/agent_docs/text.ex:564
-#: lib/vutuv_web/agent_docs/text.ex:566
+#: lib/vutuv_web/agent_docs/markdown.ex:563
+#: lib/vutuv_web/agent_docs/markdown.ex:565
+#: lib/vutuv_web/agent_docs/text.ex:565
+#: lib/vutuv_web/agent_docs/text.ex:567
 #: lib/vutuv_web/components/job_components.ex:140
 #: lib/vutuv_web/components/job_components.ex:141
 #, elixir-autogen, elixir-format
@@ -12213,18 +12215,18 @@ msgstr ""
 msgid "Report this posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:308
-#: lib/vutuv_web/agent_docs/text.ex:277
+#: lib/vutuv_web/agent_docs/markdown.ex:312
+#: lib/vutuv_web/agent_docs/text.ex:278
 #: lib/vutuv_web/live/job_posting_live/form.ex:746
 #: lib/vutuv_web/live/job_posting_live/show.ex:172
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:301
-#: lib/vutuv_web/agent_docs/markdown.ex:585
-#: lib/vutuv_web/agent_docs/text.ex:271
-#: lib/vutuv_web/agent_docs/text.ex:590
+#: lib/vutuv_web/agent_docs/markdown.ex:305
+#: lib/vutuv_web/agent_docs/markdown.ex:589
+#: lib/vutuv_web/agent_docs/text.ex:272
+#: lib/vutuv_web/agent_docs/text.ex:591
 #, elixir-autogen, elixir-format
 msgid "Salary"
 msgstr ""
@@ -12318,10 +12320,10 @@ msgstr ""
 msgid "Working student"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:299
-#: lib/vutuv_web/agent_docs/markdown.ex:583
-#: lib/vutuv_web/agent_docs/text.ex:269
-#: lib/vutuv_web/agent_docs/text.ex:588
+#: lib/vutuv_web/agent_docs/markdown.ex:303
+#: lib/vutuv_web/agent_docs/markdown.ex:587
+#: lib/vutuv_web/agent_docs/text.ex:270
+#: lib/vutuv_web/agent_docs/text.ex:589
 #: lib/vutuv_web/live/job_posting_live/form.ex:514
 #, elixir-autogen, elixir-format
 msgid "Workplace"
@@ -12466,13 +12468,13 @@ msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:336
-#: lib/vutuv_web/live/organization_live/show.ex:1071
+#: lib/vutuv_web/live/organization_live/show.ex:1108
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:334
-#: lib/vutuv_web/live/organization_live/show.ex:1062
+#: lib/vutuv_web/live/organization_live/show.ex:1099
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr ""
@@ -12521,13 +12523,13 @@ msgstr ""
 msgid "All countries"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:604
+#: lib/vutuv_web/agent_docs/markdown.ex:608
 #: lib/vutuv_web/templates/tag/show.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:608
+#: lib/vutuv_web/agent_docs/text.ex:609
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr ""
@@ -12568,17 +12570,17 @@ msgid "Minimum yearly salary"
 msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:383
-#: lib/vutuv_web/live/organization_live/show.ex:841
+#: lib/vutuv_web/live/organization_live/show.ex:864
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:323
+#: lib/vutuv_web/agent_docs/markdown.ex:327
 #, elixir-autogen, elixir-format
 msgid "Next page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:292
+#: lib/vutuv_web/agent_docs/text.ex:293
 #, elixir-autogen, elixir-format
 msgid "Next page: %{url}"
 msgstr ""
@@ -12593,11 +12595,11 @@ msgstr ""
 msgid "No matching positions. Try adjusting the filters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:602
-#: lib/vutuv_web/agent_docs/markdown.ex:614
-#: lib/vutuv_web/agent_docs/text.ex:606
-#: lib/vutuv_web/agent_docs/text.ex:618
-#: lib/vutuv_web/live/organization_live/show.ex:833
+#: lib/vutuv_web/agent_docs/markdown.ex:606
+#: lib/vutuv_web/agent_docs/markdown.ex:618
+#: lib/vutuv_web/agent_docs/text.ex:607
+#: lib/vutuv_web/agent_docs/text.ex:619
+#: lib/vutuv_web/live/organization_live/show.ex:856
 #: lib/vutuv_web/templates/tag/show.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Open positions"
@@ -12912,7 +12914,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3776
+#: lib/vutuv_web/components/post_components.ex:3819
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:788
 #: lib/vutuv_web/controllers/settings_controller.ex:806
@@ -13051,7 +13053,7 @@ msgstr ""
 msgid "Inherited from the organization"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:253
+#: lib/vutuv_web/components/organization_components.ex:254
 #: lib/vutuv_web/live/organization_live/exclusions.ex:113
 #, elixir-autogen, elixir-format
 msgid "Job exclusions"
@@ -13326,22 +13328,22 @@ msgstr ""
 msgid "Work mobile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:483
+#: lib/vutuv_web/components/post_components.ex:484
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:485
+#: lib/vutuv_web/components/post_components.ex:486
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:484
+#: lib/vutuv_web/components/post_components.ex:485
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:442
+#: lib/vutuv_web/components/post_components.ex:443
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr ""
@@ -13397,7 +13399,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1389
+#: lib/vutuv_web/templates/user/show.html.heex:1372
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13434,7 +13436,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1387
+#: lib/vutuv_web/templates/user/show.html.heex:1370
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -13511,34 +13513,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6443
+#: lib/vutuv_web/components/post_components.ex:6486
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1379
-#: lib/vutuv_web/components/post_components.ex:6400
+#: lib/vutuv_web/agent_docs/markdown.ex:1383
+#: lib/vutuv_web/components/post_components.ex:6443
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6444
+#: lib/vutuv_web/components/post_components.ex:6487
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6446
+#: lib/vutuv_web/components/post_components.ex:6489
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6442
+#: lib/vutuv_web/components/post_components.ex:6485
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1379
-#: lib/vutuv_web/components/post_components.ex:6399
+#: lib/vutuv_web/agent_docs/markdown.ex:1383
+#: lib/vutuv_web/components/post_components.ex:6442
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13549,12 +13551,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6441
+#: lib/vutuv_web/components/post_components.ex:6484
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6445
+#: lib/vutuv_web/components/post_components.ex:6488
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13574,7 +13576,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6482
+#: lib/vutuv_web/components/post_components.ex:6525
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13582,27 +13584,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6512
+#: lib/vutuv_web/components/post_components.ex:6555
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6513
+#: lib/vutuv_web/components/post_components.ex:6556
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6511
+#: lib/vutuv_web/components/post_components.ex:6554
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6471
+#: lib/vutuv_web/components/post_components.ex:6514
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6518
+#: lib/vutuv_web/components/post_components.ex:6561
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13627,12 +13629,12 @@ msgstr ""
 msgid "With qualification:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:879
+#: lib/vutuv_web/agent_docs/markdown.ex:883
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6285
+#: lib/vutuv_web/components/post_components.ex:6328
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13675,7 +13677,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6276
+#: lib/vutuv_web/components/post_components.ex:6319
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -13716,19 +13718,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1028
+#: lib/vutuv_web/agent_docs/markdown.ex:1032
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1027
+#: lib/vutuv_web/agent_docs/markdown.ex:1031
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1033
+#: lib/vutuv_web/agent_docs/markdown.ex:1037
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -13808,8 +13810,8 @@ msgstr ""
 msgid "View the uploaded proof (%{label})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:965
-#: lib/vutuv_web/agent_docs/text.ex:790
+#: lib/vutuv_web/agent_docs/markdown.ex:969
+#: lib/vutuv_web/agent_docs/text.ex:791
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr ""
@@ -13867,8 +13869,8 @@ msgstr ""
 msgid "Skip for now"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:659
-#: lib/vutuv_web/agent_docs/text.ex:637
+#: lib/vutuv_web/agent_docs/markdown.ex:663
+#: lib/vutuv_web/agent_docs/text.ex:638
 #, elixir-autogen, elixir-format
 msgid "Preferred workplace"
 msgstr ""
@@ -14022,14 +14024,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4065
+#: lib/vutuv_web/components/post_components.ex:4108
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4088
+#: lib/vutuv_web/components/post_components.ex:4131
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14056,7 +14058,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6999
+#: lib/vutuv_web/components/post_components.ex:7042
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14458,7 +14460,7 @@ msgstr ""
 msgid "none yet"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1326
+#: lib/vutuv_web/agent_docs/markdown.ex:1330
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr ""
@@ -14792,7 +14794,7 @@ msgstr ""
 msgid "Book an ad"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1096
+#: lib/vutuv_web/templates/user/show.html.heex:1079
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr ""
@@ -14842,8 +14844,8 @@ msgstr ""
 msgid "Your server"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:716
-#: lib/vutuv_web/agent_docs/text.ex:666
+#: lib/vutuv_web/agent_docs/markdown.ex:720
+#: lib/vutuv_web/agent_docs/text.ex:667
 #, elixir-autogen, elixir-format
 msgid "moved to %{address}"
 msgstr ""
@@ -15201,7 +15203,7 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6945
+#: lib/vutuv_web/components/post_components.ex:6988
 #: lib/vutuv_web/live/notification_live/index.ex:1592
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -15209,7 +15211,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6949
+#: lib/vutuv_web/components/post_components.ex:6992
 #: lib/vutuv_web/live/notification_live/index.ex:1586
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15217,15 +15219,15 @@ msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6953
+#: lib/vutuv_web/components/post_components.ex:6996
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1328
-#: lib/vutuv_web/components/post_components.ex:6904
+#: lib/vutuv_web/agent_docs/markdown.ex:1332
+#: lib/vutuv_web/components/post_components.ex:6947
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15235,22 +15237,22 @@ msgstr ""
 msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1268
-#: lib/vutuv_web/agent_docs/markdown.ex:1526
-#: lib/vutuv_web/agent_docs/text.ex:888
-#: lib/vutuv_web/agent_docs/text.ex:965
+#: lib/vutuv_web/agent_docs/markdown.ex:1272
+#: lib/vutuv_web/agent_docs/markdown.ex:1530
+#: lib/vutuv_web/agent_docs/text.ex:889
+#: lib/vutuv_web/agent_docs/text.ex:966
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1582
-#: lib/vutuv_web/components/post_components.ex:2682
+#: lib/vutuv_web/components/post_components.ex:1583
+#: lib/vutuv_web/components/post_components.ex:2683
 #: lib/vutuv_web/live/fediverse_account_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1446
+#: lib/vutuv_web/components/post_components.ex:1447
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15262,7 +15264,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:150
 #: lib/vutuv_web/agent_docs/markdown.ex:182
-#: lib/vutuv_web/agent_docs/markdown.ex:1327
+#: lib/vutuv_web/agent_docs/markdown.ex:1331
 #: lib/vutuv_web/agent_docs/text.ex:125
 #: lib/vutuv_web/agent_docs/text.ex:154
 #, elixir-autogen, elixir-format
@@ -15279,7 +15281,7 @@ msgstr ""
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1458
+#: lib/vutuv_web/components/post_components.ex:1459
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15289,7 +15291,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1472
+#: lib/vutuv_web/components/post_components.ex:1473
 #: lib/vutuv_web/live/notification_live/index.ex:1117
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -15320,10 +15322,10 @@ msgstr ""
 msgid "That reply is not yours to remove."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1528
-#: lib/vutuv_web/components/post_components.ex:1497
-#: lib/vutuv_web/components/post_components.ex:1728
-#: lib/vutuv_web/components/post_components.ex:3634
+#: lib/vutuv_web/agent_docs/markdown.ex:1532
+#: lib/vutuv_web/components/post_components.ex:1498
+#: lib/vutuv_web/components/post_components.ex:1729
+#: lib/vutuv_web/components/post_components.ex:3677
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "View the original"
@@ -15985,22 +15987,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4250
+#: lib/vutuv_web/components/post_components.ex:4293
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4376
+#: lib/vutuv_web/components/post_components.ex:4419
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4384
+#: lib/vutuv_web/components/post_components.ex:4427
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4370
+#: lib/vutuv_web/components/post_components.ex:4413
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16020,13 +16022,13 @@ msgstr ""
 msgid "Unpinned. The post is a normal post again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1169
+#: lib/vutuv_web/agent_docs/markdown.ex:1173
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:653
-#: lib/vutuv_web/agent_docs/text.ex:628
+#: lib/vutuv_web/agent_docs/markdown.ex:657
+#: lib/vutuv_web/agent_docs/text.ex:629
 #: lib/vutuv_web/templates/user/edit.html.heex:225
 #: lib/vutuv_web/templates/user/show.html.heex:291
 #: lib/vutuv_web/views/account_event_text.ex:213
@@ -16074,8 +16076,8 @@ msgstr ""
 msgid "CC0 1.0 (no rights reserved)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1445
-#: lib/vutuv_web/agent_docs/text.ex:919
+#: lib/vutuv_web/agent_docs/markdown.ex:1449
+#: lib/vutuv_web/agent_docs/text.ex:920
 #: lib/vutuv_web/live/post_live/composer.ex:2661
 #, elixir-autogen, elixir-format
 msgid "Cover"
@@ -16086,8 +16088,8 @@ msgstr ""
 msgid "Describe the photo for people who can't see it"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1456
-#: lib/vutuv_web/agent_docs/text.ex:932
+#: lib/vutuv_web/agent_docs/markdown.ex:1460
+#: lib/vutuv_web/agent_docs/text.ex:933
 #: lib/vutuv_web/components/ui.ex:3249
 #, elixir-autogen, elixir-format
 msgid "Download the original"
@@ -16123,19 +16125,19 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3829
+#: lib/vutuv_web/components/post_components.ex:3872
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5321
-#: lib/vutuv_web/components/press_kit_components.ex:344
+#: lib/vutuv_web/components/post_components.ex:5364
+#: lib/vutuv_web/components/press_kit_components.ex:399
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5549
-#: lib/vutuv_web/components/press_kit_components.ex:414
+#: lib/vutuv_web/components/post_components.ex:5592
+#: lib/vutuv_web/components/press_kit_components.ex:469
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16146,9 +16148,9 @@ msgstr ""
 msgid "Photo options"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1489
-#: lib/vutuv_web/agent_docs/text.ex:907
-#: lib/vutuv_web/components/post_components.ex:5631
+#: lib/vutuv_web/agent_docs/markdown.ex:1493
+#: lib/vutuv_web/agent_docs/text.ex:908
+#: lib/vutuv_web/components/post_components.ex:5674
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr ""
@@ -16174,7 +16176,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3882
+#: lib/vutuv_web/components/post_components.ex:3925
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16194,7 +16196,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3873
+#: lib/vutuv_web/components/post_components.ex:3916
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16204,12 +16206,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3891
+#: lib/vutuv_web/components/post_components.ex:3934
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3825
+#: lib/vutuv_web/components/post_components.ex:3868
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16224,7 +16226,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3886
+#: lib/vutuv_web/components/post_components.ex:3929
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16234,7 +16236,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3839
+#: lib/vutuv_web/components/post_components.ex:3882
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16308,14 +16310,14 @@ msgid_plural "Some of these photos carry the location they were taken at, and th
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1346
-#: lib/vutuv_web/components/post_components.ex:6942
+#: lib/vutuv_web/agent_docs/markdown.ex:1350
+#: lib/vutuv_web/components/post_components.ex:6985
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1344
-#: lib/vutuv_web/components/post_components.ex:6939
+#: lib/vutuv_web/agent_docs/markdown.ex:1348
+#: lib/vutuv_web/components/post_components.ex:6982
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16325,7 +16327,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6826
+#: lib/vutuv_web/components/post_components.ex:6869
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
@@ -16666,7 +16668,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3393
+#: lib/vutuv_web/components/post_components.ex:3436
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
@@ -16676,7 +16678,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3633
+#: lib/vutuv_web/components/post_components.ex:3676
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16696,12 +16698,12 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1869
+#: lib/vutuv_web/components/post_components.ex:1870
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3574
+#: lib/vutuv_web/components/post_components.ex:3617
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr ""
@@ -16716,7 +16718,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3366
+#: lib/vutuv_web/components/post_components.ex:3409
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -16809,34 +16811,34 @@ msgstr ""
 msgid "“LinkedIn is annoying. vutuv is not.”"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1146
+#: lib/vutuv_web/agent_docs/markdown.ex:1150
 #, elixir-autogen, elixir-format
 msgid "(a picture)"
 msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3016
+#: lib/vutuv_web/components/post_components.ex:3026
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2886
+#: lib/vutuv_web/components/post_components.ex:2887
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2881
+#: lib/vutuv_web/components/post_components.ex:2882
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3732
+#: lib/vutuv_web/components/post_components.ex:3775
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3738
+#: lib/vutuv_web/components/post_components.ex:3781
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr ""
@@ -16846,7 +16848,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3877
+#: lib/vutuv_web/components/post_components.ex:3920
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -16886,7 +16888,7 @@ msgstr ""
 msgid "That link points at a single post. You can follow its author, %{account}, from here."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:249
+#: lib/vutuv_web/views/user_html.ex:242
 #, elixir-autogen, elixir-format
 msgid "Your feed shows the posts of members you follow. Follow a few to fill it."
 msgstr ""
@@ -16953,8 +16955,8 @@ msgstr ""
 msgid "We could not reach the network just now. Please try again in a moment."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1073
-#: lib/vutuv_web/agent_docs/text.ex:712
+#: lib/vutuv_web/agent_docs/markdown.ex:1077
+#: lib/vutuv_web/agent_docs/text.ex:713
 #, elixir-autogen, elixir-format
 msgid "verified profile"
 msgstr ""
@@ -17459,12 +17461,12 @@ msgstr ""
 msgid "Screenshot blocklist"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:475
+#: lib/vutuv_web/components/post_components.ex:476
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:472
+#: lib/vutuv_web/components/post_components.ex:473
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
@@ -17507,7 +17509,7 @@ msgstr ""
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3735
+#: lib/vutuv_web/components/post_components.ex:3778
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -17574,24 +17576,24 @@ msgstr ""
 msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1314
+#: lib/vutuv_web/agent_docs/markdown.ex:1318
 #, elixir-autogen, elixir-format
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5925
+#: lib/vutuv_web/components/post_components.ex:5968
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5927
+#: lib/vutuv_web/components/post_components.ex:5970
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5938
+#: lib/vutuv_web/components/post_components.ex:5981
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -17616,12 +17618,12 @@ msgstr ""
 msgid "Your likes follow the site default again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1369
+#: lib/vutuv_web/agent_docs/markdown.ex:1373
 #, elixir-autogen, elixir-format
 msgid "%{address} (this page only)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1366
+#: lib/vutuv_web/agent_docs/markdown.ex:1370
 #, elixir-autogen, elixir-format
 msgid "%{address} (whole website)"
 msgstr ""
@@ -17631,7 +17633,7 @@ msgstr ""
 msgid "Verified webpage of the author (%{address})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1358
+#: lib/vutuv_web/agent_docs/markdown.ex:1362
 #, elixir-autogen, elixir-format
 msgid "Verified webpages of the author linked here: %{addresses}"
 msgstr ""
@@ -17763,7 +17765,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3606
+#: lib/vutuv_web/live/post_live/feed.ex:3617
 #: lib/vutuv_web/live/reference_check_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -17964,7 +17966,7 @@ msgstr ""
 msgid "Employment references of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:947
+#: lib/vutuv_web/agent_docs/markdown.ex:951
 #, elixir-autogen, elixir-format
 msgid "document"
 msgstr ""
@@ -18180,7 +18182,7 @@ msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4582
-#: lib/vutuv_web/live/press_kit_live.ex:281
+#: lib/vutuv_web/live/press_kit_live.ex:382
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "That file is larger than %{limit}. Please upload a smaller one."
@@ -19172,17 +19174,17 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3765
+#: lib/vutuv_web/components/post_components.ex:3808
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:319
+#: lib/vutuv_web/components/organization_components.ex:328
 #, elixir-autogen, elixir-format
 msgid "Editorial"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:325
+#: lib/vutuv_web/components/organization_components.ex:334
 #, elixir-autogen, elixir-format
 msgid "Edits the page and posts jobs."
 msgstr ""
@@ -19192,7 +19194,7 @@ msgstr ""
 msgid "Give members their roles on this page. Someone can hold several at once, and every role is granted on its own."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:324
+#: lib/vutuv_web/components/organization_components.ex:333
 #, elixir-autogen, elixir-format
 msgid "Manages the team and the domains, and edits the page."
 msgstr ""
@@ -19202,7 +19204,7 @@ msgstr ""
 msgid "Pick at least one role."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:327
+#: lib/vutuv_web/components/organization_components.ex:336
 #, elixir-autogen, elixir-format
 msgid "Posts jobs."
 msgstr ""
@@ -19217,7 +19219,7 @@ msgstr ""
 msgid "Roles updated."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:326
+#: lib/vutuv_web/components/organization_components.ex:335
 #, elixir-autogen, elixir-format
 msgid "Writes posts in the organization's name."
 msgstr ""
@@ -19227,7 +19229,7 @@ msgstr ""
 msgid "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:782
+#: lib/vutuv_web/live/organization_live/show.ex:805
 #, elixir-autogen, elixir-format
 msgid "Nothing published yet."
 msgstr ""
@@ -19262,7 +19264,7 @@ msgstr ""
 msgid "Stopped writing as an organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:746
+#: lib/vutuv_web/live/organization_live/show.ex:769
 #, elixir-autogen, elixir-format
 msgid "Write as %{name} for now"
 msgstr ""
@@ -19484,12 +19486,12 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/fediverse.ex:92
 #: lib/vutuv_web/live/organization_live/new.ex:211
-#: lib/vutuv_web/live/organization_live/show.ex:897
+#: lib/vutuv_web/live/organization_live/show.ex:934
 #, elixir-autogen, elixir-format
 msgid "People who have no vutuv account can follow this page and read its posts, in networks like Mastodon."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:911
+#: lib/vutuv_web/live/organization_live/show.ex:948
 #, elixir-autogen, elixir-format
 msgid "Set this page up for other networks"
 msgstr ""
@@ -19504,7 +19506,7 @@ msgstr ""
 msgid "Switch it on"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:902
+#: lib/vutuv_web/live/organization_live/show.ex:939
 #, elixir-autogen, elixir-format
 msgid "The page gets an address of its own for that, written like an email address."
 msgstr ""
@@ -19747,13 +19749,13 @@ msgstr ""
 msgid "The gravatar.com lookup is switched off on this installation."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:35
+#: lib/vutuv_web/components/organization_components.ex:36
 #, elixir-autogen, elixir-format
 msgid "A new entry can take a while to reach everyone. We keep checking %{domain} by ourselves and send you an email as soon as it works, so you can close this page."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:351
-#: lib/vutuv_web/live/organization_live/show.ex:1100
+#: lib/vutuv_web/live/organization_live/show.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Checking …"
 msgstr ""
@@ -20040,27 +20042,27 @@ msgstr ""
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5819
+#: lib/vutuv_web/components/post_components.ex:5862
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5855
+#: lib/vutuv_web/components/post_components.ex:5898
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5864
+#: lib/vutuv_web/components/post_components.ex:5907
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5867
+#: lib/vutuv_web/components/post_components.ex:5910
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5844
+#: lib/vutuv_web/components/post_components.ex:5887
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
@@ -20070,7 +20072,7 @@ msgstr ""
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5834
+#: lib/vutuv_web/components/post_components.ex:5877
 #: lib/vutuv_web/components/ui.ex:5371
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -20199,20 +20201,20 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5597
+#: lib/vutuv_web/components/post_components.ex:5640
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5594
+#: lib/vutuv_web/components/post_components.ex:5637
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2907
-#: lib/vutuv_web/components/post_components.ex:4663
+#: lib/vutuv_web/components/post_components.ex:2908
+#: lib/vutuv_web/components/post_components.ex:4706
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -20231,12 +20233,12 @@ msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:431
 #: lib/vutuv_web/live/post_live/feed.ex:964
-#: lib/vutuv_web/views/user_html.ex:372
+#: lib/vutuv_web/views/user_html.ex:365
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:375
+#: lib/vutuv_web/views/user_html.ex:368
 #, elixir-autogen, elixir-format
 msgid "Show the profile picture larger"
 msgstr ""
@@ -20353,7 +20355,7 @@ msgstr ""
 msgid "Find my contacts"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:271
+#: lib/vutuv_web/views/user_html.ex:264
 #, elixir-autogen, elixir-format
 msgid "Find people you know from LinkedIn"
 msgstr ""
@@ -20725,7 +20727,7 @@ msgstr ""
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3346
+#: lib/vutuv_web/components/post_components.ex:3389
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr ""
@@ -20850,7 +20852,7 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3771
+#: lib/vutuv_web/live/post_live/feed.ex:3782
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
@@ -21323,13 +21325,13 @@ msgid "Hide a word or a whole phrase …"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:709
-#: lib/vutuv_web/live/post_live/feed.ex:3934
+#: lib/vutuv_web/live/post_live/feed.ex:3945
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:708
-#: lib/vutuv_web/live/post_live/feed.ex:3923
+#: lib/vutuv_web/live/post_live/feed.ex:3934
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr ""
@@ -21396,7 +21398,7 @@ msgstr ""
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3797
+#: lib/vutuv_web/live/post_live/feed.ex:3808
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
@@ -21435,7 +21437,7 @@ msgid "Show posts by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:707
-#: lib/vutuv_web/live/post_live/feed.ex:3889
+#: lib/vutuv_web/live/post_live/feed.ex:3900
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr ""
@@ -21474,8 +21476,8 @@ msgid_plural "and %{formatted} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3371
-#: lib/vutuv_web/live/post_live/feed.ex:3398
+#: lib/vutuv_web/live/post_live/feed.ex:3382
+#: lib/vutuv_web/live/post_live/feed.ex:3409
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -21505,7 +21507,7 @@ msgid "Your organization page was updated. The new logo is being checked and app
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:290
-#: lib/vutuv_web/live/press_kit_live.ex:741
+#: lib/vutuv_web/live/press_kit_live.ex:882
 #, elixir-autogen, elixir-format
 msgid "%{formats}, up to %{limit}"
 msgstr ""
@@ -21536,7 +21538,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3563
+#: lib/vutuv_web/live/post_live/feed.ex:3574
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr ""
@@ -21546,7 +21548,7 @@ msgstr ""
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3609
+#: lib/vutuv_web/live/post_live/feed.ex:3620
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -21568,7 +21570,7 @@ msgstr ""
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3559
+#: lib/vutuv_web/live/post_live/feed.ex:3570
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
@@ -21595,7 +21597,7 @@ msgctxt "heatmap scale"
 msgid "More"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:549
+#: lib/vutuv_web/live/organization_live/show.ex:572
 #, elixir-autogen, elixir-format
 msgid "The website of %{name}"
 msgstr ""
@@ -21650,29 +21652,29 @@ msgstr ""
 msgid "A new version is ready."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:684
+#: lib/vutuv_web/live/organization_live/show.ex:707
 #, elixir-autogen, elixir-format
 msgid "Page management"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2448
+#: lib/vutuv_web/live/post_live/feed.ex:2459
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3501
+#: lib/vutuv_web/components/post_components.ex:3544
 #, elixir-autogen, elixir-format
 msgid "Quoted post"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1162
+#: lib/vutuv_web/agent_docs/markdown.ex:1166
 #, elixir-autogen, elixir-format
 msgid "Quotes %{name}: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1159
+#: lib/vutuv_web/agent_docs/markdown.ex:1163
 #, elixir-autogen, elixir-format
 msgid "Quotes %{url}"
 msgstr ""
@@ -21687,7 +21689,7 @@ msgstr ""
 msgid "{used} of {max} mentions"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2560
+#: lib/vutuv_web/live/post_live/feed.ex:2571
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr ""
@@ -21718,7 +21720,7 @@ msgstr ""
 msgid "only %{account}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7285
+#: lib/vutuv_web/components/post_components.ex:7330
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -21902,7 +21904,7 @@ msgctxt "phone tab bar"
 msgid "Write"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3697
+#: lib/vutuv_web/live/post_live/feed.ex:3708
 #: lib/vutuv_web/live/post_rewrites_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "%{formatted} rule"
@@ -21970,9 +21972,9 @@ msgstr ""
 msgid "Rules that rewrite the text of one account's posts before you read them: a footer under every post, a signature, a wall of hashtags. Only you see the difference. Open the ⋯ menu on any post to write rules for its author."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1451
-#: lib/vutuv_web/components/post_components.ex:3359
-#: lib/vutuv_web/components/post_components.ex:4453
+#: lib/vutuv_web/components/post_components.ex:1452
+#: lib/vutuv_web/components/post_components.ex:3402
+#: lib/vutuv_web/components/post_components.ex:4496
 #: lib/vutuv_web/components/ui.ex:5363
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
@@ -22158,11 +22160,11 @@ msgstr ""
 msgid "This video could not be converted."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1441
-#: lib/vutuv_web/agent_docs/markdown.ex:1444
-#: lib/vutuv_web/agent_docs/text.ex:916
+#: lib/vutuv_web/agent_docs/markdown.ex:1445
+#: lib/vutuv_web/agent_docs/markdown.ex:1448
 #: lib/vutuv_web/agent_docs/text.ex:917
-#: lib/vutuv_web/components/post_components.ex:2967
+#: lib/vutuv_web/agent_docs/text.ex:918
+#: lib/vutuv_web/components/post_components.ex:2977
 #: lib/vutuv_web/components/video_components.ex:127
 #: lib/vutuv_web/live/post_live/composer.ex:2458
 #, elixir-autogen, elixir-format
@@ -22225,7 +22227,7 @@ msgstr[1] ""
 msgid "Last 30 days: %{parts}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5015
+#: lib/vutuv_web/components/post_components.ex:5058
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Less"
@@ -22286,22 +22288,22 @@ msgstr ""
 msgid "The fields the most members carry, and how many of them do."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1212
-#: lib/vutuv_web/agent_docs/text.ex:840
+#: lib/vutuv_web/agent_docs/markdown.ex:1216
+#: lib/vutuv_web/agent_docs/text.ex:841
 #: lib/vutuv_web/live/job_board_live.ex:474
 #, elixir-autogen, elixir-format
 msgid "What members here work on"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1204
-#: lib/vutuv_web/agent_docs/text.ex:832
+#: lib/vutuv_web/agent_docs/markdown.ex:1208
+#: lib/vutuv_web/agent_docs/text.ex:833
 #: lib/vutuv_web/live/job_board_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "Who you would reach"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1205
-#: lib/vutuv_web/agent_docs/text.ex:833
+#: lib/vutuv_web/agent_docs/markdown.ex:1209
+#: lib/vutuv_web/agent_docs/text.ex:834
 #: lib/vutuv_web/live/job_board_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "One random vutuv account that is open to offers."
@@ -22409,8 +22411,8 @@ msgstr ""
 msgid "People here per day over the last %{days} days"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:445
-#: lib/vutuv_web/agent_docs/text.ex:400
+#: lib/vutuv_web/agent_docs/markdown.ex:449
+#: lib/vutuv_web/agent_docs/text.ex:401
 #, elixir-autogen, elixir-format
 msgid "Press material: %{url}"
 msgstr ""
@@ -22425,28 +22427,28 @@ msgstr ""
 msgid "Send a message"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:428
-#: lib/vutuv_web/agent_docs/text.ex:387
+#: lib/vutuv_web/agent_docs/markdown.ex:432
+#: lib/vutuv_web/agent_docs/text.ex:388
 #: lib/vutuv_web/templates/company/investors.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "Where we are"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:435
-#: lib/vutuv_web/agent_docs/text.ex:394
+#: lib/vutuv_web/agent_docs/markdown.ex:439
+#: lib/vutuv_web/agent_docs/text.ex:395
 #: lib/vutuv_web/templates/company/investors.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Why this is worth building"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:444
-#: lib/vutuv_web/agent_docs/text.ex:399
+#: lib/vutuv_web/agent_docs/markdown.ex:448
+#: lib/vutuv_web/agent_docs/text.ex:400
 #, elixir-autogen, elixir-format
 msgid "Write here: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:441
-#: lib/vutuv_web/agent_docs/text.ex:396
+#: lib/vutuv_web/agent_docs/markdown.ex:445
+#: lib/vutuv_web/agent_docs/text.ex:397
 #: lib/vutuv_web/templates/company/investors.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Write to me"
@@ -22462,8 +22464,8 @@ msgstr ""
 msgid "My profile:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:443
-#: lib/vutuv_web/agent_docs/text.ex:398
+#: lib/vutuv_web/agent_docs/markdown.ex:447
+#: lib/vutuv_web/agent_docs/text.ex:399
 #, elixir-autogen, elixir-format
 msgid "My profile: %{url}"
 msgstr ""
@@ -22483,8 +22485,8 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:512
-#: lib/vutuv_web/agent_docs/text.ex:469
+#: lib/vutuv_web/agent_docs/markdown.ex:516
+#: lib/vutuv_web/agent_docs/text.ex:470
 #, elixir-autogen, elixir-format
 msgid "Source: %{source}"
 msgstr ""
@@ -22539,8 +22541,8 @@ msgstr ""
 msgid "Hidden. What they pass on stays out of your feed; their own posts do not."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3331
-#: lib/vutuv_web/components/post_components.ex:4447
+#: lib/vutuv_web/components/post_components.ex:3374
+#: lib/vutuv_web/components/post_components.ex:4490
 #, elixir-autogen, elixir-format
 msgid "Hide reposts"
 msgstr ""
@@ -22721,8 +22723,8 @@ msgstr ""
 msgid "Posts loaded at once"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3633
-#: lib/vutuv_web/live/post_live/feed.ex:3637
+#: lib/vutuv_web/live/post_live/feed.ex:3644
+#: lib/vutuv_web/live/post_live/feed.ex:3648
 #, elixir-autogen, elixir-format
 msgid "Posts per page"
 msgstr ""
@@ -22737,60 +22739,60 @@ msgstr ""
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7276
-#: lib/vutuv_web/components/post_components.ex:7277
+#: lib/vutuv_web/components/post_components.ex:7321
+#: lib/vutuv_web/components/post_components.ex:7322
 #, elixir-autogen, elixir-format
 msgid "A word or phrase …"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7304
+#: lib/vutuv_web/components/post_components.ex:7349
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3694
-#: lib/vutuv_web/live/post_live/feed.ex:3853
-#: lib/vutuv_web/live/post_live/feed.ex:3862
+#: lib/vutuv_web/live/post_live/feed.ex:3705
+#: lib/vutuv_web/live/post_live/feed.ex:3864
+#: lib/vutuv_web/live/post_live/feed.ex:3873
 #, elixir-autogen, elixir-format
 msgid "Hidden"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3827
+#: lib/vutuv_web/live/post_live/feed.ex:3838
 #, elixir-autogen, elixir-format
 msgid "Hide something from your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7224
+#: lib/vutuv_web/components/post_components.ex:7267
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3868
+#: lib/vutuv_web/live/post_live/feed.ex:3879
 #, elixir-autogen, elixir-format
 msgid "Whatever these match is folded to a single line in your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3888
+#: lib/vutuv_web/live/post_live/feed.ex:3899
 #, elixir-autogen, elixir-format
 msgid "Words & tags"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7308
+#: lib/vutuv_web/components/post_components.ex:7353
 #, elixir-autogen, elixir-format
 msgid "everyone"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7311
+#: lib/vutuv_web/components/post_components.ex:7356
 #, elixir-autogen, elixir-format
 msgid "only %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7280
+#: lib/vutuv_web/components/post_components.ex:7325
 #, elixir-autogen, elixir-format
 msgid "this word"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7321
+#: lib/vutuv_web/components/post_components.ex:7366
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr ""
@@ -22842,7 +22844,7 @@ msgstr ""
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6628
+#: lib/vutuv_web/components/post_components.ex:6671
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr ""
@@ -22932,8 +22934,8 @@ msgstr ""
 msgid "Hidden. What other people pass on of them stays out of your feed; their own posts do not."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3317
-#: lib/vutuv_web/components/post_components.ex:4435
+#: lib/vutuv_web/components/post_components.ex:3360
+#: lib/vutuv_web/components/post_components.ex:4478
 #, elixir-autogen, elixir-format
 msgid "Hide when others repost them"
 msgstr ""
@@ -23153,7 +23155,7 @@ msgstr ""
 msgid "Your profile picture was not replaced: a report about it is still open. Open the case to remove the picture or to say that it is yours."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2478
+#: lib/vutuv_web/components/post_components.ex:2479
 #, elixir-autogen, elixir-format
 msgid "Fetching the answers from the servers that hold them…"
 msgstr ""
@@ -23168,13 +23170,13 @@ msgstr ""
 msgid "Nothing here we are allowed to show you."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2497
+#: lib/vutuv_web/components/post_components.ex:2498
 #, elixir-autogen, elixir-format
 msgid "Show more answers"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2386
-#: lib/vutuv_web/components/post_components.ex:2388
+#: lib/vutuv_web/components/post_components.ex:2387
+#: lib/vutuv_web/components/post_components.ex:2389
 #, elixir-autogen, elixir-format
 msgid "Show the one answer"
 msgid_plural "Show the %{count} answers"
@@ -23648,13 +23650,13 @@ msgstr ""
 msgid "“%{note}”"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5193
-#: lib/vutuv_web/components/press_kit_components.ex:152
+#: lib/vutuv_web/components/post_components.ex:5236
+#: lib/vutuv_web/components/press_kit_components.ex:207
 #, elixir-autogen, elixir-format
 msgid "Show these photos larger"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5379
+#: lib/vutuv_web/components/post_components.ex:5422
 #, elixir-autogen, elixir-format
 msgid "Show this photo larger"
 msgstr ""
@@ -23673,48 +23675,48 @@ msgid_plural "%{formatted} more entries (%{years})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:778
+#: lib/vutuv_web/live/press_kit_live.ex:941
 #, elixir-autogen, elixir-format
 msgid "%{percent}%"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:391
+#: lib/vutuv_web/live/press_kit_live.ex:536
 #, elixir-autogen, elixir-format
 msgid "%{used} of %{max}"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:650
+#: lib/vutuv_web/live/press_kit_live.ex:790
 #, elixir-autogen, elixir-format
 msgid "A photographer's @handle links to their profile and notifies nobody."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:734
+#: lib/vutuv_web/live/press_kit_live.ex:875
 #, elixir-autogen, elixir-format
 msgid "Add a logo variant"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:735
+#: lib/vutuv_web/live/press_kit_live.ex:876
 #, elixir-autogen, elixir-format
 msgid "Add a press photo"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:612
+#: lib/vutuv_web/live/press_kit_live.ex:752
 #, elixir-autogen, elixir-format
 msgid "At the desk in the Bonn office"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:644
+#: lib/vutuv_web/live/press_kit_live.ex:784
 #, elixir-autogen, elixir-format
 msgid "Caption"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:622
-#: lib/vutuv_web/live/press_kit_live.ex:686
+#: lib/vutuv_web/live/press_kit_live.ex:762
+#: lib/vutuv_web/live/press_kit_live.ex:827
 #, elixir-autogen, elixir-format
 msgid "Credit"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:416
+#: lib/vutuv_web/live/press_kit_live.ex:553
 #, elixir-autogen, elixir-format
 msgid "Dark"
 msgstr ""
@@ -23724,156 +23726,155 @@ msgstr ""
 msgid "Files a journalist may download and print"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:533
+#: lib/vutuv_web/live/press_kit_live.ex:673
 #, elixir-autogen, elixir-format
 msgid "First: the main photo"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:532
+#: lib/vutuv_web/live/press_kit_live.ex:672
 #, elixir-autogen, elixir-format
 msgid "First: the main variant"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:709
+#: lib/vutuv_web/live/press_kit_live.ex:850
 #, elixir-autogen, elixir-format
 msgid "I hold the rights to this file and release it for editorial use, as long as the credit above is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:416
+#: lib/vutuv_web/live/press_kit_live.ex:553
 #, elixir-autogen, elixir-format
 msgid "Light"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:813
+#: lib/vutuv_web/live/press_kit_live.ex:1006
 #, elixir-autogen, elixir-format
 msgid "Logo variant"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:116
-#: lib/vutuv_web/agent_docs/text.ex:412
-#: lib/vutuv_web/live/press_kit_live.ex:382
-#: lib/vutuv_web/templates/press_kit/index.html.heex:47
+#: lib/vutuv_web/agent_docs/text.ex:413
+#: lib/vutuv_web/live/press_kit_live.ex:527
+#: lib/vutuv_web/templates/press_kit/index.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "Logo variants"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:430
+#: lib/vutuv_web/live/press_kit_live.ex:567
 #, elixir-autogen, elixir-format
 msgid "No logo here yet."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:271
+#: lib/vutuv_web/live/press_kit_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} logo variants."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:274
+#: lib/vutuv_web/live/press_kit_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} press photos."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:431
+#: lib/vutuv_web/live/press_kit_live.ex:568
 #, elixir-autogen, elixir-format
 msgid "No press photo here yet."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:631
-#: lib/vutuv_web/live/press_kit_live.ex:696
+#: lib/vutuv_web/live/press_kit_live.ex:771
+#: lib/vutuv_web/live/press_kit_live.ex:837
 #, elixir-autogen, elixir-format
 msgid "Photo: Ada King"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:174
+#: lib/vutuv_web/live/press_kit_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "Picture removed."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:290
+#: lib/vutuv_web/live/press_kit_live.ex:391
 #, elixir-autogen, elixir-format
 msgid "Please confirm the rights first, then choose the file."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:813
+#: lib/vutuv_web/live/press_kit_live.ex:1006
 #, elixir-autogen, elixir-format
 msgid "Press photo"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:115
-#: lib/vutuv_web/agent_docs/text.ex:411
-#: lib/vutuv_web/live/press_kit_live.ex:382
-#: lib/vutuv_web/templates/press_kit/index.html.heex:38
+#: lib/vutuv_web/agent_docs/text.ex:412
+#: lib/vutuv_web/live/press_kit_live.ex:527
+#: lib/vutuv_web/templates/press_kit/index.html.heex:37
 #, elixir-autogen, elixir-format
 msgid "Press photos"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5277
-#: lib/vutuv_web/live/press_kit_live.ex:77
-#: lib/vutuv_web/live/press_kit_live.ex:321
+#: lib/vutuv_web/live/press_kit_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Press photos & logos"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:580
+#: lib/vutuv_web/live/press_kit_live.ex:988
 #, elixir-autogen, elixir-format
 msgid "Remove this picture from your press kit?"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:414
+#: lib/vutuv_web/live/press_kit_live.ex:551
 #, elixir-autogen, elixir-format
 msgid "Show tiles on:"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:634
+#: lib/vutuv_web/live/press_kit_live.ex:774
 #, elixir-autogen, elixir-format
 msgid "Shown beside the picture and asked for with every download."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:303
+#: lib/vutuv_web/live/press_kit_live.ex:404
 #, elixir-autogen, elixir-format
 msgid "That could not be saved."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:405
+#: lib/vutuv_web/live/press_kit_live.ex:980
 #, elixir-autogen, elixir-format
 msgid "The first photo is the one shown first. Drag a tile, or use the arrows, to change the order."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:465
+#: lib/vutuv_web/live/press_kit_live.ex:604
 #, elixir-autogen, elixir-format
 msgid "This shelf is full. Remove one picture to add another."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:325
+#: lib/vutuv_web/live/press_kit_live.ex:486
 #, elixir-autogen, elixir-format
 msgid "What a journalist writing about you may download: photos in print quality and your logo as a file. Everything here is public and free for editorial use as long as your credit is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:600
+#: lib/vutuv_web/live/press_kit_live.ex:740
 #, elixir-autogen, elixir-format
 msgid "What the picture shows"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:599
+#: lib/vutuv_web/live/press_kit_live.ex:739
 #, elixir-autogen, elixir-format
 msgid "Which variant this is"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:611
+#: lib/vutuv_web/live/press_kit_live.ex:751
 #, elixir-autogen, elixir-format
 msgid "White on a dark background"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:645
+#: lib/vutuv_web/live/press_kit_live.ex:785
 #, elixir-autogen, elixir-format
 msgid "Who took it, where, and what may be cropped."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:286
+#: lib/vutuv_web/live/press_kit_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "You cannot add a picture to this press kit."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:401
+#: lib/vutuv_web/live/press_kit_live.ex:972
 #, elixir-autogen, elixir-format
 msgid "Your logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
 msgstr ""
@@ -23895,65 +23896,69 @@ msgid_plural "%{count} bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:989
+#: lib/vutuv_web/components/press_kit_components.ex:99
 #, elixir-autogen, elixir-format
 msgid "Add press photos"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1007
+#: lib/vutuv_web/components/press_kit_components.ex:117
 #, elixir-autogen, elixir-format
 msgid "All press material"
 msgstr ""
 
-#: lib/vutuv_web/components/press_kit_components.ex:118
+#: lib/vutuv_web/components/press_kit_components.ex:173
 #, elixir-autogen, elixir-format
 msgid "All press photos"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1543
-#: lib/vutuv_web/agent_docs/text.ex:986
+#: lib/vutuv_web/agent_docs/markdown.ex:1547
+#: lib/vutuv_web/agent_docs/text.ex:987
 #, elixir-autogen, elixir-format
 msgid "Credit: %{credit}"
 msgstr ""
 
-#: lib/vutuv_web/components/press_kit_components.ex:265
-#: lib/vutuv_web/components/press_kit_components.ex:268
+#: lib/vutuv_web/components/press_kit_components.ex:320
+#: lib/vutuv_web/components/press_kit_components.ex:323
 #, elixir-autogen, elixir-format
 msgid "Download %{format}"
 msgstr ""
 
-#: lib/vutuv_web/components/press_kit_components.ex:221
+#: lib/vutuv_web/components/press_kit_components.ex:276
 #, elixir-autogen, elixir-format
 msgid "Download photo"
 msgstr ""
 
-#: lib/vutuv/press_kit.ex:452
+#: lib/vutuv/press_kit.ex:496
 #, elixir-autogen, elixir-format
 msgid "Free for editorial use with credit."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1546
+#: lib/vutuv_web/agent_docs/markdown.ex:1550
 #, elixir-autogen, elixir-format
 msgid "PNG version"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
+#: lib/vutuv_web/agent_docs/markdown.ex:290
 #: lib/vutuv_web/agent_docs/text.ex:57
-#: lib/vutuv_web/controllers/press_kit_controller.ex:45
-#: lib/vutuv_web/templates/press_kit/index.html.heex:12
-#: lib/vutuv_web/templates/user/show.html.heex:987
+#: lib/vutuv_web/agent_docs/text.ex:257
+#: lib/vutuv_web/components/organization_components.ex:262
+#: lib/vutuv_web/components/press_kit_components.ex:97
+#: lib/vutuv_web/live/organization_live/show.ex:168
+#: lib/vutuv_web/views/press_kit_html.ex:28
+#: lib/vutuv_web/views/press_kit_html.ex:46
 #, elixir-autogen, elixir-format
 msgid "Press"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/press_kit_doc.ex:48
-#: lib/vutuv_web/templates/press_kit/index.html.heex:7
+#: lib/vutuv_web/views/press_kit_html.ex:32
 #, elixir-autogen, elixir-format
 msgid "Press photos and logos of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1542
-#: lib/vutuv_web/agent_docs/text.ex:983
+#: lib/vutuv_web/agent_docs/markdown.ex:1546
+#: lib/vutuv_web/agent_docs/text.ex:984
 #, elixir-autogen, elixir-format
 msgid "Press picture"
 msgstr ""
@@ -23963,12 +23968,37 @@ msgstr ""
 msgid "Press pictures %{name} offers for download, free for editorial use with credit."
 msgstr ""
 
-#: lib/vutuv_web/templates/press_kit/index.html.heex:32
+#: lib/vutuv_web/templates/press_kit/index.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "These pictures are offered for editorial use. Use them freely in reporting, and print the credit shown with each one."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3015
+#: lib/vutuv_web/components/post_components.ex:3025
 #, elixir-autogen, elixir-format
 msgid "Video is being checked"
+msgstr ""
+
+#: lib/vutuv_web/live/press_kit_live.ex:908
+#, elixir-autogen, elixir-format
+msgid "Copies the vector file this page's logo was uploaded as onto this shelf."
+msgstr ""
+
+#: lib/vutuv_web/live/press_kit_live.ex:986
+#, elixir-autogen, elixir-format
+msgid "Remove this picture from this page's press kit?"
+msgstr ""
+
+#: lib/vutuv_web/live/press_kit_live.ex:966
+#, elixir-autogen, elixir-format
+msgid "The page's logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
+msgstr ""
+
+#: lib/vutuv_web/live/press_kit_live.ex:905
+#, elixir-autogen, elixir-format
+msgid "Use the page's own logo"
+msgstr ""
+
+#: lib/vutuv_web/live/press_kit_live.ex:468
+#, elixir-autogen, elixir-format
+msgid "What a journalist writing about this page may download: photos in print quality and its logo as a file. Everything here is public and free for editorial use as long as the credit is shown."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -33,12 +33,12 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:169
 #: lib/vutuv_web/live/organization_live/fediverse.ex:123
-#: lib/vutuv_web/live/organization_live/show.ex:920
+#: lib/vutuv_web/live/organization_live/show.ex:957
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1543
+#: lib/vutuv_web/templates/user/show.html.heex:1526
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -100,11 +100,11 @@ msgstr ""
 msgid "Birthdate"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:703
-#: lib/vutuv_web/agent_docs/markdown.ex:704
-#: lib/vutuv_web/agent_docs/text.ex:653
+#: lib/vutuv_web/agent_docs/markdown.ex:707
+#: lib/vutuv_web/agent_docs/markdown.ex:708
 #: lib/vutuv_web/agent_docs/text.ex:654
-#: lib/vutuv_web/templates/user/show.html.heex:1174
+#: lib/vutuv_web/agent_docs/text.ex:655
+#: lib/vutuv_web/templates/user/show.html.heex:1157
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
@@ -119,7 +119,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
 #: lib/vutuv_web/live/post_live/composer.ex:1917
-#: lib/vutuv_web/live/press_kit_live.ex:656
+#: lib/vutuv_web/live/press_kit_live.ex:796
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -153,7 +153,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1212
+#: lib/vutuv_web/templates/user/show.html.heex:1195
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -162,7 +162,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4392
+#: lib/vutuv_web/components/post_components.ex:4435
 #: lib/vutuv_web/components/ui.ex:4864
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
@@ -210,14 +210,14 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4357
+#: lib/vutuv_web/components/post_components.ex:4400
 #: lib/vutuv_web/components/ui.ex:4855
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
 #: lib/vutuv_web/live/job_posting_live/show.ex:201
-#: lib/vutuv_web/live/organization_live/show.ex:152
-#: lib/vutuv_web/live/press_kit_live.ex:573
+#: lib/vutuv_web/live/organization_live/show.ex:159
+#: lib/vutuv_web/live/press_kit_live.ex:713
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:19
@@ -225,7 +225,7 @@ msgstr ""
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:113
-#: lib/vutuv_web/templates/user/show.html.heex:1197
+#: lib/vutuv_web/templates/user/show.html.heex:1180
 #, elixir-autogen
 msgid "Edit"
 msgstr ""
@@ -306,14 +306,14 @@ msgstr ""
 msgid "Fax"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:689
+#: lib/vutuv_web/agent_docs/markdown.ex:693
 #: lib/vutuv_web/templates/user/edit.html.heex:170
 #, elixir-autogen
 msgid "First Name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:724
-#: lib/vutuv_web/agent_docs/text.ex:674
+#: lib/vutuv_web/agent_docs/markdown.ex:728
+#: lib/vutuv_web/agent_docs/text.ex:675
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
@@ -323,18 +323,18 @@ msgstr ""
 msgid "Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:725
-#: lib/vutuv_web/agent_docs/text.ex:675
+#: lib/vutuv_web/agent_docs/markdown.ex:729
+#: lib/vutuv_web/agent_docs/text.ex:676
 #: lib/vutuv_web/components/fediverse_components.ex:468
 #: lib/vutuv_web/components/ui.ex:3087
 #: lib/vutuv_web/components/ui.ex:3122
 #: lib/vutuv_web/controllers/followee_controller.ex:29
 #: lib/vutuv_web/live/import_connections_live.ex:469
-#: lib/vutuv_web/live/organization_live/show.ex:618
+#: lib/vutuv_web/live/organization_live/show.ex:641
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:1042
-#: lib/vutuv_web/views/user_html.ex:649
+#: lib/vutuv_web/templates/user/show.html.heex:1025
+#: lib/vutuv_web/views/user_html.ex:642
 #, elixir-autogen
 msgid "Following"
 msgstr ""
@@ -383,7 +383,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:691
+#: lib/vutuv_web/agent_docs/markdown.ex:695
 #: lib/vutuv_web/templates/user/edit.html.heex:175
 #, elixir-autogen
 msgid "Last Name"
@@ -450,7 +450,7 @@ msgstr ""
 msgid "Log in"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:690
+#: lib/vutuv_web/agent_docs/markdown.ex:694
 #: lib/vutuv_web/templates/user/edit.html.heex:180
 #, elixir-autogen
 msgid "Middle Name"
@@ -475,7 +475,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:807
+#: lib/vutuv_web/components/post_components.ex:808
 #: lib/vutuv_web/live/notification_live/index.ex:776
 #: lib/vutuv_web/live/organization_live/activity.ex:136
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
@@ -487,7 +487,7 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:693
+#: lib/vutuv_web/agent_docs/markdown.ex:697
 #: lib/vutuv_web/templates/user/edit.html.heex:185
 #, elixir-autogen
 msgid "Nickname"
@@ -568,7 +568,7 @@ msgstr ""
 msgid "Phone number updated successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:688
+#: lib/vutuv_web/agent_docs/markdown.ex:692
 #: lib/vutuv_web/templates/user/edit.html.heex:190
 #, elixir-autogen
 msgid "Prefix"
@@ -618,7 +618,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:4756
 #: lib/vutuv_web/live/organization_live/edit.ex:376
 #: lib/vutuv_web/live/post_live/composer.ex:2201
-#: lib/vutuv_web/live/press_kit_live.ex:655
+#: lib/vutuv_web/live/press_kit_live.ex:795
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
@@ -660,7 +660,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1866
+#: lib/vutuv_web/components/post_components.ex:1867
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -694,13 +694,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1326
+#: lib/vutuv_web/templates/user/show.html.heex:1309
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1328
+#: lib/vutuv_web/templates/user/show.html.heex:1311
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -725,12 +725,12 @@ msgstr ""
 msgid "Profile deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:1057
+#: lib/vutuv_web/views/user_html.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Social networks"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:1064
+#: lib/vutuv_web/views/user_html.ex:1057
 #, elixir-autogen, elixir-format
 msgid "Code & repositories"
 msgstr ""
@@ -748,7 +748,7 @@ msgstr ""
 msgid "Submit a bugreport or a feature request."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:692
+#: lib/vutuv_web/agent_docs/markdown.ex:696
 #: lib/vutuv_web/templates/user/edit.html.heex:195
 #, elixir-autogen
 msgid "Suffix"
@@ -828,7 +828,6 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/show.html.heex:4
 #: lib/vutuv_web/templates/phone_number/index.html.heex:8
 #: lib/vutuv_web/templates/phone_number/show.html.heex:4
-#: lib/vutuv_web/templates/press_kit/index.html.heex:10
 #: lib/vutuv_web/templates/qualification/index.html.heex:9
 #: lib/vutuv_web/templates/qualification/show.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/index.html.heex:8
@@ -840,21 +839,22 @@ msgstr ""
 #: lib/vutuv_web/templates/user_tag/show.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:8
 #: lib/vutuv_web/templates/work_experience/show.html.heex:4
+#: lib/vutuv_web/views/press_kit_html.ex:50
 #, elixir-autogen
 msgid "Users"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1597
-#: lib/vutuv_web/views/user_html.ex:594
-#: lib/vutuv_web/views/user_html.ex:595
-#: lib/vutuv_web/views/user_html.ex:609
+#: lib/vutuv_web/views/user_html.ex:587
+#: lib/vutuv_web/views/user_html.ex:588
+#: lib/vutuv_web/views/user_html.ex:602
 #, elixir-autogen
 msgid "vCard"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4925
-#: lib/vutuv_web/templates/user/show.html.heex:1036
-#: lib/vutuv_web/templates/user/show.html.heex:1059
+#: lib/vutuv_web/templates/user/show.html.heex:1019
+#: lib/vutuv_web/templates/user/show.html.heex:1042
 #, elixir-autogen
 msgid "View All"
 msgstr ""
@@ -930,6 +930,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/init_assigns.ex:54
 #: lib/vutuv_web/live/post_live/feed.ex:169
+#: lib/vutuv_web/live/press_kit_live.ex:109
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1040,7 +1041,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1163
+#: lib/vutuv_web/templates/user/show.html.heex:1146
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1123,7 +1124,7 @@ msgstr ""
 msgid "Add Localization"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:315
+#: lib/vutuv_web/components/organization_components.ex:324
 #: lib/vutuv_web/live/admin/activity_live.ex:153
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
@@ -1181,7 +1182,7 @@ msgstr ""
 msgid "All tag urls"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5006
+#: lib/vutuv_web/components/post_components.ex:5049
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:643
@@ -1348,11 +1349,11 @@ msgid "Tag urls"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:34
-#: lib/vutuv_web/agent_docs/markdown.ex:596
-#: lib/vutuv_web/agent_docs/markdown.ex:1237
+#: lib/vutuv_web/agent_docs/markdown.ex:600
+#: lib/vutuv_web/agent_docs/markdown.ex:1241
 #: lib/vutuv_web/agent_docs/text.ex:31
-#: lib/vutuv_web/agent_docs/text.ex:601
-#: lib/vutuv_web/agent_docs/text.ex:867
+#: lib/vutuv_web/agent_docs/text.ex:602
+#: lib/vutuv_web/agent_docs/text.ex:868
 #: lib/vutuv_web/components/ui.ex:5305
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
@@ -1674,12 +1675,12 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:320
 #: lib/vutuv_web/live/organization_live/following.ex:340
 #: lib/vutuv_web/live/organization_live/following.ex:421
-#: lib/vutuv_web/live/organization_live/show.ex:579
-#: lib/vutuv_web/live/organization_live/show.ex:616
+#: lib/vutuv_web/live/organization_live/show.ex:602
+#: lib/vutuv_web/live/organization_live/show.ex:639
 #: lib/vutuv_web/live/post_live/feed.ex:902
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
-#: lib/vutuv_web/templates/user/show.html.heex:1367
-#: lib/vutuv_web/views/user_html.ex:660
+#: lib/vutuv_web/templates/user/show.html.heex:1350
+#: lib/vutuv_web/views/user_html.ex:653
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
@@ -1695,7 +1696,7 @@ msgstr ""
 msgid "Log out"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:321
+#: lib/vutuv_web/components/organization_components.ex:330
 #: lib/vutuv_web/live/admin/activity_live.ex:143
 #: lib/vutuv_web/live/admin/activity_live.ex:175
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
@@ -1710,10 +1711,10 @@ msgstr ""
 msgid "Member"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:638
-#: lib/vutuv_web/views/user_html.ex:687
-#: lib/vutuv_web/views/user_html.ex:688
-#: lib/vutuv_web/views/user_html.ex:698
+#: lib/vutuv_web/live/organization_live/show.ex:661
+#: lib/vutuv_web/views/user_html.ex:680
+#: lib/vutuv_web/views/user_html.ex:681
+#: lib/vutuv_web/views/user_html.ex:691
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
@@ -1733,7 +1734,7 @@ msgstr ""
 msgid "Network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:486
+#: lib/vutuv_web/components/post_components.ex:487
 #: lib/vutuv_web/components/ui.ex:4974
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
@@ -1823,7 +1824,7 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:27
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:18
 #: lib/vutuv_web/templates/user/show.html.heex:232
-#: lib/vutuv_web/views/user_html.ex:1109
+#: lib/vutuv_web/views/user_html.ex:1102
 #, elixir-autogen, elixir-format
 msgid "Verified profile"
 msgstr ""
@@ -1843,7 +1844,7 @@ msgstr ""
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:247
+#: lib/vutuv_web/views/user_html.ex:240
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr ""
@@ -1862,14 +1863,14 @@ msgstr ""
 
 #: lib/vutuv_web/open_graph.ex:418
 #: lib/vutuv_web/templates/tag/show.html.heex:32
-#: lib/vutuv_web/views/user_html.ex:531
+#: lib/vutuv_web/views/user_html.ex:524
 #, elixir-autogen, elixir-format
 msgid "follower"
 msgid_plural "followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_html.ex:535
+#: lib/vutuv_web/views/user_html.ex:528
 #, elixir-autogen, elixir-format
 msgid "following"
 msgstr ""
@@ -1899,7 +1900,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:4999
 #: lib/vutuv_web/live/organization_live/activity.ex:159
 #: lib/vutuv_web/live/organization_live/feed.ex:258
-#: lib/vutuv_web/live/organization_live/show.ex:787
+#: lib/vutuv_web/live/organization_live/show.ex:810
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr ""
@@ -2020,12 +2021,12 @@ msgstr ""
 msgid "May"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:299
+#: lib/vutuv_web/views/user_html.ex:292
 #, elixir-autogen, elixir-format
 msgid "Member since %{month} %{year}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:304
+#: lib/vutuv_web/views/user_html.ex:297
 #, elixir-autogen, elixir-format
 msgid "Member since %{year}"
 msgstr ""
@@ -2070,7 +2071,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/post_live/composer.ex:2015
 #: lib/vutuv_web/live/post_live/composer.ex:2038
-#: lib/vutuv_web/live/press_kit_live.ex:786
+#: lib/vutuv_web/live/press_kit_live.ex:949
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2080,7 +2081,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4389
+#: lib/vutuv_web/components/post_components.ex:4432
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2092,11 +2093,11 @@ msgstr ""
 msgid "Edit post"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:265
+#: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:203
 #: lib/vutuv_web/live/post_live/feed.ex:331
-#: lib/vutuv_web/live/post_live/feed.ex:3254
+#: lib/vutuv_web/live/post_live/feed.ex:3265
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1341
 #: lib/vutuv_web/live/shell_live.ex:1686
@@ -2125,8 +2126,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4343
-#: lib/vutuv_web/components/post_components.ex:4345
+#: lib/vutuv_web/components/post_components.ex:4386
+#: lib/vutuv_web/components/post_components.ex:4388
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2142,7 +2143,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3583
+#: lib/vutuv_web/live/post_live/feed.ex:3594
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2180,7 +2181,7 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:113
 #: lib/vutuv_web/live/admin/dashboard_live.ex:270
 #: lib/vutuv_web/live/fediverse_account_live.ex:446
-#: lib/vutuv_web/live/organization_live/show.ex:710
+#: lib/vutuv_web/live/organization_live/show.ex:733
 #: lib/vutuv_web/live/post_live/saved.ex:536
 #: lib/vutuv_web/live/search_live.ex:348
 #: lib/vutuv_web/live/search_live.ex:832
@@ -2190,13 +2191,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4879
-#: lib/vutuv_web/components/post_components.ex:4883
+#: lib/vutuv_web/components/post_components.ex:4922
+#: lib/vutuv_web/components/post_components.ex:4926
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4880
+#: lib/vutuv_web/components/post_components.ex:4923
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2206,7 +2207,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:497
 #: lib/vutuv_web/components/job_exclusion_components.ex:189
-#: lib/vutuv_web/components/post_components.ex:1448
+#: lib/vutuv_web/components/post_components.ex:1449
 #: lib/vutuv_web/live/admin/screenshot_live.ex:352
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:229
@@ -2218,7 +2219,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:666
 #: lib/vutuv_web/live/post_live/saved.ex:694
 #: lib/vutuv_web/live/post_rewrites_live.ex:376
-#: lib/vutuv_web/live/press_kit_live.ex:582
+#: lib/vutuv_web/live/press_kit_live.ex:722
 #: lib/vutuv_web/templates/connection/index.html.heex:45
 #: lib/vutuv_web/views/settings_html.ex:386
 #, elixir-autogen, elixir-format
@@ -2235,7 +2236,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2454
+#: lib/vutuv_web/live/post_live/feed.ex:2465
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2249,7 +2250,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/post_live/composer.ex:1520
 #: lib/vutuv_web/live/post_live/composer.ex:1588
-#: lib/vutuv_web/live/press_kit_live.ex:294
+#: lib/vutuv_web/live/press_kit_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
@@ -2293,27 +2294,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4340
+#: lib/vutuv_web/components/post_components.ex:4383
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6646
+#: lib/vutuv_web/components/post_components.ex:6689
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6650
+#: lib/vutuv_web/components/post_components.ex:6693
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6648
+#: lib/vutuv_web/components/post_components.ex:6691
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6649
+#: lib/vutuv_web/components/post_components.ex:6692
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2357,15 +2358,15 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2180
-#: lib/vutuv_web/components/post_components.ex:6749
+#: lib/vutuv_web/components/post_components.ex:2181
+#: lib/vutuv_web/components/post_components.ex:6792
 #: lib/vutuv_web/components/ui.ex:4298
-#: lib/vutuv_web/views/user_html.ex:493
+#: lib/vutuv_web/views/user_html.ex:486
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1291
+#: lib/vutuv_web/agent_docs/markdown.ex:1295
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:529
 #: lib/vutuv_web/live/shell_live.ex:1499
@@ -2376,17 +2377,17 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2124
-#: lib/vutuv_web/components/post_components.ex:6990
+#: lib/vutuv_web/components/post_components.ex:2125
+#: lib/vutuv_web/components/post_components.ex:7033
 #: lib/vutuv_web/components/ui.ex:4284
 #: lib/vutuv_web/notification_line.ex:317
-#: lib/vutuv_web/views/user_html.ex:503
+#: lib/vutuv_web/views/user_html.ex:496
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1290
-#: lib/vutuv_web/components/post_components.ex:7000
+#: lib/vutuv_web/agent_docs/markdown.ex:1294
+#: lib/vutuv_web/components/post_components.ex:7043
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
 #: lib/vutuv_web/live/shell_live.ex:1590
@@ -2407,58 +2408,58 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6737
+#: lib/vutuv_web/components/post_components.ex:6780
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2179
-#: lib/vutuv_web/components/post_components.ex:6748
+#: lib/vutuv_web/components/post_components.ex:2180
+#: lib/vutuv_web/components/post_components.ex:6791
 #: lib/vutuv_web/live/post_live/saved.ex:822
-#: lib/vutuv_web/views/user_html.ex:493
+#: lib/vutuv_web/views/user_html.ex:486
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2160
-#: lib/vutuv_web/components/post_components.ex:6733
+#: lib/vutuv_web/components/post_components.ex:2161
+#: lib/vutuv_web/components/post_components.ex:6776
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2753
-#: lib/vutuv_web/components/post_components.ex:5752
+#: lib/vutuv_web/components/post_components.ex:2754
+#: lib/vutuv_web/components/post_components.ex:5795
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2159
-#: lib/vutuv_web/components/post_components.ex:6732
+#: lib/vutuv_web/components/post_components.ex:2160
+#: lib/vutuv_web/components/post_components.ex:6775
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2123
-#: lib/vutuv_web/components/post_components.ex:6989
+#: lib/vutuv_web/components/post_components.ex:2124
+#: lib/vutuv_web/components/post_components.ex:7032
 #: lib/vutuv_web/live/post_live/saved.ex:821
-#: lib/vutuv_web/views/user_html.ex:503
+#: lib/vutuv_web/views/user_html.ex:496
 #, elixir-autogen, elixir-format
 msgid "Unlike"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:498
-#: lib/vutuv_web/components/post_components.ex:3351
+#: lib/vutuv_web/components/post_components.ex:3394
 #: lib/vutuv_web/components/ui.ex:3047
 #: lib/vutuv_web/components/ui.ex:3047
 #: lib/vutuv_web/components/ui.ex:3123
 #: lib/vutuv_web/live/organization_live/following.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:476
-#: lib/vutuv_web/live/organization_live/show.ex:621
+#: lib/vutuv_web/live/organization_live/show.ex:644
 #: lib/vutuv_web/live/post_live/feed.ex:889
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:42
-#: lib/vutuv_web/views/user_html.ex:650
+#: lib/vutuv_web/views/user_html.ex:643
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr ""
@@ -2468,20 +2469,20 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7044
+#: lib/vutuv_web/components/post_components.ex:7087
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:444
+#: lib/vutuv_web/components/post_components.ex:445
 #: lib/vutuv_web/live/notification_live/index.ex:1331
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2369
-#: lib/vutuv_web/components/post_components.ex:7027
-#: lib/vutuv_web/components/post_components.ex:7028
+#: lib/vutuv_web/components/post_components.ex:2370
+#: lib/vutuv_web/components/post_components.ex:7070
+#: lib/vutuv_web/components/post_components.ex:7071
 #: lib/vutuv_web/live/notification_live/index.ex:993
 #: lib/vutuv_web/live/post_live/reply.ex:49
 #: lib/vutuv_web/notification_line.ex:314
@@ -2489,7 +2490,7 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4299
+#: lib/vutuv_web/components/post_components.ex:4342
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2510,7 +2511,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3817
+#: lib/vutuv_web/components/post_components.ex:3860
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:63
 #: lib/vutuv_web/live/post_live/remote_reply.ex:61
 #: lib/vutuv_web/live/post_live/reply.ex:63
@@ -2518,14 +2519,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4271
+#: lib/vutuv_web/components/post_components.ex:4314
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4262
-#: lib/vutuv_web/components/post_components.ex:4291
-#: lib/vutuv_web/components/post_components.ex:4294
+#: lib/vutuv_web/components/post_components.ex:4305
+#: lib/vutuv_web/components/post_components.ex:4334
+#: lib/vutuv_web/components/post_components.ex:4337
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2698,26 +2699,26 @@ msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1286
+#: lib/vutuv_web/templates/user/show.html.heex:1269
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1545
+#: lib/vutuv_web/templates/user/show.html.heex:1528
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1214
+#: lib/vutuv_web/templates/user/show.html.heex:1197
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1165
+#: lib/vutuv_web/templates/user/show.html.heex:1148
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
@@ -2748,7 +2749,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:884
+#: lib/vutuv_web/components/post_components.ex:885
 #: lib/vutuv_web/controllers/page_controller.ex:211
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2778,8 +2779,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:726
-#: lib/vutuv_web/agent_docs/text.ex:676
+#: lib/vutuv_web/agent_docs/markdown.ex:730
+#: lib/vutuv_web/agent_docs/text.ex:677
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -2817,14 +2818,14 @@ msgid "This post is for the connections of %{name}"
 msgstr ""
 
 #: lib/vutuv_web/views/admin/moderation_html.ex:127
-#: lib/vutuv_web/views/user_html.ex:545
+#: lib/vutuv_web/views/user_html.ex:538
 #, elixir-autogen, elixir-format
 msgid "connection"
 msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6647
+#: lib/vutuv_web/components/post_components.ex:6690
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2834,7 +2835,7 @@ msgstr ""
 msgid "Open someone's profile to message them."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:259
+#: lib/vutuv_web/components/organization_components.ex:268
 #: lib/vutuv_web/live/organization_live/activity.ex:112
 #: lib/vutuv_web/notification_line.ex:331
 #, elixir-autogen, elixir-format
@@ -2852,7 +2853,7 @@ msgid "Endorsement"
 msgstr ""
 
 #: lib/vutuv_web/notification_line.ex:312
-#: lib/vutuv_web/templates/user/show.html.heex:1020
+#: lib/vutuv_web/templates/user/show.html.heex:1003
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -2921,8 +2922,8 @@ msgstr ""
 msgid "Bullying or harassment"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:400
-#: lib/vutuv_web/agent_docs/text.ex:366
+#: lib/vutuv_web/agent_docs/markdown.ex:404
+#: lib/vutuv_web/agent_docs/text.ex:367
 #: lib/vutuv_web/controllers/page_controller.ex:76
 #: lib/vutuv_web/templates/layout/app.html.heex:126
 #: lib/vutuv_web/templates/page/community.html.heex:4
@@ -3068,13 +3069,13 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1254
-#: lib/vutuv_web/templates/user/show.html.heex:1255
+#: lib/vutuv_web/templates/user/show.html.heex:1237
+#: lib/vutuv_web/templates/user/show.html.heex:1238
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4238
+#: lib/vutuv_web/components/post_components.ex:4281
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3100,7 +3101,7 @@ msgstr ""
 msgid "Opened"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:314
+#: lib/vutuv_web/components/organization_components.ex:323
 #: lib/vutuv_web/live/admin/api_app_live.ex:72
 #: lib/vutuv_web/live/admin/deliverability_live.ex:171
 #: lib/vutuv_web/live/admin/moderation_live.ex:56
@@ -3132,10 +3133,10 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1461
-#: lib/vutuv_web/components/post_components.ex:3371
-#: lib/vutuv_web/components/post_components.ex:4456
-#: lib/vutuv_web/live/organization_live/show.ex:661
+#: lib/vutuv_web/components/post_components.ex:1462
+#: lib/vutuv_web/components/post_components.ex:3414
+#: lib/vutuv_web/components/post_components.ex:4499
+#: lib/vutuv_web/live/organization_live/show.ex:684
 #: lib/vutuv_web/templates/user/show.html.heex:252
 #, elixir-autogen, elixir-format
 msgid "Report"
@@ -3765,12 +3766,12 @@ msgstr ""
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:833
+#: lib/vutuv_web/agent_docs/markdown.ex:837
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1412
+#: lib/vutuv_web/agent_docs/markdown.ex:1416
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3784,11 +3785,11 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:92
 #: lib/vutuv_web/agent_docs/markdown.ex:219
 #: lib/vutuv_web/agent_docs/markdown.ex:233
-#: lib/vutuv_web/agent_docs/markdown.ex:1237
+#: lib/vutuv_web/agent_docs/markdown.ex:1241
 #: lib/vutuv_web/agent_docs/text.ex:87
 #: lib/vutuv_web/agent_docs/text.ex:188
 #: lib/vutuv_web/agent_docs/text.ex:202
-#: lib/vutuv_web/agent_docs/text.ex:867
+#: lib/vutuv_web/agent_docs/text.ex:868
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
@@ -3807,28 +3808,28 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1255
-#: lib/vutuv_web/agent_docs/text.ex:878
+#: lib/vutuv_web/agent_docs/markdown.ex:1259
+#: lib/vutuv_web/agent_docs/text.ex:879
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1252
-#: lib/vutuv_web/agent_docs/text.ex:875
+#: lib/vutuv_web/agent_docs/markdown.ex:1256
+#: lib/vutuv_web/agent_docs/text.ex:876
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1259
-#: lib/vutuv_web/agent_docs/markdown.ex:1505
-#: lib/vutuv_web/agent_docs/text.ex:882
-#: lib/vutuv_web/agent_docs/text.ex:951
+#: lib/vutuv_web/agent_docs/markdown.ex:1263
+#: lib/vutuv_web/agent_docs/markdown.ex:1509
+#: lib/vutuv_web/agent_docs/text.ex:883
+#: lib/vutuv_web/agent_docs/text.ex:952
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:661
-#: lib/vutuv_web/agent_docs/text.ex:639
+#: lib/vutuv_web/agent_docs/markdown.ex:665
+#: lib/vutuv_web/agent_docs/text.ex:640
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr ""
@@ -3867,23 +3868,23 @@ msgstr ""
 msgid "Posts (%{count} total)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:655
-#: lib/vutuv_web/agent_docs/text.ex:633
+#: lib/vutuv_web/agent_docs/markdown.ex:659
+#: lib/vutuv_web/agent_docs/text.ex:634
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1183
+#: lib/vutuv_web/agent_docs/markdown.ex:1187
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1045
+#: lib/vutuv_web/agent_docs/markdown.ex:1049
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1046
+#: lib/vutuv_web/agent_docs/markdown.ex:1050
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -3959,8 +3960,8 @@ msgstr ""
 msgid "Billing name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:414
-#: lib/vutuv_web/agent_docs/text.ex:374
+#: lib/vutuv_web/agent_docs/markdown.ex:418
+#: lib/vutuv_web/agent_docs/text.ex:375
 #, elixir-autogen, elixir-format
 msgid "Book online (login required): %{url}"
 msgstr ""
@@ -4012,8 +4013,8 @@ msgstr ""
 msgid "Markdown is supported. At most %{max} characters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:404
-#: lib/vutuv_web/agent_docs/text.ex:370
+#: lib/vutuv_web/agent_docs/markdown.ex:408
+#: lib/vutuv_web/agent_docs/text.ex:371
 #: lib/vutuv_web/templates/ad/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Next available day"
@@ -4029,8 +4030,8 @@ msgstr ""
 msgid "One text-only ad per calendar day, seen by every visitor."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:401
-#: lib/vutuv_web/agent_docs/text.ex:367
+#: lib/vutuv_web/agent_docs/markdown.ex:405
+#: lib/vutuv_web/agent_docs/text.ex:368
 #: lib/vutuv_web/templates/ad/index.html.heex:35
 #: lib/vutuv_web/templates/ad/preview.html.heex:32
 #: lib/vutuv_web/views/admin/ad_html.ex:59
@@ -4244,14 +4245,14 @@ msgstr ""
 msgid "deleted account"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:406
-#: lib/vutuv_web/agent_docs/text.ex:372
+#: lib/vutuv_web/agent_docs/markdown.ex:410
+#: lib/vutuv_web/agent_docs/text.ex:373
 #, elixir-autogen, elixir-format
 msgid "Already booked"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:402
-#: lib/vutuv_web/agent_docs/text.ex:368
+#: lib/vutuv_web/agent_docs/markdown.ex:406
+#: lib/vutuv_web/agent_docs/text.ex:369
 #, elixir-autogen, elixir-format
 msgid "Booking window"
 msgstr ""
@@ -4475,7 +4476,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3588
+#: lib/vutuv_web/live/post_live/feed.ex:3599
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4485,11 +4486,11 @@ msgstr ""
 msgid "Find members"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:271
+#: lib/vutuv_web/components/organization_components.ex:280
 #: lib/vutuv_web/live/organization_live/following.ex:313
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:1042
+#: lib/vutuv_web/templates/user/show.html.heex:1025
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -4530,12 +4531,12 @@ msgid "Not an exact match, but sounds like your search."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/investors_doc.ex:212
-#: lib/vutuv_web/agent_docs/markdown.ex:537
-#: lib/vutuv_web/agent_docs/text.ex:542
+#: lib/vutuv_web/agent_docs/markdown.ex:541
+#: lib/vutuv_web/agent_docs/text.ex:543
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/live/notification_live/index.ex:640
 #: lib/vutuv_web/live/notification_live/index.ex:1333
-#: lib/vutuv_web/live/organization_live/show.ex:797
+#: lib/vutuv_web/live/organization_live/show.ex:820
 #: lib/vutuv_web/live/post_live/saved.ex:539
 #: lib/vutuv_web/live/search_live.ex:346
 #: lib/vutuv_web/live/search_live.ex:774
@@ -4553,8 +4554,8 @@ msgstr ""
 msgid "Similar names"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:441
-#: lib/vutuv_web/components/post_components.ex:460
+#: lib/vutuv_web/components/post_components.ex:442
+#: lib/vutuv_web/components/post_components.ex:461
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
@@ -4652,8 +4653,8 @@ msgstr ""
 msgid "Edit your profile and its sections"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:303
-#: lib/vutuv_web/agent_docs/text.ex:273
+#: lib/vutuv_web/agent_docs/markdown.ex:307
+#: lib/vutuv_web/agent_docs/text.ex:274
 #: lib/vutuv_web/live/admin/job_live.ex:389
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:140
 #: lib/vutuv_web/live/job_posting_live/show.ex:159
@@ -5352,11 +5353,11 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4536
-#: lib/vutuv_web/components/post_components.ex:5145
-#: lib/vutuv_web/components/post_components.ex:5483
+#: lib/vutuv_web/components/post_components.ex:4579
+#: lib/vutuv_web/components/post_components.ex:5188
+#: lib/vutuv_web/components/post_components.ex:5526
 #: lib/vutuv_web/live/notification_live/index.ex:1069
-#: lib/vutuv_web/views/user_html.ex:140
+#: lib/vutuv_web/views/user_html.ex:133
 #, elixir-autogen, elixir-format
 msgid "View post"
 msgstr ""
@@ -5380,7 +5381,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:33
 #: lib/vutuv_web/views/email_html.ex:12
-#: lib/vutuv_web/views/user_html.ex:1234
+#: lib/vutuv_web/views/user_html.ex:1227
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr ""
@@ -5562,7 +5563,7 @@ msgstr ""
 msgid "@%{slug} started following you on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:284
+#: lib/vutuv_web/components/organization_components.ex:293
 #: lib/vutuv_web/live/organization_live/apps.ex:167
 #: lib/vutuv_web/templates/settings/apps.html.heex:12
 #, elixir-autogen, elixir-format
@@ -6020,7 +6021,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1595
+#: lib/vutuv_web/templates/user/show.html.heex:1578
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6064,16 +6065,16 @@ msgstr ""
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1180
-#: lib/vutuv_web/templates/user/show.html.heex:1190
+#: lib/vutuv_web/templates/user/show.html.heex:1163
+#: lib/vutuv_web/templates/user/show.html.heex:1173
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:705
-#: lib/vutuv_web/agent_docs/text.ex:655
+#: lib/vutuv_web/agent_docs/markdown.ex:709
+#: lib/vutuv_web/agent_docs/text.ex:656
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr ""
@@ -6105,12 +6106,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1302
+#: lib/vutuv_web/templates/user/show.html.heex:1285
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1313
+#: lib/vutuv_web/templates/user/show.html.heex:1296
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6145,21 +6146,21 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1290
-#: lib/vutuv_web/components/post_components.ex:443
+#: lib/vutuv_web/agent_docs/markdown.ex:1294
+#: lib/vutuv_web/components/post_components.ex:444
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1311
+#: lib/vutuv_web/templates/user/show.html.heex:1294
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
 
 #: lib/vutuv_web/live/feed_languages_live.ex:235
-#: lib/vutuv_web/live/press_kit_live.ex:496
+#: lib/vutuv_web/live/press_kit_live.ex:636
 #: lib/vutuv_web/live/section_reorder_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder"
@@ -6172,7 +6173,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/feed_languages_live.ex:267
 #: lib/vutuv_web/live/post_rewrites_live.ex:364
-#: lib/vutuv_web/live/press_kit_live.ex:558
+#: lib/vutuv_web/live/press_kit_live.ex:698
 #: lib/vutuv_web/live/section_reorder_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Move down"
@@ -6180,7 +6181,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/feed_languages_live.ex:256
 #: lib/vutuv_web/live/post_rewrites_live.ex:352
-#: lib/vutuv_web/live/press_kit_live.ex:547
+#: lib/vutuv_web/live/press_kit_live.ex:687
 #: lib/vutuv_web/live/section_reorder_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -6215,9 +6216,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1585
-#: lib/vutuv_web/templates/user/show.html.heex:1589
-#: lib/vutuv_web/templates/user/show.html.heex:1601
+#: lib/vutuv_web/templates/user/show.html.heex:1568
+#: lib/vutuv_web/templates/user/show.html.heex:1572
+#: lib/vutuv_web/templates/user/show.html.heex:1584
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6258,7 +6259,7 @@ msgstr ""
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1250
+#: lib/vutuv_web/agent_docs/markdown.ex:1254
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -6544,9 +6545,9 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3298
-#: lib/vutuv_web/components/post_components.ex:4409
-#: lib/vutuv_web/components/post_components.ex:4423
+#: lib/vutuv_web/components/post_components.ex:3341
+#: lib/vutuv_web/components/post_components.ex:4452
+#: lib/vutuv_web/components/post_components.ex:4466
 #: lib/vutuv_web/components/ui.ex:3195
 #: lib/vutuv_web/live/fediverse_account_live.ex:437
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6574,7 +6575,7 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4409
+#: lib/vutuv_web/components/post_components.ex:4452
 #: lib/vutuv_web/components/ui.ex:3194
 #: lib/vutuv_web/live/fediverse_account_live.ex:435
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6603,12 +6604,12 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:1233
+#: lib/vutuv_web/views/user_html.ex:1226
 #, elixir-autogen, elixir-format
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:786
+#: lib/vutuv_web/views/user_html.ex:779
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr ""
@@ -7129,7 +7130,7 @@ msgid "open the dev email inbox"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:45
-#: lib/vutuv_web/views/user_html.ex:785
+#: lib/vutuv_web/views/user_html.ex:778
 #, elixir-autogen, elixir-format
 msgid "Connected"
 msgstr ""
@@ -7267,7 +7268,7 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:6900
+#: lib/vutuv_web/components/post_components.ex:6943
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #: lib/vutuv_web/live/shell_live.ex:1817
 #, elixir-autogen, elixir-format
@@ -7371,9 +7372,9 @@ msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3877
+#: lib/vutuv_web/live/post_live/feed.ex:3888
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
-#: lib/vutuv_web/live/press_kit_live.ex:573
+#: lib/vutuv_web/live/press_kit_live.ex:713
 #, elixir-autogen
 msgid "Done"
 msgstr ""
@@ -7447,17 +7448,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1417
+#: lib/vutuv_web/agent_docs/markdown.ex:1421
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1420
+#: lib/vutuv_web/agent_docs/markdown.ex:1424
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1427
+#: lib/vutuv_web/agent_docs/markdown.ex:1431
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -8254,13 +8255,13 @@ msgstr ""
 msgid "Please check the fields marked in red."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:1118
+#: lib/vutuv_web/views/user_html.ex:1111
 #, elixir-autogen, elixir-format
 msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:140
-#: lib/vutuv_web/templates/user/show.html.heex:1449
+#: lib/vutuv_web/templates/user/show.html.heex:1432
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8517,7 +8518,7 @@ msgstr ""
 msgid "Not written yet"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:244
+#: lib/vutuv_web/components/organization_components.ex:245
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "Page"
@@ -8549,11 +8550,11 @@ msgstr ""
 msgid "Write it under Admin › Legal pages"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:715
 #: lib/vutuv_web/agent_docs/markdown.ex:719
-#: lib/vutuv_web/agent_docs/text.ex:665
-#: lib/vutuv_web/agent_docs/text.ex:669
-#: lib/vutuv_web/components/organization_components.ex:276
+#: lib/vutuv_web/agent_docs/markdown.ex:723
+#: lib/vutuv_web/agent_docs/text.ex:666
+#: lib/vutuv_web/agent_docs/text.ex:670
+#: lib/vutuv_web/components/organization_components.ex:285
 #: lib/vutuv_web/components/ui.ex:1807
 #: lib/vutuv_web/components/ui.ex:5459
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
@@ -8562,13 +8563,13 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:277
 #: lib/vutuv_web/live/organization_live/fediverse.ex:84
-#: lib/vutuv_web/live/organization_live/show.ex:165
+#: lib/vutuv_web/live/organization_live/show.ex:181
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:329
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:5
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:1354
+#: lib/vutuv_web/templates/user/show.html.heex:1337
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr ""
@@ -8678,13 +8679,13 @@ msgstr ""
 msgid "Higher Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:923
+#: lib/vutuv_web/agent_docs/markdown.ex:927
 #: lib/vutuv_web/views/education_html.ex:54
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:922
+#: lib/vutuv_web/agent_docs/markdown.ex:926
 #: lib/vutuv_web/views/education_html.ex:53
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -8710,14 +8711,14 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5755
+#: lib/vutuv_web/components/post_components.ex:5798
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1186
+#: lib/vutuv_web/agent_docs/markdown.ex:1190
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -8942,8 +8943,8 @@ msgstr ""
 msgid "Honor tag (only site admins can assign it)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:735
-#: lib/vutuv_web/agent_docs/text.ex:683
+#: lib/vutuv_web/agent_docs/markdown.ex:739
+#: lib/vutuv_web/agent_docs/text.ex:684
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr ""
@@ -9367,8 +9368,8 @@ msgstr ""
 msgid "Yoruba"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:657
-#: lib/vutuv_web/agent_docs/text.ex:635
+#: lib/vutuv_web/agent_docs/markdown.ex:661
+#: lib/vutuv_web/agent_docs/text.ex:636
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr ""
@@ -9471,7 +9472,7 @@ msgstr[1] ""
 msgid "Add a certificate or license"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1039
+#: lib/vutuv_web/agent_docs/markdown.ex:1043
 #: lib/vutuv_web/views/qualification_html.ex:14
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -9551,7 +9552,7 @@ msgstr ""
 msgid "Expired"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1014
+#: lib/vutuv_web/agent_docs/markdown.ex:1018
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr ""
@@ -9568,7 +9569,7 @@ msgstr ""
 msgid "Issuer"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1038
+#: lib/vutuv_web/agent_docs/markdown.ex:1042
 #: lib/vutuv_web/views/qualification_html.ex:15
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -9595,7 +9596,7 @@ msgstr ""
 msgid "Verification link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1012
+#: lib/vutuv_web/agent_docs/markdown.ex:1016
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr ""
@@ -9610,7 +9611,7 @@ msgstr ""
 msgid "e.g. Amazon Web Services"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1013
+#: lib/vutuv_web/agent_docs/markdown.ex:1017
 #: lib/vutuv_web/views/qualification_html.ex:91
 #, elixir-autogen, elixir-format
 msgid "valid until %{date}"
@@ -9626,15 +9627,15 @@ msgstr ""
 msgid "Preferred"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:850
+#: lib/vutuv_web/agent_docs/markdown.ex:854
 #: lib/vutuv_web/live/section_reorder_live.ex:289
 #: lib/vutuv_web/views/language_html.ex:114
 #, elixir-autogen, elixir-format
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1276
-#: lib/vutuv_web/templates/user/show.html.heex:1277
+#: lib/vutuv_web/templates/user/show.html.heex:1259
+#: lib/vutuv_web/templates/user/show.html.heex:1260
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -10081,21 +10082,21 @@ msgstr ""
 msgid "Sign in with a one-time code (OTP) from an authenticator app or from a printed code list, typed into the normal PIN field. Your emailed PIN always keeps working."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:810
+#: lib/vutuv_web/agent_docs/markdown.ex:814
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:808
+#: lib/vutuv_web/agent_docs/markdown.ex:812
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:806
+#: lib/vutuv_web/agent_docs/markdown.ex:810
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10103,16 +10104,16 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:1416
-#: lib/vutuv_web/live/organization_live/show.ex:648
-#: lib/vutuv_web/views/user_html.ex:982
-#: lib/vutuv_web/views/user_html.ex:1158
+#: lib/vutuv_web/live/organization_live/show.ex:671
+#: lib/vutuv_web/views/user_html.ex:975
+#: lib/vutuv_web/views/user_html.ex:1151
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower"
 msgid_plural "%{formatted} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_html.ex:975
+#: lib/vutuv_web/views/user_html.ex:968
 #, elixir-autogen, elixir-format
 msgid "%{formatted} star"
 msgid_plural "%{formatted} stars"
@@ -10121,7 +10122,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:72
 #: lib/vutuv_web/agent_docs/text.ex:67
-#: lib/vutuv_web/templates/user/show.html.heex:1423
+#: lib/vutuv_web/templates/user/show.html.heex:1406
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -10137,7 +10138,7 @@ msgstr ""
 msgid "If you list a GitHub, GitLab or Codeberg account, your profile can show its public statistics: stars, repositories, followers, languages and recent activity."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:989
+#: lib/vutuv_web/views/user_html.ex:982
 #, elixir-autogen, elixir-format
 msgid "Last active %{date}"
 msgstr ""
@@ -10152,17 +10153,17 @@ msgstr ""
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:824
+#: lib/vutuv_web/agent_docs/markdown.ex:828
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:811
+#: lib/vutuv_web/agent_docs/markdown.ex:815
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:905
+#: lib/vutuv_web/views/user_html.ex:898
 #, elixir-autogen, elixir-format
 msgid "since %{year}"
 msgstr ""
@@ -10903,7 +10904,7 @@ msgstr ""
 msgid "AI agents"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:700
+#: lib/vutuv_web/live/organization_live/show.ex:723
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
@@ -10916,7 +10917,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:284
 #: lib/vutuv_web/live/organization_live/domains.ex:319
 #: lib/vutuv_web/live/organization_live/new.ex:161
-#: lib/vutuv_web/live/organization_live/show.ex:1043
+#: lib/vutuv_web/live/organization_live/show.ex:1080
 #: lib/vutuv_web/templates/url/verify.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
@@ -10924,8 +10925,8 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:204
 #: lib/vutuv_web/live/organization_live/domains.ex:359
-#: lib/vutuv_web/live/organization_live/show.ex:1108
-#: lib/vutuv_web/live/organization_live/show.ex:1116
+#: lib/vutuv_web/live/organization_live/show.ex:1145
+#: lib/vutuv_web/live/organization_live/show.ex:1153
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr ""
@@ -10951,13 +10952,13 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
 
-#: lib/vutuv_web/controllers/organization_controller.ex:290
+#: lib/vutuv_web/controllers/organization_controller.ex:305
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:31
 #, elixir-autogen, elixir-format
 msgid "Please log in first."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:1016
+#: lib/vutuv_web/live/organization_live/show.ex:1053
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr ""
@@ -10978,13 +10979,13 @@ msgstr ""
 msgid "Search engines"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:142
+#: lib/vutuv_web/components/organization_components.ex:143
 #, elixir-autogen, elixir-format
 msgid "Select a country"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:338
-#: lib/vutuv_web/live/organization_live/show.ex:1078
+#: lib/vutuv_web/live/organization_live/show.ex:1115
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr ""
@@ -11006,12 +11007,12 @@ msgid "The upload failed."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:1031
+#: lib/vutuv_web/live/organization_live/show.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:942
+#: lib/vutuv_web/live/organization_live/show.ex:979
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr ""
@@ -11022,18 +11023,18 @@ msgstr ""
 msgid "Verified via"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:1002
+#: lib/vutuv_web/live/organization_live/show.ex:1039
 #, elixir-autogen, elixir-format
 msgid "Verified via %{domain}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:1013
+#: lib/vutuv_web/live/organization_live/show.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:353
-#: lib/vutuv_web/live/organization_live/show.ex:1102
+#: lib/vutuv_web/live/organization_live/show.ex:1139
 #, elixir-autogen, elixir-format
 msgid "Verify now"
 msgstr ""
@@ -11048,7 +11049,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:285
 #: lib/vutuv_web/live/organization_live/domains.ex:329
-#: lib/vutuv_web/live/organization_live/show.ex:1054
+#: lib/vutuv_web/live/organization_live/show.ex:1091
 #: lib/vutuv_web/templates/url/verify.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11065,7 +11066,7 @@ msgid "You will publish a record or file to prove control of the domain on the n
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:340
-#: lib/vutuv_web/live/organization_live/show.ex:1084
+#: lib/vutuv_web/live/organization_live/show.ex:1121
 #: lib/vutuv_web/templates/url/verify.html.heex:109
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
@@ -11076,7 +11077,7 @@ msgstr ""
 msgid "@handle or email"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:333
+#: lib/vutuv_web/components/organization_components.ex:342
 #: lib/vutuv_web/live/organization_live/edit.ex:421
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
@@ -11097,7 +11098,7 @@ msgstr ""
 msgid "Added @%{handle} to the team."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:334
+#: lib/vutuv_web/components/organization_components.ex:343
 #: lib/vutuv_web/live/organization_live/edit.ex:419
 #, elixir-autogen, elixir-format
 msgid "Alias"
@@ -11113,10 +11114,10 @@ msgstr ""
 msgid "Alias removed."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:529
-#: lib/vutuv_web/agent_docs/text.ex:535
+#: lib/vutuv_web/agent_docs/markdown.ex:533
+#: lib/vutuv_web/agent_docs/text.ex:536
 #: lib/vutuv_web/live/organization_live/edit.ex:384
-#: lib/vutuv_web/live/organization_live/show.ex:930
+#: lib/vutuv_web/live/organization_live/show.ex:967
 #: lib/vutuv_web/templates/tag/single_card.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Also known as"
@@ -11143,7 +11144,7 @@ msgstr ""
 msgid "Archived"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:332
+#: lib/vutuv_web/components/organization_components.ex:341
 #: lib/vutuv_web/live/organization_live/edit.ex:420
 #, elixir-autogen, elixir-format
 msgid "Brand"
@@ -11179,10 +11180,10 @@ msgstr ""
 msgid "Domain verified."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:250
+#: lib/vutuv_web/components/organization_components.ex:251
 #: lib/vutuv_web/live/admin/organization_live.ex:302
 #: lib/vutuv_web/live/organization_live/domains.ex:198
-#: lib/vutuv_web/live/organization_live/show.ex:159
+#: lib/vutuv_web/live/organization_live/show.ex:175
 #, elixir-autogen, elixir-format
 msgid "Domains"
 msgstr ""
@@ -11192,7 +11193,7 @@ msgstr ""
 msgid "Domains – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:331
+#: lib/vutuv_web/components/organization_components.ex:340
 #, elixir-autogen, elixir-format
 msgid "Former name"
 msgstr ""
@@ -11270,7 +11271,7 @@ msgstr ""
 msgid "Primary domain updated."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:320
+#: lib/vutuv_web/components/organization_components.ex:329
 #, elixir-autogen, elixir-format
 msgid "Recruiter"
 msgstr ""
@@ -11295,10 +11296,10 @@ msgstr ""
 msgid "Search name, alias or domain"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:247
+#: lib/vutuv_web/components/organization_components.ex:248
 #: lib/vutuv_web/live/admin/organization_live.ex:318
 #: lib/vutuv_web/live/organization_live/roles.ex:184
-#: lib/vutuv_web/live/organization_live/show.ex:155
+#: lib/vutuv_web/live/organization_live/show.ex:171
 #, elixir-autogen, elixir-format
 msgid "Team"
 msgstr ""
@@ -11335,8 +11336,8 @@ msgstr ""
 msgid "primary"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:550
-#: lib/vutuv_web/agent_docs/text.ex:555
+#: lib/vutuv_web/agent_docs/markdown.ex:554
+#: lib/vutuv_web/agent_docs/text.ex:556
 #: lib/vutuv_web/live/admin/organization_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "verified"
@@ -11459,8 +11460,8 @@ msgstr ""
 msgid "Verify via file"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1059
-#: lib/vutuv_web/agent_docs/text.ex:811
+#: lib/vutuv_web/agent_docs/markdown.ex:1063
+#: lib/vutuv_web/agent_docs/text.ex:812
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -11470,7 +11471,7 @@ msgstr ""
 msgid "%{min} to %{max} characters: letters (a-z), numbers (0-9) and underscores."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:819
+#: lib/vutuv_web/live/organization_live/show.ex:842
 #, elixir-autogen, elixir-format
 msgid "Former"
 msgstr ""
@@ -11496,8 +11497,8 @@ msgstr ""
 msgid "Remove link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:541
-#: lib/vutuv_web/agent_docs/text.ex:546
+#: lib/vutuv_web/agent_docs/markdown.ex:545
+#: lib/vutuv_web/agent_docs/text.ex:547
 #, elixir-autogen, elixir-format
 msgid "former"
 msgstr ""
@@ -11575,7 +11576,7 @@ msgstr ""
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:1025
+#: lib/vutuv_web/live/organization_live/show.ex:1062
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr ""
@@ -11680,9 +11681,9 @@ msgstr ""
 msgid "Organization unfrozen."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:520
-#: lib/vutuv_web/agent_docs/organization_doc.ex:123
-#: lib/vutuv_web/agent_docs/text.ex:479
+#: lib/vutuv_web/agent_docs/markdown.ex:524
+#: lib/vutuv_web/agent_docs/organization_doc.ex:138
+#: lib/vutuv_web/agent_docs/text.ex:480
 #: lib/vutuv_web/components/ui.ex:5486
 #: lib/vutuv_web/controllers/settings_controller.ex:222
 #: lib/vutuv_web/live/organization_live/index.ex:32
@@ -11693,22 +11694,23 @@ msgstr ""
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:80
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
+#: lib/vutuv_web/views/press_kit_html.ex:49
 #, elixir-autogen, elixir-format
 msgid "Organizations"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:169
+#: lib/vutuv_web/components/organization_components.ex:170
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:90
 #, elixir-autogen, elixir-format
 msgid "Please choose"
 msgstr ""
 
-#: lib/vutuv_web/controllers/organization_controller.ex:128
+#: lib/vutuv_web/controllers/organization_controller.ex:129
 #, elixir-autogen, elixir-format
 msgid "Please confirm your email address before claiming an organization page."
 msgstr ""
 
-#: lib/vutuv_web/controllers/organization_controller.ex:134
+#: lib/vutuv_web/controllers/organization_controller.ex:135
 #, elixir-autogen, elixir-format
 msgid "Please log in to claim an organization page."
 msgstr ""
@@ -11738,7 +11740,7 @@ msgstr ""
 msgid "The organization page was deleted."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:470
+#: lib/vutuv_web/live/organization_live/show.ex:493
 #, elixir-autogen, elixir-format
 msgid "This organization page was reported and is hidden while it is reviewed. Only you and the moderators can see it."
 msgstr ""
@@ -11748,7 +11750,7 @@ msgstr ""
 msgid "Verified organization pages on vutuv, each with a proven web domain."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/organization_doc.ex:124
+#: lib/vutuv_web/agent_docs/organization_doc.ex:139
 #, elixir-autogen, elixir-format
 msgid "Verified organization pages on vutuv."
 msgstr ""
@@ -11768,8 +11770,8 @@ msgstr ""
 msgid "Your organization handle is set."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:356
-#: lib/vutuv_web/live/organization_live/show.ex:409
+#: lib/vutuv_web/live/organization_live/show.ex:379
+#: lib/vutuv_web/live/organization_live/show.ex:432
 #, elixir-autogen, elixir-format
 msgid "Your organization page is verified and now live."
 msgstr ""
@@ -11938,10 +11940,10 @@ msgstr ""
 msgid "Edit posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:297
-#: lib/vutuv_web/agent_docs/markdown.ex:581
-#: lib/vutuv_web/agent_docs/text.ex:267
-#: lib/vutuv_web/agent_docs/text.ex:586
+#: lib/vutuv_web/agent_docs/markdown.ex:301
+#: lib/vutuv_web/agent_docs/markdown.ex:585
+#: lib/vutuv_web/agent_docs/text.ex:268
+#: lib/vutuv_web/agent_docs/text.ex:587
 #: lib/vutuv_web/live/admin/job_live.ex:340
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:17
 #: lib/vutuv_web/views/account_event_text.ex:225
@@ -11954,10 +11956,10 @@ msgstr ""
 msgid "Employer name (optional)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:298
-#: lib/vutuv_web/agent_docs/markdown.ex:582
-#: lib/vutuv_web/agent_docs/text.ex:268
-#: lib/vutuv_web/agent_docs/text.ex:587
+#: lib/vutuv_web/agent_docs/markdown.ex:302
+#: lib/vutuv_web/agent_docs/markdown.ex:586
+#: lib/vutuv_web/agent_docs/text.ex:269
+#: lib/vutuv_web/agent_docs/text.ex:588
 #: lib/vutuv_web/live/job_board_live.ex:526
 #: lib/vutuv_web/live/job_posting_live/form.ex:499
 #, elixir-autogen, elixir-format
@@ -12029,12 +12031,12 @@ msgstr ""
 msgid "Let search engines index this posting."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:556
-#: lib/vutuv_web/agent_docs/markdown.ex:559
-#: lib/vutuv_web/agent_docs/markdown.ex:561
-#: lib/vutuv_web/agent_docs/text.ex:561
-#: lib/vutuv_web/agent_docs/text.ex:564
-#: lib/vutuv_web/agent_docs/text.ex:566
+#: lib/vutuv_web/agent_docs/markdown.ex:560
+#: lib/vutuv_web/agent_docs/markdown.ex:563
+#: lib/vutuv_web/agent_docs/markdown.ex:565
+#: lib/vutuv_web/agent_docs/text.ex:562
+#: lib/vutuv_web/agent_docs/text.ex:565
+#: lib/vutuv_web/agent_docs/text.ex:567
 #: lib/vutuv_web/live/job_posting_live/form.ex:549
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -12083,8 +12085,8 @@ msgstr ""
 msgid "New posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:309
-#: lib/vutuv_web/agent_docs/text.ex:278
+#: lib/vutuv_web/agent_docs/markdown.ex:313
+#: lib/vutuv_web/agent_docs/text.ex:279
 #: lib/vutuv_web/live/job_posting_live/form.ex:756
 #: lib/vutuv_web/live/job_posting_live/show.ex:177
 #, elixir-autogen, elixir-format
@@ -12168,10 +12170,10 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:302
-#: lib/vutuv_web/agent_docs/markdown.ex:586
-#: lib/vutuv_web/agent_docs/text.ex:272
-#: lib/vutuv_web/agent_docs/text.ex:591
+#: lib/vutuv_web/agent_docs/markdown.ex:306
+#: lib/vutuv_web/agent_docs/markdown.ex:590
+#: lib/vutuv_web/agent_docs/text.ex:273
+#: lib/vutuv_web/agent_docs/text.ex:592
 #: lib/vutuv_web/live/job_posting_live/show.ex:156
 #, elixir-autogen, elixir-format
 msgid "Posted"
@@ -12196,10 +12198,10 @@ msgstr ""
 #: lib/vutuv/accounts/user.ex:1291
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:590
-#: lib/vutuv_web/agent_docs/markdown.ex:559
-#: lib/vutuv_web/agent_docs/markdown.ex:561
-#: lib/vutuv_web/agent_docs/text.ex:564
-#: lib/vutuv_web/agent_docs/text.ex:566
+#: lib/vutuv_web/agent_docs/markdown.ex:563
+#: lib/vutuv_web/agent_docs/markdown.ex:565
+#: lib/vutuv_web/agent_docs/text.ex:565
+#: lib/vutuv_web/agent_docs/text.ex:567
 #: lib/vutuv_web/components/job_components.ex:140
 #: lib/vutuv_web/components/job_components.ex:141
 #, elixir-autogen, elixir-format
@@ -12211,18 +12213,18 @@ msgstr ""
 msgid "Report this posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:308
-#: lib/vutuv_web/agent_docs/text.ex:277
+#: lib/vutuv_web/agent_docs/markdown.ex:312
+#: lib/vutuv_web/agent_docs/text.ex:278
 #: lib/vutuv_web/live/job_posting_live/form.ex:746
 #: lib/vutuv_web/live/job_posting_live/show.ex:172
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:301
-#: lib/vutuv_web/agent_docs/markdown.ex:585
-#: lib/vutuv_web/agent_docs/text.ex:271
-#: lib/vutuv_web/agent_docs/text.ex:590
+#: lib/vutuv_web/agent_docs/markdown.ex:305
+#: lib/vutuv_web/agent_docs/markdown.ex:589
+#: lib/vutuv_web/agent_docs/text.ex:272
+#: lib/vutuv_web/agent_docs/text.ex:591
 #, elixir-autogen, elixir-format
 msgid "Salary"
 msgstr ""
@@ -12316,10 +12318,10 @@ msgstr ""
 msgid "Working student"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:299
-#: lib/vutuv_web/agent_docs/markdown.ex:583
-#: lib/vutuv_web/agent_docs/text.ex:269
-#: lib/vutuv_web/agent_docs/text.ex:588
+#: lib/vutuv_web/agent_docs/markdown.ex:303
+#: lib/vutuv_web/agent_docs/markdown.ex:587
+#: lib/vutuv_web/agent_docs/text.ex:270
+#: lib/vutuv_web/agent_docs/text.ex:589
 #: lib/vutuv_web/live/job_posting_live/form.ex:514
 #, elixir-autogen, elixir-format
 msgid "Workplace"
@@ -12464,13 +12466,13 @@ msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:336
-#: lib/vutuv_web/live/organization_live/show.ex:1071
+#: lib/vutuv_web/live/organization_live/show.ex:1108
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:334
-#: lib/vutuv_web/live/organization_live/show.ex:1062
+#: lib/vutuv_web/live/organization_live/show.ex:1099
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr ""
@@ -12519,13 +12521,13 @@ msgstr ""
 msgid "All countries"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:604
+#: lib/vutuv_web/agent_docs/markdown.ex:608
 #: lib/vutuv_web/templates/tag/show.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:608
+#: lib/vutuv_web/agent_docs/text.ex:609
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr ""
@@ -12566,17 +12568,17 @@ msgid "Minimum yearly salary"
 msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:383
-#: lib/vutuv_web/live/organization_live/show.ex:841
+#: lib/vutuv_web/live/organization_live/show.ex:864
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:323
+#: lib/vutuv_web/agent_docs/markdown.ex:327
 #, elixir-autogen, elixir-format
 msgid "Next page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:292
+#: lib/vutuv_web/agent_docs/text.ex:293
 #, elixir-autogen, elixir-format
 msgid "Next page: %{url}"
 msgstr ""
@@ -12591,11 +12593,11 @@ msgstr ""
 msgid "No matching positions. Try adjusting the filters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:602
-#: lib/vutuv_web/agent_docs/markdown.ex:614
-#: lib/vutuv_web/agent_docs/text.ex:606
-#: lib/vutuv_web/agent_docs/text.ex:618
-#: lib/vutuv_web/live/organization_live/show.ex:833
+#: lib/vutuv_web/agent_docs/markdown.ex:606
+#: lib/vutuv_web/agent_docs/markdown.ex:618
+#: lib/vutuv_web/agent_docs/text.ex:607
+#: lib/vutuv_web/agent_docs/text.ex:619
+#: lib/vutuv_web/live/organization_live/show.ex:856
 #: lib/vutuv_web/templates/tag/show.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Open positions"
@@ -12910,7 +12912,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3776
+#: lib/vutuv_web/components/post_components.ex:3819
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:788
 #: lib/vutuv_web/controllers/settings_controller.ex:806
@@ -13049,7 +13051,7 @@ msgstr ""
 msgid "Inherited from the organization"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:253
+#: lib/vutuv_web/components/organization_components.ex:254
 #: lib/vutuv_web/live/organization_live/exclusions.ex:113
 #, elixir-autogen, elixir-format
 msgid "Job exclusions"
@@ -13324,22 +13326,22 @@ msgstr ""
 msgid "Work mobile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:483
+#: lib/vutuv_web/components/post_components.ex:484
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:485
+#: lib/vutuv_web/components/post_components.ex:486
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:484
+#: lib/vutuv_web/components/post_components.ex:485
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:442
+#: lib/vutuv_web/components/post_components.ex:443
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr ""
@@ -13395,7 +13397,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1389
+#: lib/vutuv_web/templates/user/show.html.heex:1372
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13432,7 +13434,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1387
+#: lib/vutuv_web/templates/user/show.html.heex:1370
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -13509,34 +13511,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6443
+#: lib/vutuv_web/components/post_components.ex:6486
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1379
-#: lib/vutuv_web/components/post_components.ex:6400
+#: lib/vutuv_web/agent_docs/markdown.ex:1383
+#: lib/vutuv_web/components/post_components.ex:6443
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6444
+#: lib/vutuv_web/components/post_components.ex:6487
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6446
+#: lib/vutuv_web/components/post_components.ex:6489
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6442
+#: lib/vutuv_web/components/post_components.ex:6485
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1379
-#: lib/vutuv_web/components/post_components.ex:6399
+#: lib/vutuv_web/agent_docs/markdown.ex:1383
+#: lib/vutuv_web/components/post_components.ex:6442
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13547,12 +13549,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6441
+#: lib/vutuv_web/components/post_components.ex:6484
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6445
+#: lib/vutuv_web/components/post_components.ex:6488
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13572,7 +13574,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6482
+#: lib/vutuv_web/components/post_components.ex:6525
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13580,27 +13582,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6512
+#: lib/vutuv_web/components/post_components.ex:6555
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6513
+#: lib/vutuv_web/components/post_components.ex:6556
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6511
+#: lib/vutuv_web/components/post_components.ex:6554
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6471
+#: lib/vutuv_web/components/post_components.ex:6514
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6518
+#: lib/vutuv_web/components/post_components.ex:6561
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13625,12 +13627,12 @@ msgstr ""
 msgid "With qualification:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:879
+#: lib/vutuv_web/agent_docs/markdown.ex:883
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6285
+#: lib/vutuv_web/components/post_components.ex:6328
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13673,7 +13675,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6276
+#: lib/vutuv_web/components/post_components.ex:6319
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -13714,19 +13716,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1028
+#: lib/vutuv_web/agent_docs/markdown.ex:1032
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1027
+#: lib/vutuv_web/agent_docs/markdown.ex:1031
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1033
+#: lib/vutuv_web/agent_docs/markdown.ex:1037
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -13806,8 +13808,8 @@ msgstr ""
 msgid "View the uploaded proof (%{label})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:965
-#: lib/vutuv_web/agent_docs/text.ex:790
+#: lib/vutuv_web/agent_docs/markdown.ex:969
+#: lib/vutuv_web/agent_docs/text.ex:791
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr ""
@@ -13865,8 +13867,8 @@ msgstr ""
 msgid "Skip for now"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:659
-#: lib/vutuv_web/agent_docs/text.ex:637
+#: lib/vutuv_web/agent_docs/markdown.ex:663
+#: lib/vutuv_web/agent_docs/text.ex:638
 #, elixir-autogen, elixir-format
 msgid "Preferred workplace"
 msgstr ""
@@ -14020,14 +14022,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4065
+#: lib/vutuv_web/components/post_components.ex:4108
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4088
+#: lib/vutuv_web/components/post_components.ex:4131
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14054,7 +14056,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6999
+#: lib/vutuv_web/components/post_components.ex:7042
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14456,7 +14458,7 @@ msgstr ""
 msgid "none yet"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1326
+#: lib/vutuv_web/agent_docs/markdown.ex:1330
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr ""
@@ -14790,7 +14792,7 @@ msgstr ""
 msgid "Book an ad"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1096
+#: lib/vutuv_web/templates/user/show.html.heex:1079
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr ""
@@ -14840,8 +14842,8 @@ msgstr ""
 msgid "Your server"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:716
-#: lib/vutuv_web/agent_docs/text.ex:666
+#: lib/vutuv_web/agent_docs/markdown.ex:720
+#: lib/vutuv_web/agent_docs/text.ex:667
 #, elixir-autogen, elixir-format
 msgid "moved to %{address}"
 msgstr ""
@@ -15199,7 +15201,7 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6945
+#: lib/vutuv_web/components/post_components.ex:6988
 #: lib/vutuv_web/live/notification_live/index.ex:1592
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
@@ -15207,7 +15209,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6949
+#: lib/vutuv_web/components/post_components.ex:6992
 #: lib/vutuv_web/live/notification_live/index.ex:1586
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15215,15 +15217,15 @@ msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6953
+#: lib/vutuv_web/components/post_components.ex:6996
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1328
-#: lib/vutuv_web/components/post_components.ex:6904
+#: lib/vutuv_web/agent_docs/markdown.ex:1332
+#: lib/vutuv_web/components/post_components.ex:6947
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15233,22 +15235,22 @@ msgstr ""
 msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1268
-#: lib/vutuv_web/agent_docs/markdown.ex:1526
-#: lib/vutuv_web/agent_docs/text.ex:888
-#: lib/vutuv_web/agent_docs/text.ex:965
+#: lib/vutuv_web/agent_docs/markdown.ex:1272
+#: lib/vutuv_web/agent_docs/markdown.ex:1530
+#: lib/vutuv_web/agent_docs/text.ex:889
+#: lib/vutuv_web/agent_docs/text.ex:966
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1582
-#: lib/vutuv_web/components/post_components.ex:2682
+#: lib/vutuv_web/components/post_components.ex:1583
+#: lib/vutuv_web/components/post_components.ex:2683
 #: lib/vutuv_web/live/fediverse_account_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1446
+#: lib/vutuv_web/components/post_components.ex:1447
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15260,7 +15262,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:150
 #: lib/vutuv_web/agent_docs/markdown.ex:182
-#: lib/vutuv_web/agent_docs/markdown.ex:1327
+#: lib/vutuv_web/agent_docs/markdown.ex:1331
 #: lib/vutuv_web/agent_docs/text.ex:125
 #: lib/vutuv_web/agent_docs/text.ex:154
 #, elixir-autogen, elixir-format
@@ -15277,7 +15279,7 @@ msgstr ""
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1458
+#: lib/vutuv_web/components/post_components.ex:1459
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15287,7 +15289,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1472
+#: lib/vutuv_web/components/post_components.ex:1473
 #: lib/vutuv_web/live/notification_live/index.ex:1117
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -15318,10 +15320,10 @@ msgstr ""
 msgid "That reply is not yours to remove."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1528
-#: lib/vutuv_web/components/post_components.ex:1497
-#: lib/vutuv_web/components/post_components.ex:1728
-#: lib/vutuv_web/components/post_components.ex:3634
+#: lib/vutuv_web/agent_docs/markdown.ex:1532
+#: lib/vutuv_web/components/post_components.ex:1498
+#: lib/vutuv_web/components/post_components.ex:1729
+#: lib/vutuv_web/components/post_components.ex:3677
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "View the original"
@@ -15983,22 +15985,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4250
+#: lib/vutuv_web/components/post_components.ex:4293
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4376
+#: lib/vutuv_web/components/post_components.ex:4419
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4384
+#: lib/vutuv_web/components/post_components.ex:4427
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4370
+#: lib/vutuv_web/components/post_components.ex:4413
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16018,13 +16020,13 @@ msgstr ""
 msgid "Unpinned. The post is a normal post again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1169
+#: lib/vutuv_web/agent_docs/markdown.ex:1173
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:653
-#: lib/vutuv_web/agent_docs/text.ex:628
+#: lib/vutuv_web/agent_docs/markdown.ex:657
+#: lib/vutuv_web/agent_docs/text.ex:629
 #: lib/vutuv_web/templates/user/edit.html.heex:225
 #: lib/vutuv_web/templates/user/show.html.heex:291
 #: lib/vutuv_web/views/account_event_text.ex:213
@@ -16072,8 +16074,8 @@ msgstr ""
 msgid "CC0 1.0 (no rights reserved)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1445
-#: lib/vutuv_web/agent_docs/text.ex:919
+#: lib/vutuv_web/agent_docs/markdown.ex:1449
+#: lib/vutuv_web/agent_docs/text.ex:920
 #: lib/vutuv_web/live/post_live/composer.ex:2661
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover"
@@ -16084,8 +16086,8 @@ msgstr ""
 msgid "Describe the photo for people who can't see it"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1456
-#: lib/vutuv_web/agent_docs/text.ex:932
+#: lib/vutuv_web/agent_docs/markdown.ex:1460
+#: lib/vutuv_web/agent_docs/text.ex:933
 #: lib/vutuv_web/components/ui.ex:3249
 #, elixir-autogen, elixir-format
 msgid "Download the original"
@@ -16121,19 +16123,19 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3829
+#: lib/vutuv_web/components/post_components.ex:3872
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5321
-#: lib/vutuv_web/components/press_kit_components.ex:344
+#: lib/vutuv_web/components/post_components.ex:5364
+#: lib/vutuv_web/components/press_kit_components.ex:399
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5549
-#: lib/vutuv_web/components/press_kit_components.ex:414
+#: lib/vutuv_web/components/post_components.ex:5592
+#: lib/vutuv_web/components/press_kit_components.ex:469
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16144,9 +16146,9 @@ msgstr ""
 msgid "Photo options"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1489
-#: lib/vutuv_web/agent_docs/text.ex:907
-#: lib/vutuv_web/components/post_components.ex:5631
+#: lib/vutuv_web/agent_docs/markdown.ex:1493
+#: lib/vutuv_web/agent_docs/text.ex:908
+#: lib/vutuv_web/components/post_components.ex:5674
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
 msgstr ""
@@ -16172,7 +16174,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3882
+#: lib/vutuv_web/components/post_components.ex:3925
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16192,7 +16194,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3873
+#: lib/vutuv_web/components/post_components.ex:3916
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16202,12 +16204,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3891
+#: lib/vutuv_web/components/post_components.ex:3934
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3825
+#: lib/vutuv_web/components/post_components.ex:3868
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16222,7 +16224,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3886
+#: lib/vutuv_web/components/post_components.ex:3929
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16232,7 +16234,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3839
+#: lib/vutuv_web/components/post_components.ex:3882
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16306,14 +16308,14 @@ msgid_plural "Some of these photos carry the location they were taken at, and th
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1346
-#: lib/vutuv_web/components/post_components.ex:6942
+#: lib/vutuv_web/agent_docs/markdown.ex:1350
+#: lib/vutuv_web/components/post_components.ex:6985
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1344
-#: lib/vutuv_web/components/post_components.ex:6939
+#: lib/vutuv_web/agent_docs/markdown.ex:1348
+#: lib/vutuv_web/components/post_components.ex:6982
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16323,7 +16325,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6826
+#: lib/vutuv_web/components/post_components.ex:6869
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
@@ -16664,7 +16666,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3393
+#: lib/vutuv_web/components/post_components.ex:3436
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
@@ -16674,7 +16676,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3633
+#: lib/vutuv_web/components/post_components.ex:3676
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16694,12 +16696,12 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1869
+#: lib/vutuv_web/components/post_components.ex:1870
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3574
+#: lib/vutuv_web/components/post_components.ex:3617
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Marked as sensitive by its author"
 msgstr ""
@@ -16714,7 +16716,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3366
+#: lib/vutuv_web/components/post_components.ex:3409
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -16807,34 +16809,34 @@ msgstr ""
 msgid "“LinkedIn is annoying. vutuv is not.”"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1146
+#: lib/vutuv_web/agent_docs/markdown.ex:1150
 #, elixir-autogen, elixir-format
 msgid "(a picture)"
 msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3016
+#: lib/vutuv_web/components/post_components.ex:3026
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2886
+#: lib/vutuv_web/components/post_components.ex:2887
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2881
+#: lib/vutuv_web/components/post_components.ex:2882
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3732
+#: lib/vutuv_web/components/post_components.ex:3775
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3738
+#: lib/vutuv_web/components/post_components.ex:3781
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That post is not here any more."
 msgstr ""
@@ -16844,7 +16846,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3877
+#: lib/vutuv_web/components/post_components.ex:3920
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -16884,7 +16886,7 @@ msgstr ""
 msgid "That link points at a single post. You can follow its author, %{account}, from here."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:249
+#: lib/vutuv_web/views/user_html.ex:242
 #, elixir-autogen, elixir-format
 msgid "Your feed shows the posts of members you follow. Follow a few to fill it."
 msgstr ""
@@ -16951,8 +16953,8 @@ msgstr ""
 msgid "We could not reach the network just now. Please try again in a moment."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1073
-#: lib/vutuv_web/agent_docs/text.ex:712
+#: lib/vutuv_web/agent_docs/markdown.ex:1077
+#: lib/vutuv_web/agent_docs/text.ex:713
 #, elixir-autogen, elixir-format, fuzzy
 msgid "verified profile"
 msgstr ""
@@ -17457,12 +17459,12 @@ msgstr ""
 msgid "Screenshot blocklist"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:475
+#: lib/vutuv_web/components/post_components.ex:476
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:472
+#: lib/vutuv_web/components/post_components.ex:473
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
@@ -17505,7 +17507,7 @@ msgstr ""
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3735
+#: lib/vutuv_web/components/post_components.ex:3778
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -17572,24 +17574,24 @@ msgstr ""
 msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1314
+#: lib/vutuv_web/agent_docs/markdown.ex:1318
 #, elixir-autogen, elixir-format
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5925
+#: lib/vutuv_web/components/post_components.ex:5968
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5927
+#: lib/vutuv_web/components/post_components.ex:5970
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5938
+#: lib/vutuv_web/components/post_components.ex:5981
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -17614,12 +17616,12 @@ msgstr ""
 msgid "Your likes follow the site default again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1369
+#: lib/vutuv_web/agent_docs/markdown.ex:1373
 #, elixir-autogen, elixir-format
 msgid "%{address} (this page only)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1366
+#: lib/vutuv_web/agent_docs/markdown.ex:1370
 #, elixir-autogen, elixir-format
 msgid "%{address} (whole website)"
 msgstr ""
@@ -17629,7 +17631,7 @@ msgstr ""
 msgid "Verified webpage of the author (%{address})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1358
+#: lib/vutuv_web/agent_docs/markdown.ex:1362
 #, elixir-autogen, elixir-format
 msgid "Verified webpages of the author linked here: %{addresses}"
 msgstr ""
@@ -17761,7 +17763,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3606
+#: lib/vutuv_web/live/post_live/feed.ex:3617
 #: lib/vutuv_web/live/reference_check_live.ex:169
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Loading…"
@@ -17962,7 +17964,7 @@ msgstr ""
 msgid "Employment references of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:947
+#: lib/vutuv_web/agent_docs/markdown.ex:951
 #, elixir-autogen, elixir-format, fuzzy
 msgid "document"
 msgstr ""
@@ -18178,7 +18180,7 @@ msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4582
-#: lib/vutuv_web/live/press_kit_live.ex:281
+#: lib/vutuv_web/live/press_kit_live.ex:382
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "That file is larger than %{limit}. Please upload a smaller one."
@@ -19170,17 +19172,17 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3765
+#: lib/vutuv_web/components/post_components.ex:3808
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:319
+#: lib/vutuv_web/components/organization_components.ex:328
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Editorial"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:325
+#: lib/vutuv_web/components/organization_components.ex:334
 #, elixir-autogen, elixir-format
 msgid "Edits the page and posts jobs."
 msgstr ""
@@ -19190,7 +19192,7 @@ msgstr ""
 msgid "Give members their roles on this page. Someone can hold several at once, and every role is granted on its own."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:324
+#: lib/vutuv_web/components/organization_components.ex:333
 #, elixir-autogen, elixir-format
 msgid "Manages the team and the domains, and edits the page."
 msgstr ""
@@ -19200,7 +19202,7 @@ msgstr ""
 msgid "Pick at least one role."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:327
+#: lib/vutuv_web/components/organization_components.ex:336
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posts jobs."
 msgstr ""
@@ -19215,7 +19217,7 @@ msgstr ""
 msgid "Roles updated."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:326
+#: lib/vutuv_web/components/organization_components.ex:335
 #, elixir-autogen, elixir-format
 msgid "Writes posts in the organization's name."
 msgstr ""
@@ -19225,7 +19227,7 @@ msgstr ""
 msgid "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:782
+#: lib/vutuv_web/live/organization_live/show.ex:805
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing published yet."
 msgstr ""
@@ -19260,7 +19262,7 @@ msgstr ""
 msgid "Stopped writing as an organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:746
+#: lib/vutuv_web/live/organization_live/show.ex:769
 #, elixir-autogen, elixir-format
 msgid "Write as %{name} for now"
 msgstr ""
@@ -19482,12 +19484,12 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/fediverse.ex:92
 #: lib/vutuv_web/live/organization_live/new.ex:211
-#: lib/vutuv_web/live/organization_live/show.ex:897
+#: lib/vutuv_web/live/organization_live/show.ex:934
 #, elixir-autogen, elixir-format
 msgid "People who have no vutuv account can follow this page and read its posts, in networks like Mastodon."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:911
+#: lib/vutuv_web/live/organization_live/show.ex:948
 #, elixir-autogen, elixir-format
 msgid "Set this page up for other networks"
 msgstr ""
@@ -19502,7 +19504,7 @@ msgstr ""
 msgid "Switch it on"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:902
+#: lib/vutuv_web/live/organization_live/show.ex:939
 #, elixir-autogen, elixir-format
 msgid "The page gets an address of its own for that, written like an email address."
 msgstr ""
@@ -19745,13 +19747,13 @@ msgstr ""
 msgid "The gravatar.com lookup is switched off on this installation."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:35
+#: lib/vutuv_web/components/organization_components.ex:36
 #, elixir-autogen, elixir-format
 msgid "A new entry can take a while to reach everyone. We keep checking %{domain} by ourselves and send you an email as soon as it works, so you can close this page."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:351
-#: lib/vutuv_web/live/organization_live/show.ex:1100
+#: lib/vutuv_web/live/organization_live/show.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Checking …"
 msgstr ""
@@ -20038,27 +20040,27 @@ msgstr ""
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5819
+#: lib/vutuv_web/components/post_components.ex:5862
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5855
+#: lib/vutuv_web/components/post_components.ex:5898
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5864
+#: lib/vutuv_web/components/post_components.ex:5907
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5867
+#: lib/vutuv_web/components/post_components.ex:5910
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5844
+#: lib/vutuv_web/components/post_components.ex:5887
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
@@ -20068,7 +20070,7 @@ msgstr ""
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5834
+#: lib/vutuv_web/components/post_components.ex:5877
 #: lib/vutuv_web/components/ui.ex:5371
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -20197,20 +20199,20 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5597
+#: lib/vutuv_web/components/post_components.ex:5640
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5594
+#: lib/vutuv_web/components/post_components.ex:5637
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2907
-#: lib/vutuv_web/components/post_components.ex:4663
+#: lib/vutuv_web/components/post_components.ex:2908
+#: lib/vutuv_web/components/post_components.ex:4706
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -20229,12 +20231,12 @@ msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:431
 #: lib/vutuv_web/live/post_live/feed.ex:964
-#: lib/vutuv_web/views/user_html.ex:372
+#: lib/vutuv_web/views/user_html.ex:365
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:375
+#: lib/vutuv_web/views/user_html.ex:368
 #, elixir-autogen, elixir-format
 msgid "Show the profile picture larger"
 msgstr ""
@@ -20351,7 +20353,7 @@ msgstr ""
 msgid "Find my contacts"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:271
+#: lib/vutuv_web/views/user_html.ex:264
 #, elixir-autogen, elixir-format
 msgid "Find people you know from LinkedIn"
 msgstr ""
@@ -20723,7 +20725,7 @@ msgstr ""
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3346
+#: lib/vutuv_web/components/post_components.ex:3389
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr ""
@@ -20848,7 +20850,7 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3771
+#: lib/vutuv_web/live/post_live/feed.ex:3782
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
@@ -21321,13 +21323,13 @@ msgid "Hide a word or a whole phrase …"
 msgstr "Hide a word or a whole phrase …"
 
 #: lib/vutuv_web/live/post_live/feed.ex:709
-#: lib/vutuv_web/live/post_live/feed.ex:3934
+#: lib/vutuv_web/live/post_live/feed.ex:3945
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Hide tags"
 
 #: lib/vutuv_web/live/post_live/feed.ex:708
-#: lib/vutuv_web/live/post_live/feed.ex:3923
+#: lib/vutuv_web/live/post_live/feed.ex:3934
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Hide words"
@@ -21394,7 +21396,7 @@ msgstr "Posts carrying one of these tags are folded the same way."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3797
+#: lib/vutuv_web/live/post_live/feed.ex:3808
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
@@ -21433,7 +21435,7 @@ msgid "Show posts by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:707
-#: lib/vutuv_web/live/post_live/feed.ex:3889
+#: lib/vutuv_web/live/post_live/feed.ex:3900
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sources"
 msgstr ""
@@ -21472,8 +21474,8 @@ msgid_plural "and %{formatted} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3371
-#: lib/vutuv_web/live/post_live/feed.ex:3398
+#: lib/vutuv_web/live/post_live/feed.ex:3382
+#: lib/vutuv_web/live/post_live/feed.ex:3409
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -21503,7 +21505,7 @@ msgid "Your organization page was updated. The new logo is being checked and app
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:290
-#: lib/vutuv_web/live/press_kit_live.ex:741
+#: lib/vutuv_web/live/press_kit_live.ex:882
 #, elixir-autogen, elixir-format
 msgid "%{formats}, up to %{limit}"
 msgstr ""
@@ -21534,7 +21536,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3563
+#: lib/vutuv_web/live/post_live/feed.ex:3574
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Back to now"
 msgstr ""
@@ -21544,7 +21546,7 @@ msgstr ""
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3609
+#: lib/vutuv_web/live/post_live/feed.ex:3620
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -21566,7 +21568,7 @@ msgstr ""
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3559
+#: lib/vutuv_web/live/post_live/feed.ex:3570
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
@@ -21593,7 +21595,7 @@ msgctxt "heatmap scale"
 msgid "More"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:549
+#: lib/vutuv_web/live/organization_live/show.ex:572
 #, elixir-autogen, elixir-format
 msgid "The website of %{name}"
 msgstr ""
@@ -21648,29 +21650,29 @@ msgstr ""
 msgid "A new version is ready."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:684
+#: lib/vutuv_web/live/organization_live/show.ex:707
 #, elixir-autogen, elixir-format
 msgid "Page management"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2448
+#: lib/vutuv_web/live/post_live/feed.ex:2459
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3501
+#: lib/vutuv_web/components/post_components.ex:3544
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Quoted post"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1162
+#: lib/vutuv_web/agent_docs/markdown.ex:1166
 #, elixir-autogen, elixir-format
 msgid "Quotes %{name}: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1159
+#: lib/vutuv_web/agent_docs/markdown.ex:1163
 #, elixir-autogen, elixir-format
 msgid "Quotes %{url}"
 msgstr ""
@@ -21685,7 +21687,7 @@ msgstr ""
 msgid "{used} of {max} mentions"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2560
+#: lib/vutuv_web/live/post_live/feed.ex:2571
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr ""
@@ -21716,7 +21718,7 @@ msgstr ""
 msgid "only %{account}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7285
+#: lib/vutuv_web/components/post_components.ex:7330
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -21900,7 +21902,7 @@ msgctxt "phone tab bar"
 msgid "Write"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3697
+#: lib/vutuv_web/live/post_live/feed.ex:3708
 #: lib/vutuv_web/live/post_rewrites_live.ex:287
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} rule"
@@ -21968,9 +21970,9 @@ msgstr ""
 msgid "Rules that rewrite the text of one account's posts before you read them: a footer under every post, a signature, a wall of hashtags. Only you see the difference. Open the ⋯ menu on any post to write rules for its author."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1451
-#: lib/vutuv_web/components/post_components.ex:3359
-#: lib/vutuv_web/components/post_components.ex:4453
+#: lib/vutuv_web/components/post_components.ex:1452
+#: lib/vutuv_web/components/post_components.ex:3402
+#: lib/vutuv_web/components/post_components.ex:4496
 #: lib/vutuv_web/components/ui.ex:5363
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
@@ -22156,11 +22158,11 @@ msgstr ""
 msgid "This video could not be converted."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1441
-#: lib/vutuv_web/agent_docs/markdown.ex:1444
-#: lib/vutuv_web/agent_docs/text.ex:916
+#: lib/vutuv_web/agent_docs/markdown.ex:1445
+#: lib/vutuv_web/agent_docs/markdown.ex:1448
 #: lib/vutuv_web/agent_docs/text.ex:917
-#: lib/vutuv_web/components/post_components.ex:2967
+#: lib/vutuv_web/agent_docs/text.ex:918
+#: lib/vutuv_web/components/post_components.ex:2977
 #: lib/vutuv_web/components/video_components.ex:127
 #: lib/vutuv_web/live/post_live/composer.ex:2458
 #, elixir-autogen, elixir-format
@@ -22223,7 +22225,7 @@ msgstr[1] ""
 msgid "Last 30 days: %{parts}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5015
+#: lib/vutuv_web/components/post_components.ex:5058
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Less"
@@ -22284,22 +22286,22 @@ msgstr ""
 msgid "The fields the most members carry, and how many of them do."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1212
-#: lib/vutuv_web/agent_docs/text.ex:840
+#: lib/vutuv_web/agent_docs/markdown.ex:1216
+#: lib/vutuv_web/agent_docs/text.ex:841
 #: lib/vutuv_web/live/job_board_live.ex:474
 #, elixir-autogen, elixir-format
 msgid "What members here work on"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1204
-#: lib/vutuv_web/agent_docs/text.ex:832
+#: lib/vutuv_web/agent_docs/markdown.ex:1208
+#: lib/vutuv_web/agent_docs/text.ex:833
 #: lib/vutuv_web/live/job_board_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "Who you would reach"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1205
-#: lib/vutuv_web/agent_docs/text.ex:833
+#: lib/vutuv_web/agent_docs/markdown.ex:1209
+#: lib/vutuv_web/agent_docs/text.ex:834
 #: lib/vutuv_web/live/job_board_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "One random vutuv account that is open to offers."
@@ -22407,8 +22409,8 @@ msgstr ""
 msgid "People here per day over the last %{days} days"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:445
-#: lib/vutuv_web/agent_docs/text.ex:400
+#: lib/vutuv_web/agent_docs/markdown.ex:449
+#: lib/vutuv_web/agent_docs/text.ex:401
 #, elixir-autogen, elixir-format
 msgid "Press material: %{url}"
 msgstr ""
@@ -22423,28 +22425,28 @@ msgstr ""
 msgid "Send a message"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:428
-#: lib/vutuv_web/agent_docs/text.ex:387
+#: lib/vutuv_web/agent_docs/markdown.ex:432
+#: lib/vutuv_web/agent_docs/text.ex:388
 #: lib/vutuv_web/templates/company/investors.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "Where we are"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:435
-#: lib/vutuv_web/agent_docs/text.ex:394
+#: lib/vutuv_web/agent_docs/markdown.ex:439
+#: lib/vutuv_web/agent_docs/text.ex:395
 #: lib/vutuv_web/templates/company/investors.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Why this is worth building"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:444
-#: lib/vutuv_web/agent_docs/text.ex:399
+#: lib/vutuv_web/agent_docs/markdown.ex:448
+#: lib/vutuv_web/agent_docs/text.ex:400
 #, elixir-autogen, elixir-format
 msgid "Write here: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:441
-#: lib/vutuv_web/agent_docs/text.ex:396
+#: lib/vutuv_web/agent_docs/markdown.ex:445
+#: lib/vutuv_web/agent_docs/text.ex:397
 #: lib/vutuv_web/templates/company/investors.html.heex:127
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Write to me"
@@ -22460,8 +22462,8 @@ msgstr ""
 msgid "My profile:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:443
-#: lib/vutuv_web/agent_docs/text.ex:398
+#: lib/vutuv_web/agent_docs/markdown.ex:447
+#: lib/vutuv_web/agent_docs/text.ex:399
 #, elixir-autogen, elixir-format
 msgid "My profile: %{url}"
 msgstr ""
@@ -22481,8 +22483,8 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:512
-#: lib/vutuv_web/agent_docs/text.ex:469
+#: lib/vutuv_web/agent_docs/markdown.ex:516
+#: lib/vutuv_web/agent_docs/text.ex:470
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Source: %{source}"
 msgstr ""
@@ -22537,8 +22539,8 @@ msgstr ""
 msgid "Hidden. What they pass on stays out of your feed; their own posts do not."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3331
-#: lib/vutuv_web/components/post_components.ex:4447
+#: lib/vutuv_web/components/post_components.ex:3374
+#: lib/vutuv_web/components/post_components.ex:4490
 #, elixir-autogen, elixir-format
 msgid "Hide reposts"
 msgstr ""
@@ -22719,8 +22721,8 @@ msgstr ""
 msgid "Posts loaded at once"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3633
-#: lib/vutuv_web/live/post_live/feed.ex:3637
+#: lib/vutuv_web/live/post_live/feed.ex:3644
+#: lib/vutuv_web/live/post_live/feed.ex:3648
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posts per page"
 msgstr ""
@@ -22735,60 +22737,60 @@ msgstr ""
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7276
-#: lib/vutuv_web/components/post_components.ex:7277
+#: lib/vutuv_web/components/post_components.ex:7321
+#: lib/vutuv_web/components/post_components.ex:7322
 #, elixir-autogen, elixir-format, fuzzy
 msgid "A word or phrase …"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7304
+#: lib/vutuv_web/components/post_components.ex:7349
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3694
-#: lib/vutuv_web/live/post_live/feed.ex:3853
-#: lib/vutuv_web/live/post_live/feed.ex:3862
+#: lib/vutuv_web/live/post_live/feed.ex:3705
+#: lib/vutuv_web/live/post_live/feed.ex:3864
+#: lib/vutuv_web/live/post_live/feed.ex:3873
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Hidden"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3827
+#: lib/vutuv_web/live/post_live/feed.ex:3838
 #, elixir-autogen, elixir-format
 msgid "Hide something from your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7224
+#: lib/vutuv_web/components/post_components.ex:7267
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3868
+#: lib/vutuv_web/live/post_live/feed.ex:3879
 #, elixir-autogen, elixir-format
 msgid "Whatever these match is folded to a single line in your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3888
+#: lib/vutuv_web/live/post_live/feed.ex:3899
 #, elixir-autogen, elixir-format
 msgid "Words & tags"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7308
+#: lib/vutuv_web/components/post_components.ex:7353
 #, elixir-autogen, elixir-format, fuzzy
 msgid "everyone"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7311
+#: lib/vutuv_web/components/post_components.ex:7356
 #, elixir-autogen, elixir-format, fuzzy
 msgid "only %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7280
+#: lib/vutuv_web/components/post_components.ex:7325
 #, elixir-autogen, elixir-format, fuzzy
 msgid "this word"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7321
+#: lib/vutuv_web/components/post_components.ex:7366
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr "only %{server}"
@@ -22840,7 +22842,7 @@ msgstr ""
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6628
+#: lib/vutuv_web/components/post_components.ex:6671
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr ""
@@ -22930,8 +22932,8 @@ msgstr ""
 msgid "Hidden. What other people pass on of them stays out of your feed; their own posts do not."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3317
-#: lib/vutuv_web/components/post_components.ex:4435
+#: lib/vutuv_web/components/post_components.ex:3360
+#: lib/vutuv_web/components/post_components.ex:4478
 #, elixir-autogen, elixir-format
 msgid "Hide when others repost them"
 msgstr ""
@@ -23151,7 +23153,7 @@ msgstr ""
 msgid "Your profile picture was not replaced: a report about it is still open. Open the case to remove the picture or to say that it is yours."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2478
+#: lib/vutuv_web/components/post_components.ex:2479
 #, elixir-autogen, elixir-format
 msgid "Fetching the answers from the servers that hold them…"
 msgstr ""
@@ -23166,13 +23168,13 @@ msgstr ""
 msgid "Nothing here we are allowed to show you."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2497
+#: lib/vutuv_web/components/post_components.ex:2498
 #, elixir-autogen, elixir-format
 msgid "Show more answers"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2386
-#: lib/vutuv_web/components/post_components.ex:2388
+#: lib/vutuv_web/components/post_components.ex:2387
+#: lib/vutuv_web/components/post_components.ex:2389
 #, elixir-autogen, elixir-format
 msgid "Show the one answer"
 msgid_plural "Show the %{count} answers"
@@ -23646,13 +23648,13 @@ msgstr ""
 msgid "“%{note}”"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5193
-#: lib/vutuv_web/components/press_kit_components.ex:152
+#: lib/vutuv_web/components/post_components.ex:5236
+#: lib/vutuv_web/components/press_kit_components.ex:207
 #, elixir-autogen, elixir-format
 msgid "Show these photos larger"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5379
+#: lib/vutuv_web/components/post_components.ex:5422
 #, elixir-autogen, elixir-format
 msgid "Show this photo larger"
 msgstr ""
@@ -23671,48 +23673,48 @@ msgid_plural "%{formatted} more entries (%{years})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:778
+#: lib/vutuv_web/live/press_kit_live.ex:941
 #, elixir-autogen, elixir-format
 msgid "%{percent}%"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:391
+#: lib/vutuv_web/live/press_kit_live.ex:536
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{used} of %{max}"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:650
+#: lib/vutuv_web/live/press_kit_live.ex:790
 #, elixir-autogen, elixir-format
 msgid "A photographer's @handle links to their profile and notifies nobody."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:734
+#: lib/vutuv_web/live/press_kit_live.ex:875
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add a logo variant"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:735
+#: lib/vutuv_web/live/press_kit_live.ex:876
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add a press photo"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:612
+#: lib/vutuv_web/live/press_kit_live.ex:752
 #, elixir-autogen, elixir-format
 msgid "At the desk in the Bonn office"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:644
+#: lib/vutuv_web/live/press_kit_live.ex:784
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Caption"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:622
-#: lib/vutuv_web/live/press_kit_live.ex:686
+#: lib/vutuv_web/live/press_kit_live.ex:762
+#: lib/vutuv_web/live/press_kit_live.ex:827
 #, elixir-autogen, elixir-format
 msgid "Credit"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:416
+#: lib/vutuv_web/live/press_kit_live.ex:553
 #, elixir-autogen, elixir-format
 msgid "Dark"
 msgstr ""
@@ -23722,156 +23724,155 @@ msgstr ""
 msgid "Files a journalist may download and print"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:533
+#: lib/vutuv_web/live/press_kit_live.ex:673
 #, elixir-autogen, elixir-format
 msgid "First: the main photo"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:532
+#: lib/vutuv_web/live/press_kit_live.ex:672
 #, elixir-autogen, elixir-format
 msgid "First: the main variant"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:709
+#: lib/vutuv_web/live/press_kit_live.ex:850
 #, elixir-autogen, elixir-format
 msgid "I hold the rights to this file and release it for editorial use, as long as the credit above is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:416
+#: lib/vutuv_web/live/press_kit_live.ex:553
 #, elixir-autogen, elixir-format
 msgid "Light"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:813
+#: lib/vutuv_web/live/press_kit_live.ex:1006
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Logo variant"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:116
-#: lib/vutuv_web/agent_docs/text.ex:412
-#: lib/vutuv_web/live/press_kit_live.ex:382
-#: lib/vutuv_web/templates/press_kit/index.html.heex:47
+#: lib/vutuv_web/agent_docs/text.ex:413
+#: lib/vutuv_web/live/press_kit_live.ex:527
+#: lib/vutuv_web/templates/press_kit/index.html.heex:46
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Logo variants"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:430
+#: lib/vutuv_web/live/press_kit_live.ex:567
 #, elixir-autogen, elixir-format
 msgid "No logo here yet."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:271
+#: lib/vutuv_web/live/press_kit_live.ex:372
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No more than %{max} logo variants."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:274
+#: lib/vutuv_web/live/press_kit_live.ex:375
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No more than %{max} press photos."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:431
+#: lib/vutuv_web/live/press_kit_live.ex:568
 #, elixir-autogen, elixir-format
 msgid "No press photo here yet."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:631
-#: lib/vutuv_web/live/press_kit_live.ex:696
+#: lib/vutuv_web/live/press_kit_live.ex:771
+#: lib/vutuv_web/live/press_kit_live.ex:837
 #, elixir-autogen, elixir-format
 msgid "Photo: Ada King"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:174
+#: lib/vutuv_web/live/press_kit_live.ex:249
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Picture removed."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:290
+#: lib/vutuv_web/live/press_kit_live.ex:391
 #, elixir-autogen, elixir-format
 msgid "Please confirm the rights first, then choose the file."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:813
+#: lib/vutuv_web/live/press_kit_live.ex:1006
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Press photo"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:115
-#: lib/vutuv_web/agent_docs/text.ex:411
-#: lib/vutuv_web/live/press_kit_live.ex:382
-#: lib/vutuv_web/templates/press_kit/index.html.heex:38
+#: lib/vutuv_web/agent_docs/text.ex:412
+#: lib/vutuv_web/live/press_kit_live.ex:527
+#: lib/vutuv_web/templates/press_kit/index.html.heex:37
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Press photos"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5277
-#: lib/vutuv_web/live/press_kit_live.ex:77
-#: lib/vutuv_web/live/press_kit_live.ex:321
+#: lib/vutuv_web/live/press_kit_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Press photos & logos"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:580
+#: lib/vutuv_web/live/press_kit_live.ex:988
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove this picture from your press kit?"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:414
+#: lib/vutuv_web/live/press_kit_live.ex:551
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Show tiles on:"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:634
+#: lib/vutuv_web/live/press_kit_live.ex:774
 #, elixir-autogen, elixir-format
 msgid "Shown beside the picture and asked for with every download."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:303
+#: lib/vutuv_web/live/press_kit_live.ex:404
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That could not be saved."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:405
+#: lib/vutuv_web/live/press_kit_live.ex:980
 #, elixir-autogen, elixir-format
 msgid "The first photo is the one shown first. Drag a tile, or use the arrows, to change the order."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:465
+#: lib/vutuv_web/live/press_kit_live.ex:604
 #, elixir-autogen, elixir-format
 msgid "This shelf is full. Remove one picture to add another."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:325
+#: lib/vutuv_web/live/press_kit_live.ex:486
 #, elixir-autogen, elixir-format
 msgid "What a journalist writing about you may download: photos in print quality and your logo as a file. Everything here is public and free for editorial use as long as your credit is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:600
+#: lib/vutuv_web/live/press_kit_live.ex:740
 #, elixir-autogen, elixir-format, fuzzy
 msgid "What the picture shows"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:599
+#: lib/vutuv_web/live/press_kit_live.ex:739
 #, elixir-autogen, elixir-format
 msgid "Which variant this is"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:611
+#: lib/vutuv_web/live/press_kit_live.ex:751
 #, elixir-autogen, elixir-format
 msgid "White on a dark background"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:645
+#: lib/vutuv_web/live/press_kit_live.ex:785
 #, elixir-autogen, elixir-format
 msgid "Who took it, where, and what may be cropped."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:286
+#: lib/vutuv_web/live/press_kit_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "You cannot add a picture to this press kit."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:401
+#: lib/vutuv_web/live/press_kit_live.ex:972
 #, elixir-autogen, elixir-format
 msgid "Your logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
 msgstr ""
@@ -23893,65 +23894,69 @@ msgid_plural "%{count} bytes"
 msgstr[0] "%{count} byte"
 msgstr[1] "%{count} bytes"
 
-#: lib/vutuv_web/templates/user/show.html.heex:989
+#: lib/vutuv_web/components/press_kit_components.ex:99
 #, elixir-autogen, elixir-format
 msgid "Add press photos"
 msgstr "Add press photos"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1007
+#: lib/vutuv_web/components/press_kit_components.ex:117
 #, elixir-autogen, elixir-format
 msgid "All press material"
 msgstr "All press material"
 
-#: lib/vutuv_web/components/press_kit_components.ex:118
+#: lib/vutuv_web/components/press_kit_components.ex:173
 #, elixir-autogen, elixir-format
 msgid "All press photos"
 msgstr "All press photos"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1543
-#: lib/vutuv_web/agent_docs/text.ex:986
+#: lib/vutuv_web/agent_docs/markdown.ex:1547
+#: lib/vutuv_web/agent_docs/text.ex:987
 #, elixir-autogen, elixir-format
 msgid "Credit: %{credit}"
 msgstr "Credit: %{credit}"
 
-#: lib/vutuv_web/components/press_kit_components.ex:265
-#: lib/vutuv_web/components/press_kit_components.ex:268
+#: lib/vutuv_web/components/press_kit_components.ex:320
+#: lib/vutuv_web/components/press_kit_components.ex:323
 #, elixir-autogen, elixir-format
 msgid "Download %{format}"
 msgstr "Download %{format}"
 
-#: lib/vutuv_web/components/press_kit_components.ex:221
+#: lib/vutuv_web/components/press_kit_components.ex:276
 #, elixir-autogen, elixir-format
 msgid "Download photo"
 msgstr "Download photo"
 
-#: lib/vutuv/press_kit.ex:452
+#: lib/vutuv/press_kit.ex:496
 #, elixir-autogen, elixir-format
 msgid "Free for editorial use with credit."
 msgstr "Free for editorial use with credit."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1546
+#: lib/vutuv_web/agent_docs/markdown.ex:1550
 #, elixir-autogen, elixir-format
 msgid "PNG version"
 msgstr "PNG version"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
+#: lib/vutuv_web/agent_docs/markdown.ex:290
 #: lib/vutuv_web/agent_docs/text.ex:57
-#: lib/vutuv_web/controllers/press_kit_controller.ex:45
-#: lib/vutuv_web/templates/press_kit/index.html.heex:12
-#: lib/vutuv_web/templates/user/show.html.heex:987
+#: lib/vutuv_web/agent_docs/text.ex:257
+#: lib/vutuv_web/components/organization_components.ex:262
+#: lib/vutuv_web/components/press_kit_components.ex:97
+#: lib/vutuv_web/live/organization_live/show.ex:168
+#: lib/vutuv_web/views/press_kit_html.ex:28
+#: lib/vutuv_web/views/press_kit_html.ex:46
 #, elixir-autogen, elixir-format
 msgid "Press"
 msgstr "Press"
 
 #: lib/vutuv_web/agent_docs/press_kit_doc.ex:48
-#: lib/vutuv_web/templates/press_kit/index.html.heex:7
+#: lib/vutuv_web/views/press_kit_html.ex:32
 #, elixir-autogen, elixir-format
 msgid "Press photos and logos of %{name}"
 msgstr "Press photos and logos of %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1542
-#: lib/vutuv_web/agent_docs/text.ex:983
+#: lib/vutuv_web/agent_docs/markdown.ex:1546
+#: lib/vutuv_web/agent_docs/text.ex:984
 #, elixir-autogen, elixir-format
 msgid "Press picture"
 msgstr "Press picture"
@@ -23961,12 +23966,37 @@ msgstr "Press picture"
 msgid "Press pictures %{name} offers for download, free for editorial use with credit."
 msgstr "Press pictures %{name} offers for download, free for editorial use with credit."
 
-#: lib/vutuv_web/templates/press_kit/index.html.heex:32
+#: lib/vutuv_web/templates/press_kit/index.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "These pictures are offered for editorial use. Use them freely in reporting, and print the credit shown with each one."
 msgstr "These pictures are offered for editorial use. Use them freely in reporting, and print the credit shown with each one."
 
-#: lib/vutuv_web/components/post_components.ex:3015
+#: lib/vutuv_web/components/post_components.ex:3025
 #, elixir-autogen, elixir-format
 msgid "Video is being checked"
+msgstr ""
+
+#: lib/vutuv_web/live/press_kit_live.ex:908
+#, elixir-autogen, elixir-format
+msgid "Copies the vector file this page's logo was uploaded as onto this shelf."
+msgstr ""
+
+#: lib/vutuv_web/live/press_kit_live.ex:986
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Remove this picture from this page's press kit?"
+msgstr ""
+
+#: lib/vutuv_web/live/press_kit_live.ex:966
+#, elixir-autogen, elixir-format, fuzzy
+msgid "The page's logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
+msgstr ""
+
+#: lib/vutuv_web/live/press_kit_live.ex:905
+#, elixir-autogen, elixir-format
+msgid "Use the page's own logo"
+msgstr ""
+
+#: lib/vutuv_web/live/press_kit_live.ex:468
+#, elixir-autogen, elixir-format, fuzzy
+msgid "What a journalist writing about this page may download: photos in print quality and its logo as a file. Everything here is public and free for editorial use as long as the credit is shown."
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -35,12 +35,12 @@ msgstr "Aggiungi"
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:169
 #: lib/vutuv_web/live/organization_live/fediverse.ex:123
-#: lib/vutuv_web/live/organization_live/show.ex:920
+#: lib/vutuv_web/live/organization_live/show.ex:957
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1543
+#: lib/vutuv_web/templates/user/show.html.heex:1526
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -102,11 +102,11 @@ msgstr "Immagine del profilo"
 msgid "Birthdate"
 msgstr "Data di nascita"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:703
-#: lib/vutuv_web/agent_docs/markdown.ex:704
-#: lib/vutuv_web/agent_docs/text.ex:653
+#: lib/vutuv_web/agent_docs/markdown.ex:707
+#: lib/vutuv_web/agent_docs/markdown.ex:708
 #: lib/vutuv_web/agent_docs/text.ex:654
-#: lib/vutuv_web/templates/user/show.html.heex:1174
+#: lib/vutuv_web/agent_docs/text.ex:655
+#: lib/vutuv_web/templates/user/show.html.heex:1157
 #, elixir-autogen
 msgid "Birthday"
 msgstr "Compleanno"
@@ -121,7 +121,7 @@ msgstr "Compleanno"
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
 #: lib/vutuv_web/live/post_live/composer.ex:1917
-#: lib/vutuv_web/live/press_kit_live.ex:656
+#: lib/vutuv_web/live/press_kit_live.ex:796
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -155,7 +155,7 @@ msgstr "Selezioni una voce"
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1212
+#: lib/vutuv_web/templates/user/show.html.heex:1195
 #, elixir-autogen
 msgid "Contact"
 msgstr "Contatto"
@@ -164,7 +164,7 @@ msgstr "Contatto"
 msgid "Couldn't follow back to %{name}."
 msgstr "Non è stato possibile ricambiare il follow a %{name}."
 
-#: lib/vutuv_web/components/post_components.ex:4392
+#: lib/vutuv_web/components/post_components.ex:4435
 #: lib/vutuv_web/components/ui.ex:4864
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
@@ -212,14 +212,14 @@ msgstr "Disattiva"
 msgid "Download"
 msgstr "Scarica"
 
-#: lib/vutuv_web/components/post_components.ex:4357
+#: lib/vutuv_web/components/post_components.ex:4400
 #: lib/vutuv_web/components/ui.ex:4855
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
 #: lib/vutuv_web/live/job_posting_live/show.ex:201
-#: lib/vutuv_web/live/organization_live/show.ex:152
-#: lib/vutuv_web/live/press_kit_live.ex:573
+#: lib/vutuv_web/live/organization_live/show.ex:159
+#: lib/vutuv_web/live/press_kit_live.ex:713
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:19
@@ -227,7 +227,7 @@ msgstr "Scarica"
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:113
-#: lib/vutuv_web/templates/user/show.html.heex:1197
+#: lib/vutuv_web/templates/user/show.html.heex:1180
 #, elixir-autogen
 msgid "Edit"
 msgstr "Modifica"
@@ -308,14 +308,14 @@ msgstr "Esperienza"
 msgid "Fax"
 msgstr "Fax"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:689
+#: lib/vutuv_web/agent_docs/markdown.ex:693
 #: lib/vutuv_web/templates/user/edit.html.heex:170
 #, elixir-autogen
 msgid "First Name"
 msgstr "Nome"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:724
-#: lib/vutuv_web/agent_docs/text.ex:674
+#: lib/vutuv_web/agent_docs/markdown.ex:728
+#: lib/vutuv_web/agent_docs/text.ex:675
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
@@ -325,18 +325,18 @@ msgstr "Nome"
 msgid "Followers"
 msgstr "Follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:725
-#: lib/vutuv_web/agent_docs/text.ex:675
+#: lib/vutuv_web/agent_docs/markdown.ex:729
+#: lib/vutuv_web/agent_docs/text.ex:676
 #: lib/vutuv_web/components/fediverse_components.ex:468
 #: lib/vutuv_web/components/ui.ex:3087
 #: lib/vutuv_web/components/ui.ex:3122
 #: lib/vutuv_web/controllers/followee_controller.ex:29
 #: lib/vutuv_web/live/import_connections_live.ex:469
-#: lib/vutuv_web/live/organization_live/show.ex:618
+#: lib/vutuv_web/live/organization_live/show.ex:641
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:1042
-#: lib/vutuv_web/views/user_html.ex:649
+#: lib/vutuv_web/templates/user/show.html.heex:1025
+#: lib/vutuv_web/views/user_html.ex:642
 #, elixir-autogen
 msgid "Following"
 msgstr "Seguiti"
@@ -387,7 +387,7 @@ msgstr "Qualifica"
 msgid "Language"
 msgstr "Lingua"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:691
+#: lib/vutuv_web/agent_docs/markdown.ex:695
 #: lib/vutuv_web/templates/user/edit.html.heex:175
 #, elixir-autogen
 msgid "Last Name"
@@ -454,7 +454,7 @@ msgstr "Esci"
 msgid "Log in"
 msgstr "Accedi"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:690
+#: lib/vutuv_web/agent_docs/markdown.ex:694
 #: lib/vutuv_web/templates/user/edit.html.heex:180
 #, elixir-autogen
 msgid "Middle Name"
@@ -479,7 +479,7 @@ msgstr "Altro"
 msgid "Name"
 msgstr "Nome"
 
-#: lib/vutuv_web/components/post_components.ex:807
+#: lib/vutuv_web/components/post_components.ex:808
 #: lib/vutuv_web/live/notification_live/index.ex:776
 #: lib/vutuv_web/live/organization_live/activity.ex:136
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
@@ -491,7 +491,7 @@ msgstr "Nome"
 msgid "New"
 msgstr "Nuovo"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:693
+#: lib/vutuv_web/agent_docs/markdown.ex:697
 #: lib/vutuv_web/templates/user/edit.html.heex:185
 #, elixir-autogen
 msgid "Nickname"
@@ -572,7 +572,7 @@ msgstr "Numero di telefono eliminato."
 msgid "Phone number updated successfully."
 msgstr "Numero di telefono aggiornato."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:688
+#: lib/vutuv_web/agent_docs/markdown.ex:692
 #: lib/vutuv_web/templates/user/edit.html.heex:190
 #, elixir-autogen
 msgid "Prefix"
@@ -622,7 +622,7 @@ msgstr "Pubblico"
 #: lib/vutuv_web/components/ui.ex:4756
 #: lib/vutuv_web/live/organization_live/edit.ex:376
 #: lib/vutuv_web/live/post_live/composer.ex:2201
-#: lib/vutuv_web/live/press_kit_live.ex:655
+#: lib/vutuv_web/live/press_kit_live.ex:795
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
@@ -664,7 +664,7 @@ msgstr "Salva"
 msgid "Search"
 msgstr "Cerca"
 
-#: lib/vutuv_web/components/post_components.ex:1866
+#: lib/vutuv_web/components/post_components.ex:1867
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -698,13 +698,13 @@ msgstr "Slug"
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1326
+#: lib/vutuv_web/templates/user/show.html.heex:1309
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profili"
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1328
+#: lib/vutuv_web/templates/user/show.html.heex:1311
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr "Aggiungi un profilo"
@@ -729,12 +729,12 @@ msgstr "Profilo aggiornato."
 msgid "Profile deleted successfully."
 msgstr "Profilo eliminato."
 
-#: lib/vutuv_web/views/user_html.ex:1057
+#: lib/vutuv_web/views/user_html.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Social networks"
 msgstr "Social network"
 
-#: lib/vutuv_web/views/user_html.ex:1064
+#: lib/vutuv_web/views/user_html.ex:1057
 #, elixir-autogen, elixir-format
 msgid "Code & repositories"
 msgstr "Codice e repository"
@@ -752,7 +752,7 @@ msgstr "Qualcosa è andato storto"
 msgid "Submit a bugreport or a feature request."
 msgstr "Segnali un problema o proponga una funzione."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:692
+#: lib/vutuv_web/agent_docs/markdown.ex:696
 #: lib/vutuv_web/templates/user/edit.html.heex:195
 #, elixir-autogen
 msgid "Suffix"
@@ -832,7 +832,6 @@ msgstr "Nome utente"
 #: lib/vutuv_web/templates/messenger/show.html.heex:4
 #: lib/vutuv_web/templates/phone_number/index.html.heex:8
 #: lib/vutuv_web/templates/phone_number/show.html.heex:4
-#: lib/vutuv_web/templates/press_kit/index.html.heex:10
 #: lib/vutuv_web/templates/qualification/index.html.heex:9
 #: lib/vutuv_web/templates/qualification/show.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/index.html.heex:8
@@ -844,21 +843,22 @@ msgstr "Nome utente"
 #: lib/vutuv_web/templates/user_tag/show.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:8
 #: lib/vutuv_web/templates/work_experience/show.html.heex:4
+#: lib/vutuv_web/views/press_kit_html.ex:50
 #, elixir-autogen
 msgid "Users"
 msgstr "Utenti"
 
 #: lib/vutuv_web/components/ui.ex:1597
-#: lib/vutuv_web/views/user_html.ex:594
-#: lib/vutuv_web/views/user_html.ex:595
-#: lib/vutuv_web/views/user_html.ex:609
+#: lib/vutuv_web/views/user_html.ex:587
+#: lib/vutuv_web/views/user_html.ex:588
+#: lib/vutuv_web/views/user_html.ex:602
 #, elixir-autogen
 msgid "vCard"
 msgstr "vCard"
 
 #: lib/vutuv_web/components/ui.ex:4925
-#: lib/vutuv_web/templates/user/show.html.heex:1036
-#: lib/vutuv_web/templates/user/show.html.heex:1059
+#: lib/vutuv_web/templates/user/show.html.heex:1019
+#: lib/vutuv_web/templates/user/show.html.heex:1042
 #, elixir-autogen
 msgid "View All"
 msgstr "Mostra tutti"
@@ -941,6 +941,7 @@ msgstr "Ora segue anche %{name}."
 
 #: lib/vutuv_web/live/init_assigns.ex:54
 #: lib/vutuv_web/live/post_live/feed.ex:169
+#: lib/vutuv_web/live/press_kit_live.ex:109
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1062,7 +1063,7 @@ msgstr "Non ha i permessi per vedere questa pagina."
 msgid "An error occurred"
 msgstr "Si è verificato un errore"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1163
+#: lib/vutuv_web/templates/user/show.html.heex:1146
 #, elixir-autogen
 msgid "General Info"
 msgstr "Informazioni generali"
@@ -1146,7 +1147,7 @@ msgstr "Selezioni un social network"
 msgid "Add Localization"
 msgstr "Aggiungi localizzazione"
 
-#: lib/vutuv_web/components/organization_components.ex:315
+#: lib/vutuv_web/components/organization_components.ex:324
 #: lib/vutuv_web/live/admin/activity_live.ex:153
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
@@ -1204,7 +1205,7 @@ msgstr "Tutti i sinonimi dei tag"
 msgid "All tag urls"
 msgstr "Tutti gli URL dei tag"
 
-#: lib/vutuv_web/components/post_components.ex:5006
+#: lib/vutuv_web/components/post_components.ex:5049
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:643
@@ -1373,11 +1374,11 @@ msgid "Tag urls"
 msgstr "URL dei tag"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:34
-#: lib/vutuv_web/agent_docs/markdown.ex:596
-#: lib/vutuv_web/agent_docs/markdown.ex:1237
+#: lib/vutuv_web/agent_docs/markdown.ex:600
+#: lib/vutuv_web/agent_docs/markdown.ex:1241
 #: lib/vutuv_web/agent_docs/text.ex:31
-#: lib/vutuv_web/agent_docs/text.ex:601
-#: lib/vutuv_web/agent_docs/text.ex:867
+#: lib/vutuv_web/agent_docs/text.ex:602
+#: lib/vutuv_web/agent_docs/text.ex:868
 #: lib/vutuv_web/components/ui.ex:5305
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
@@ -1704,12 +1705,12 @@ msgstr "Conferma"
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:320
 #: lib/vutuv_web/live/organization_live/following.ex:340
 #: lib/vutuv_web/live/organization_live/following.ex:421
-#: lib/vutuv_web/live/organization_live/show.ex:579
-#: lib/vutuv_web/live/organization_live/show.ex:616
+#: lib/vutuv_web/live/organization_live/show.ex:602
+#: lib/vutuv_web/live/organization_live/show.ex:639
 #: lib/vutuv_web/live/post_live/feed.ex:902
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
-#: lib/vutuv_web/templates/user/show.html.heex:1367
-#: lib/vutuv_web/views/user_html.ex:660
+#: lib/vutuv_web/templates/user/show.html.heex:1350
+#: lib/vutuv_web/views/user_html.ex:653
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr "Segui"
@@ -1727,7 +1728,7 @@ msgstr ""
 msgid "Log out"
 msgstr "Esci"
 
-#: lib/vutuv_web/components/organization_components.ex:321
+#: lib/vutuv_web/components/organization_components.ex:330
 #: lib/vutuv_web/live/admin/activity_live.ex:143
 #: lib/vutuv_web/live/admin/activity_live.ex:175
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
@@ -1742,10 +1743,10 @@ msgstr "Esci"
 msgid "Member"
 msgstr "Membro"
 
-#: lib/vutuv_web/live/organization_live/show.ex:638
-#: lib/vutuv_web/views/user_html.ex:687
-#: lib/vutuv_web/views/user_html.ex:688
-#: lib/vutuv_web/views/user_html.ex:698
+#: lib/vutuv_web/live/organization_live/show.ex:661
+#: lib/vutuv_web/views/user_html.ex:680
+#: lib/vutuv_web/views/user_html.ex:681
+#: lib/vutuv_web/views/user_html.ex:691
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr "Messaggio"
@@ -1765,7 +1766,7 @@ msgstr "Messaggi"
 msgid "Network"
 msgstr "Rete"
 
-#: lib/vutuv_web/components/post_components.ex:486
+#: lib/vutuv_web/components/post_components.ex:487
 #: lib/vutuv_web/components/ui.ex:4974
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
@@ -1855,7 +1856,7 @@ msgstr "Troppi tentativi. Riprovi più tardi."
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:27
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:18
 #: lib/vutuv_web/templates/user/show.html.heex:232
-#: lib/vutuv_web/views/user_html.ex:1109
+#: lib/vutuv_web/views/user_html.ex:1102
 #, elixir-autogen, elixir-format
 msgid "Verified profile"
 msgstr "Profilo verificato"
@@ -1881,7 +1882,7 @@ msgstr ""
 "Abbiamo inviato un PIN al Suo nuovo indirizzo e-mail. Lo inserisca qui sotto"
 " per confermare l'indirizzo."
 
-#: lib/vutuv_web/views/user_html.ex:247
+#: lib/vutuv_web/views/user_html.ex:240
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr "Chi seguire"
@@ -1900,14 +1901,14 @@ msgstr "La Sua sessione di accesso è scaduta. Riprovi."
 
 #: lib/vutuv_web/open_graph.ex:418
 #: lib/vutuv_web/templates/tag/show.html.heex:32
-#: lib/vutuv_web/views/user_html.ex:531
+#: lib/vutuv_web/views/user_html.ex:524
 #, elixir-autogen, elixir-format
 msgid "follower"
 msgid_plural "followers"
 msgstr[0] "follower"
 msgstr[1] "follower"
 
-#: lib/vutuv_web/views/user_html.ex:535
+#: lib/vutuv_web/views/user_html.ex:528
 #, elixir-autogen, elixir-format
 msgid "following"
 msgstr "seguiti"
@@ -1937,7 +1938,7 @@ msgstr "Paginazione"
 #: lib/vutuv_web/components/ui.ex:4999
 #: lib/vutuv_web/live/organization_live/activity.ex:159
 #: lib/vutuv_web/live/organization_live/feed.ex:258
-#: lib/vutuv_web/live/organization_live/show.ex:787
+#: lib/vutuv_web/live/organization_live/show.ex:810
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr "Carica altro"
@@ -2060,12 +2061,12 @@ msgstr "Marzo"
 msgid "May"
 msgstr "Maggio"
 
-#: lib/vutuv_web/views/user_html.ex:299
+#: lib/vutuv_web/views/user_html.ex:292
 #, elixir-autogen, elixir-format
 msgid "Member since %{month} %{year}"
 msgstr "Membro da %{month} %{year}"
 
-#: lib/vutuv_web/views/user_html.ex:304
+#: lib/vutuv_web/views/user_html.ex:297
 #, elixir-autogen, elixir-format
 msgid "Member since %{year}"
 msgstr "Membro dal %{year}"
@@ -2112,7 +2113,7 @@ msgstr "Torna al post"
 
 #: lib/vutuv_web/live/post_live/composer.ex:2015
 #: lib/vutuv_web/live/post_live/composer.ex:2038
-#: lib/vutuv_web/live/press_kit_live.ex:786
+#: lib/vutuv_web/live/press_kit_live.ex:949
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr "Annulla il caricamento"
@@ -2122,7 +2123,7 @@ msgstr "Annulla il caricamento"
 msgid "Delete post"
 msgstr "Elimina il post"
 
-#: lib/vutuv_web/components/post_components.ex:4389
+#: lib/vutuv_web/components/post_components.ex:4432
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2134,11 +2135,11 @@ msgstr "Eliminare definitivamente questo post?"
 msgid "Edit post"
 msgstr "Modifica il post"
 
-#: lib/vutuv_web/components/organization_components.ex:265
+#: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:203
 #: lib/vutuv_web/live/post_live/feed.ex:331
-#: lib/vutuv_web/live/post_live/feed.ex:3254
+#: lib/vutuv_web/live/post_live/feed.ex:3265
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1341
 #: lib/vutuv_web/live/shell_live.ex:1686
@@ -2167,8 +2168,8 @@ msgstr "Nascondi a una persona specifica…"
 msgid "Hide this post from…"
 msgstr "Nascondi questo post a…"
 
-#: lib/vutuv_web/components/post_components.ex:4343
-#: lib/vutuv_web/components/post_components.ex:4345
+#: lib/vutuv_web/components/post_components.ex:4386
+#: lib/vutuv_web/components/post_components.ex:4388
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Pubblico limitato"
@@ -2184,7 +2185,7 @@ msgstr "Visitatori non connessi"
 msgid "No more than %{max} images per post."
 msgstr "Non più di %{max} immagini per post."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3583
+#: lib/vutuv_web/live/post_live/feed.ex:3594
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2224,7 +2225,7 @@ msgstr "Post eliminato."
 #: lib/vutuv_web/gettext_extraction_anchors.ex:113
 #: lib/vutuv_web/live/admin/dashboard_live.ex:270
 #: lib/vutuv_web/live/fediverse_account_live.ex:446
-#: lib/vutuv_web/live/organization_live/show.ex:710
+#: lib/vutuv_web/live/organization_live/show.ex:733
 #: lib/vutuv_web/live/post_live/saved.ex:536
 #: lib/vutuv_web/live/search_live.ex:348
 #: lib/vutuv_web/live/search_live.ex:832
@@ -2234,13 +2235,13 @@ msgstr "Post eliminato."
 msgid "Posts"
 msgstr "Post"
 
-#: lib/vutuv_web/components/post_components.ex:4879
-#: lib/vutuv_web/components/post_components.ex:4883
+#: lib/vutuv_web/components/post_components.ex:4922
+#: lib/vutuv_web/components/post_components.ex:4926
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Leggi tutto"
 
-#: lib/vutuv_web/components/post_components.ex:4880
+#: lib/vutuv_web/components/post_components.ex:4923
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2250,7 +2251,7 @@ msgstr "Mostra meno"
 
 #: lib/vutuv_web/components/fediverse_components.ex:497
 #: lib/vutuv_web/components/job_exclusion_components.ex:189
-#: lib/vutuv_web/components/post_components.ex:1448
+#: lib/vutuv_web/components/post_components.ex:1449
 #: lib/vutuv_web/live/admin/screenshot_live.ex:352
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:229
@@ -2262,7 +2263,7 @@ msgstr "Mostra meno"
 #: lib/vutuv_web/live/post_live/saved.ex:666
 #: lib/vutuv_web/live/post_live/saved.ex:694
 #: lib/vutuv_web/live/post_rewrites_live.ex:376
-#: lib/vutuv_web/live/press_kit_live.ex:582
+#: lib/vutuv_web/live/press_kit_live.ex:722
 #: lib/vutuv_web/templates/connection/index.html.heex:45
 #: lib/vutuv_web/views/settings_html.ex:386
 #, elixir-autogen, elixir-format
@@ -2281,7 +2282,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Salvataggio…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2454
+#: lib/vutuv_web/live/post_live/feed.ex:2465
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2295,7 +2296,7 @@ msgstr "Spiacenti, la pagina non è stata trovata."
 
 #: lib/vutuv_web/live/post_live/composer.ex:1520
 #: lib/vutuv_web/live/post_live/composer.ex:1588
-#: lib/vutuv_web/live/press_kit_live.ex:294
+#: lib/vutuv_web/live/press_kit_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr "Non è stato possibile elaborare il file."
@@ -2339,27 +2340,27 @@ msgstr "Che c'è di nuovo?"
 msgid "What's new? Markdown is supported."
 msgstr "Che c'è di nuovo? Markdown è supportato."
 
-#: lib/vutuv_web/components/post_components.ex:4340
+#: lib/vutuv_web/components/post_components.ex:4383
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "modificato"
 
-#: lib/vutuv_web/components/post_components.ex:6646
+#: lib/vutuv_web/components/post_components.ex:6689
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "tutti gli altri"
 
-#: lib/vutuv_web/components/post_components.ex:6650
+#: lib/vutuv_web/components/post_components.ex:6693
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "visitatori non connessi"
 
-#: lib/vutuv_web/components/post_components.ex:6648
+#: lib/vutuv_web/components/post_components.ex:6691
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "persone che non La seguono"
 
-#: lib/vutuv_web/components/post_components.ex:6649
+#: lib/vutuv_web/components/post_components.ex:6692
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "persone che non segue"
@@ -2403,15 +2404,15 @@ msgstr "Vedi tutti i %{count} post"
 msgid "All posts"
 msgstr "Tutti i post"
 
-#: lib/vutuv_web/components/post_components.ex:2180
-#: lib/vutuv_web/components/post_components.ex:6749
+#: lib/vutuv_web/components/post_components.ex:2181
+#: lib/vutuv_web/components/post_components.ex:6792
 #: lib/vutuv_web/components/ui.ex:4298
-#: lib/vutuv_web/views/user_html.ex:493
+#: lib/vutuv_web/views/user_html.ex:486
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr "Salva"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1291
+#: lib/vutuv_web/agent_docs/markdown.ex:1295
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:529
 #: lib/vutuv_web/live/shell_live.ex:1499
@@ -2422,17 +2423,17 @@ msgstr "Salva"
 msgid "Bookmarks"
 msgstr "Salvati"
 
-#: lib/vutuv_web/components/post_components.ex:2124
-#: lib/vutuv_web/components/post_components.ex:6990
+#: lib/vutuv_web/components/post_components.ex:2125
+#: lib/vutuv_web/components/post_components.ex:7033
 #: lib/vutuv_web/components/ui.ex:4284
 #: lib/vutuv_web/notification_line.ex:317
-#: lib/vutuv_web/views/user_html.ex:503
+#: lib/vutuv_web/views/user_html.ex:496
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr "Mi piace"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1290
-#: lib/vutuv_web/components/post_components.ex:7000
+#: lib/vutuv_web/agent_docs/markdown.ex:1294
+#: lib/vutuv_web/components/post_components.ex:7043
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
 #: lib/vutuv_web/live/shell_live.ex:1590
@@ -2453,58 +2454,58 @@ msgstr "Qui non c'è ancora nulla. I post che salva compaiono qui."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Qui non c'è ancora nulla. I post a cui mette Mi piace compaiono qui."
 
-#: lib/vutuv_web/components/post_components.ex:6737
+#: lib/vutuv_web/components/post_components.ex:6780
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Solo i post pubblici possono essere ripubblicati."
 
-#: lib/vutuv_web/components/post_components.ex:2179
-#: lib/vutuv_web/components/post_components.ex:6748
+#: lib/vutuv_web/components/post_components.ex:2180
+#: lib/vutuv_web/components/post_components.ex:6791
 #: lib/vutuv_web/live/post_live/saved.ex:822
-#: lib/vutuv_web/views/user_html.ex:493
+#: lib/vutuv_web/views/user_html.ex:486
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr "Rimuovi dai salvati"
 
-#: lib/vutuv_web/components/post_components.ex:2160
-#: lib/vutuv_web/components/post_components.ex:6733
+#: lib/vutuv_web/components/post_components.ex:2161
+#: lib/vutuv_web/components/post_components.ex:6776
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Ripubblica"
 
-#: lib/vutuv_web/components/post_components.ex:2753
-#: lib/vutuv_web/components/post_components.ex:5752
+#: lib/vutuv_web/components/post_components.ex:2754
+#: lib/vutuv_web/components/post_components.ex:5795
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Ripubblicato da %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:2159
-#: lib/vutuv_web/components/post_components.ex:6732
+#: lib/vutuv_web/components/post_components.ex:2160
+#: lib/vutuv_web/components/post_components.ex:6775
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Annulla la ripubblicazione"
 
-#: lib/vutuv_web/components/post_components.ex:2123
-#: lib/vutuv_web/components/post_components.ex:6989
+#: lib/vutuv_web/components/post_components.ex:2124
+#: lib/vutuv_web/components/post_components.ex:7032
 #: lib/vutuv_web/live/post_live/saved.ex:821
-#: lib/vutuv_web/views/user_html.ex:503
+#: lib/vutuv_web/views/user_html.ex:496
 #, elixir-autogen, elixir-format
 msgid "Unlike"
 msgstr "Togli Mi piace"
 
 #: lib/vutuv_web/components/fediverse_components.ex:498
-#: lib/vutuv_web/components/post_components.ex:3351
+#: lib/vutuv_web/components/post_components.ex:3394
 #: lib/vutuv_web/components/ui.ex:3047
 #: lib/vutuv_web/components/ui.ex:3047
 #: lib/vutuv_web/components/ui.ex:3123
 #: lib/vutuv_web/live/organization_live/following.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:476
-#: lib/vutuv_web/live/organization_live/show.ex:621
+#: lib/vutuv_web/live/organization_live/show.ex:644
 #: lib/vutuv_web/live/post_live/feed.ex:889
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:42
-#: lib/vutuv_web/views/user_html.ex:650
+#: lib/vutuv_web/views/user_html.ex:643
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr "Non seguire più"
@@ -2514,20 +2515,20 @@ msgstr "Non seguire più"
 msgid "Welcome to vutuv!"
 msgstr "Benvenuto su vutuv."
 
-#: lib/vutuv_web/components/post_components.ex:7044
+#: lib/vutuv_web/components/post_components.ex:7087
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Solo ai post pubblici si può rispondere."
 
-#: lib/vutuv_web/components/post_components.ex:444
+#: lib/vutuv_web/components/post_components.ex:445
 #: lib/vutuv_web/live/notification_live/index.ex:1331
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Risposte"
 
-#: lib/vutuv_web/components/post_components.ex:2369
-#: lib/vutuv_web/components/post_components.ex:7027
-#: lib/vutuv_web/components/post_components.ex:7028
+#: lib/vutuv_web/components/post_components.ex:2370
+#: lib/vutuv_web/components/post_components.ex:7070
+#: lib/vutuv_web/components/post_components.ex:7071
 #: lib/vutuv_web/live/notification_live/index.ex:993
 #: lib/vutuv_web/live/post_live/reply.ex:49
 #: lib/vutuv_web/notification_line.ex:314
@@ -2535,7 +2536,7 @@ msgstr "Risposte"
 msgid "Reply"
 msgstr "Rispondi"
 
-#: lib/vutuv_web/components/post_components.ex:4299
+#: lib/vutuv_web/components/post_components.ex:4342
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Risposta a un post eliminato"
@@ -2561,7 +2562,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr "ha risposto al Suo post."
 
-#: lib/vutuv_web/components/post_components.ex:3817
+#: lib/vutuv_web/components/post_components.ex:3860
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:63
 #: lib/vutuv_web/live/post_live/remote_reply.ex:61
 #: lib/vutuv_web/live/post_live/reply.ex:63
@@ -2569,14 +2570,14 @@ msgstr "ha risposto al Suo post."
 msgid "Reply to %{handle}"
 msgstr "Rispondi a %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:4271
+#: lib/vutuv_web/components/post_components.ex:4314
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Risposta a un post di %{handle} ora eliminato"
 
-#: lib/vutuv_web/components/post_components.ex:4262
-#: lib/vutuv_web/components/post_components.ex:4291
-#: lib/vutuv_web/components/post_components.ex:4294
+#: lib/vutuv_web/components/post_components.ex:4305
+#: lib/vutuv_web/components/post_components.ex:4334
+#: lib/vutuv_web/components/post_components.ex:4337
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "In risposta a %{handle}"
@@ -2751,26 +2752,26 @@ msgstr "Aggiungi un link"
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1286
+#: lib/vutuv_web/templates/user/show.html.heex:1269
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr "Aggiungi un numero di telefono"
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1545
+#: lib/vutuv_web/templates/user/show.html.heex:1528
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr "Aggiungi un indirizzo"
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1214
+#: lib/vutuv_web/templates/user/show.html.heex:1197
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr "Aggiungi un indirizzo e-mail"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1165
+#: lib/vutuv_web/templates/user/show.html.heex:1148
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr "Aggiungi i dati personali"
@@ -2801,7 +2802,7 @@ msgstr "Scriva il Suo primo post"
 msgid "Manage"
 msgstr "Gestisci"
 
-#: lib/vutuv_web/components/post_components.ex:884
+#: lib/vutuv_web/components/post_components.ex:885
 #: lib/vutuv_web/controllers/page_controller.ex:211
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2831,8 +2832,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] "+1 altro tag"
 msgstr[1] "+%{formatted} altri tag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:726
-#: lib/vutuv_web/agent_docs/text.ex:676
+#: lib/vutuv_web/agent_docs/markdown.ex:730
+#: lib/vutuv_web/agent_docs/text.ex:677
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -2870,14 +2871,14 @@ msgid "This post is for the connections of %{name}"
 msgstr "Questo post è per i collegamenti di %{name}"
 
 #: lib/vutuv_web/views/admin/moderation_html.ex:127
-#: lib/vutuv_web/views/user_html.ex:545
+#: lib/vutuv_web/views/user_html.ex:538
 #, elixir-autogen, elixir-format
 msgid "connection"
 msgid_plural "connections"
 msgstr[0] "collegamento"
 msgstr[1] "collegamenti"
 
-#: lib/vutuv_web/components/post_components.ex:6647
+#: lib/vutuv_web/components/post_components.ex:6690
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "persone che non sono Suoi collegamenti"
@@ -2887,7 +2888,7 @@ msgstr "persone che non sono Suoi collegamenti"
 msgid "Open someone's profile to message them."
 msgstr "Apra il profilo di una persona per scriverle."
 
-#: lib/vutuv_web/components/organization_components.ex:259
+#: lib/vutuv_web/components/organization_components.ex:268
 #: lib/vutuv_web/live/organization_live/activity.ex:112
 #: lib/vutuv_web/notification_line.ex:331
 #, elixir-autogen, elixir-format
@@ -2905,7 +2906,7 @@ msgid "Endorsement"
 msgstr "Conferma"
 
 #: lib/vutuv_web/notification_line.ex:312
-#: lib/vutuv_web/templates/user/show.html.heex:1020
+#: lib/vutuv_web/templates/user/show.html.heex:1003
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -2976,8 +2977,8 @@ msgstr "Qualcosa che i nostri amministratori dovrebbero sapere? (facoltativo)"
 msgid "Bullying or harassment"
 msgstr "Bullismo o molestie"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:400
-#: lib/vutuv_web/agent_docs/text.ex:366
+#: lib/vutuv_web/agent_docs/markdown.ex:404
+#: lib/vutuv_web/agent_docs/text.ex:367
 #: lib/vutuv_web/controllers/page_controller.ex:76
 #: lib/vutuv_web/templates/layout/app.html.heex:126
 #: lib/vutuv_web/templates/page/community.html.heex:4
@@ -3136,13 +3137,13 @@ msgstr "Qui non c'è nulla: al momento nessun Suo contenuto è segnalato."
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr "Nudità, violenza o altri contenuti che non hanno posto su vutuv."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1254
-#: lib/vutuv_web/templates/user/show.html.heex:1255
+#: lib/vutuv_web/templates/user/show.html.heex:1237
+#: lib/vutuv_web/templates/user/show.html.heex:1238
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr "Visibile solo a Lei"
 
-#: lib/vutuv_web/components/post_components.ex:4238
+#: lib/vutuv_web/components/post_components.ex:4281
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solo Lei può vedere questo post finché la segnalazione è in corso."
@@ -3170,7 +3171,7 @@ msgstr "Apri la coda"
 msgid "Opened"
 msgstr "Aperto"
 
-#: lib/vutuv_web/components/organization_components.ex:314
+#: lib/vutuv_web/components/organization_components.ex:323
 #: lib/vutuv_web/live/admin/api_app_live.ex:72
 #: lib/vutuv_web/live/admin/deliverability_live.ex:171
 #: lib/vutuv_web/live/admin/moderation_live.ex:56
@@ -3202,10 +3203,10 @@ msgstr "Respinta"
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Lo rimuova. La segnalazione si chiude, senza altre domande."
 
-#: lib/vutuv_web/components/post_components.ex:1461
-#: lib/vutuv_web/components/post_components.ex:3371
-#: lib/vutuv_web/components/post_components.ex:4456
-#: lib/vutuv_web/live/organization_live/show.ex:661
+#: lib/vutuv_web/components/post_components.ex:1462
+#: lib/vutuv_web/components/post_components.ex:3414
+#: lib/vutuv_web/components/post_components.ex:4499
+#: lib/vutuv_web/live/organization_live/show.ex:684
 #: lib/vutuv_web/templates/user/show.html.heex:252
 #, elixir-autogen, elixir-format
 msgid "Report"
@@ -3889,12 +3890,12 @@ msgstr "messaggio segnalato"
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr "Scorra dentro il riquadro, o prema per aprire l'immagine intera."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:833
+#: lib/vutuv_web/agent_docs/markdown.ex:837
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr "%{count} conferme"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1412
+#: lib/vutuv_web/agent_docs/markdown.ex:1416
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr "%{count} in questa pagina, usi ?page=N"
@@ -3908,11 +3909,11 @@ msgstr "%{count} post di %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:92
 #: lib/vutuv_web/agent_docs/markdown.ex:219
 #: lib/vutuv_web/agent_docs/markdown.ex:233
-#: lib/vutuv_web/agent_docs/markdown.ex:1237
+#: lib/vutuv_web/agent_docs/markdown.ex:1241
 #: lib/vutuv_web/agent_docs/text.ex:87
 #: lib/vutuv_web/agent_docs/text.ex:188
 #: lib/vutuv_web/agent_docs/text.ex:202
-#: lib/vutuv_web/agent_docs/text.ex:867
+#: lib/vutuv_web/agent_docs/text.ex:868
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr "%{count} in totale"
@@ -3931,28 +3932,28 @@ msgstr "Follower di %{name}"
 msgid "Images"
 msgstr "Immagini"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1255
-#: lib/vutuv_web/agent_docs/text.ex:878
+#: lib/vutuv_web/agent_docs/markdown.ex:1259
+#: lib/vutuv_web/agent_docs/text.ex:879
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr "In risposta a un post eliminato di %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1252
-#: lib/vutuv_web/agent_docs/text.ex:875
+#: lib/vutuv_web/agent_docs/markdown.ex:1256
+#: lib/vutuv_web/agent_docs/text.ex:876
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr "In risposta a un post eliminato."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1259
-#: lib/vutuv_web/agent_docs/markdown.ex:1505
-#: lib/vutuv_web/agent_docs/text.ex:882
-#: lib/vutuv_web/agent_docs/text.ex:951
+#: lib/vutuv_web/agent_docs/markdown.ex:1263
+#: lib/vutuv_web/agent_docs/markdown.ex:1509
+#: lib/vutuv_web/agent_docs/text.ex:883
+#: lib/vutuv_web/agent_docs/text.ex:952
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr "In risposta a un post di %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:661
-#: lib/vutuv_web/agent_docs/text.ex:639
+#: lib/vutuv_web/agent_docs/markdown.ex:665
+#: lib/vutuv_web/agent_docs/text.ex:640
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr "Membro da"
@@ -3991,23 +3992,23 @@ msgstr "Post di %{name}"
 msgid "Posts (%{count} total)"
 msgstr "Post (%{count} in totale)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:655
-#: lib/vutuv_web/agent_docs/text.ex:633
+#: lib/vutuv_web/agent_docs/markdown.ex:659
+#: lib/vutuv_web/agent_docs/text.ex:634
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr "Profilo verificato: sì"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1183
+#: lib/vutuv_web/agent_docs/markdown.ex:1187
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr "ripubblicato da %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1045
+#: lib/vutuv_web/agent_docs/markdown.ex:1049
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr "oggi"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1046
+#: lib/vutuv_web/agent_docs/markdown.ex:1050
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr "fino al %{date}"
@@ -4085,8 +4086,8 @@ msgstr ""
 msgid "Billing name"
 msgstr "Intestazione della fattura"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:414
-#: lib/vutuv_web/agent_docs/text.ex:374
+#: lib/vutuv_web/agent_docs/markdown.ex:418
+#: lib/vutuv_web/agent_docs/text.ex:375
 #, elixir-autogen, elixir-format
 msgid "Book online (login required): %{url}"
 msgstr "Prenoti online (serve l'accesso): %{url}"
@@ -4138,8 +4139,8 @@ msgstr "Giorno"
 msgid "Markdown is supported. At most %{max} characters."
 msgstr "Markdown è supportato. Al massimo %{max} caratteri."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:404
-#: lib/vutuv_web/agent_docs/text.ex:370
+#: lib/vutuv_web/agent_docs/markdown.ex:408
+#: lib/vutuv_web/agent_docs/text.ex:371
 #: lib/vutuv_web/templates/ad/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Next available day"
@@ -4156,8 +4157,8 @@ msgid "One text-only ad per calendar day, seen by every visitor."
 msgstr ""
 "Una sola pubblicità di solo testo al giorno, vista da tutti i visitatori."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:401
-#: lib/vutuv_web/agent_docs/text.ex:367
+#: lib/vutuv_web/agent_docs/markdown.ex:405
+#: lib/vutuv_web/agent_docs/text.ex:368
 #: lib/vutuv_web/templates/ad/index.html.heex:35
 #: lib/vutuv_web/templates/ad/preview.html.heex:32
 #: lib/vutuv_web/views/admin/ad_html.ex:59
@@ -4392,14 +4393,14 @@ msgstr "prenotata il"
 msgid "deleted account"
 msgstr "account eliminato"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:406
-#: lib/vutuv_web/agent_docs/text.ex:372
+#: lib/vutuv_web/agent_docs/markdown.ex:410
+#: lib/vutuv_web/agent_docs/text.ex:373
 #, elixir-autogen, elixir-format
 msgid "Already booked"
 msgstr "Già prenotato"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:402
-#: lib/vutuv_web/agent_docs/text.ex:368
+#: lib/vutuv_web/agent_docs/markdown.ex:406
+#: lib/vutuv_web/agent_docs/text.ex:369
 #, elixir-autogen, elixir-format
 msgid "Booking window"
 msgstr "Periodo di prenotazione"
@@ -4643,7 +4644,7 @@ msgstr "Non ha bloccato nessuno."
 msgid "You unblocked @%{slug}."
 msgstr "Ha sbloccato @%{slug}."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3588
+#: lib/vutuv_web/live/post_live/feed.ex:3599
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Scopra persone da seguire"
@@ -4653,11 +4654,11 @@ msgstr "Scopra persone da seguire"
 msgid "Find members"
 msgstr "Trova membri"
 
-#: lib/vutuv_web/components/organization_components.ex:271
+#: lib/vutuv_web/components/organization_components.ex:280
 #: lib/vutuv_web/live/organization_live/following.ex:313
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:1042
+#: lib/vutuv_web/templates/user/show.html.heex:1025
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr "Segue"
@@ -4698,12 +4699,12 @@ msgid "Not an exact match, but sounds like your search."
 msgstr "Non è una corrispondenza esatta, ma somiglia alla Sua ricerca."
 
 #: lib/vutuv_web/agent_docs/investors_doc.ex:212
-#: lib/vutuv_web/agent_docs/markdown.ex:537
-#: lib/vutuv_web/agent_docs/text.ex:542
+#: lib/vutuv_web/agent_docs/markdown.ex:541
+#: lib/vutuv_web/agent_docs/text.ex:543
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/live/notification_live/index.ex:640
 #: lib/vutuv_web/live/notification_live/index.ex:1333
-#: lib/vutuv_web/live/organization_live/show.ex:797
+#: lib/vutuv_web/live/organization_live/show.ex:820
 #: lib/vutuv_web/live/post_live/saved.ex:539
 #: lib/vutuv_web/live/search_live.ex:346
 #: lib/vutuv_web/live/search_live.ex:774
@@ -4721,8 +4722,8 @@ msgstr "I risultati compaiono dopo almeno tre lettere."
 msgid "Similar names"
 msgstr "Nomi simili"
 
-#: lib/vutuv_web/components/post_components.ex:441
-#: lib/vutuv_web/components/post_components.ex:460
+#: lib/vutuv_web/components/post_components.ex:442
+#: lib/vutuv_web/components/post_components.ex:461
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
@@ -4822,8 +4823,8 @@ msgstr "Sviluppatori"
 msgid "Edit your profile and its sections"
 msgstr "Modificare il Suo profilo e le sue sezioni"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:303
-#: lib/vutuv_web/agent_docs/text.ex:273
+#: lib/vutuv_web/agent_docs/markdown.ex:307
+#: lib/vutuv_web/agent_docs/text.ex:274
 #: lib/vutuv_web/live/admin/job_live.ex:389
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:140
 #: lib/vutuv_web/live/job_posting_live/show.ex:159
@@ -5560,11 +5561,11 @@ msgstr "Navigazione principale"
 msgid "Footer navigation"
 msgstr "Navigazione a piè di pagina"
 
-#: lib/vutuv_web/components/post_components.ex:4536
-#: lib/vutuv_web/components/post_components.ex:5145
-#: lib/vutuv_web/components/post_components.ex:5483
+#: lib/vutuv_web/components/post_components.ex:4579
+#: lib/vutuv_web/components/post_components.ex:5188
+#: lib/vutuv_web/components/post_components.ex:5526
 #: lib/vutuv_web/live/notification_live/index.ex:1069
-#: lib/vutuv_web/views/user_html.ex:140
+#: lib/vutuv_web/views/user_html.ex:133
 #, elixir-autogen, elixir-format
 msgid "View post"
 msgstr "Vedi il post"
@@ -5588,7 +5589,7 @@ msgstr "Altro"
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:33
 #: lib/vutuv_web/views/email_html.ex:12
-#: lib/vutuv_web/views/user_html.ex:1234
+#: lib/vutuv_web/views/user_html.ex:1227
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr "Personale"
@@ -5772,7 +5773,7 @@ msgstr "@%{slug} L'ha confermata su vutuv"
 msgid "@%{slug} started following you on vutuv"
 msgstr "@%{slug} ha iniziato a seguirla su vutuv"
 
-#: lib/vutuv_web/components/organization_components.ex:284
+#: lib/vutuv_web/components/organization_components.ex:293
 #: lib/vutuv_web/live/organization_live/apps.ex:167
 #: lib/vutuv_web/templates/settings/apps.html.heex:12
 #, elixir-autogen, elixir-format
@@ -6240,7 +6241,7 @@ msgstr[1] "post"
 msgid "After choosing a file you can reposition and zoom it."
 msgstr "Dopo aver scelto un file può spostarlo e ingrandirlo."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1595
+#: lib/vutuv_web/templates/user/show.html.heex:1578
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr "Anche su"
@@ -6286,16 +6287,16 @@ msgstr "Usa questa foto"
 msgid "Zoom"
 msgstr "Ingrandimento"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1180
-#: lib/vutuv_web/templates/user/show.html.heex:1190
+#: lib/vutuv_web/templates/user/show.html.heex:1163
+#: lib/vutuv_web/templates/user/show.html.heex:1173
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
 msgstr[0] "%{count} anno"
 msgstr[1] "%{count} anni"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:705
-#: lib/vutuv_web/agent_docs/text.ex:655
+#: lib/vutuv_web/agent_docs/markdown.ex:709
+#: lib/vutuv_web/agent_docs/text.ex:656
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr "Età"
@@ -6329,12 +6330,12 @@ msgstr "Rapporto giornaliero del %{day}"
 msgid "Jump to a day"
 msgstr "Vai a un giorno"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1302
+#: lib/vutuv_web/templates/user/show.html.heex:1285
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr "Gestisci gli indirizzi e-mail"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1313
+#: lib/vutuv_web/templates/user/show.html.heex:1296
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr "Gestisci i numeri di telefono"
@@ -6369,21 +6370,21 @@ msgstr "Apri il rapporto giornaliero"
 msgid "Previous day"
 msgstr "Giorno precedente"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1290
-#: lib/vutuv_web/components/post_components.ex:443
+#: lib/vutuv_web/agent_docs/markdown.ex:1294
+#: lib/vutuv_web/components/post_components.ex:444
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reposts"
 msgstr "Ripubblicazioni"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1311
+#: lib/vutuv_web/templates/user/show.html.heex:1294
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr "Vedi tutti i numeri di telefono"
 
 #: lib/vutuv_web/live/feed_languages_live.ex:235
-#: lib/vutuv_web/live/press_kit_live.ex:496
+#: lib/vutuv_web/live/press_kit_live.ex:636
 #: lib/vutuv_web/live/section_reorder_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder"
@@ -6398,7 +6399,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/feed_languages_live.ex:267
 #: lib/vutuv_web/live/post_rewrites_live.ex:364
-#: lib/vutuv_web/live/press_kit_live.ex:558
+#: lib/vutuv_web/live/press_kit_live.ex:698
 #: lib/vutuv_web/live/section_reorder_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Move down"
@@ -6406,7 +6407,7 @@ msgstr "Sposta giù"
 
 #: lib/vutuv_web/live/feed_languages_live.ex:256
 #: lib/vutuv_web/live/post_rewrites_live.ex:352
-#: lib/vutuv_web/live/press_kit_live.ex:547
+#: lib/vutuv_web/live/press_kit_live.ex:687
 #: lib/vutuv_web/live/section_reorder_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -6441,9 +6442,9 @@ msgstr "Servizi di mappe da mostrare"
 msgid "Maps"
 msgstr "Mappe"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1585
-#: lib/vutuv_web/templates/user/show.html.heex:1589
-#: lib/vutuv_web/templates/user/show.html.heex:1601
+#: lib/vutuv_web/templates/user/show.html.heex:1568
+#: lib/vutuv_web/templates/user/show.html.heex:1572
+#: lib/vutuv_web/templates/user/show.html.heex:1584
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr "Apri in %{name}"
@@ -6488,7 +6489,7 @@ msgstr "Ancora nessuna conferma."
 msgid "and %{count} more"
 msgstr "e altri %{count}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1250
+#: lib/vutuv_web/agent_docs/markdown.ex:1254
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr "confermato il %{date}"
@@ -6801,9 +6802,9 @@ msgstr ""
 "Se disattiva un'opzione, la relativa esclusione viaggia con le pagine e le "
 "risposte che La riguardano. Con entrambe disattivate, ad esempio:"
 
-#: lib/vutuv_web/components/post_components.ex:3298
-#: lib/vutuv_web/components/post_components.ex:4409
-#: lib/vutuv_web/components/post_components.ex:4423
+#: lib/vutuv_web/components/post_components.ex:3341
+#: lib/vutuv_web/components/post_components.ex:4452
+#: lib/vutuv_web/components/post_components.ex:4466
 #: lib/vutuv_web/components/ui.ex:3195
 #: lib/vutuv_web/live/fediverse_account_live.ex:437
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6831,7 +6832,7 @@ msgstr "Nuovi messaggi e nuovi collegamenti"
 msgid "Remove this connection? You will stop following them."
 msgstr "Rimuovere questo collegamento? Smetterà di seguire questa persona."
 
-#: lib/vutuv_web/components/post_components.ex:4409
+#: lib/vutuv_web/components/post_components.ex:4452
 #: lib/vutuv_web/components/ui.ex:3194
 #: lib/vutuv_web/live/fediverse_account_live.ex:435
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6860,12 +6861,12 @@ msgstr "Seguitevi a vicenda per collegarsi con %{name} e leggerlo."
 msgid "Go to profile to follow"
 msgstr "Vada al profilo per seguire"
 
-#: lib/vutuv_web/views/user_html.ex:1233
+#: lib/vutuv_web/views/user_html.ex:1226
 #, elixir-autogen, elixir-format
 msgid "Professional"
 msgstr "Professionale"
 
-#: lib/vutuv_web/views/user_html.ex:786
+#: lib/vutuv_web/views/user_html.ex:779
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr "La segue"
@@ -7404,7 +7405,7 @@ msgid "open the dev email inbox"
 msgstr "apri la casella e-mail di sviluppo"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:45
-#: lib/vutuv_web/views/user_html.ex:785
+#: lib/vutuv_web/views/user_html.ex:778
 #, elixir-autogen, elixir-format
 msgid "Connected"
 msgstr "Collegato"
@@ -7548,7 +7549,7 @@ msgid "applies to the whole list, not just this page"
 msgstr "vale per l'intero elenco, non solo per questa pagina"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:6900
+#: lib/vutuv_web/components/post_components.ex:6943
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #: lib/vutuv_web/live/shell_live.ex:1817
 #, elixir-autogen, elixir-format
@@ -7657,9 +7658,9 @@ msgstr "Si aggiorna da sola. Può lasciare questa pagina: l'invio prosegue."
 
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3877
+#: lib/vutuv_web/live/post_live/feed.ex:3888
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
-#: lib/vutuv_web/live/press_kit_live.ex:573
+#: lib/vutuv_web/live/press_kit_live.ex:713
 #, elixir-autogen
 msgid "Done"
 msgstr "Fatto"
@@ -7739,17 +7740,17 @@ msgstr "Feed di %{name}"
 msgid "The vutuv newsfeed of %{name}"
 msgstr "Il feed di notizie vutuv di %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1417
+#: lib/vutuv_web/agent_docs/markdown.ex:1421
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr "Il Suo feed è vuoto."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1420
+#: lib/vutuv_web/agent_docs/markdown.ex:1424
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr "%{count} post in questa pagina"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1427
+#: lib/vutuv_web/agent_docs/markdown.ex:1431
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr "altri post disponibili, aggiunga ?cursor=%{cursor}"
@@ -8601,13 +8602,13 @@ msgstr "Troppe importazioni. Riprovi tra poco."
 msgid "Please check the fields marked in red."
 msgstr "Controlli i campi contrassegnati in rosso."
 
-#: lib/vutuv_web/views/user_html.ex:1118
+#: lib/vutuv_web/views/user_html.ex:1111
 #, elixir-autogen, elixir-format
 msgid "Loading posts"
 msgstr "Caricamento dei post"
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:140
-#: lib/vutuv_web/templates/user/show.html.heex:1449
+#: lib/vutuv_web/templates/user/show.html.heex:1432
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr "Post dai social media"
@@ -8897,7 +8898,7 @@ msgstr ""
 msgid "Not written yet"
 msgstr "Non ancora scritta"
 
-#: lib/vutuv_web/components/organization_components.ex:244
+#: lib/vutuv_web/components/organization_components.ex:245
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "Page"
@@ -8930,11 +8931,11 @@ msgstr "La pagina è stata pubblicata."
 msgid "Write it under Admin › Legal pages"
 msgstr "La scriva in Amministrazione › Pagine legali"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:715
 #: lib/vutuv_web/agent_docs/markdown.ex:719
-#: lib/vutuv_web/agent_docs/text.ex:665
-#: lib/vutuv_web/agent_docs/text.ex:669
-#: lib/vutuv_web/components/organization_components.ex:276
+#: lib/vutuv_web/agent_docs/markdown.ex:723
+#: lib/vutuv_web/agent_docs/text.ex:666
+#: lib/vutuv_web/agent_docs/text.ex:670
+#: lib/vutuv_web/components/organization_components.ex:285
 #: lib/vutuv_web/components/ui.ex:1807
 #: lib/vutuv_web/components/ui.ex:5459
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
@@ -8943,13 +8944,13 @@ msgstr "La scriva in Amministrazione › Pagine legali"
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:277
 #: lib/vutuv_web/live/organization_live/fediverse.ex:84
-#: lib/vutuv_web/live/organization_live/show.ex:165
+#: lib/vutuv_web/live/organization_live/show.ex:181
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:329
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:5
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:1354
+#: lib/vutuv_web/templates/user/show.html.heex:1337
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr "Fediverso"
@@ -9066,13 +9067,13 @@ msgstr "Il Suo profilo come CV"
 msgid "Higher Education"
 msgstr "Istruzione universitaria"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:923
+#: lib/vutuv_web/agent_docs/markdown.ex:927
 #: lib/vutuv_web/views/education_html.ex:54
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr "Istruzione scolastica"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:922
+#: lib/vutuv_web/agent_docs/markdown.ex:926
 #: lib/vutuv_web/views/education_html.ex:53
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -9100,14 +9101,14 @@ msgstr ""
 msgid "CV download"
 msgstr "Download del CV"
 
-#: lib/vutuv_web/components/post_components.ex:5755
+#: lib/vutuv_web/components/post_components.ex:5798
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] "Ripubblicato da %{name} e da %{formatted} altro"
 msgstr[1] "Ripubblicato da %{name} e da altri %{formatted}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1186
+#: lib/vutuv_web/agent_docs/markdown.ex:1190
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr "ripubblicato da %{name} e da altri %{count}"
@@ -9356,8 +9357,8 @@ msgstr "Tag d'onore"
 msgid "Honor tag (only site admins can assign it)"
 msgstr "Tag d'onore (può assegnarlo solo un amministratore del sito)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:735
-#: lib/vutuv_web/agent_docs/text.ex:683
+#: lib/vutuv_web/agent_docs/markdown.ex:739
+#: lib/vutuv_web/agent_docs/text.ex:684
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr "tag d'onore"
@@ -9781,8 +9782,8 @@ msgstr "Gallese"
 msgid "Yoruba"
 msgstr "Yoruba"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:657
-#: lib/vutuv_web/agent_docs/text.ex:635
+#: lib/vutuv_web/agent_docs/markdown.ex:661
+#: lib/vutuv_web/agent_docs/text.ex:636
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr "Situazione lavorativa"
@@ -9895,7 +9896,7 @@ msgstr[1] "%{count} certificati o abilitazioni"
 msgid "Add a certificate or license"
 msgstr "Aggiungi un certificato o un'abilitazione"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1039
+#: lib/vutuv_web/agent_docs/markdown.ex:1043
 #: lib/vutuv_web/views/qualification_html.ex:14
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -9975,7 +9976,7 @@ msgstr "Non scade"
 msgid "Expired"
 msgstr "Scaduto"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1014
+#: lib/vutuv_web/agent_docs/markdown.ex:1018
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr "ID: %{id}"
@@ -9992,7 +9993,7 @@ msgstr "Rilasciato"
 msgid "Issuer"
 msgstr "Ente rilasciante"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1038
+#: lib/vutuv_web/agent_docs/markdown.ex:1042
 #: lib/vutuv_web/views/qualification_html.ex:15
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -10022,7 +10023,7 @@ msgstr "Documento di prova"
 msgid "Verification link"
 msgstr "Link di verifica"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1012
+#: lib/vutuv_web/agent_docs/markdown.ex:1016
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr "conseguito il %{date}"
@@ -10037,7 +10038,7 @@ msgstr "ad esempio AWS Solutions Architect – Associate"
 msgid "e.g. Amazon Web Services"
 msgstr "ad esempio Amazon Web Services"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1013
+#: lib/vutuv_web/agent_docs/markdown.ex:1017
 #: lib/vutuv_web/views/qualification_html.ex:91
 #, elixir-autogen, elixir-format
 msgid "valid until %{date}"
@@ -10055,15 +10056,15 @@ msgstr ""
 msgid "Preferred"
 msgstr "Preferita"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:850
+#: lib/vutuv_web/agent_docs/markdown.ex:854
 #: lib/vutuv_web/live/section_reorder_live.ex:289
 #: lib/vutuv_web/views/language_html.ex:114
 #, elixir-autogen, elixir-format
 msgid "Preferred contact language"
 msgstr "Lingua di contatto preferita"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1276
-#: lib/vutuv_web/templates/user/show.html.heex:1277
+#: lib/vutuv_web/templates/user/show.html.heex:1259
+#: lib/vutuv_web/templates/user/show.html.heex:1260
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr "+%{code} è il prefisso telefonico di %{region}"
@@ -10551,21 +10552,21 @@ msgstr ""
 "elenco stampato, digitandolo nel normale campo del PIN. Il Suo PIN via "
 "e-mail continua sempre a funzionare."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:810
+#: lib/vutuv_web/agent_docs/markdown.ex:814
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] "%{count} follower"
 msgstr[1] "%{count} follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:808
+#: lib/vutuv_web/agent_docs/markdown.ex:812
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] "%{count} repository"
 msgstr[1] "%{count} repository"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:806
+#: lib/vutuv_web/agent_docs/markdown.ex:810
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10573,16 +10574,16 @@ msgstr[0] "%{count} stella"
 msgstr[1] "%{count} stelle"
 
 #: lib/vutuv_web/live/notification_live/index.ex:1416
-#: lib/vutuv_web/live/organization_live/show.ex:648
-#: lib/vutuv_web/views/user_html.ex:982
-#: lib/vutuv_web/views/user_html.ex:1158
+#: lib/vutuv_web/live/organization_live/show.ex:671
+#: lib/vutuv_web/views/user_html.ex:975
+#: lib/vutuv_web/views/user_html.ex:1151
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower"
 msgid_plural "%{formatted} followers"
 msgstr[0] "%{formatted} follower"
 msgstr[1] "%{formatted} follower"
 
-#: lib/vutuv_web/views/user_html.ex:975
+#: lib/vutuv_web/views/user_html.ex:968
 #, elixir-autogen, elixir-format
 msgid "%{formatted} star"
 msgid_plural "%{formatted} stars"
@@ -10591,7 +10592,7 @@ msgstr[1] "%{formatted} stelle"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:72
 #: lib/vutuv_web/agent_docs/text.ex:67
-#: lib/vutuv_web/templates/user/show.html.heex:1423
+#: lib/vutuv_web/templates/user/show.html.heex:1406
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr "Codice"
@@ -10610,7 +10611,7 @@ msgstr ""
 " le statistiche pubbliche: stelle, repository, follower, linguaggi e "
 "attività recente."
 
-#: lib/vutuv_web/views/user_html.ex:989
+#: lib/vutuv_web/views/user_html.ex:982
 #, elixir-autogen, elixir-format
 msgid "Last active %{date}"
 msgstr "Ultima attività il %{date}"
@@ -10627,17 +10628,17 @@ msgstr ""
 "Se disattivo, la scheda Social media elenca i Suoi account come semplici "
 "link."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:824
+#: lib/vutuv_web/agent_docs/markdown.ex:828
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr "ultima attività il %{date}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:811
+#: lib/vutuv_web/agent_docs/markdown.ex:815
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr "dal %{date}"
 
-#: lib/vutuv_web/views/user_html.ex:905
+#: lib/vutuv_web/views/user_html.ex:898
 #, elixir-autogen, elixir-format
 msgid "since %{year}"
 msgstr "dal %{year}"
@@ -11450,7 +11451,7 @@ msgstr "Il Suo elenco è vuoto. Non è ancora escluso nessuno."
 msgid "AI agents"
 msgstr "Agenti IA"
 
-#: lib/vutuv_web/live/organization_live/show.ex:700
+#: lib/vutuv_web/live/organization_live/show.ex:723
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "Presentazione"
@@ -11463,7 +11464,7 @@ msgstr "Prosegui con la verifica"
 #: lib/vutuv_web/live/organization_live/domains.ex:284
 #: lib/vutuv_web/live/organization_live/domains.ex:319
 #: lib/vutuv_web/live/organization_live/new.ex:161
-#: lib/vutuv_web/live/organization_live/show.ex:1043
+#: lib/vutuv_web/live/organization_live/show.ex:1080
 #: lib/vutuv_web/templates/url/verify.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
@@ -11471,8 +11472,8 @@ msgstr "Record DNS TXT"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:204
 #: lib/vutuv_web/live/organization_live/domains.ex:359
-#: lib/vutuv_web/live/organization_live/show.ex:1108
-#: lib/vutuv_web/live/organization_live/show.ex:1116
+#: lib/vutuv_web/live/organization_live/show.ex:1145
+#: lib/vutuv_web/live/organization_live/show.ex:1153
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr "La verifica dei domini è disattivata su questa installazione."
@@ -11502,13 +11503,13 @@ msgstr ""
 "Offri i formati leggibili dalle macchine (.md/.txt/.json/.xml) ed elencali "
 "per gli agenti IA."
 
-#: lib/vutuv_web/controllers/organization_controller.ex:290
+#: lib/vutuv_web/controllers/organization_controller.ex:305
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:31
 #, elixir-autogen, elixir-format
 msgid "Please log in first."
 msgstr "Prima acceda."
 
-#: lib/vutuv_web/live/organization_live/show.ex:1016
+#: lib/vutuv_web/live/organization_live/show.ex:1053
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr "Dimostri di controllare %{domain} per pubblicare questa pagina."
@@ -11529,13 +11530,13 @@ msgstr "Cerchi per nome o città"
 msgid "Search engines"
 msgstr "Motori di ricerca"
 
-#: lib/vutuv_web/components/organization_components.ex:142
+#: lib/vutuv_web/components/organization_components.ex:143
 #, elixir-autogen, elixir-format
 msgid "Select a country"
 msgstr "Selezioni un paese"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:338
-#: lib/vutuv_web/live/organization_live/show.ex:1078
+#: lib/vutuv_web/live/organization_live/show.ex:1115
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr "Pubblichi questo file all'indirizzo:"
@@ -11557,12 +11558,12 @@ msgid "The upload failed."
 msgstr "Il caricamento non è riuscito."
 
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:1031
+#: lib/vutuv_web/live/organization_live/show.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr "Metodo di verifica"
 
-#: lib/vutuv_web/live/organization_live/show.ex:942
+#: lib/vutuv_web/live/organization_live/show.ex:979
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr "Domini verificati"
@@ -11573,18 +11574,18 @@ msgstr "Domini verificati"
 msgid "Verified via"
 msgstr "Verificato tramite"
 
-#: lib/vutuv_web/live/organization_live/show.ex:1002
+#: lib/vutuv_web/live/organization_live/show.ex:1039
 #, elixir-autogen, elixir-format
 msgid "Verified via %{domain}"
 msgstr "Verificato tramite %{domain}"
 
-#: lib/vutuv_web/live/organization_live/show.ex:1013
+#: lib/vutuv_web/live/organization_live/show.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr "Verifica %{name}"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:353
-#: lib/vutuv_web/live/organization_live/show.ex:1102
+#: lib/vutuv_web/live/organization_live/show.ex:1139
 #, elixir-autogen, elixir-format
 msgid "Verify now"
 msgstr "Verifica ora"
@@ -11599,7 +11600,7 @@ msgstr "Sito web"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:285
 #: lib/vutuv_web/live/organization_live/domains.ex:329
-#: lib/vutuv_web/live/organization_live/show.ex:1054
+#: lib/vutuv_web/live/organization_live/show.ex:1091
 #: lib/vutuv_web/templates/url/verify.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11618,7 +11619,7 @@ msgstr ""
 "controllare il dominio."
 
 #: lib/vutuv_web/live/organization_live/domains.ex:340
-#: lib/vutuv_web/live/organization_live/show.ex:1084
+#: lib/vutuv_web/live/organization_live/show.ex:1121
 #: lib/vutuv_web/templates/url/verify.html.heex:109
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
@@ -11629,7 +11630,7 @@ msgstr "con esattamente questo contenuto:"
 msgid "@handle or email"
 msgstr "@handle o e-mail"
 
-#: lib/vutuv_web/components/organization_components.ex:333
+#: lib/vutuv_web/components/organization_components.ex:342
 #: lib/vutuv_web/live/organization_live/edit.ex:421
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
@@ -11650,7 +11651,7 @@ msgstr "Aggiungi un membro"
 msgid "Added @%{handle} to the team."
 msgstr "@%{handle} è stato aggiunto al team."
 
-#: lib/vutuv_web/components/organization_components.ex:334
+#: lib/vutuv_web/components/organization_components.ex:343
 #: lib/vutuv_web/live/organization_live/edit.ex:419
 #, elixir-autogen, elixir-format
 msgid "Alias"
@@ -11666,10 +11667,10 @@ msgstr "Alias aggiunto."
 msgid "Alias removed."
 msgstr "Alias rimosso."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:529
-#: lib/vutuv_web/agent_docs/text.ex:535
+#: lib/vutuv_web/agent_docs/markdown.ex:533
+#: lib/vutuv_web/agent_docs/text.ex:536
 #: lib/vutuv_web/live/organization_live/edit.ex:384
-#: lib/vutuv_web/live/organization_live/show.ex:930
+#: lib/vutuv_web/live/organization_live/show.ex:967
 #: lib/vutuv_web/templates/tag/single_card.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Also known as"
@@ -11696,7 +11697,7 @@ msgstr "Archiviare questa pagina?"
 msgid "Archived"
 msgstr "Archiviata"
 
-#: lib/vutuv_web/components/organization_components.ex:332
+#: lib/vutuv_web/components/organization_components.ex:341
 #: lib/vutuv_web/live/organization_live/edit.ex:420
 #, elixir-autogen, elixir-format
 msgid "Brand"
@@ -11734,10 +11735,10 @@ msgstr "Dominio rimosso."
 msgid "Domain verified."
 msgstr "Dominio verificato."
 
-#: lib/vutuv_web/components/organization_components.ex:250
+#: lib/vutuv_web/components/organization_components.ex:251
 #: lib/vutuv_web/live/admin/organization_live.ex:302
 #: lib/vutuv_web/live/organization_live/domains.ex:198
-#: lib/vutuv_web/live/organization_live/show.ex:159
+#: lib/vutuv_web/live/organization_live/show.ex:175
 #, elixir-autogen, elixir-format
 msgid "Domains"
 msgstr "Domini"
@@ -11747,7 +11748,7 @@ msgstr "Domini"
 msgid "Domains – %{name}"
 msgstr "Domini – %{name}"
 
-#: lib/vutuv_web/components/organization_components.ex:331
+#: lib/vutuv_web/components/organization_components.ex:340
 #, elixir-autogen, elixir-format
 msgid "Former name"
 msgstr "Nome precedente"
@@ -11827,7 +11828,7 @@ msgstr "Principale"
 msgid "Primary domain updated."
 msgstr "Dominio principale aggiornato."
 
-#: lib/vutuv_web/components/organization_components.ex:320
+#: lib/vutuv_web/components/organization_components.ex:329
 #, elixir-autogen, elixir-format
 msgid "Recruiter"
 msgstr "Selezionatore"
@@ -11852,10 +11853,10 @@ msgstr "Rimuovere questo nome?"
 msgid "Search name, alias or domain"
 msgstr "Cerchi nome, alias o dominio"
 
-#: lib/vutuv_web/components/organization_components.ex:247
+#: lib/vutuv_web/components/organization_components.ex:248
 #: lib/vutuv_web/live/admin/organization_live.ex:318
 #: lib/vutuv_web/live/organization_live/roles.ex:184
-#: lib/vutuv_web/live/organization_live/show.ex:155
+#: lib/vutuv_web/live/organization_live/show.ex:171
 #, elixir-autogen, elixir-format
 msgid "Team"
 msgstr "Team"
@@ -11892,8 +11893,8 @@ msgstr "in attesa"
 msgid "primary"
 msgstr "principale"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:550
-#: lib/vutuv_web/agent_docs/text.ex:555
+#: lib/vutuv_web/agent_docs/markdown.ex:554
+#: lib/vutuv_web/agent_docs/text.ex:556
 #: lib/vutuv_web/live/admin/organization_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "verified"
@@ -12022,8 +12023,8 @@ msgstr "Verifica tramite link di ritorno"
 msgid "Verify via file"
 msgstr "Verifica tramite file"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1059
-#: lib/vutuv_web/agent_docs/text.ex:811
+#: lib/vutuv_web/agent_docs/markdown.ex:1063
+#: lib/vutuv_web/agent_docs/text.ex:812
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr "pagina web verificata"
@@ -12034,7 +12035,7 @@ msgid "%{min} to %{max} characters: letters (a-z), numbers (0-9) and underscores
 msgstr ""
 "Da %{min} a %{max} caratteri: lettere (a-z), cifre (0-9) e trattini bassi."
 
-#: lib/vutuv_web/live/organization_live/show.ex:819
+#: lib/vutuv_web/live/organization_live/show.ex:842
 #, elixir-autogen, elixir-format
 msgid "Former"
 msgstr "Precedente"
@@ -12060,8 +12061,8 @@ msgstr "Collegata a {name}"
 msgid "Remove link"
 msgstr "Rimuovi il collegamento"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:541
-#: lib/vutuv_web/agent_docs/text.ex:546
+#: lib/vutuv_web/agent_docs/markdown.ex:545
+#: lib/vutuv_web/agent_docs/text.ex:547
 #, elixir-autogen, elixir-format
 msgid "former"
 msgstr "precedente"
@@ -12168,7 +12169,7 @@ msgstr ""
 "successivo mostriamo le istruzioni esatte, così può semplicemente "
 "inoltrarle."
 
-#: lib/vutuv_web/live/organization_live/show.ex:1025
+#: lib/vutuv_web/live/organization_live/show.ex:1062
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr ""
@@ -12282,9 +12283,9 @@ msgstr "Ruolo nell'organizzazione"
 msgid "Organization unfrozen."
 msgstr "Organizzazione sbloccata."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:520
-#: lib/vutuv_web/agent_docs/organization_doc.ex:123
-#: lib/vutuv_web/agent_docs/text.ex:479
+#: lib/vutuv_web/agent_docs/markdown.ex:524
+#: lib/vutuv_web/agent_docs/organization_doc.ex:138
+#: lib/vutuv_web/agent_docs/text.ex:480
 #: lib/vutuv_web/components/ui.ex:5486
 #: lib/vutuv_web/controllers/settings_controller.ex:222
 #: lib/vutuv_web/live/organization_live/index.ex:32
@@ -12295,24 +12296,25 @@ msgstr "Organizzazione sbloccata."
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:80
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
+#: lib/vutuv_web/views/press_kit_html.ex:49
 #, elixir-autogen, elixir-format
 msgid "Organizations"
 msgstr "Organizzazioni"
 
-#: lib/vutuv_web/components/organization_components.ex:169
+#: lib/vutuv_web/components/organization_components.ex:170
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:90
 #, elixir-autogen, elixir-format
 msgid "Please choose"
 msgstr "Scelga"
 
-#: lib/vutuv_web/controllers/organization_controller.ex:128
+#: lib/vutuv_web/controllers/organization_controller.ex:129
 #, elixir-autogen, elixir-format
 msgid "Please confirm your email address before claiming an organization page."
 msgstr ""
 "Confermi il Suo indirizzo e-mail prima di rivendicare una pagina di "
 "organizzazione."
 
-#: lib/vutuv_web/controllers/organization_controller.ex:134
+#: lib/vutuv_web/controllers/organization_controller.ex:135
 #, elixir-autogen, elixir-format
 msgid "Please log in to claim an organization page."
 msgstr "Acceda per rivendicare una pagina di organizzazione."
@@ -12342,7 +12344,7 @@ msgstr "Questo nome è già presente per questa organizzazione."
 msgid "The organization page was deleted."
 msgstr "La pagina dell'organizzazione è stata eliminata."
 
-#: lib/vutuv_web/live/organization_live/show.ex:470
+#: lib/vutuv_web/live/organization_live/show.ex:493
 #, elixir-autogen, elixir-format
 msgid "This organization page was reported and is hidden while it is reviewed. Only you and the moderators can see it."
 msgstr ""
@@ -12356,7 +12358,7 @@ msgstr ""
 "Pagine di organizzazioni verificate su vutuv, ciascuna con un dominio web "
 "dimostrato."
 
-#: lib/vutuv_web/agent_docs/organization_doc.ex:124
+#: lib/vutuv_web/agent_docs/organization_doc.ex:139
 #, elixir-autogen, elixir-format
 msgid "Verified organization pages on vutuv."
 msgstr "Pagine di organizzazioni verificate su vutuv."
@@ -12378,8 +12380,8 @@ msgstr "Non ha i permessi per eliminare questa organizzazione."
 msgid "Your organization handle is set."
 msgstr "L'handle della Sua organizzazione è impostato."
 
-#: lib/vutuv_web/live/organization_live/show.ex:356
-#: lib/vutuv_web/live/organization_live/show.ex:409
+#: lib/vutuv_web/live/organization_live/show.ex:379
+#: lib/vutuv_web/live/organization_live/show.ex:432
 #, elixir-autogen, elixir-format
 msgid "Your organization page is verified and now live."
 msgstr "La pagina della Sua organizzazione è verificata e ora è online."
@@ -12556,10 +12558,10 @@ msgstr "Bozze"
 msgid "Edit posting"
 msgstr "Modifica l'annuncio"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:297
-#: lib/vutuv_web/agent_docs/markdown.ex:581
-#: lib/vutuv_web/agent_docs/text.ex:267
-#: lib/vutuv_web/agent_docs/text.ex:586
+#: lib/vutuv_web/agent_docs/markdown.ex:301
+#: lib/vutuv_web/agent_docs/markdown.ex:585
+#: lib/vutuv_web/agent_docs/text.ex:268
+#: lib/vutuv_web/agent_docs/text.ex:587
 #: lib/vutuv_web/live/admin/job_live.ex:340
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:17
 #: lib/vutuv_web/views/account_event_text.ex:225
@@ -12572,10 +12574,10 @@ msgstr "Datore di lavoro"
 msgid "Employer name (optional)"
 msgstr "Nome del datore di lavoro (facoltativo)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:298
-#: lib/vutuv_web/agent_docs/markdown.ex:582
-#: lib/vutuv_web/agent_docs/text.ex:268
-#: lib/vutuv_web/agent_docs/text.ex:587
+#: lib/vutuv_web/agent_docs/markdown.ex:302
+#: lib/vutuv_web/agent_docs/markdown.ex:586
+#: lib/vutuv_web/agent_docs/text.ex:269
+#: lib/vutuv_web/agent_docs/text.ex:588
 #: lib/vutuv_web/live/job_board_live.ex:526
 #: lib/vutuv_web/live/job_posting_live/form.ex:499
 #, elixir-autogen, elixir-format
@@ -12647,12 +12649,12 @@ msgstr "Lavoro"
 msgid "Let search engines index this posting."
 msgstr "Consenti ai motori di ricerca di indicizzare questo annuncio."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:556
-#: lib/vutuv_web/agent_docs/markdown.ex:559
-#: lib/vutuv_web/agent_docs/markdown.ex:561
-#: lib/vutuv_web/agent_docs/text.ex:561
-#: lib/vutuv_web/agent_docs/text.ex:564
-#: lib/vutuv_web/agent_docs/text.ex:566
+#: lib/vutuv_web/agent_docs/markdown.ex:560
+#: lib/vutuv_web/agent_docs/markdown.ex:563
+#: lib/vutuv_web/agent_docs/markdown.ex:565
+#: lib/vutuv_web/agent_docs/text.ex:562
+#: lib/vutuv_web/agent_docs/text.ex:565
+#: lib/vutuv_web/agent_docs/text.ex:567
 #: lib/vutuv_web/live/job_posting_live/form.ex:549
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -12701,8 +12703,8 @@ msgstr "I nuovi account possono pubblicare dopo qualche giorno."
 msgid "New posting"
 msgstr "Nuovo annuncio"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:309
-#: lib/vutuv_web/agent_docs/text.ex:278
+#: lib/vutuv_web/agent_docs/markdown.ex:313
+#: lib/vutuv_web/agent_docs/text.ex:279
 #: lib/vutuv_web/live/job_posting_live/form.ex:756
 #: lib/vutuv_web/live/job_posting_live/show.ex:177
 #, elixir-autogen, elixir-format
@@ -12791,10 +12793,10 @@ msgstr "Pubblica come"
 msgid "Postal code"
 msgstr "CAP"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:302
-#: lib/vutuv_web/agent_docs/markdown.ex:586
-#: lib/vutuv_web/agent_docs/text.ex:272
-#: lib/vutuv_web/agent_docs/text.ex:591
+#: lib/vutuv_web/agent_docs/markdown.ex:306
+#: lib/vutuv_web/agent_docs/markdown.ex:590
+#: lib/vutuv_web/agent_docs/text.ex:273
+#: lib/vutuv_web/agent_docs/text.ex:592
 #: lib/vutuv_web/live/job_posting_live/show.ex:156
 #, elixir-autogen, elixir-format
 msgid "Posted"
@@ -12819,10 +12821,10 @@ msgstr "Pubblica"
 #: lib/vutuv/accounts/user.ex:1291
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:590
-#: lib/vutuv_web/agent_docs/markdown.ex:559
-#: lib/vutuv_web/agent_docs/markdown.ex:561
-#: lib/vutuv_web/agent_docs/text.ex:564
-#: lib/vutuv_web/agent_docs/text.ex:566
+#: lib/vutuv_web/agent_docs/markdown.ex:563
+#: lib/vutuv_web/agent_docs/markdown.ex:565
+#: lib/vutuv_web/agent_docs/text.ex:565
+#: lib/vutuv_web/agent_docs/text.ex:567
 #: lib/vutuv_web/components/job_components.ex:140
 #: lib/vutuv_web/components/job_components.ex:141
 #, elixir-autogen, elixir-format
@@ -12834,18 +12836,18 @@ msgstr "Da remoto"
 msgid "Report this posting"
 msgstr "Segnala questo annuncio"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:308
-#: lib/vutuv_web/agent_docs/text.ex:277
+#: lib/vutuv_web/agent_docs/markdown.ex:312
+#: lib/vutuv_web/agent_docs/text.ex:278
 #: lib/vutuv_web/live/job_posting_live/form.ex:746
 #: lib/vutuv_web/live/job_posting_live/show.ex:172
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr "Richiesto"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:301
-#: lib/vutuv_web/agent_docs/markdown.ex:585
-#: lib/vutuv_web/agent_docs/text.ex:271
-#: lib/vutuv_web/agent_docs/text.ex:590
+#: lib/vutuv_web/agent_docs/markdown.ex:305
+#: lib/vutuv_web/agent_docs/markdown.ex:589
+#: lib/vutuv_web/agent_docs/text.ex:272
+#: lib/vutuv_web/agent_docs/text.ex:591
 #, elixir-autogen, elixir-format
 msgid "Salary"
 msgstr "Retribuzione"
@@ -12944,10 +12946,10 @@ msgstr "Chi può vederlo"
 msgid "Working student"
 msgstr "Studente lavoratore"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:299
-#: lib/vutuv_web/agent_docs/markdown.ex:583
-#: lib/vutuv_web/agent_docs/text.ex:269
-#: lib/vutuv_web/agent_docs/text.ex:588
+#: lib/vutuv_web/agent_docs/markdown.ex:303
+#: lib/vutuv_web/agent_docs/markdown.ex:587
+#: lib/vutuv_web/agent_docs/text.ex:270
+#: lib/vutuv_web/agent_docs/text.ex:589
 #: lib/vutuv_web/live/job_posting_live/form.ex:514
 #, elixir-autogen, elixir-format
 msgid "Workplace"
@@ -13113,7 +13115,7 @@ msgstr ""
 "invece questo nome, con esattamente lo stesso valore di sopra:"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:336
-#: lib/vutuv_web/live/organization_live/show.ex:1071
+#: lib/vutuv_web/live/organization_live/show.ex:1108
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr ""
@@ -13121,7 +13123,7 @@ msgstr ""
 "con un CNAME), metta il record su %{name}, con lo stesso valore."
 
 #: lib/vutuv_web/live/organization_live/domains.ex:334
-#: lib/vutuv_web/live/organization_live/show.ex:1062
+#: lib/vutuv_web/live/organization_live/show.ex:1099
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr ""
@@ -13175,13 +13177,13 @@ msgstr "%{km} km"
 msgid "All countries"
 msgstr "Tutti i paesi"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:604
+#: lib/vutuv_web/agent_docs/markdown.ex:608
 #: lib/vutuv_web/templates/tag/show.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr "Tutti gli annunci con questo tag"
 
-#: lib/vutuv_web/agent_docs/text.ex:608
+#: lib/vutuv_web/agent_docs/text.ex:609
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr "Tutti gli annunci con questo tag: %{url}"
@@ -13222,17 +13224,17 @@ msgid "Minimum yearly salary"
 msgstr "Retribuzione annua minima"
 
 #: lib/vutuv_web/live/job_board_live.ex:383
-#: lib/vutuv_web/live/organization_live/show.ex:841
+#: lib/vutuv_web/live/organization_live/show.ex:864
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr "Altri annunci"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:323
+#: lib/vutuv_web/agent_docs/markdown.ex:327
 #, elixir-autogen, elixir-format
 msgid "Next page"
 msgstr "Pagina successiva"
 
-#: lib/vutuv_web/agent_docs/text.ex:292
+#: lib/vutuv_web/agent_docs/text.ex:293
 #, elixir-autogen, elixir-format
 msgid "Next page: %{url}"
 msgstr "Pagina successiva: %{url}"
@@ -13247,11 +13249,11 @@ msgstr "Ancora nessun annuncio di lavoro."
 msgid "No matching positions. Try adjusting the filters."
 msgstr "Nessuna posizione corrispondente. Provi a modificare i filtri."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:602
-#: lib/vutuv_web/agent_docs/markdown.ex:614
-#: lib/vutuv_web/agent_docs/text.ex:606
-#: lib/vutuv_web/agent_docs/text.ex:618
-#: lib/vutuv_web/live/organization_live/show.ex:833
+#: lib/vutuv_web/agent_docs/markdown.ex:606
+#: lib/vutuv_web/agent_docs/markdown.ex:618
+#: lib/vutuv_web/agent_docs/text.ex:607
+#: lib/vutuv_web/agent_docs/text.ex:619
+#: lib/vutuv_web/live/organization_live/show.ex:856
 #: lib/vutuv_web/templates/tag/show.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Open positions"
@@ -13581,7 +13583,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "Interrompere gli avvisi via e-mail per la Sua ricerca salvata \"%{label}\"?"
 
-#: lib/vutuv_web/components/post_components.ex:3776
+#: lib/vutuv_web/components/post_components.ex:3819
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:788
 #: lib/vutuv_web/controllers/settings_controller.ex:806
@@ -13737,7 +13739,7 @@ msgstr ""
 msgid "Inherited from the organization"
 msgstr "Ereditato dall'organizzazione"
 
-#: lib/vutuv_web/components/organization_components.ex:253
+#: lib/vutuv_web/components/organization_components.ex:254
 #: lib/vutuv_web/live/organization_live/exclusions.ex:113
 #, elixir-autogen, elixir-format
 msgid "Job exclusions"
@@ -14048,22 +14050,22 @@ msgstr "Cellulare privato"
 msgid "Work mobile"
 msgstr "Cellulare di lavoro"
 
-#: lib/vutuv_web/components/post_components.ex:483
+#: lib/vutuv_web/components/post_components.ex:484
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr "Ancora nessun post."
 
-#: lib/vutuv_web/components/post_components.ex:485
+#: lib/vutuv_web/components/post_components.ex:486
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr "Ancora nessuna risposta."
 
-#: lib/vutuv_web/components/post_components.ex:484
+#: lib/vutuv_web/components/post_components.ex:485
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr "Ancora nessuna ripubblicazione."
 
-#: lib/vutuv_web/components/post_components.ex:442
+#: lib/vutuv_web/components/post_components.ex:443
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr "Post propri"
@@ -14127,7 +14129,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1389
+#: lib/vutuv_web/templates/user/show.html.heex:1372
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr "Aggiungi un messenger"
@@ -14164,7 +14166,7 @@ msgstr "Messenger aggiornato."
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1387
+#: lib/vutuv_web/templates/user/show.html.heex:1370
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr "Messenger"
@@ -14246,34 +14248,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr "ha aggiunto %{count} nuove voci al proprio CV:"
 
-#: lib/vutuv_web/components/post_components.ex:6443
+#: lib/vutuv_web/components/post_components.ex:6486
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Audiolibro"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1379
-#: lib/vutuv_web/components/post_components.ex:6400
+#: lib/vutuv_web/agent_docs/markdown.ex:1383
+#: lib/vutuv_web/components/post_components.ex:6443
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Recensione di un libro"
 
-#: lib/vutuv_web/components/post_components.ex:6444
+#: lib/vutuv_web/components/post_components.ex:6487
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Cinema"
 
-#: lib/vutuv_web/components/post_components.ex:6446
+#: lib/vutuv_web/components/post_components.ex:6489
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:6442
+#: lib/vutuv_web/components/post_components.ex:6485
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-book"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1379
-#: lib/vutuv_web/components/post_components.ex:6399
+#: lib/vutuv_web/agent_docs/markdown.ex:1383
+#: lib/vutuv_web/components/post_components.ex:6442
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Recensione di un film"
@@ -14284,12 +14286,12 @@ msgstr "Recensione di un film"
 msgid "Look up"
 msgstr "Cerca"
 
-#: lib/vutuv_web/components/post_components.ex:6441
+#: lib/vutuv_web/components/post_components.ex:6484
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Libro cartaceo"
 
-#: lib/vutuv_web/components/post_components.ex:6445
+#: lib/vutuv_web/components/post_components.ex:6488
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14309,7 +14311,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Anno"
 
-#: lib/vutuv_web/components/post_components.ex:6482
+#: lib/vutuv_web/components/post_components.ex:6525
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14317,27 +14319,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} pagina"
 msgstr[1] "%{formatted} pagine"
 
-#: lib/vutuv_web/components/post_components.ex:6512
+#: lib/vutuv_web/components/post_components.ex:6555
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} h"
 
-#: lib/vutuv_web/components/post_components.ex:6513
+#: lib/vutuv_web/components/post_components.ex:6556
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} h %{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:6511
+#: lib/vutuv_web/components/post_components.ex:6554
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:6471
+#: lib/vutuv_web/components/post_components.ex:6514
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(edizione cartacea)"
 
-#: lib/vutuv_web/components/post_components.ex:6518
+#: lib/vutuv_web/components/post_components.ex:6561
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "circa %{duration}"
@@ -14364,12 +14366,12 @@ msgstr "Certificazione"
 msgid "With qualification:"
 msgstr "Con certificazione:"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:879
+#: lib/vutuv_web/agent_docs/markdown.ex:883
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr "Con certificazione: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:6285
+#: lib/vutuv_web/components/post_components.ex:6328
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Editore:"
@@ -14412,7 +14414,7 @@ msgstr "ora La seguono."
 msgid "endorsed you for %{tags}."
 msgstr "L'ha confermata per %{tags}."
 
-#: lib/vutuv_web/components/post_components.ex:6276
+#: lib/vutuv_web/components/post_components.ex:6319
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "di:"
@@ -14453,19 +14455,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] "Usato per %{formatted} impiego"
 msgstr[1] "Usato per %{formatted} impieghi"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1028
+#: lib/vutuv_web/agent_docs/markdown.ex:1032
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr "attualmente in uso"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1027
+#: lib/vutuv_web/agent_docs/markdown.ex:1031
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] "usato per %{count} impiego"
 msgstr[1] "usato per %{count} impieghi"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1033
+#: lib/vutuv_web/agent_docs/markdown.ex:1037
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -14549,8 +14551,8 @@ msgstr "Prova caricata per %{name}"
 msgid "View the uploaded proof (%{label})"
 msgstr "Vedi la prova caricata (%{label})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:965
-#: lib/vutuv_web/agent_docs/text.ex:790
+#: lib/vutuv_web/agent_docs/markdown.ex:969
+#: lib/vutuv_web/agent_docs/text.ex:791
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr "documento di prova"
@@ -14613,8 +14615,8 @@ msgstr "Come vuole lavorare?"
 msgid "Skip for now"
 msgstr "Salta per ora"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:659
-#: lib/vutuv_web/agent_docs/text.ex:637
+#: lib/vutuv_web/agent_docs/markdown.ex:663
+#: lib/vutuv_web/agent_docs/text.ex:638
 #, elixir-autogen, elixir-format
 msgid "Preferred workplace"
 msgstr "Modalità di lavoro preferita"
@@ -14789,14 +14791,14 @@ msgstr "Cerchi un account da bloccare"
 msgid "See all frozen accounts"
 msgstr "Vedi tutti gli account bloccati"
 
-#: lib/vutuv_web/components/post_components.ex:4065
+#: lib/vutuv_web/components/post_components.ex:4108
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "Mostra %{formatted} post precedente"
 msgstr[1] "Mostra %{formatted} post precedenti"
 
-#: lib/vutuv_web/components/post_components.ex:4088
+#: lib/vutuv_web/components/post_components.ex:4131
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14825,7 +14827,7 @@ msgstr ""
 "Digiti un nome, un @handle o un indirizzo e-mail per trovare un account da "
 "bloccare."
 
-#: lib/vutuv_web/components/post_components.ex:6999
+#: lib/vutuv_web/components/post_components.ex:7042
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Non può mettere Mi piace al Suo stesso post."
@@ -15276,7 +15278,7 @@ msgstr "%{blocked} server bloccati, il più attivo in entrata: %{host}."
 msgid "none yet"
 msgstr "ancora nessuno"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1326
+#: lib/vutuv_web/agent_docs/markdown.ex:1330
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr "Reazioni da altre reti"
@@ -15642,7 +15644,7 @@ msgstr "Modifica l'applicazione"
 msgid "Book an ad"
 msgstr "Prenoti una pubblicità"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1096
+#: lib/vutuv_web/templates/user/show.html.heex:1079
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr ""
@@ -15703,8 +15705,8 @@ msgstr ""
 msgid "Your server"
 msgstr "Il Suo server"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:716
-#: lib/vutuv_web/agent_docs/text.ex:666
+#: lib/vutuv_web/agent_docs/markdown.ex:720
+#: lib/vutuv_web/agent_docs/text.ex:667
 #, elixir-autogen, elixir-format
 msgid "moved to %{address}"
 msgstr "spostato a %{address}"
@@ -16091,7 +16093,7 @@ msgstr ""
 " vedere dove va a finire. Modificare o eliminare un post su vutuv è solo una"
 " richiesta rivolta a quei server, e non tutti la rispettano."
 
-#: lib/vutuv_web/components/post_components.ex:6945
+#: lib/vutuv_web/components/post_components.ex:6988
 #: lib/vutuv_web/live/notification_live/index.ex:1592
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -16099,7 +16101,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} risposta"
 msgstr[1] "%{formatted} risposte"
 
-#: lib/vutuv_web/components/post_components.ex:6949
+#: lib/vutuv_web/components/post_components.ex:6992
 #: lib/vutuv_web/live/notification_live/index.ex:1586
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -16107,15 +16109,15 @@ msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Mi piace"
 msgstr[1] "%{formatted} Mi piace"
 
-#: lib/vutuv_web/components/post_components.ex:6953
+#: lib/vutuv_web/components/post_components.ex:6996
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
 msgstr[0] "%{formatted} ripubblicazione"
 msgstr[1] "%{formatted} ripubblicazioni"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1328
-#: lib/vutuv_web/components/post_components.ex:6904
+#: lib/vutuv_web/agent_docs/markdown.ex:1332
+#: lib/vutuv_web/components/post_components.ex:6947
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Già conteggiate nei numeri qui sopra."
@@ -16130,22 +16132,22 @@ msgstr ""
 " se l'autore la elimina, sparisce anche la nostra. Può rimuovere qualsiasi "
 "singola risposta, e disattivando questa opzione vengono eliminate tutte."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1268
-#: lib/vutuv_web/agent_docs/markdown.ex:1526
-#: lib/vutuv_web/agent_docs/text.ex:888
-#: lib/vutuv_web/agent_docs/text.ex:965
+#: lib/vutuv_web/agent_docs/markdown.ex:1272
+#: lib/vutuv_web/agent_docs/markdown.ex:1530
+#: lib/vutuv_web/agent_docs/text.ex:889
+#: lib/vutuv_web/agent_docs/text.ex:966
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr "Avviso sul contenuto"
 
-#: lib/vutuv_web/components/post_components.ex:1582
-#: lib/vutuv_web/components/post_components.ex:2682
+#: lib/vutuv_web/components/post_components.ex:1583
+#: lib/vutuv_web/components/post_components.ex:2683
 #: lib/vutuv_web/live/fediverse_account_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr "Da un'altra rete"
 
-#: lib/vutuv_web/components/post_components.ex:1446
+#: lib/vutuv_web/components/post_components.ex:1447
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr "Rimuovere questa risposta dal Suo post?"
@@ -16157,7 +16159,7 @@ msgstr "Rimossa dal membro"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:150
 #: lib/vutuv_web/agent_docs/markdown.ex:182
-#: lib/vutuv_web/agent_docs/markdown.ex:1327
+#: lib/vutuv_web/agent_docs/markdown.ex:1331
 #: lib/vutuv_web/agent_docs/text.ex:125
 #: lib/vutuv_web/agent_docs/text.ex:154
 #, elixir-autogen, elixir-format
@@ -16174,7 +16176,7 @@ msgstr "Risposta da un'altra rete"
 msgid "Reply removed."
 msgstr "Risposta rimossa."
 
-#: lib/vutuv_web/components/post_components.ex:1458
+#: lib/vutuv_web/components/post_components.ex:1459
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -16185,7 +16187,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr "Segnalata come non appropriata"
 
-#: lib/vutuv_web/components/post_components.ex:1472
+#: lib/vutuv_web/components/post_components.ex:1473
 #: lib/vutuv_web/live/notification_live/index.ex:1117
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -16216,10 +16218,10 @@ msgstr "Grazie. La risposta è stata eliminata subito."
 msgid "That reply is not yours to remove."
 msgstr "Questa risposta non spetta a Lei rimuoverla."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1528
-#: lib/vutuv_web/components/post_components.ex:1497
-#: lib/vutuv_web/components/post_components.ex:1728
-#: lib/vutuv_web/components/post_components.ex:3634
+#: lib/vutuv_web/agent_docs/markdown.ex:1532
+#: lib/vutuv_web/components/post_components.ex:1498
+#: lib/vutuv_web/components/post_components.ex:1729
+#: lib/vutuv_web/components/post_components.ex:3677
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "View the original"
@@ -16913,22 +16915,22 @@ msgstr ""
 msgid "device or detail"
 msgstr "dispositivo o dettaglio"
 
-#: lib/vutuv_web/components/post_components.ex:4250
+#: lib/vutuv_web/components/post_components.ex:4293
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Post fissato"
 
-#: lib/vutuv_web/components/post_components.ex:4376
+#: lib/vutuv_web/components/post_components.ex:4419
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "Fissa sul profilo"
 
-#: lib/vutuv_web/components/post_components.ex:4384
+#: lib/vutuv_web/components/post_components.ex:4427
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Togli dal profilo"
 
-#: lib/vutuv_web/components/post_components.ex:4370
+#: lib/vutuv_web/components/post_components.ex:4413
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16951,13 +16953,13 @@ msgstr ""
 msgid "Unpinned. The post is a normal post again."
 msgstr "Non più fissato. Il post torna a essere un post normale."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1169
+#: lib/vutuv_web/agent_docs/markdown.ex:1173
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr "post fissato"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:653
-#: lib/vutuv_web/agent_docs/text.ex:628
+#: lib/vutuv_web/agent_docs/markdown.ex:657
+#: lib/vutuv_web/agent_docs/text.ex:629
 #: lib/vutuv_web/templates/user/edit.html.heex:225
 #: lib/vutuv_web/templates/user/show.html.heex:291
 #: lib/vutuv_web/views/account_event_text.ex:213
@@ -17009,8 +17011,8 @@ msgstr "CC BY-SA 4.0 (attribuzione, stessa licenza)"
 msgid "CC0 1.0 (no rights reserved)"
 msgstr "CC0 1.0 (nessun diritto riservato)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1445
-#: lib/vutuv_web/agent_docs/text.ex:919
+#: lib/vutuv_web/agent_docs/markdown.ex:1449
+#: lib/vutuv_web/agent_docs/text.ex:920
 #: lib/vutuv_web/live/post_live/composer.ex:2661
 #, elixir-autogen, elixir-format
 msgid "Cover"
@@ -17021,8 +17023,8 @@ msgstr "Copertina"
 msgid "Describe the photo for people who can't see it"
 msgstr "Descriva la foto per chi non può vederla"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1456
-#: lib/vutuv_web/agent_docs/text.ex:932
+#: lib/vutuv_web/agent_docs/markdown.ex:1460
+#: lib/vutuv_web/agent_docs/text.ex:933
 #: lib/vutuv_web/components/ui.ex:3249
 #, elixir-autogen, elixir-format
 msgid "Download the original"
@@ -17060,19 +17062,19 @@ msgstr "Foto successiva"
 msgid "No image description yet"
 msgstr "Ancora nessuna descrizione dell'immagine"
 
-#: lib/vutuv_web/components/post_components.ex:3829
+#: lib/vutuv_web/components/post_components.ex:3872
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Apri le impostazioni del Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:5321
-#: lib/vutuv_web/components/press_kit_components.ex:344
+#: lib/vutuv_web/components/post_components.ex:5364
+#: lib/vutuv_web/components/press_kit_components.ex:399
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} di %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:5549
-#: lib/vutuv_web/components/press_kit_components.ex:414
+#: lib/vutuv_web/components/post_components.ex:5592
+#: lib/vutuv_web/components/press_kit_components.ex:469
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "La foto è in fase di controllo"
@@ -17083,9 +17085,9 @@ msgstr "La foto è in fase di controllo"
 msgid "Photo options"
 msgstr "Opzioni della foto"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1489
-#: lib/vutuv_web/agent_docs/text.ex:907
-#: lib/vutuv_web/components/post_components.ex:5631
+#: lib/vutuv_web/agent_docs/markdown.ex:1493
+#: lib/vutuv_web/agent_docs/text.ex:908
+#: lib/vutuv_web/components/post_components.ex:5674
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Foto:"
@@ -17113,7 +17115,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr "Mostra le impostazioni della fotocamera"
 
-#: lib/vutuv_web/components/post_components.ex:3882
+#: lib/vutuv_web/components/post_components.ex:3925
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -17139,7 +17141,7 @@ msgstr ""
 "Questa foto porta con sé il luogo in cui è stata scattata. Chiunque scarichi"
 " il file esatto può leggerlo."
 
-#: lib/vutuv_web/components/post_components.ex:3873
+#: lib/vutuv_web/components/post_components.ex:3916
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -17154,12 +17156,12 @@ msgstr ""
 "inviare le Sue parole a quella rete, cosa che vutuv fa solo per i membri che"
 " hanno attivato la partecipazione al Fediverso."
 
-#: lib/vutuv_web/components/post_components.ex:3891
+#: lib/vutuv_web/components/post_components.ex:3934
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Questo sito non partecipa al Fediverso."
 
-#: lib/vutuv_web/components/post_components.ex:3825
+#: lib/vutuv_web/components/post_components.ex:3868
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Attivi la partecipazione al Fediverso per rispondere"
@@ -17175,7 +17177,7 @@ msgid "You have sent a lot of answers to other networks in the past hour. Please
 msgstr ""
 "Nell'ultima ora ha inviato molte risposte ad altre reti. Riprovi più tardi."
 
-#: lib/vutuv_web/components/post_components.ex:3886
+#: lib/vutuv_web/components/post_components.ex:3929
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -17189,7 +17191,7 @@ msgstr ""
 "Al momento le Sue impostazioni del Fediverso non consentono di inviare una "
 "risposta."
 
-#: lib/vutuv_web/components/post_components.ex:3839
+#: lib/vutuv_web/components/post_components.ex:3882
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -17271,14 +17273,14 @@ msgstr[1] ""
 "Alcune di queste foto portano con sé il luogo in cui sono state scattate, e "
 "il file esatto lo rivela."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1346
-#: lib/vutuv_web/components/post_components.ex:6942
+#: lib/vutuv_web/agent_docs/markdown.ex:1350
+#: lib/vutuv_web/components/post_components.ex:6985
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "A %{handle} è piaciuto"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1344
-#: lib/vutuv_web/components/post_components.ex:6939
+#: lib/vutuv_web/agent_docs/markdown.ex:1348
+#: lib/vutuv_web/components/post_components.ex:6982
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} lo ha condiviso"
@@ -17288,7 +17290,7 @@ msgstr "%{handle} lo ha condiviso"
 msgid "Fediverse reactions"
 msgstr "Reazioni dal Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:6826
+#: lib/vutuv_web/components/post_components.ex:6869
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Da altre reti"
@@ -17675,7 +17677,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr "Post in cache"
 
-#: lib/vutuv_web/components/post_components.ex:3393
+#: lib/vutuv_web/components/post_components.ex:3436
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr "Solo per i follower di questo account"
@@ -17685,7 +17687,7 @@ msgstr "Solo per i follower di questo account"
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Grazie. La nostra copia è stata eliminata subito."
 
-#: lib/vutuv_web/components/post_components.ex:3633
+#: lib/vutuv_web/components/post_components.ex:3676
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Vota sull'originale"
@@ -17711,12 +17713,12 @@ msgstr "Post in cache segnalato, rimosso per tutti qui"
 msgid "Content from other networks taken down by members"
 msgstr "Contenuti da altre reti rimossi dai membri"
 
-#: lib/vutuv_web/components/post_components.ex:1869
+#: lib/vutuv_web/components/post_components.ex:1870
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Nascondi"
 
-#: lib/vutuv_web/components/post_components.ex:3574
+#: lib/vutuv_web/components/post_components.ex:3617
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Contrassegnato come sensibile dal suo autore"
@@ -17731,7 +17733,7 @@ msgstr "Silenziato. Continua a seguirlo; i suoi post spariscono dal Suo feed."
 msgid "Nobody has removed or reported anything yet."
 msgstr "Nessuno ha ancora rimosso o segnalato nulla."
 
-#: lib/vutuv_web/components/post_components.ex:3366
+#: lib/vutuv_web/components/post_components.ex:3409
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -17839,34 +17841,34 @@ msgstr "Lo spostamento del Suo account"
 msgid "“LinkedIn is annoying. vutuv is not.”"
 msgstr "“LinkedIn è fastidioso. vutuv no.”"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1146
+#: lib/vutuv_web/agent_docs/markdown.ex:1150
 #, elixir-autogen, elixir-format
 msgid "(a picture)"
 msgid_plural "(%{count} pictures)"
 msgstr[0] "(un'immagine)"
 msgstr[1] "(%{count} immagini)"
 
-#: lib/vutuv_web/components/post_components.ex:3016
+#: lib/vutuv_web/components/post_components.ex:3026
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr "L'immagine è in fase di controllo"
 
-#: lib/vutuv_web/components/post_components.ex:2886
+#: lib/vutuv_web/components/post_components.ex:2887
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr "Coprila di nuovo"
 
-#: lib/vutuv_web/components/post_components.ex:2881
+#: lib/vutuv_web/components/post_components.ex:2882
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr "Contenuto sensibile. Mostra l'immagine."
 
-#: lib/vutuv_web/components/post_components.ex:3732
+#: lib/vutuv_web/components/post_components.ex:3775
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Sono molti Mi piace in un'ora. Riprovi più tardi."
 
-#: lib/vutuv_web/components/post_components.ex:3738
+#: lib/vutuv_web/components/post_components.ex:3781
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Quel post non è più qui."
@@ -17876,7 +17878,7 @@ msgstr "Quel post non è più qui."
 msgid "Back to the feed"
 msgstr "Torna al feed"
 
-#: lib/vutuv_web/components/post_components.ex:3877
+#: lib/vutuv_web/components/post_components.ex:3920
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17925,7 +17927,7 @@ msgstr ""
 "Quel link punta a un singolo post. Da qui può seguire il suo autore, "
 "%{account}."
 
-#: lib/vutuv_web/views/user_html.ex:249
+#: lib/vutuv_web/views/user_html.ex:242
 #, elixir-autogen, elixir-format
 msgid "Your feed shows the posts of members you follow. Follow a few to fill it."
 msgstr ""
@@ -17999,8 +18001,8 @@ msgid "We could not reach the network just now. Please try again in a moment."
 msgstr ""
 "Al momento non siamo riusciti a raggiungere la rete. Riprovi tra poco."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1073
-#: lib/vutuv_web/agent_docs/text.ex:712
+#: lib/vutuv_web/agent_docs/markdown.ex:1077
+#: lib/vutuv_web/agent_docs/text.ex:713
 #, elixir-autogen, elixir-format
 msgid "verified profile"
 msgstr "profilo verificato"
@@ -18558,14 +18560,14 @@ msgstr ""
 msgid "Screenshot blocklist"
 msgstr "Elenco dei bloccati per gli screenshot"
 
-#: lib/vutuv_web/components/post_components.ex:475
+#: lib/vutuv_web/components/post_components.ex:476
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 "Ancora nulla dal Fediverso. Segua account là fuori per riempire questa "
 "scheda."
 
-#: lib/vutuv_web/components/post_components.ex:472
+#: lib/vutuv_web/components/post_components.ex:473
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr "Ancora nulla da vutuv. Segua persone qui per riempire questa scheda."
@@ -18608,7 +18610,7 @@ msgstr "Nessun post su vutuv porta ancora questo tag."
 msgid "word in a post"
 msgstr "parola in un post"
 
-#: lib/vutuv_web/components/post_components.ex:3735
+#: lib/vutuv_web/components/post_components.ex:3778
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Quella risposta non è più qui."
@@ -18681,24 +18683,24 @@ msgstr ""
 "La pagina di un post mostra i membri a cui è piaciuto, subito sotto il "
 "contatore. Questa impostazione decide se Lei è tra quei volti."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1314
+#: lib/vutuv_web/agent_docs/markdown.ex:1318
 #, elixir-autogen, elixir-format
 msgid "Liked by"
 msgstr "Piace a"
 
-#: lib/vutuv_web/components/post_components.ex:5925
+#: lib/vutuv_web/components/post_components.ex:5968
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Piace a %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:5927
+#: lib/vutuv_web/components/post_components.ex:5970
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Piace a %{name} e a %{formatted} altro"
 msgstr[1] "Piace a %{name} e ad altri %{formatted}"
 
-#: lib/vutuv_web/components/post_components.ex:5938
+#: lib/vutuv_web/components/post_components.ex:5981
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -18729,12 +18731,12 @@ msgstr ""
 msgid "Your likes follow the site default again."
 msgstr "I Suoi Mi piace tornano a seguire il valore predefinito del sito."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1369
+#: lib/vutuv_web/agent_docs/markdown.ex:1373
 #, elixir-autogen, elixir-format
 msgid "%{address} (this page only)"
 msgstr "%{address} (solo questa pagina)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1366
+#: lib/vutuv_web/agent_docs/markdown.ex:1370
 #, elixir-autogen, elixir-format
 msgid "%{address} (whole website)"
 msgstr "%{address} (intero sito web)"
@@ -18744,7 +18746,7 @@ msgstr "%{address} (intero sito web)"
 msgid "Verified webpage of the author (%{address})"
 msgstr "Pagina web verificata dell'autore (%{address})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1358
+#: lib/vutuv_web/agent_docs/markdown.ex:1362
 #, elixir-autogen, elixir-format
 msgid "Verified webpages of the author linked here: %{addresses}"
 msgstr "Pagine web verificate dell'autore collegate qui: %{addresses}"
@@ -18879,7 +18881,7 @@ msgstr "Rilasciato il"
 msgid "Label"
 msgstr "Etichetta"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3606
+#: lib/vutuv_web/live/post_live/feed.ex:3617
 #: lib/vutuv_web/live/reference_check_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -19097,7 +19099,7 @@ msgstr "Non abbiamo scritto né il prompt né il modello."
 msgid "Employment references of %{name}"
 msgstr "Attestati di lavoro di %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:947
+#: lib/vutuv_web/agent_docs/markdown.ex:951
 #, elixir-autogen, elixir-format
 msgid "document"
 msgstr "documento"
@@ -19326,7 +19328,7 @@ msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr "PDF, JPG, PNG o WebP, fino a %{limit}"
 
 #: lib/vutuv_web/components/ui.ex:4582
-#: lib/vutuv_web/live/press_kit_live.ex:281
+#: lib/vutuv_web/live/press_kit_live.ex:382
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "That file is larger than %{limit}. Please upload a smaller one."
@@ -20428,7 +20430,7 @@ msgstr ""
 msgid "Start over"
 msgstr "Ricomincia"
 
-#: lib/vutuv_web/components/post_components.ex:3765
+#: lib/vutuv_web/components/post_components.ex:3808
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -20436,12 +20438,12 @@ msgstr ""
 "questo post, e al momento il Suo account non partecipa al Fediverso. Può "
 "attivarlo nelle {settings}."
 
-#: lib/vutuv_web/components/organization_components.ex:319
+#: lib/vutuv_web/components/organization_components.ex:328
 #, elixir-autogen, elixir-format
 msgid "Editorial"
 msgstr "Redazione"
 
-#: lib/vutuv_web/components/organization_components.ex:325
+#: lib/vutuv_web/components/organization_components.ex:334
 #, elixir-autogen, elixir-format
 msgid "Edits the page and posts jobs."
 msgstr "Modifica la pagina e pubblica annunci di lavoro."
@@ -20453,7 +20455,7 @@ msgstr ""
 "Assegni ai membri i loro ruoli su questa pagina. Una persona può averne più "
 "di uno, e ogni ruolo viene concesso a sé."
 
-#: lib/vutuv_web/components/organization_components.ex:324
+#: lib/vutuv_web/components/organization_components.ex:333
 #, elixir-autogen, elixir-format
 msgid "Manages the team and the domains, and edits the page."
 msgstr "Gestisce il team e i domini, e modifica la pagina."
@@ -20463,7 +20465,7 @@ msgstr "Gestisce il team e i domini, e modifica la pagina."
 msgid "Pick at least one role."
 msgstr "Scelga almeno un ruolo."
 
-#: lib/vutuv_web/components/organization_components.ex:327
+#: lib/vutuv_web/components/organization_components.ex:336
 #, elixir-autogen, elixir-format
 msgid "Posts jobs."
 msgstr "Pubblica annunci di lavoro."
@@ -20478,7 +20480,7 @@ msgstr "Ruoli"
 msgid "Roles updated."
 msgstr "Ruoli aggiornati."
 
-#: lib/vutuv_web/components/organization_components.ex:326
+#: lib/vutuv_web/components/organization_components.ex:335
 #, elixir-autogen, elixir-format
 msgid "Writes posts in the organization's name."
 msgstr "Scrive post a nome dell'organizzazione."
@@ -20492,7 +20494,7 @@ msgstr ""
 "avere più ruoli, e la facoltà di scrivere a nome dell'organizzazione viene "
 "sempre concessa a sé."
 
-#: lib/vutuv_web/live/organization_live/show.ex:782
+#: lib/vutuv_web/live/organization_live/show.ex:805
 #, elixir-autogen, elixir-format
 msgid "Nothing published yet."
 msgstr "Ancora nulla di pubblicato."
@@ -20527,7 +20529,7 @@ msgstr "Ha iniziato a scrivere come organizzazione"
 msgid "Stopped writing as an organization"
 msgstr "Ha smesso di scrivere come organizzazione"
 
-#: lib/vutuv_web/live/organization_live/show.ex:746
+#: lib/vutuv_web/live/organization_live/show.ex:769
 #, elixir-autogen, elixir-format
 msgid "Write as %{name} for now"
 msgstr "Scrivi come %{name} per ora"
@@ -20767,14 +20769,14 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/fediverse.ex:92
 #: lib/vutuv_web/live/organization_live/new.ex:211
-#: lib/vutuv_web/live/organization_live/show.ex:897
+#: lib/vutuv_web/live/organization_live/show.ex:934
 #, elixir-autogen, elixir-format
 msgid "People who have no vutuv account can follow this page and read its posts, in networks like Mastodon."
 msgstr ""
 "Le persone che non hanno un account vutuv possono seguire questa pagina e "
 "leggerne i post, su reti come Mastodon."
 
-#: lib/vutuv_web/live/organization_live/show.ex:911
+#: lib/vutuv_web/live/organization_live/show.ex:948
 #, elixir-autogen, elixir-format
 msgid "Set this page up for other networks"
 msgstr "Prepari questa pagina per le altre reti"
@@ -20789,7 +20791,7 @@ msgstr "Disattivalo"
 msgid "Switch it on"
 msgstr "Attivalo"
 
-#: lib/vutuv_web/live/organization_live/show.ex:902
+#: lib/vutuv_web/live/organization_live/show.ex:939
 #, elixir-autogen, elixir-format
 msgid "The page gets an address of its own for that, written like an email address."
 msgstr ""
@@ -21073,7 +21075,7 @@ msgstr ""
 msgid "The gravatar.com lookup is switched off on this installation."
 msgstr "La ricerca su gravatar.com è disattivata su questa installazione."
 
-#: lib/vutuv_web/components/organization_components.ex:35
+#: lib/vutuv_web/components/organization_components.ex:36
 #, elixir-autogen, elixir-format
 msgid "A new entry can take a while to reach everyone. We keep checking %{domain} by ourselves and send you an email as soon as it works, so you can close this page."
 msgstr ""
@@ -21082,7 +21084,7 @@ msgstr ""
 "così può chiudere questa pagina."
 
 #: lib/vutuv_web/live/organization_live/domains.ex:351
-#: lib/vutuv_web/live/organization_live/show.ex:1100
+#: lib/vutuv_web/live/organization_live/show.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Checking …"
 msgstr "Controllo in corso…"
@@ -21390,27 +21392,27 @@ msgstr "Lingua"
 msgid "The language this post is written in"
 msgstr "La lingua in cui è scritto questo post"
 
-#: lib/vutuv_web/components/post_components.ex:5819
+#: lib/vutuv_web/components/post_components.ex:5862
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Mostra l'originale"
 
-#: lib/vutuv_web/components/post_components.ex:5855
+#: lib/vutuv_web/components/post_components.ex:5898
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Traduci"
 
-#: lib/vutuv_web/components/post_components.ex:5864
+#: lib/vutuv_web/components/post_components.ex:5907
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Tradotto"
 
-#: lib/vutuv_web/components/post_components.ex:5867
+#: lib/vutuv_web/components/post_components.ex:5910
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Tradotto da %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:5844
+#: lib/vutuv_web/components/post_components.ex:5887
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Traduzione in corso…"
@@ -21421,7 +21423,7 @@ msgid "Feed language settings reset to the site defaults."
 msgstr ""
 "Impostazioni delle lingue del feed riportate ai valori predefiniti del sito."
 
-#: lib/vutuv_web/components/post_components.ex:5834
+#: lib/vutuv_web/components/post_components.ex:5877
 #: lib/vutuv_web/components/ui.ex:5371
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -21564,7 +21566,7 @@ msgid "Your username, or paste the address of your profile page."
 msgstr ""
 "Il Suo nome utente, oppure incolli l'indirizzo della Sua pagina di profilo."
 
-#: lib/vutuv_web/components/post_components.ex:5597
+#: lib/vutuv_web/components/post_components.ex:5640
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
@@ -21575,13 +21577,13 @@ msgstr[1] ""
 "La nostra IA le sta ancora controllando, %{done} su %{total} fatte. Appena "
 "avrà finito con l'ultima, le foto compariranno da sé."
 
-#: lib/vutuv_web/components/post_components.ex:5594
+#: lib/vutuv_web/components/post_components.ex:5637
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Il Suo post è pubblicato, la foto non c'è ancora."
 
-#: lib/vutuv_web/components/post_components.ex:2907
-#: lib/vutuv_web/components/post_components.ex:4663
+#: lib/vutuv_web/components/post_components.ex:2908
+#: lib/vutuv_web/components/post_components.ex:4706
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -21602,12 +21604,12 @@ msgstr "Consigliato: quadrata, almeno %{width} × %{height} pixel."
 
 #: lib/vutuv_web/live/job_board_live.ex:431
 #: lib/vutuv_web/live/post_live/feed.ex:964
-#: lib/vutuv_web/views/user_html.ex:372
+#: lib/vutuv_web/views/user_html.ex:365
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
 msgstr "Immagine del profilo di %{name}"
 
-#: lib/vutuv_web/views/user_html.ex:375
+#: lib/vutuv_web/views/user_html.ex:368
 #, elixir-autogen, elixir-format
 msgid "Show the profile picture larger"
 msgstr "Mostra l'immagine del profilo più grande"
@@ -21747,7 +21749,7 @@ msgstr "Analizza un altro file"
 msgid "Find my contacts"
 msgstr "Trova i miei contatti"
 
-#: lib/vutuv_web/views/user_html.ex:271
+#: lib/vutuv_web/views/user_html.ex:264
 #, elixir-autogen, elixir-format
 msgid "Find people you know from LinkedIn"
 msgstr "Trovi le persone che conosce da LinkedIn"
@@ -22154,7 +22156,7 @@ msgstr ""
 "Questa pagina sta seguendo il numero massimo di account che consentiamo "
 "(%{max})."
 
-#: lib/vutuv_web/components/post_components.ex:3346
+#: lib/vutuv_web/components/post_components.ex:3389
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr "Smettere di seguire %{handle}? I suoi post spariscono dal Suo feed."
@@ -22297,7 +22299,7 @@ msgstr ""
 "Segua #%{tag} da Mastodon o da qualsiasi altra app del Fediverso e i suoi "
 "post pubblici arriveranno nella Sua cronologia. Non serve un account vutuv."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3771
+#: lib/vutuv_web/live/post_live/feed.ex:3782
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Saluti gli altri membri"
@@ -22783,13 +22785,13 @@ msgid "Hide a word or a whole phrase …"
 msgstr "Nascondi una parola o un'intera frase …"
 
 #: lib/vutuv_web/live/post_live/feed.ex:709
-#: lib/vutuv_web/live/post_live/feed.ex:3934
+#: lib/vutuv_web/live/post_live/feed.ex:3945
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Nascondi tag"
 
 #: lib/vutuv_web/live/post_live/feed.ex:708
-#: lib/vutuv_web/live/post_live/feed.ex:3923
+#: lib/vutuv_web/live/post_live/feed.ex:3934
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Nascondi parole"
@@ -22856,7 +22858,7 @@ msgstr "I post con uno di questi tag vengono ridotti allo stesso modo."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "I post che contengono una di queste parole vengono ridotti a una riga — non eliminati, e con un modo per aprirli comunque."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3797
+#: lib/vutuv_web/live/post_live/feed.ex:3808
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Messe da parte:"
@@ -22895,7 +22897,7 @@ msgid "Show posts by %{name}"
 msgstr "Mostra i post di %{name}"
 
 #: lib/vutuv_web/live/post_live/feed.ex:707
-#: lib/vutuv_web/live/post_live/feed.ex:3889
+#: lib/vutuv_web/live/post_live/feed.ex:3900
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr "Fonti"
@@ -22934,8 +22936,8 @@ msgid_plural "and %{formatted} more"
 msgstr[0] "e 1 altro"
 msgstr[1] "e altri %{formatted}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3371
-#: lib/vutuv_web/live/post_live/feed.ex:3398
+#: lib/vutuv_web/live/post_live/feed.ex:3382
+#: lib/vutuv_web/live/post_live/feed.ex:3409
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -22967,7 +22969,7 @@ msgstr ""
 "verifica e comparirà al termine del controllo."
 
 #: lib/vutuv_web/live/organization_live/edit.ex:290
-#: lib/vutuv_web/live/press_kit_live.ex:741
+#: lib/vutuv_web/live/press_kit_live.ex:882
 #, elixir-autogen, elixir-format
 msgid "%{formats}, up to %{limit}"
 msgstr "%{formats}, fino a %{limit}"
@@ -23000,7 +23002,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} post il %{day}"
 msgstr[1] "%{count} post il %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3563
+#: lib/vutuv_web/live/post_live/feed.ex:3574
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Torna al presente"
@@ -23010,7 +23012,7 @@ msgstr "Torna al presente"
 msgid "Busy month: the shading counts at least this much."
 msgstr "Mese intenso: la tonalità indica almeno questo valore."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3609
+#: lib/vutuv_web/live/post_live/feed.ex:3620
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -23032,7 +23034,7 @@ msgstr "Mese successivo"
 msgid "Next year"
 msgstr "Anno successivo"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3559
+#: lib/vutuv_web/live/post_live/feed.ex:3570
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Il %{day} non è arrivato nulla nel Suo feed."
@@ -23059,7 +23061,7 @@ msgctxt "heatmap scale"
 msgid "More"
 msgstr "Più"
 
-#: lib/vutuv_web/live/organization_live/show.ex:549
+#: lib/vutuv_web/live/organization_live/show.ex:572
 #, elixir-autogen, elixir-format
 msgid "The website of %{name}"
 msgstr "Il sito web di %{name}"
@@ -23114,29 +23116,29 @@ msgstr "Da scansionare con il dispositivo su cui è installata l'app"
 msgid "A new version is ready."
 msgstr "È pronta una nuova versione."
 
-#: lib/vutuv_web/live/organization_live/show.ex:684
+#: lib/vutuv_web/live/organization_live/show.ex:707
 #, elixir-autogen, elixir-format
 msgid "Page management"
 msgstr "Gestione"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2448
+#: lib/vutuv_web/live/post_live/feed.ex:2459
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
 msgstr[0] "Nuovo:"
 msgstr[1] "Nuovi (%{formatted}):"
 
-#: lib/vutuv_web/components/post_components.ex:3501
+#: lib/vutuv_web/components/post_components.ex:3544
 #, elixir-autogen, elixir-format
 msgid "Quoted post"
 msgstr "Post citato"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1162
+#: lib/vutuv_web/agent_docs/markdown.ex:1166
 #, elixir-autogen, elixir-format
 msgid "Quotes %{name}: %{url}"
 msgstr "Cita %{name}: %{url}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1159
+#: lib/vutuv_web/agent_docs/markdown.ex:1163
 #, elixir-autogen, elixir-format
 msgid "Quotes %{url}"
 msgstr "Cita %{url}"
@@ -23151,7 +23153,7 @@ msgstr "Menziona un account"
 msgid "{used} of {max} mentions"
 msgstr "{used} di {max} menzioni"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2560
+#: lib/vutuv_web/live/post_live/feed.ex:2571
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr ""
@@ -23182,7 +23184,7 @@ msgstr "Solo questi account (vuoto = tutti) …"
 msgid "only %{account}"
 msgstr "solo %{account}"
 
-#: lib/vutuv_web/components/post_components.ex:7285
+#: lib/vutuv_web/components/post_components.ex:7330
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -23366,7 +23368,7 @@ msgctxt "phone tab bar"
 msgid "Write"
 msgstr "Scrivi"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3697
+#: lib/vutuv_web/live/post_live/feed.ex:3708
 #: lib/vutuv_web/live/post_rewrites_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "%{formatted} rule"
@@ -23434,9 +23436,9 @@ msgstr "Regole per %{account}"
 msgid "Rules that rewrite the text of one account's posts before you read them: a footer under every post, a signature, a wall of hashtags. Only you see the difference. Open the ⋯ menu on any post to write rules for its author."
 msgstr "Regole che riscrivono il testo dei post di un account prima che Lei li legga: un piè di pagina sotto ogni post, una firma, un muro di hashtag. Solo Lei vede la differenza. Apra il menu ⋯ di un post per scrivere regole per il suo autore."
 
-#: lib/vutuv_web/components/post_components.ex:1451
-#: lib/vutuv_web/components/post_components.ex:3359
-#: lib/vutuv_web/components/post_components.ex:4453
+#: lib/vutuv_web/components/post_components.ex:1452
+#: lib/vutuv_web/components/post_components.ex:3402
+#: lib/vutuv_web/components/post_components.ex:4496
 #: lib/vutuv_web/components/ui.ex:5363
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
@@ -23622,11 +23624,11 @@ msgstr "Questo post La sta ancora aspettando"
 msgid "This video could not be converted."
 msgstr "Questo video non può essere convertito."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1441
-#: lib/vutuv_web/agent_docs/markdown.ex:1444
-#: lib/vutuv_web/agent_docs/text.ex:916
+#: lib/vutuv_web/agent_docs/markdown.ex:1445
+#: lib/vutuv_web/agent_docs/markdown.ex:1448
 #: lib/vutuv_web/agent_docs/text.ex:917
-#: lib/vutuv_web/components/post_components.ex:2967
+#: lib/vutuv_web/agent_docs/text.ex:918
+#: lib/vutuv_web/components/post_components.ex:2977
 #: lib/vutuv_web/components/video_components.ex:127
 #: lib/vutuv_web/live/post_live/composer.ex:2458
 #, elixir-autogen, elixir-format
@@ -23689,7 +23691,7 @@ msgstr[1] "%{formatted} nuovi follower"
 msgid "Last 30 days: %{parts}"
 msgstr "Ultimi 30 giorni: %{parts}"
 
-#: lib/vutuv_web/components/post_components.ex:5015
+#: lib/vutuv_web/components/post_components.ex:5058
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Less"
@@ -23750,22 +23752,22 @@ msgstr "Membri con questi tag:"
 msgid "The fields the most members carry, and how many of them do."
 msgstr "Gli ambiti con più membri, e quanti sono per ciascuno."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1212
-#: lib/vutuv_web/agent_docs/text.ex:840
+#: lib/vutuv_web/agent_docs/markdown.ex:1216
+#: lib/vutuv_web/agent_docs/text.ex:841
 #: lib/vutuv_web/live/job_board_live.ex:474
 #, elixir-autogen, elixir-format
 msgid "What members here work on"
 msgstr "Di cosa si occupano i membri qui"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1204
-#: lib/vutuv_web/agent_docs/text.ex:832
+#: lib/vutuv_web/agent_docs/markdown.ex:1208
+#: lib/vutuv_web/agent_docs/text.ex:833
 #: lib/vutuv_web/live/job_board_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "Who you would reach"
 msgstr "Chi raggiungerebbe"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1205
-#: lib/vutuv_web/agent_docs/text.ex:833
+#: lib/vutuv_web/agent_docs/markdown.ex:1209
+#: lib/vutuv_web/agent_docs/text.ex:834
 #: lib/vutuv_web/live/job_board_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "One random vutuv account that is open to offers."
@@ -23873,8 +23875,8 @@ msgstr ""
 msgid "People here per day over the last %{days} days"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:445
-#: lib/vutuv_web/agent_docs/text.ex:400
+#: lib/vutuv_web/agent_docs/markdown.ex:449
+#: lib/vutuv_web/agent_docs/text.ex:401
 #, elixir-autogen, elixir-format
 msgid "Press material: %{url}"
 msgstr ""
@@ -23889,28 +23891,28 @@ msgstr ""
 msgid "Send a message"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:428
-#: lib/vutuv_web/agent_docs/text.ex:387
+#: lib/vutuv_web/agent_docs/markdown.ex:432
+#: lib/vutuv_web/agent_docs/text.ex:388
 #: lib/vutuv_web/templates/company/investors.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "Where we are"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:435
-#: lib/vutuv_web/agent_docs/text.ex:394
+#: lib/vutuv_web/agent_docs/markdown.ex:439
+#: lib/vutuv_web/agent_docs/text.ex:395
 #: lib/vutuv_web/templates/company/investors.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Why this is worth building"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:444
-#: lib/vutuv_web/agent_docs/text.ex:399
+#: lib/vutuv_web/agent_docs/markdown.ex:448
+#: lib/vutuv_web/agent_docs/text.ex:400
 #, elixir-autogen, elixir-format
 msgid "Write here: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:441
-#: lib/vutuv_web/agent_docs/text.ex:396
+#: lib/vutuv_web/agent_docs/markdown.ex:445
+#: lib/vutuv_web/agent_docs/text.ex:397
 #: lib/vutuv_web/templates/company/investors.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Write to me"
@@ -23926,8 +23928,8 @@ msgstr ""
 msgid "My profile:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:443
-#: lib/vutuv_web/agent_docs/text.ex:398
+#: lib/vutuv_web/agent_docs/markdown.ex:447
+#: lib/vutuv_web/agent_docs/text.ex:399
 #, elixir-autogen, elixir-format
 msgid "My profile: %{url}"
 msgstr ""
@@ -23947,8 +23949,8 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:512
-#: lib/vutuv_web/agent_docs/text.ex:469
+#: lib/vutuv_web/agent_docs/markdown.ex:516
+#: lib/vutuv_web/agent_docs/text.ex:470
 #, elixir-autogen, elixir-format
 msgid "Source: %{source}"
 msgstr ""
@@ -24003,8 +24005,8 @@ msgstr "Account che ha silenziato e account di cui nasconde le ripubblicazioni"
 msgid "Hidden. What they pass on stays out of your feed; their own posts do not."
 msgstr "Nascosto. Ciò che questo account ripubblica non compare più nel Suo feed, i suoi post sì."
 
-#: lib/vutuv_web/components/post_components.ex:3331
-#: lib/vutuv_web/components/post_components.ex:4447
+#: lib/vutuv_web/components/post_components.ex:3374
+#: lib/vutuv_web/components/post_components.ex:4490
 #, elixir-autogen, elixir-format
 msgid "Hide reposts"
 msgstr "Nascondi le ripubblicazioni"
@@ -24185,8 +24187,8 @@ msgstr ""
 msgid "Posts loaded at once"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3633
-#: lib/vutuv_web/live/post_live/feed.ex:3637
+#: lib/vutuv_web/live/post_live/feed.ex:3644
+#: lib/vutuv_web/live/post_live/feed.ex:3648
 #, elixir-autogen, elixir-format
 msgid "Posts per page"
 msgstr "Post per pagina"
@@ -24201,60 +24203,60 @@ msgstr ""
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7276
-#: lib/vutuv_web/components/post_components.ex:7277
+#: lib/vutuv_web/components/post_components.ex:7321
+#: lib/vutuv_web/components/post_components.ex:7322
 #, elixir-autogen, elixir-format
 msgid "A word or phrase …"
 msgstr "Una parola o un'espressione …"
 
-#: lib/vutuv_web/components/post_components.ex:7304
+#: lib/vutuv_web/components/post_components.ex:7349
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr "Per chi %{thing} viene nascosto"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3694
-#: lib/vutuv_web/live/post_live/feed.ex:3853
-#: lib/vutuv_web/live/post_live/feed.ex:3862
+#: lib/vutuv_web/live/post_live/feed.ex:3705
+#: lib/vutuv_web/live/post_live/feed.ex:3864
+#: lib/vutuv_web/live/post_live/feed.ex:3873
 #, elixir-autogen, elixir-format
 msgid "Hidden"
 msgstr "Nascosti"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3827
+#: lib/vutuv_web/live/post_live/feed.ex:3838
 #, elixir-autogen, elixir-format
 msgid "Hide something from your feed"
 msgstr "Nascondi qualcosa dal tuo feed"
 
-#: lib/vutuv_web/components/post_components.ex:7224
+#: lib/vutuv_web/components/post_components.ex:7267
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr "Non mostrare più"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3868
+#: lib/vutuv_web/live/post_live/feed.ex:3879
 #, elixir-autogen, elixir-format
 msgid "Whatever these match is folded to a single line in your feed."
 msgstr "Ciò che corrisponde viene ridotto a una riga nel tuo feed."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3888
+#: lib/vutuv_web/live/post_live/feed.ex:3899
 #, elixir-autogen, elixir-format
 msgid "Words & tags"
 msgstr "Parole e tag"
 
-#: lib/vutuv_web/components/post_components.ex:7308
+#: lib/vutuv_web/components/post_components.ex:7353
 #, elixir-autogen, elixir-format
 msgid "everyone"
 msgstr "per tutti"
 
-#: lib/vutuv_web/components/post_components.ex:7311
+#: lib/vutuv_web/components/post_components.ex:7356
 #, elixir-autogen, elixir-format
 msgid "only %{handle}"
 msgstr "solo %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:7280
+#: lib/vutuv_web/components/post_components.ex:7325
 #, elixir-autogen, elixir-format
 msgid "this word"
 msgstr "questa parola"
 
-#: lib/vutuv_web/components/post_components.ex:7321
+#: lib/vutuv_web/components/post_components.ex:7366
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr "solo %{server}"
@@ -24306,7 +24308,7 @@ msgstr "Questo sito è offline in questo momento."
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr "Il sito funziona, è questo indirizzo a non essere uno dei nostri. Probabilmente il link è vecchio oppure contiene un errore di battitura."
 
-#: lib/vutuv_web/components/post_components.ex:6628
+#: lib/vutuv_web/components/post_components.ex:6671
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr "Ingrandisci lo screenshot"
@@ -24396,8 +24398,8 @@ msgstr "Il Suo contenuto è stato nascosto automaticamente dopo una segnalazione
 msgid "Hidden. What other people pass on of them stays out of your feed; their own posts do not."
 msgstr "Nascosto. Ciò che altri ripubblicano di questo account non compare più nel Suo feed, i suoi post sì."
 
-#: lib/vutuv_web/components/post_components.ex:3317
-#: lib/vutuv_web/components/post_components.ex:4435
+#: lib/vutuv_web/components/post_components.ex:3360
+#: lib/vutuv_web/components/post_components.ex:4478
 #, elixir-autogen, elixir-format
 msgid "Hide when others repost them"
 msgstr "Nascondi quando altri lo ripubblicano"
@@ -24653,7 +24655,7 @@ msgstr "La tua immagine di copertina non è stata sostituita: una segnalazione �
 msgid "Your profile picture was not replaced: a report about it is still open. Open the case to remove the picture or to say that it is yours."
 msgstr "La tua immagine del profilo non è stata sostituita: una segnalazione è ancora aperta. Apri il caso per rimuovere l'immagine o per dire che è tua."
 
-#: lib/vutuv_web/components/post_components.ex:2478
+#: lib/vutuv_web/components/post_components.ex:2479
 #, elixir-autogen, elixir-format
 msgid "Fetching the answers from the servers that hold them…"
 msgstr "Le risposte vengono recuperate dai server che le ospitano…"
@@ -24668,13 +24670,13 @@ msgstr "Non è stato possibile recuperare tutte le risposte. Le altre sono sul s
 msgid "Nothing here we are allowed to show you."
 msgstr "Qui non c'è nulla che possiamo mostrarti."
 
-#: lib/vutuv_web/components/post_components.ex:2497
+#: lib/vutuv_web/components/post_components.ex:2498
 #, elixir-autogen, elixir-format
 msgid "Show more answers"
 msgstr "Mostra altre risposte"
 
-#: lib/vutuv_web/components/post_components.ex:2386
-#: lib/vutuv_web/components/post_components.ex:2388
+#: lib/vutuv_web/components/post_components.ex:2387
+#: lib/vutuv_web/components/post_components.ex:2389
 #, elixir-autogen, elixir-format
 msgid "Show the one answer"
 msgid_plural "Show the %{count} answers"
@@ -25159,13 +25161,13 @@ msgstr "il modulo di segnalazione"
 msgid "“%{note}”"
 msgstr "“%{note}”"
 
-#: lib/vutuv_web/components/post_components.ex:5193
-#: lib/vutuv_web/components/press_kit_components.ex:152
+#: lib/vutuv_web/components/post_components.ex:5236
+#: lib/vutuv_web/components/press_kit_components.ex:207
 #, elixir-autogen, elixir-format
 msgid "Show these photos larger"
 msgstr "Ingrandisci le foto"
 
-#: lib/vutuv_web/components/post_components.ex:5379
+#: lib/vutuv_web/components/post_components.ex:5422
 #, elixir-autogen, elixir-format
 msgid "Show this photo larger"
 msgstr "Ingrandisci la foto"
@@ -25184,48 +25186,48 @@ msgid_plural "%{formatted} more entries (%{years})"
 msgstr[0] "Un'altra voce (%{years})"
 msgstr[1] "Altre %{formatted} voci (%{years})"
 
-#: lib/vutuv_web/live/press_kit_live.ex:778
+#: lib/vutuv_web/live/press_kit_live.ex:941
 #, elixir-autogen, elixir-format
 msgid "%{percent}%"
 msgstr "%{percent}%"
 
-#: lib/vutuv_web/live/press_kit_live.ex:391
+#: lib/vutuv_web/live/press_kit_live.ex:536
 #, elixir-autogen, elixir-format
 msgid "%{used} of %{max}"
 msgstr "%{used} di %{max}"
 
-#: lib/vutuv_web/live/press_kit_live.ex:650
+#: lib/vutuv_web/live/press_kit_live.ex:790
 #, elixir-autogen, elixir-format
 msgid "A photographer's @handle links to their profile and notifies nobody."
 msgstr "L'@handle di un fotografo rimanda al suo profilo e non avvisa nessuno."
 
-#: lib/vutuv_web/live/press_kit_live.ex:734
+#: lib/vutuv_web/live/press_kit_live.ex:875
 #, elixir-autogen, elixir-format
 msgid "Add a logo variant"
 msgstr "Aggiungere una variante del logo"
 
-#: lib/vutuv_web/live/press_kit_live.ex:735
+#: lib/vutuv_web/live/press_kit_live.ex:876
 #, elixir-autogen, elixir-format
 msgid "Add a press photo"
 msgstr "Aggiungere una foto per la stampa"
 
-#: lib/vutuv_web/live/press_kit_live.ex:612
+#: lib/vutuv_web/live/press_kit_live.ex:752
 #, elixir-autogen, elixir-format
 msgid "At the desk in the Bonn office"
 msgstr "Alla scrivania nell'ufficio di Bonn"
 
-#: lib/vutuv_web/live/press_kit_live.ex:644
+#: lib/vutuv_web/live/press_kit_live.ex:784
 #, elixir-autogen, elixir-format
 msgid "Caption"
 msgstr "Didascalia"
 
-#: lib/vutuv_web/live/press_kit_live.ex:622
-#: lib/vutuv_web/live/press_kit_live.ex:686
+#: lib/vutuv_web/live/press_kit_live.ex:762
+#: lib/vutuv_web/live/press_kit_live.ex:827
 #, elixir-autogen, elixir-format
 msgid "Credit"
 msgstr "Crediti"
 
-#: lib/vutuv_web/live/press_kit_live.ex:416
+#: lib/vutuv_web/live/press_kit_live.ex:553
 #, elixir-autogen, elixir-format
 msgid "Dark"
 msgstr "Scuro"
@@ -25235,156 +25237,155 @@ msgstr "Scuro"
 msgid "Files a journalist may download and print"
 msgstr "File che una redazione può scaricare e stampare"
 
-#: lib/vutuv_web/live/press_kit_live.ex:533
+#: lib/vutuv_web/live/press_kit_live.ex:673
 #, elixir-autogen, elixir-format
 msgid "First: the main photo"
 msgstr "Al primo posto: la foto principale"
 
-#: lib/vutuv_web/live/press_kit_live.ex:532
+#: lib/vutuv_web/live/press_kit_live.ex:672
 #, elixir-autogen, elixir-format
 msgid "First: the main variant"
 msgstr "Al primo posto: la variante principale"
 
-#: lib/vutuv_web/live/press_kit_live.ex:709
+#: lib/vutuv_web/live/press_kit_live.ex:850
 #, elixir-autogen, elixir-format
 msgid "I hold the rights to this file and release it for editorial use, as long as the credit above is shown."
 msgstr "Detengo i diritti su questo file e lo rilascio per uso editoriale, purché vengano indicati i crediti qui sopra."
 
-#: lib/vutuv_web/live/press_kit_live.ex:416
+#: lib/vutuv_web/live/press_kit_live.ex:553
 #, elixir-autogen, elixir-format
 msgid "Light"
 msgstr "Chiaro"
 
-#: lib/vutuv_web/live/press_kit_live.ex:813
+#: lib/vutuv_web/live/press_kit_live.ex:1006
 #, elixir-autogen, elixir-format
 msgid "Logo variant"
 msgstr "Variante del logo"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:116
-#: lib/vutuv_web/agent_docs/text.ex:412
-#: lib/vutuv_web/live/press_kit_live.ex:382
-#: lib/vutuv_web/templates/press_kit/index.html.heex:47
+#: lib/vutuv_web/agent_docs/text.ex:413
+#: lib/vutuv_web/live/press_kit_live.ex:527
+#: lib/vutuv_web/templates/press_kit/index.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "Logo variants"
 msgstr "Varianti del logo"
 
-#: lib/vutuv_web/live/press_kit_live.ex:430
+#: lib/vutuv_web/live/press_kit_live.ex:567
 #, elixir-autogen, elixir-format
 msgid "No logo here yet."
 msgstr "Qui non c'è ancora nessun logo."
 
-#: lib/vutuv_web/live/press_kit_live.ex:271
+#: lib/vutuv_web/live/press_kit_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} logo variants."
 msgstr "Non più di %{max} varianti del logo."
 
-#: lib/vutuv_web/live/press_kit_live.ex:274
+#: lib/vutuv_web/live/press_kit_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} press photos."
 msgstr "Non più di %{max} foto per la stampa."
 
-#: lib/vutuv_web/live/press_kit_live.ex:431
+#: lib/vutuv_web/live/press_kit_live.ex:568
 #, elixir-autogen, elixir-format
 msgid "No press photo here yet."
 msgstr "Qui non c'è ancora nessuna foto per la stampa."
 
-#: lib/vutuv_web/live/press_kit_live.ex:631
-#: lib/vutuv_web/live/press_kit_live.ex:696
+#: lib/vutuv_web/live/press_kit_live.ex:771
+#: lib/vutuv_web/live/press_kit_live.ex:837
 #, elixir-autogen, elixir-format
 msgid "Photo: Ada King"
 msgstr "Foto: Ada King"
 
-#: lib/vutuv_web/live/press_kit_live.ex:174
+#: lib/vutuv_web/live/press_kit_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "Picture removed."
 msgstr "Immagine rimossa."
 
-#: lib/vutuv_web/live/press_kit_live.ex:290
+#: lib/vutuv_web/live/press_kit_live.ex:391
 #, elixir-autogen, elixir-format
 msgid "Please confirm the rights first, then choose the file."
 msgstr "Confermi prima i diritti e scelga poi il file."
 
-#: lib/vutuv_web/live/press_kit_live.ex:813
+#: lib/vutuv_web/live/press_kit_live.ex:1006
 #, elixir-autogen, elixir-format
 msgid "Press photo"
 msgstr "Foto per la stampa"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:115
-#: lib/vutuv_web/agent_docs/text.ex:411
-#: lib/vutuv_web/live/press_kit_live.ex:382
-#: lib/vutuv_web/templates/press_kit/index.html.heex:38
+#: lib/vutuv_web/agent_docs/text.ex:412
+#: lib/vutuv_web/live/press_kit_live.ex:527
+#: lib/vutuv_web/templates/press_kit/index.html.heex:37
 #, elixir-autogen, elixir-format
 msgid "Press photos"
 msgstr "Foto per la stampa"
 
 #: lib/vutuv_web/components/ui.ex:5277
-#: lib/vutuv_web/live/press_kit_live.ex:77
-#: lib/vutuv_web/live/press_kit_live.ex:321
+#: lib/vutuv_web/live/press_kit_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Press photos & logos"
 msgstr "Foto per la stampa e loghi"
 
-#: lib/vutuv_web/live/press_kit_live.ex:580
+#: lib/vutuv_web/live/press_kit_live.ex:988
 #, elixir-autogen, elixir-format
 msgid "Remove this picture from your press kit?"
 msgstr "Rimuovere questa immagine dal Suo kit stampa?"
 
-#: lib/vutuv_web/live/press_kit_live.ex:414
+#: lib/vutuv_web/live/press_kit_live.ex:551
 #, elixir-autogen, elixir-format
 msgid "Show tiles on:"
 msgstr "Mostrare i riquadri su:"
 
-#: lib/vutuv_web/live/press_kit_live.ex:634
+#: lib/vutuv_web/live/press_kit_live.ex:774
 #, elixir-autogen, elixir-format
 msgid "Shown beside the picture and asked for with every download."
 msgstr "Compaiono accanto all'immagine e sono richiesti a ogni download."
 
-#: lib/vutuv_web/live/press_kit_live.ex:303
+#: lib/vutuv_web/live/press_kit_live.ex:404
 #, elixir-autogen, elixir-format
 msgid "That could not be saved."
 msgstr "Non è stato possibile salvare."
 
-#: lib/vutuv_web/live/press_kit_live.ex:405
+#: lib/vutuv_web/live/press_kit_live.ex:980
 #, elixir-autogen, elixir-format
 msgid "The first photo is the one shown first. Drag a tile, or use the arrows, to change the order."
 msgstr "La prima foto è quella mostrata per prima. Trascini un riquadro oppure usi le frecce per cambiare l'ordine."
 
-#: lib/vutuv_web/live/press_kit_live.ex:465
+#: lib/vutuv_web/live/press_kit_live.ex:604
 #, elixir-autogen, elixir-format
 msgid "This shelf is full. Remove one picture to add another."
 msgstr "Qui non c'è più spazio. Rimuova un'immagine per aggiungerne un'altra."
 
-#: lib/vutuv_web/live/press_kit_live.ex:325
+#: lib/vutuv_web/live/press_kit_live.ex:486
 #, elixir-autogen, elixir-format
 msgid "What a journalist writing about you may download: photos in print quality and your logo as a file. Everything here is public and free for editorial use as long as your credit is shown."
 msgstr "Ciò che una redazione che scrive di Lei può scaricare: foto in qualità di stampa e il Suo logo come file. Tutto qui è pubblico e libero per uso editoriale, purché vengano indicati i Suoi crediti."
 
-#: lib/vutuv_web/live/press_kit_live.ex:600
+#: lib/vutuv_web/live/press_kit_live.ex:740
 #, elixir-autogen, elixir-format
 msgid "What the picture shows"
 msgstr "Che cosa mostra l'immagine"
 
-#: lib/vutuv_web/live/press_kit_live.ex:599
+#: lib/vutuv_web/live/press_kit_live.ex:739
 #, elixir-autogen, elixir-format
 msgid "Which variant this is"
 msgstr "Di quale variante si tratta"
 
-#: lib/vutuv_web/live/press_kit_live.ex:611
+#: lib/vutuv_web/live/press_kit_live.ex:751
 #, elixir-autogen, elixir-format
 msgid "White on a dark background"
 msgstr "Bianco su sfondo scuro"
 
-#: lib/vutuv_web/live/press_kit_live.ex:645
+#: lib/vutuv_web/live/press_kit_live.ex:785
 #, elixir-autogen, elixir-format
 msgid "Who took it, where, and what may be cropped."
 msgstr "Chi l'ha scattata, dove e che cosa si può ritagliare."
 
-#: lib/vutuv_web/live/press_kit_live.ex:286
+#: lib/vutuv_web/live/press_kit_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "You cannot add a picture to this press kit."
 msgstr "Non può aggiungere un'immagine a questo kit stampa."
 
-#: lib/vutuv_web/live/press_kit_live.ex:401
+#: lib/vutuv_web/live/press_kit_live.ex:972
 #, elixir-autogen, elixir-format
 msgid "Your logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
 msgstr "Il Suo logo come file, un riquadro per variante. Una tipografia chiede un vettoriale (SVG); tutti gli altri possono aprire un PNG."
@@ -25406,65 +25407,69 @@ msgid_plural "%{count} bytes"
 msgstr[0] "%{count} byte"
 msgstr[1] "%{count} byte"
 
-#: lib/vutuv_web/templates/user/show.html.heex:989
+#: lib/vutuv_web/components/press_kit_components.ex:99
 #, elixir-autogen, elixir-format
 msgid "Add press photos"
 msgstr "Aggiungi foto stampa"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1007
+#: lib/vutuv_web/components/press_kit_components.ex:117
 #, elixir-autogen, elixir-format
 msgid "All press material"
 msgstr "Tutto il materiale stampa"
 
-#: lib/vutuv_web/components/press_kit_components.ex:118
+#: lib/vutuv_web/components/press_kit_components.ex:173
 #, elixir-autogen, elixir-format
 msgid "All press photos"
 msgstr "Tutte le foto stampa"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1543
-#: lib/vutuv_web/agent_docs/text.ex:986
+#: lib/vutuv_web/agent_docs/markdown.ex:1547
+#: lib/vutuv_web/agent_docs/text.ex:987
 #, elixir-autogen, elixir-format
 msgid "Credit: %{credit}"
 msgstr "Credito: %{credit}"
 
-#: lib/vutuv_web/components/press_kit_components.ex:265
-#: lib/vutuv_web/components/press_kit_components.ex:268
+#: lib/vutuv_web/components/press_kit_components.ex:320
+#: lib/vutuv_web/components/press_kit_components.ex:323
 #, elixir-autogen, elixir-format
 msgid "Download %{format}"
 msgstr "Scarica %{format}"
 
-#: lib/vutuv_web/components/press_kit_components.ex:221
+#: lib/vutuv_web/components/press_kit_components.ex:276
 #, elixir-autogen, elixir-format
 msgid "Download photo"
 msgstr "Scarica la foto"
 
-#: lib/vutuv/press_kit.ex:452
+#: lib/vutuv/press_kit.ex:496
 #, elixir-autogen, elixir-format
 msgid "Free for editorial use with credit."
 msgstr "Libera per uso editoriale, citando il credito."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1546
+#: lib/vutuv_web/agent_docs/markdown.ex:1550
 #, elixir-autogen, elixir-format
 msgid "PNG version"
 msgstr "Versione PNG"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
+#: lib/vutuv_web/agent_docs/markdown.ex:290
 #: lib/vutuv_web/agent_docs/text.ex:57
-#: lib/vutuv_web/controllers/press_kit_controller.ex:45
-#: lib/vutuv_web/templates/press_kit/index.html.heex:12
-#: lib/vutuv_web/templates/user/show.html.heex:987
+#: lib/vutuv_web/agent_docs/text.ex:257
+#: lib/vutuv_web/components/organization_components.ex:262
+#: lib/vutuv_web/components/press_kit_components.ex:97
+#: lib/vutuv_web/live/organization_live/show.ex:168
+#: lib/vutuv_web/views/press_kit_html.ex:28
+#: lib/vutuv_web/views/press_kit_html.ex:46
 #, elixir-autogen, elixir-format
 msgid "Press"
 msgstr "Stampa"
 
 #: lib/vutuv_web/agent_docs/press_kit_doc.ex:48
-#: lib/vutuv_web/templates/press_kit/index.html.heex:7
+#: lib/vutuv_web/views/press_kit_html.ex:32
 #, elixir-autogen, elixir-format
 msgid "Press photos and logos of %{name}"
 msgstr "Foto stampa e loghi di %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1542
-#: lib/vutuv_web/agent_docs/text.ex:983
+#: lib/vutuv_web/agent_docs/markdown.ex:1546
+#: lib/vutuv_web/agent_docs/text.ex:984
 #, elixir-autogen, elixir-format
 msgid "Press picture"
 msgstr "Immagine stampa"
@@ -25474,12 +25479,37 @@ msgstr "Immagine stampa"
 msgid "Press pictures %{name} offers for download, free for editorial use with credit."
 msgstr "Immagini stampa che %{name} offre in download, libere per uso editoriale citando il credito."
 
-#: lib/vutuv_web/templates/press_kit/index.html.heex:32
+#: lib/vutuv_web/templates/press_kit/index.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "These pictures are offered for editorial use. Use them freely in reporting, and print the credit shown with each one."
 msgstr "Queste immagini sono offerte per uso editoriale. Usatele liberamente nei vostri servizi e riportate il credito indicato accanto a ciascuna."
 
-#: lib/vutuv_web/components/post_components.ex:3015
+#: lib/vutuv_web/components/post_components.ex:3025
 #, elixir-autogen, elixir-format
 msgid "Video is being checked"
 msgstr "Il video è in fase di controllo"
+
+#: lib/vutuv_web/live/press_kit_live.ex:908
+#, elixir-autogen, elixir-format
+msgid "Copies the vector file this page's logo was uploaded as onto this shelf."
+msgstr "Copia qui il file vettoriale con cui è stato caricato il logo di questa pagina."
+
+#: lib/vutuv_web/live/press_kit_live.ex:986
+#, elixir-autogen, elixir-format
+msgid "Remove this picture from this page's press kit?"
+msgstr "Rimuovere questa immagine dal kit stampa di questa pagina?"
+
+#: lib/vutuv_web/live/press_kit_live.ex:966
+#, elixir-autogen, elixir-format
+msgid "The page's logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
+msgstr "Il logo di questa pagina come file, un riquadro per variante. Una tipografia chiede un vettoriale (SVG); tutti gli altri possono aprire un PNG."
+
+#: lib/vutuv_web/live/press_kit_live.ex:905
+#, elixir-autogen, elixir-format
+msgid "Use the page's own logo"
+msgstr "Usa il logo di questa pagina"
+
+#: lib/vutuv_web/live/press_kit_live.ex:468
+#, elixir-autogen, elixir-format
+msgid "What a journalist writing about this page may download: photos in print quality and its logo as a file. Everything here is public and free for editorial use as long as the credit is shown."
+msgstr "Ciò che una redazione che scrive di questa pagina può scaricare: foto in qualità di stampa e il suo logo come file. Tutto qui è pubblico e libero per uso editoriale, purché vengano indicati i crediti."

--- a/test/support/image_helpers.ex
+++ b/test/support/image_helpers.ex
@@ -15,6 +15,7 @@ defmodule Vutuv.ImageHelpers do
   alias Vutuv.Accounts.User
   alias Vutuv.Images
   alias Vutuv.Images.Image
+  alias Vutuv.Organizations.Organization
   alias Vutuv.Repo
 
   alias Vutuv.UUIDv7
@@ -103,22 +104,35 @@ defmodule Vutuv.ImageHelpers do
     do: Repo.get_by(Image, post_review_id: id, kind: "review_cover")
 
   @doc """
-  An inserted press-kit picture (#2083) for a member, with the columns a stored
-  one carries. `attrs` override any of them — `:logo`, `:position`,
-  `:moderation`, `:alt`, `:credit`, `:caption`, `:content_type`, `:size_bytes`.
+  An inserted press-kit picture (#2083) for a member **or a page** (#2087), with
+  the columns a stored one carries. `attrs` override any of them — `:logo`,
+  `:position`, `:moderation`, `:alt`, `:credit`, `:caption`, `:content_type`,
+  `:size_bytes`, and for a page `:uploader_user_id`.
+
+  The owner column follows the owner argument, because the two are a nullable
+  pair the database refuses to see both halves of
+  (`images_press_kit_has_one_owner`): a member's picture names `user_id`, a
+  page's names `organization_id` and leaves `user_id` empty.
 
   Inserted rather than uploaded on purpose: the surfaces that read a press kit
   (#2086's card, its section page and their agent documents) build proxy URLs
   and read columns, and none of them opens a file. `Vutuv.PressKitTest` is where
   the upload path itself is exercised, through `Vutuv.PressKit.create/4`.
   """
-  def put_press_picture(%User{} = user, attrs \\ []) do
+  def put_press_picture(owner, attrs \\ [])
+
+  def put_press_picture(%User{} = user, attrs),
+    do: insert_press_picture([user_id: user.id] ++ attrs)
+
+  def put_press_picture(%Organization{} = organization, attrs),
+    do: insert_press_picture([organization_id: organization.id] ++ attrs)
+
+  defp insert_press_picture(attrs) do
     Repo.insert!(
       struct!(
         %Image{
           kind: "press_kit",
           token: Vutuv.Uploads.gen_token(),
-          user_id: user.id,
           logo: false,
           moderation: "approved",
           position: 0,

--- a/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
+++ b/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
@@ -1508,6 +1508,19 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     assert_fact_everywhere(rendered, "/petra_people")
   end
 
+  test "an organization page's press kit appears in every format" do
+    organization = insert(:organization, name: "Press Verified AG", slug: "press-verified")
+
+    Vutuv.ImageHelpers.put_press_picture(organization,
+      alt: "Vor dem Werk",
+      credit: "Foto: Rea Fotografin"
+    )
+
+    rendered = formats_for("/organizations/press-verified")
+    assert_fact_everywhere(rendered, "Vor dem Werk")
+    assert_fact_everywhere(rendered, "Foto: Rea Fotografin")
+  end
+
   test "an organization's kind (Art) appears in every format" do
     insert(:organization,
       name: "City Hall",

--- a/test/vutuv_web/live/press_kit_live_test.exs
+++ b/test/vutuv_web/live/press_kit_live_test.exs
@@ -97,6 +97,55 @@ defmodule VutuvWeb.PressKitLiveTest do
 
   defp ids(images), do: Enum.map(images, & &1.id)
 
+  ## A page's editor (#2087)
+
+  defp open_page_editor(conn, organization), do: live(conn, PressKit.editor_path(organization))
+
+  # A second member of the page's team, signed in — the colleague whose view of
+  # a picture somebody else uploaded is what #2087's gate is about. Its own
+  # `build_conn/0`, because this module's setup already signed a member in on
+  # the test's conn and a sent conn cannot make a second request.
+  defp member_with_role(organization, role, granted_by) do
+    # The page's own verification mail is already in this process's mailbox and
+    # `sent_pin/0` reads the oldest `{:email, _}` it finds, so the login below
+    # would read a message with no PIN in it.
+    _ = flush_emails()
+    {member_conn, member} = create_and_login_user(fresh_conn())
+    {:ok, _} = Vutuv.Organizations.add_role(organization, member, role, granted_by)
+    {member_conn, member}
+  end
+
+  # What `VutuvWeb.ConnCase`'s own setup hands each test, built again for a
+  # second member.
+  defp fresh_conn, do: build_conn() |> Plug.Test.init_test_session(%{})
+
+  # The page's own logo, as a vector — the file the one-click adoption copies.
+  defp with_svg_logo(organization, owner, tmp) do
+    path = Path.join(tmp, "mark-#{System.unique_integer([:positive])}.svg")
+
+    File.write!(path, """
+    <svg xmlns="http://www.w3.org/2000/svg" width="240" height="80" viewBox="0 0 240 80">
+      <rect width="240" height="80" fill="#0a5" />
+      <circle cx="60" cy="40" r="24" fill="#fff" />
+    </svg>
+    """)
+
+    store_logo!(organization, owner, path, "mark.svg")
+  end
+
+  defp with_png_logo(organization, owner, tmp) do
+    path = Path.join(tmp, "mark-#{System.unique_integer([:positive])}.png")
+    {:ok, img} = Image.new(240, 80, color: [0, 170, 85])
+    {:ok, _} = Image.write(img, path)
+
+    store_logo!(organization, owner, path, "mark.png")
+  end
+
+  defp store_logo!(organization, owner, path, filename) do
+    {:ok, _organization} = Vutuv.Organizations.store_logo(organization, owner, path, filename)
+    Repo.reload!(organization)
+  end
+
   describe "the page" do
     test "lists the member's own press photos", %{conn: conn, user: user, tmp: tmp} do
       photo = add_photo!(user, tmp, %{"caption" => "Am Schreibtisch"})
@@ -287,6 +336,37 @@ defmodule VutuvWeb.PressKitLiveTest do
       {:ok, _live, html} = open(conn)
 
       assert html =~ ~s(value="Foto: Grace Hopper")
+    end
+
+    test "an empty shelf offers the member's own name instead of an empty field", %{
+      conn: conn,
+      user: user
+    } do
+      {:ok, live, _html} = open(conn)
+
+      name = Vutuv.Identity.display_name(user)
+
+      # Both shelves: a member with nothing on either meets their own name twice
+      # rather than two empty fields.
+      assert has_element?(live, "#press-new-credit-photo[value='#{name}']")
+      assert has_element?(live, "#press-new-credit-logo[value='#{name}']")
+    end
+
+    test "it stays a default: a cleared field stores an empty credit", %{
+      conn: conn,
+      user: user,
+      tmp: tmp
+    } do
+      {:ok, live, _html} = open(conn)
+
+      live
+      |> form("#press-add-photo", %{"shelf" => "photo", "rights" => "on", "credit" => ""})
+      |> render_change()
+
+      upload_photo(live, tmp)
+
+      assert [photo] = PressKit.photos(user)
+      assert photo.credit in [nil, ""]
     end
   end
 
@@ -499,6 +579,184 @@ defmodule VutuvWeb.PressKitLiveTest do
       notice = %{kind: "image_rejected", image_kind: "press_kit", category: "nudity"}
 
       assert VutuvWeb.NotificationLine.notification_target(notice, user) == "/settings/press"
+    end
+  end
+
+  describe "a page's press kit editor" do
+    setup %{conn: conn, user: user} do
+      put_config(:verify_organization_domains, true)
+      organization = active_organization_for(user)
+
+      {:ok, conn: conn, organization: organization, owner: user}
+    end
+
+    test "its owner opens it, and the page's manage menu points there", %{
+      conn: conn,
+      organization: organization
+    } do
+      {:ok, _live, html} = open_page_editor(conn, organization)
+
+      assert html =~ ~s(data-press-shelf="photo")
+      assert html =~ ~s(data-press-shelf="logo")
+
+      page = conn |> get(~p"/organizations/#{organization.slug}") |> html_response(200)
+      assert page =~ "organization-manage-press"
+      assert page =~ PressKit.editor_path(organization)
+    end
+
+    test "a publisher opens it and writes the page's kit, an outsider gets nothing", %{
+      organization: organization,
+      owner: owner,
+      tmp: tmp
+    } do
+      {publisher_conn, publisher} = member_with_role(organization, "publisher", owner)
+      _ = flush_emails()
+      {outsider_conn, _outsider} = create_and_login_user(fresh_conn())
+
+      {:ok, live, _html} = open_page_editor(publisher_conn, organization)
+
+      live
+      |> confirm_rights("photo", "Foto: Rea Fotografin")
+      |> upload_photo(tmp)
+
+      assert [photo] = PressKit.photos(organization)
+      # The row is the page's; the colleague who uploaded it is only recorded,
+      # which is what keeps it when their account goes (#2087).
+      assert photo.organization_id == organization.id
+      assert is_nil(photo.user_id)
+      assert photo.uploader_user_id == publisher.id
+
+      assert outsider_conn |> get(PressKit.editor_path(organization)) |> html_response(404)
+    end
+
+    test "a role that is neither owner nor publisher is refused", %{
+      organization: organization,
+      owner: owner
+    } do
+      {recruiter_conn, _recruiter} = member_with_role(organization, "recruiter", owner)
+
+      assert recruiter_conn |> get(PressKit.editor_path(organization)) |> html_response(404)
+    end
+
+    test "a picture waiting for the AI check is on every team member's editor", %{
+      conn: conn,
+      organization: organization,
+      owner: owner,
+      tmp: tmp
+    } do
+      # Uploaded by one colleague…
+      {publisher_conn, _publisher} = member_with_role(organization, "publisher", owner)
+      put_config(:moderate_images, true)
+      {:ok, live, _html} = open_page_editor(publisher_conn, organization)
+
+      live
+      |> confirm_rights("photo", "Foto: Rea Fotografin")
+      |> upload_photo(tmp)
+
+      assert [photo] = PressKit.photos(organization)
+      assert photo.moderation == "pending"
+
+      # …and looked at by another, who has to be able to see what is being
+      # checked. The editor lists the **page's** shelf, not the uploader's.
+      {:ok, _other_live, html} = open_page_editor(conn, organization)
+
+      assert html =~ "data-press-picture=\"#{photo.id}\""
+      assert html =~ "Being checked"
+    end
+
+    test "the page's own vector logo is one press away, and the file it copies stays", %{
+      conn: conn,
+      organization: organization,
+      owner: owner,
+      tmp: tmp
+    } do
+      organization = with_svg_logo(organization, owner, tmp)
+      source = Vutuv.OrganizationImageStore.original_path(organization.logo)
+
+      {:ok, live, _html} = open_page_editor(conn, organization)
+
+      # Armed by the shelf's own rights tick, like the picker beside it.
+      assert has_element?(live, "#press-adopt-logo[disabled]")
+
+      live
+      |> confirm_rights("logo", "Logo: Acme GmbH")
+      |> element("#press-adopt-logo")
+      |> render_click()
+
+      assert [logo] = PressKit.logos(organization)
+      assert logo.content_type == "image/svg+xml"
+      assert logo.organization_id == organization.id
+      assert logo.rights_confirmed_at
+
+      # Copied, never moved: the page's own logo must still be there.
+      assert File.exists?(source)
+    end
+
+    test "the credit field offers the page's name, not the uploading member's", %{
+      organization: organization,
+      owner: owner
+    } do
+      {publisher_conn, publisher} = member_with_role(organization, "publisher", owner)
+
+      {:ok, live, _html} = open_page_editor(publisher_conn, organization)
+
+      # The kit belongs to the page, so the credit it offers names the page —
+      # the colleague uploading for it is not who a journalist must print. The
+      # refute is on the field, not on the page: the member's own name is in the
+      # chrome of every page they are signed in to.
+      assert has_element?(live, "#press-new-credit-photo[value='#{organization.name}']")
+
+      refute has_element?(
+               live,
+               "#press-new-credit-photo[value='#{Vutuv.Identity.display_name(publisher)}']"
+             )
+    end
+
+    test "a raster logo is not offered, since its file is not the printable one", %{
+      conn: conn,
+      organization: organization,
+      owner: owner,
+      tmp: tmp
+    } do
+      organization = with_png_logo(organization, owner, tmp)
+
+      {:ok, live, _html} = open_page_editor(conn, organization)
+
+      refute has_element?(live, "#press-adopt-logo")
+    end
+
+    test "a page with no logo at all is offered nothing", %{
+      conn: conn,
+      organization: organization
+    } do
+      {:ok, live, _html} = open_page_editor(conn, organization)
+
+      refute has_element?(live, "#press-adopt-logo")
+    end
+
+    test "the page says the German words, in the page's own voice", %{
+      conn: conn,
+      organization: organization,
+      owner: owner,
+      tmp: tmp
+    } do
+      organization = with_svg_logo(organization, owner, tmp)
+      conn = conn |> recycle() |> put_req_header("accept-language", "de-DE,de")
+
+      {:ok, _live, html} = open_page_editor(conn, organization)
+
+      # The shelves and their gate, in German…
+      assert html =~ "Pressefotos"
+      assert html =~ "Logo-Varianten"
+      assert html =~ "Rechte"
+      # …and the two sentences that had to leave the member's msgid behind,
+      # because its German addresses the reader as the owner ("Ihr Logo",
+      # "über Sie schreibt") and a page's team is not the page. Both were
+      # fuzzy-filled with exactly that member-voiced German by
+      # `gettext.extract --merge`, which is why they are asserted by name.
+      assert html =~ "Was eine Redaktion, die über diese Seite schreibt"
+      assert html =~ "Das Logo dieser Seite als Datei"
+      assert html =~ "Logo dieser Seite verwenden"
     end
   end
 

--- a/test/vutuv_web/live/press_kit_live_test.exs
+++ b/test/vutuv_web/live/press_kit_live_test.exs
@@ -119,6 +119,19 @@ defmodule VutuvWeb.PressKitLiveTest do
   # second member.
   defp fresh_conn, do: build_conn() |> Plug.Test.init_test_session(%{})
 
+  # A press photo on a **page's** shelf, uploaded by one of its members — the
+  # owner and the uploader are two people here, which is the whole difference
+  # from `add_photo!/3`.
+  defp add_page_photo!(organization, uploader, tmp) do
+    {:ok, image} =
+      PressKit.create(organization, uploader, {photo_path(tmp), "portrait.jpg"}, %{
+        "rights_confirmed" => "true",
+        "credit" => "Foto: Ada King"
+      })
+
+    image
+  end
+
   # The page's own logo, as a vector — the file the one-click adoption copies.
   defp with_svg_logo(organization, owner, tmp) do
     path = Path.join(tmp, "mark-#{System.unique_integer([:positive])}.svg")
@@ -710,6 +723,56 @@ defmodule VutuvWeb.PressKitLiveTest do
                live,
                "#press-new-credit-photo[value='#{Vutuv.Identity.display_name(publisher)}']"
              )
+    end
+
+    # Both of these are the same hole seen twice: `ManageGate` asks the role at
+    # **mount**, and an editor is open for as long as the tab is. While the kit's
+    # owner was the viewer, resolving a picture out of `owned/2` was itself the
+    # viewer check; with a page it no longer is, so every event has to re-ask.
+    test "an edit by somebody whose role was withdrawn is refused, not a crash", %{
+      conn: conn,
+      organization: organization,
+      owner: owner,
+      tmp: tmp
+    } do
+      {publisher_conn, publisher} = member_with_role(organization, "publisher", owner)
+      photo = add_page_photo!(organization, owner, tmp)
+
+      {:ok, live, _html} = open_page_editor(publisher_conn, organization)
+
+      {:ok, _} = Vutuv.Organizations.set_roles(organization, publisher, [], owner)
+
+      # `PressKit.update/3` answers `{:error, :forbidden}`, which is not a
+      # changeset — the handler used to hand it to `first_error/1` and take the
+      # socket down with a FunctionClauseError. A refused write leaves the
+      # picture as it was, exactly as a refused move or reorder does.
+      render_click(live, "save", %{"picture_id" => photo.id, "picture" => %{"credit" => "theirs"}})
+
+      assert Repo.get!(ImageRow, photo.id).credit == "Foto: Ada King"
+      assert render(live) =~ "data-press-picture"
+    end
+
+    test "a withdrawn role cannot remove a picture", %{
+      conn: conn,
+      organization: organization,
+      owner: owner,
+      tmp: tmp
+    } do
+      {publisher_conn, publisher} = member_with_role(organization, "publisher", owner)
+      photo = add_page_photo!(organization, owner, tmp)
+
+      {:ok, live, _html} = open_page_editor(publisher_conn, organization)
+
+      {:ok, _} = Vutuv.Organizations.set_roles(organization, publisher, [], owner)
+
+      # The irreversible one: `Images.purge_by/2` drops the row **and** the
+      # private original, and nothing derives a print file back. `PressKit.delete/1`
+      # takes no viewer on purpose (#2084's AI rejection has none), so the
+      # question is asked here, per event.
+      render_click(live, "delete", %{"id" => photo.id})
+
+      assert Repo.get(ImageRow, photo.id)
+      assert [_] = PressKit.photos(organization)
     end
 
     test "a raster logo is not offered, since its file is not the printable one", %{

--- a/test/vutuv_web/live/press_kit_live_test.exs
+++ b/test/vutuv_web/live/press_kit_live_test.exs
@@ -730,7 +730,6 @@ defmodule VutuvWeb.PressKitLiveTest do
     # owner was the viewer, resolving a picture out of `owned/2` was itself the
     # viewer check; with a page it no longer is, so every event has to re-ask.
     test "an edit by somebody whose role was withdrawn is refused, not a crash", %{
-      conn: conn,
       organization: organization,
       owner: owner,
       tmp: tmp
@@ -753,7 +752,6 @@ defmodule VutuvWeb.PressKitLiveTest do
     end
 
     test "a withdrawn role cannot remove a picture", %{
-      conn: conn,
       organization: organization,
       owner: owner,
       tmp: tmp

--- a/test/vutuv_web/organization_press_kit_test.exs
+++ b/test/vutuv_web/organization_press_kit_test.exs
@@ -1,0 +1,322 @@
+defmodule VutuvWeb.OrganizationPressKitTest do
+  @moduledoc """
+  A page's press section (issue #2087): the card on the organization page and
+  the section page at `/organizations/:slug/press` that hands the files over —
+  the twin of the member surfaces #2086 built, drawn by the same components off
+  the same two shelves.
+
+  What the tests below hold:
+
+    * the same card and the same section page, for a page rather than a member,
+      with every URL built from the page's slug — a page that claimed a root
+      handle is **not** addressed by it here, because the handle dispatches only
+      the bare `/:slug`;
+    * the rows are the **page's**: a picture stays when the colleague who
+      uploaded it closes their account, and every owner and publisher sees the
+      one the AI check is still holding — not only whoever uploaded it;
+    * the agent-format siblings, the sitemap entry and the schema.org markup a
+      member's press page carries, which is the whole reason that page is
+      crawlable at all;
+    * the German page says the German words, which is what a `.po` fuzzy-fill
+      would otherwise ship as confident nonsense.
+
+  Rows are inserted rather than uploaded: every surface here builds proxy URLs
+  and reads columns, and none of them opens a file. The upload path itself is
+  `VutuvWeb.PressKitLiveTest`'s.
+  """
+  use VutuvWeb.ConnCase, async: true
+
+  import Vutuv.ImageHelpers, only: [put_press_picture: 1, put_press_picture: 2]
+
+  alias Vutuv.Accounts
+  alias Vutuv.Organizations
+  alias Vutuv.Repo
+
+  setup do
+    organization = insert(:organization, name: "Acme GmbH")
+    {:ok, organization: organization}
+  end
+
+  defp de(conn), do: put_req_header(conn, "accept-language", "de-DE,de;q=0.9")
+
+  defp press_path(organization), do: "/organizations/#{organization.slug}/press"
+
+  # A team member holding `role` on the page, and a conn signed in as them.
+  defp team_member(conn, organization, role) do
+    {conn, member} = create_and_login_user(conn)
+    {:ok, _} = Organizations.add_role(organization, member, role, member)
+    {conn, member}
+  end
+
+  describe "the card on the organization page" do
+    test "shows the photos, the logos and the rights line", %{
+      conn: conn,
+      organization: organization
+    } do
+      put_press_picture(organization, alt: "Vor dem Werk", credit: "Foto: Rea Fotografin")
+      put_press_picture(organization, logo: true, alt: "Wortmarke, dunkel")
+
+      html = conn |> get(~p"/organizations/#{organization.slug}") |> html_response(200)
+
+      assert html =~ "organization-press"
+      assert html =~ "data-press-photos"
+      assert html =~ "data-press-logos"
+      assert html =~ "data-press-rights"
+      assert html =~ "Wortmarke, dunkel"
+      assert html =~ press_path(organization)
+    end
+
+    test "is not there for a page without one", %{conn: conn, organization: organization} do
+      html = conn |> get(~p"/organizations/#{organization.slug}") |> html_response(200)
+
+      refute html =~ "organization-press"
+    end
+
+    test "its team gets the add tile instead of an empty card", %{
+      conn: conn,
+      organization: organization
+    } do
+      {conn, _owner} = team_member(conn, organization, "owner")
+
+      html = conn |> get(~p"/organizations/#{organization.slug}") |> html_response(200)
+
+      assert html =~ "organization-press"
+      assert html =~ "data-empty-add"
+      assert html =~ "/organizations/#{organization.slug}/press/edit"
+    end
+  end
+
+  describe "the section page" do
+    test "names each picture's caption, credit, dimensions and file size", %{
+      conn: conn,
+      organization: organization
+    } do
+      picture =
+        put_press_picture(organization,
+          caption: "Vor dem Werk in Bremen",
+          credit: "Foto: Rea Fotografin",
+          size_bytes: 2_400_000
+        )
+
+      html = conn |> get(press_path(organization)) |> html_response(200)
+
+      assert html =~ "Press photos and logos of Acme GmbH"
+      assert html =~ "Vor dem Werk in Bremen"
+      assert html =~ "Foto: Rea Fotografin"
+      assert html =~ "3000 × 2000 · 2.4 MB"
+      assert html =~ "/system/press_kit/#{picture.token}/download.orig"
+    end
+
+    test "a vector logo offers its SVG and its PNG", %{conn: conn, organization: organization} do
+      logo =
+        put_press_picture(organization,
+          logo: true,
+          content_type: "image/svg+xml",
+          alt: "Wortmarke"
+        )
+
+      html = conn |> get(press_path(organization)) |> html_response(200)
+
+      assert html =~ "/system/press_kit/#{logo.token}/download.orig"
+      assert html =~ "/system/press_kit/#{logo.token}/download.png"
+    end
+
+    test "an empty press kit is an empty page rather than a 404", %{
+      conn: conn,
+      organization: organization
+    } do
+      assert conn |> get(press_path(organization)) |> html_response(200)
+    end
+
+    test "a page nobody may see has no press page either", %{conn: conn} do
+      hidden = insert(:organization, status: "pending")
+
+      assert conn |> get(press_path(hidden)) |> html_response(404)
+    end
+
+    test "its team reaches the editor from the page, a stranger sees no such link", %{
+      conn: conn,
+      organization: organization
+    } do
+      put_press_picture(organization)
+      {owner_conn, _owner} = team_member(conn, organization, "owner")
+
+      assert owner_conn |> get(press_path(organization)) |> html_response(200) =~
+               "/organizations/#{organization.slug}/press/edit"
+
+      refute conn |> get(press_path(organization)) |> html_response(200) =~ "press/edit"
+    end
+  end
+
+  describe "the rows belong to the page, not to whoever uploaded them" do
+    test "a picture stays when the colleague who uploaded it closes their account", %{
+      organization: organization
+    } do
+      colleague = insert(:activated_user)
+
+      picture =
+        put_press_picture(organization, uploader_user_id: colleague.id, alt: "Vor dem Werk")
+
+      assert {:ok, _} = Accounts.delete_user(colleague)
+
+      kept = Repo.get(Vutuv.Images.Image, picture.id)
+
+      assert kept
+      assert kept.organization_id == organization.id
+      assert is_nil(kept.uploader_user_id)
+    end
+
+    test "a picture the AI check holds is shown to every owner and publisher", %{
+      conn: conn,
+      organization: organization
+    } do
+      uploader = insert(:activated_user)
+      {:ok, _} = Organizations.add_role(organization, uploader, "publisher", uploader)
+
+      pending =
+        put_press_picture(organization,
+          moderation: "pending",
+          uploader_user_id: uploader.id
+        )
+
+      # Somebody else on the team — the colleague who has to be able to look at
+      # what is being checked, which is the whole point of #2087's gate.
+      {owner_conn, _owner} = team_member(conn, organization, "owner")
+      {publisher_conn, _publisher} = team_member(conn, organization, "publisher")
+
+      for team_conn <- [owner_conn, publisher_conn] do
+        html = team_conn |> get(press_path(organization)) |> html_response(200)
+
+        assert html =~ "/system/press_kit/#{pending.token}/download.orig"
+        refute html =~ "data-press-held"
+      end
+
+      stranger = conn |> get(press_path(organization)) |> html_response(200)
+
+      assert stranger =~ "data-press-held"
+      refute stranger =~ "/system/press_kit/#{pending.token}/download.orig"
+    end
+  end
+
+  describe "the agent formats" do
+    setup %{organization: organization} do
+      put_press_picture(organization,
+        alt: "Vor dem Werk",
+        credit: "Foto: Rea Fotografin",
+        caption: "Die Halle in Bremen"
+      )
+
+      :ok
+    end
+
+    test "every format carries the same facts", %{conn: conn, organization: organization} do
+      for extension <- ~w(.md .txt .json .xml) do
+        body = conn |> get(press_path(organization) <> extension) |> Map.fetch!(:resp_body)
+
+        assert body =~ "Acme GmbH", "#{extension} does not name the page"
+        assert body =~ "Foto: Rea Fotografin", "#{extension} does not carry the credit"
+        assert body =~ "download.orig", "#{extension} offers no download"
+      end
+    end
+
+    test "the JSON names the page as the owner and the page's own URL", %{
+      conn: conn,
+      organization: organization
+    } do
+      doc =
+        conn
+        |> get(press_path(organization) <> ".json")
+        |> Map.fetch!(:resp_body)
+        |> Jason.decode!()
+
+      assert doc["owner"]["name"] == "Acme GmbH"
+      assert doc["url"] =~ press_path(organization)
+      assert [%{"credit" => "Foto: Rea Fotografin"}] = doc["photos"]
+    end
+
+    test "a .md URL never serves HTML", %{conn: conn, organization: organization} do
+      body = conn |> get(press_path(organization) <> ".md") |> Map.fetch!(:resp_body)
+
+      refute body =~ "<html"
+    end
+
+    test "a page that serves no agent documents serves none of these either", %{conn: conn} do
+      quiet = insert(:organization, geo?: false)
+      put_press_picture(quiet)
+
+      assert conn |> get(press_path(quiet) <> ".json") |> Map.fetch!(:status) == 404
+    end
+  end
+
+  describe "it is crawlable, like a member's" do
+    test "no noindex header, and the pictures carry the licensable markup", %{
+      conn: conn,
+      organization: organization
+    } do
+      put_press_picture(organization, credit: "Foto: Rea Fotografin")
+
+      conn = get(conn, press_path(organization))
+      html = html_response(conn, 200)
+
+      assert get_resp_header(conn, "x-robots-tag") == []
+      assert html =~ ~s("@type": "CollectionPage")
+      assert html =~ ~s("@type": "ImageObject")
+      assert html =~ ~s("creditText": "Foto: Rea Fotografin")
+      assert html =~ "acquireLicensePage"
+    end
+
+    test "a page that opted out of search engines is noindexed", %{
+      conn: conn,
+      organization: organization
+    } do
+      Repo.update!(Ecto.Changeset.change(organization, seo?: false))
+      put_press_picture(organization)
+
+      conn = get(conn, press_path(organization))
+
+      assert get_resp_header(conn, "x-robots-tag") == ["noindex"]
+    end
+
+    test "a page with pictures is in the sitemap, one without is not", %{
+      conn: conn,
+      organization: organization
+    } do
+      quiet = insert(:organization)
+      put_press_picture(organization)
+
+      index = conn |> get(~p"/sitemap.xml") |> Map.fetch!(:resp_body)
+      assert index =~ "/sitemaps/organization_press-1.xml"
+
+      chunk = conn |> get("/sitemaps/organization_press-1.xml") |> Map.fetch!(:resp_body)
+      assert chunk =~ press_path(organization)
+      refute chunk =~ press_path(quiet)
+    end
+
+    test "it is listed in /llms.txt", %{conn: conn} do
+      assert conn |> get(~p"/llms.txt") |> Map.fetch!(:resp_body) =~
+               "/organizations/<slug>/press"
+    end
+  end
+
+  describe "in German" do
+    test "the card and the page say the German words", %{
+      conn: conn,
+      organization: organization
+    } do
+      put_press_picture(organization, caption: "Die Halle", credit: "Foto: Rea")
+      put_press_picture(organization, logo: true, alt: "Wortmarke", content_type: "image/svg+xml")
+
+      card = conn |> de() |> get(~p"/organizations/#{organization.slug}") |> html_response(200)
+      page = conn |> de() |> get(press_path(organization)) |> html_response(200)
+
+      assert card =~ "Presse"
+      assert card =~ "Zur freien redaktionellen Verwendung mit Bildnachweis."
+      assert page =~ "Pressefotos"
+      assert page =~ "Logo-Varianten"
+      assert page =~ "Foto herunterladen"
+      assert page =~ "SVG herunterladen"
+      # The heading names the page, not a bare category.
+      assert page =~ "Pressefotos und Logos von Acme GmbH"
+    end
+  end
+end

--- a/test/vutuv_web/press_card_class_availability_test.exs
+++ b/test/vutuv_web/press_card_class_availability_test.exs
@@ -8,20 +8,21 @@ defmodule VutuvWeb.PressCardClassAvailabilityTest do
   class only this card uses is a class that document cannot draw.
 
   `VutuvWeb.ClassAvailability` runs the check and explains the method; what is
-  here is the two places the press markup lives and how it spells its classes.
-  It covers the section page's markup as well — that page is a dead render and
-  could not be caught out this way, but one bound over the whole module means
-  nobody has to work out which half of it is safe.
+  here is where the press markup lives and how it spells its classes. Since
+  #2087 that is one file: the card was lifted out of the profile template into
+  `press_card/1` when an organization page needed the same one. It covers the
+  section page's markup as well — that page is a dead render and could not be
+  caught out this way, but one bound over the whole module means nobody has to
+  work out which half of it is safe.
   """
   use ExUnit.Case, async: true
 
   alias VutuvWeb.ClassAvailability
 
   @components "lib/vutuv_web/components/press_kit_components.ex"
-  @profile "lib/vutuv_web/templates/user/show.html.heex"
 
   test "every class the press surfaces draw with also ships elsewhere in the tree" do
-    own = [File.read!(@components), card_markup()]
+    own = [File.read!(@components)]
 
     # A vacuous run is this guard's own failure mode: an extractor that reads
     # none of the markup vouches for nothing while passing. The card and the two
@@ -37,17 +38,6 @@ defmodule VutuvWeb.PressCardClassAvailabilityTest do
              "release's stylesheet has no rule for them and a profile tab open across\n" <>
              "a deploy draws the Press card unstyled. Pick a class the tree already\n" <>
              "uses bare:\n" <> Enum.join(orphans, "\n")
-  end
-
-  # The `<.card :if={press_any?…}>` block of the profile template, from its
-  # opening tag to its close. It says so rather than raising a `MatchError` on
-  # nil: renaming that card is the likeliest way to break this guard, and "no
-  # match of right hand side value: nil" names neither.
-  defp card_markup do
-    case Regex.run(~r/(<\.card :if=\{press_any\?.*?<\/\.card>)/s, File.read!(@profile)) do
-      [_, markup] -> markup
-      nil -> flunk("no `<.card :if={press_any?…}>` block in #{@profile}")
-    end
   end
 
   # Both spellings this codebase uses: the literal attribute and the list form.


### PR DESCRIPTION
A page had one screen-sized logo and nothing a journalist could download, while
`Vutuv.PressKit` has taken either owner kind since #2083.

The card, the section page, the four agent-format siblings, the sitemap entry
and the editor are now the same code with an organization as the owner. The
editor is `/organizations/:slug/press/edit` — the member's own
`VutuvWeb.PressKitLive`, embedded rather than routed — on the manage tab bar for
an **owner or publisher**. A page whose logo is a vector takes it onto the logo
shelf with one press, and every team member sees a picture the AI check still
holds, not only whoever uploaded it.

Underneath: `PressKit.page_path/1` built a page's URL from its root handle,
which serves the bare `/:slug` only. It answered a 404.

On top of #2087, on your word: the credit field falls back to the account's
name — the page's, for a page's kit.

Closes #2087

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01WPMGFtmCZNip8EJiRrx6ch
