### PR TITLE
Hiding a word from a post's ⋯ menu folds that post too

### DIFF
--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -7143,14 +7143,16 @@ defmodule VutuvWeb.PostComponents do
 
       <%!-- Which word annoys somebody is not a thing a machine can offer a
       list of, so this row stays a field. It carries the same reach select, so
-      the two ways in write the same shape of rule. --%>
+      the two ways in write the same shape of rule.
+
+      Unlike the ticks above it sends no `post_id`: a word takes this post down
+      with every other one it matches, so there is nothing to hold open. --%>
       <form
         phx-submit="hide-word"
         data-hide-word
         data-post={@id}
         class="flex flex-wrap items-center gap-2 px-3 py-2"
       >
-        <input type="hidden" name="post_id" value={@id} />
         <input
           type="text"
           name="pattern"

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -1524,7 +1524,11 @@ defmodule VutuvWeb.PostLive.Feed do
           whole_word: false
         })
 
-        {:noreply, refresh_after_rule_change(socket, params["post_id"])}
+        # And it folds this post too, unlike the tag ticks above: sparing the
+        # card the menu hangs off keeps a reader from losing it mid-gesture,
+        # but a written word has nothing left to read there, so the reprieve
+        # only leaves the rule looking as if it did nothing.
+        {:noreply, refresh_after_rule_change(socket, nil)}
     end
   end
 

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -1514,7 +1514,14 @@ defmodule VutuvWeb.PostLive.Feed do
         ContentFilters.create_filter(user, %{
           kind: :keyword,
           pattern: trimmed,
-          account: if(scope == "", do: ContentFilter.every_account(), else: scope)
+          account: if(scope == "", do: ContentFilter.every_account(), else: scope),
+          # Substring, exactly as the panel's field writes it — the reasoning is
+          # over there, on `FilterBand.add_filter/3`, and the schema default is
+          # the older, stricter answer. Leaving it out here let one word behave
+          # differently depending on which of the two fields it was typed into,
+          # and this is the field standing beside the post, where "Zeugnis"
+          # visibly means "Arbeitszeugnis" too.
+          whole_word: false
         })
 
         {:noreply, refresh_after_rule_change(socket, params["post_id"])}

--- a/test/vutuv_web/live/feed_hide_menu_test.exs
+++ b/test/vutuv_web/live/feed_hide_menu_test.exs
@@ -142,6 +142,27 @@ defmodule VutuvWeb.PostLive.FeedHideMenuTest do
     assert [%{kind: :keyword, pattern: "Fahrplan"}] = ContentFilters.list_for_user(user)
   end
 
+  # The panel's field writes substring rules deliberately — German glues words
+  # together, so a member muting "Zeugnis" means "Arbeitszeugnis" too — and this
+  # field is the same question about the same column. It used to leave
+  # `whole_word` to the schema default, so the two ways in wrote different rules
+  # and the one standing beside the post was the stricter of them, silently.
+  test "a word typed here reaches inside a longer word, as the panel's does", %{conn: conn} do
+    %{conn: conn, user: user, friend: friend, post: post} = with_tagged_post(conn)
+    {:ok, _} = Posts.create_post(friend, %{body: "Die Zeugnisanalyse läuft gut."})
+
+    {:ok, live, _html} = live(conn, ~p"/feed")
+
+    live
+    |> element(~s(form[data-hide-word][data-post="#{post.id}"]))
+    |> render_submit(%{"pattern" => "Zeugnis", "scope" => ""})
+
+    assert [%{kind: :keyword, pattern: "Zeugnis", whole_word: false}] =
+             ContentFilters.list_for_user(user)
+
+    refute render(live) =~ "Die Zeugnisanalyse läuft gut."
+  end
+
   test "the row reads back what it just wrote", %{conn: conn} do
     %{conn: conn, friend: friend, post: post} = with_tagged_post(conn)
 

--- a/test/vutuv_web/live/feed_hide_menu_test.exs
+++ b/test/vutuv_web/live/feed_hide_menu_test.exs
@@ -163,6 +163,25 @@ defmodule VutuvWeb.PostLive.FeedHideMenuTest do
     refute render(live) =~ "Die Zeugnisanalyse läuft gut."
   end
 
+  # The post whose menu the word was typed in folds like every other one. It
+  # used to be spared, so that the card the open menu hangs off would not
+  # vanish mid-gesture — but a rule that leaves the very post it was written
+  # about standing reads as a rule that did nothing (Stefan, 2026-09-10). The
+  # tag checkboxes below keep the reprieve, for a reason the word field does
+  # not share: a tick is a state the reader goes on reading and untick.
+  test "the post the word was typed on folds with the rest", %{conn: conn} do
+    %{conn: conn, post: post} = with_tagged_post(conn)
+
+    {:ok, live, _html} = live(conn, ~p"/feed")
+
+    live
+    |> element(~s(form[data-hide-word][data-post="#{post.id}"]))
+    |> render_submit(%{"pattern" => "Fahrplan", "scope" => ""})
+
+    assert has_element?(live, ~s([data-filtered-post="Fahrplan"]))
+    refute render(live) =~ "Bahnhof und Fahrplan"
+  end
+
   test "the row reads back what it just wrote", %{conn: conn} do
     %{conn: conn, friend: friend, post: post} = with_tagged_post(conn)
 


### PR DESCRIPTION
Typing a word into the "Stop showing" field in a post's ⋯ menu on /feed did two things it should not.

It wrote a whole-word rule, while the same field in the filter panel writes a substring one, so "Zeugnis" typed here missed "Arbeitszeugnis", which is exactly what the panel promises it catches. German glues words together, so substring is the answer both fields should give.

And it spared the post the menu hangs off, which reads as a rule that did nothing: that post is the reason the word was typed. It now folds like every other match. The tag checkboxes in the same menu keep the reprieve, because a tick is a state the reader goes on reading and can untick.

Where: the `hide-word` handler in `VutuvWeb.PostLive.Feed`, and `PostComponents.hide_list/1`.

Both tests were calibrated red first.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_012pS5Ff74nmVYVrnHUgdaTZ