### PR TITLE
Report a press photo or logo, with or without an account

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -2976,8 +2976,13 @@ html.lightbox-open { overflow: hidden; }
   font-size: 0.8125rem;
   color: #94a3b8;
 }
-.lightbox__license { color: #94a3b8; text-decoration: underline; }
-.lightbox__license:hover { color: #e2e8f0; }
+/* The licence, and beside it the quiet way out for a rights holder who disputes
+   it (issue #2089): one weight for both, and never the download's — one act is
+   what the page is for and the other is a complaint about it. */
+.lightbox__license,
+.lightbox__report { color: #94a3b8; text-decoration: underline; }
+.lightbox__license:hover,
+.lightbox__report:hover { color: #e2e8f0; }
 .lightbox__license.is-plain { text-decoration: none; pointer-events: none; }
 .lightbox__download {
   font-weight: 600;

--- a/assets/js/lightbox.js
+++ b/assets/js/lightbox.js
@@ -31,6 +31,7 @@ function applyLabels(gallery) {
     prev: gallery.dataset.labelPrev || "",
     next: gallery.dataset.labelNext || "",
     download: gallery.dataset.labelDownload || "",
+    report: gallery.dataset.labelReport || "",
   }
 
   q("[data-lb-close]").setAttribute("aria-label", labels.close)
@@ -65,6 +66,7 @@ function build() {
           <span class="lightbox__position" data-lb-position></span>
           <a class="lightbox__license" data-lb-license target="_blank" rel="license noopener"></a>
           <a class="lightbox__download" data-lb-download download></a>
+          <a class="lightbox__report" data-lb-report></a>
         </p>
       </figcaption>
     </figure>
@@ -159,6 +161,14 @@ function show(index) {
   const href = photo.dataset.photoDownload
   text(download, href ? labels.download : "")
   if (href) download.href = href
+
+  // Reporting the picture itself (issue #2089), on the press surfaces only: a
+  // post photo is reported through its post, so its tiles carry no such
+  // address and the line stays hidden the way every empty one here does.
+  const report = q("[data-lb-report]")
+  const reportHref = photo.dataset.photoReport
+  text(report, reportHref ? labels.report : "")
+  if (reportHref) report.href = reportHref
 
   // Only ever navigate within one gallery.
   const many = photos.length > 1

--- a/lib/vutuv/images.ex
+++ b/lib/vutuv/images.ex
@@ -47,6 +47,7 @@ defmodule Vutuv.Images do
 
   alias Vutuv.Accounts.User
   alias Vutuv.Images.Image
+  alias Vutuv.PressKit
   alias Vutuv.PressKitStore
   alias Vutuv.Repo
   alias Vutuv.Uploads
@@ -639,41 +640,6 @@ defmodule Vutuv.Images do
   end
 
   @doc """
-  Where this picture's bytes are **right now**, wherever that is: the takedown
-  hold while a copyright case holds it (`Vutuv.Uploads.hold_dir/1`), otherwise
-  the tree its member row points at. `nil` when neither has them.
-
-  The one answer the two case pages need — a frozen picture is out of every
-  tree nginx serves, so an admin ruling on a copyright claim can see it only
-  through this.
-  """
-  def bytes_path(%Image{} = image, version \\ nil) do
-    config = @profile_columns[image.kind]
-    version = version || config.preview
-
-    case Uploads.held_version_path(image.id, version, image.fingerprint) do
-      path when is_binary(path) ->
-        path
-
-      nil ->
-        with %User{} = owner <- owner(image),
-             do: stored_path(owner, image.kind, version)
-    end
-  end
-
-  @doc """
-  What a reader is shown for this picture — the same URL the profile renders,
-  so a picture already held by another case (or still in the AI gate) shows the
-  silhouette here too rather than a URL nothing answers. For the report form.
-  """
-  def preview_url(%Image{} = image) do
-    config = @profile_columns[image.kind]
-
-    with %User{} = owner <- owner(image),
-         do: config.module.display_url(owner, config.preview)
-  end
-
-  @doc """
   Records the picture a member just uploaded, replacing whatever row that
   member had for this kind.
 
@@ -1030,6 +996,82 @@ defmodule Vutuv.Images do
   before the row existed: reporting the posting or the page the picture sits on.
   """
   def takedown_ready?(%Image{kind: kind}), do: is_map_key(@takedown, kind)
+
+  @doc """
+  Where this picture's bytes are **right now**, wherever that is: the takedown
+  hold while a copyright case holds it (`Vutuv.Uploads.hold_dir/1`), otherwise
+  the tree its member row points at. `nil` when neither has them.
+
+  The one answer the two case pages need — a frozen picture is out of every
+  tree nginx serves, so an admin ruling on a copyright claim can see it only
+  through this.
+
+  **Per takedown strategy, not per column map.** Both this and `preview_url/1`
+  used to index `@profile_columns` by kind and dereference what came back, which
+  is a `BadMapError` the moment a kind outside that map is reportable — and
+  #2084 made `press_kit` exactly that, so the report form and the admin case
+  page's picture endpoint (the step an uphold needs) both 500ed on one. A kind
+  with no takedown at all answers `nil`: nothing can report it, so nobody can
+  ask, and a raise there would be a crash rather than an empty preview.
+  """
+  # The version a human is shown a press picture at, on the report form and on
+  # the two case pages. Both shelves derive a `large`, so one name answers for a
+  # photo and for a logo variant.
+  @press_kit_preview "large"
+
+  def bytes_path(image, version \\ nil)
+
+  def bytes_path(%Image{kind: kind} = image, version) when is_map_key(@takedown, kind),
+    do: bytes_path_by(@takedown[kind], image, version)
+
+  def bytes_path(%Image{}, _version), do: nil
+
+  defp bytes_path_by(:profile, %Image{} = image, version) do
+    version = version || @profile_columns[image.kind].preview
+
+    case Uploads.held_version_path(image.id, version, image.fingerprint) do
+      path when is_binary(path) ->
+        path
+
+      nil ->
+        with %User{} = owner <- owner(image),
+             do: stored_path(owner, image.kind, version)
+    end
+  end
+
+  # A press picture's files are named by version alone inside a directory of the
+  # row's own token (`press_kit/<token>/large.avif`), so neither of the two
+  # naming schemes `Uploads.held_version_path/3` globs for is on disk — the
+  # store owns that name and answers for both trees.
+  defp bytes_path_by(:press_kit, %Image{} = image, version) do
+    version = version || @press_kit_preview
+
+    PressKitStore.held_version_path(image, version) ||
+      PressKitStore.version_path(image.token, version)
+  end
+
+  @doc """
+  What a reader is shown for this picture — the same URL the profile renders,
+  so a picture already held by another case (or still in the AI gate) shows the
+  silhouette here too rather than a URL nothing answers. For the report form.
+  """
+  def preview_url(%Image{kind: kind} = image) when is_map_key(@takedown, kind),
+    do: preview_url_by(@takedown[kind], image)
+
+  def preview_url(%Image{}), do: nil
+
+  defp preview_url_by(:profile, %Image{} = image) do
+    config = @profile_columns[image.kind]
+
+    with %User{} = owner <- owner(image),
+         do: config.module.display_url(owner, config.preview)
+  end
+
+  # The context that owns the kind owns which version a human is shown and when
+  # there is one at all — `Vutuv.PressKit.preview_url/1` says why. Every other
+  # per-kind hook here points down at the module that owns the files in exactly
+  # this way.
+  defp preview_url_by(:press_kit, %Image{} = image), do: PressKit.preview_url(image)
 
   # A kind whose row exists but whose takedown does not. Loud rather than
   # half-done: the alternative is a stamped `frozen_at` no reader consults and

--- a/lib/vutuv/moderation.ex
+++ b/lib/vutuv/moderation.ex
@@ -79,10 +79,12 @@ defmodule Vutuv.Moderation do
     Strike
   }
 
+  alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
   alias Vutuv.Pages
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
+  alias Vutuv.PressKit
   alias Vutuv.Repo
   alias Vutuv.SearchText
   alias Vutuv.Token
@@ -162,6 +164,35 @@ defmodule Vutuv.Moderation do
   def can_report?(%User{} = reporter, content),
     do: can_report?(reporter, content, open_case_for(content))
 
+  @doc """
+  Whether there is anybody to hold accountable for `content` — the half of
+  `can_report?/2` that depends on the content alone, for a surface deciding
+  whether to **draw** a Report control at all (issue #2089).
+
+  A page's content answers to the member who claimed the page, and that column
+  is `nilify_all`: once that account is gone there is no strike ladder and
+  `report_content/3` refuses, so a link rendered anyway would send the reporter
+  to a 404. Cheap for a member's row (a column) and one indexed read for a
+  page's, which is why a caller drawing a whole shelf asks it **once** — every
+  picture on one has the same owner.
+  """
+  def reportable?(content), do: owner_id(content) != nil
+
+  @doc """
+  Which report categories `content` offers — the one place the two forms and the
+  changeset read it from, so a form cannot show a choice the changeset then
+  refuses.
+
+  It takes the **row** rather than the wire string because one type answers two
+  ways: a profile picture leaves `spam` out on purpose (an advert as an avatar
+  is a complaint about the account), while a press picture is published for
+  redistribution and can perfectly well *be* the advert (issue #2089).
+  """
+  # The whole list, because a press picture is published for redistribution and
+  # a section full of them is exactly where a picture is itself the advert.
+  def report_categories(%Image{kind: "press_kit"}), do: Report.categories()
+  def report_categories(content), do: Report.categories_for(content_type(content))
+
   # The arity-3 twin exists so `report_content/3`, which has already loaded the
   # open case to decide what to do with it, does not read the same row twice.
   defp can_report?(%User{} = reporter, content, open) do
@@ -187,7 +218,7 @@ defmodule Vutuv.Moderation do
 
   defp open_new_case(reporter, content, attrs) do
     report_changeset =
-      Report.changeset(%Report{reporter_id: reporter.id}, attrs, content_type(content))
+      Report.changeset(%Report{reporter_id: reporter.id}, attrs, report_categories(content))
 
     # Read off the changeset rather than out of `attrs`, so the answer does not
     # depend on whether the caller passed string or atom keys. A crafted
@@ -274,7 +305,7 @@ defmodule Vutuv.Moderation do
       Report.changeset(
         %Report{reporter_id: reporter.id, case_id: open.id},
         attrs,
-        content_type(content)
+        report_categories(content)
       )
 
     case Repo.insert(report_changeset) do
@@ -327,7 +358,7 @@ defmodule Vutuv.Moderation do
           # request locale is per-process web state.
           reporter_locale: locale
         }
-        |> Report.outside_changeset(attrs, content_type(content))
+        |> Report.outside_changeset(attrs, report_categories(content))
 
       case open_case_for(content) do
         nil -> open_notice_case(content, changeset, token)
@@ -2271,9 +2302,8 @@ defmodule Vutuv.Moderation do
   # since lost the role would otherwise still carry strikes for it. When that
   # member is gone (`nilify_all`) there is nobody to strike and the report is
   # refused, exactly as it already is for the organization page itself.
-  defp owner_id(%Post{user_id: nil, organization_id: id}) when is_binary(id) do
-    Repo.one(from(o in Organization, where: o.id == ^id, select: o.created_by_user_id))
-  end
+  defp owner_id(%Post{user_id: nil, organization_id: id}) when is_binary(id),
+    do: Organizations.accountable_user_id(id)
 
   defp owner_id(%Post{user_id: user_id}), do: user_id
   defp owner_id(%Message{sender_id: sender_id}), do: sender_id
@@ -2282,11 +2312,28 @@ defmodule Vutuv.Moderation do
   # creator has since deleted their account (nilify_all) has no owner to strike,
   # so report_content/3 refuses it (owner_id == nil), leaving the report path
   # only for admin freeze.
-  defp owner_id(%Organization{created_by_user_id: user_id}), do: user_id
+  defp owner_id(%Organization{} = organization),
+    do: Organizations.accountable_user_id(organization)
+
   defp owner_id(%JobPosting{user_id: user_id}), do: user_id
+  # A press picture published in a **page's** name (issue #2089). Its
+  # `images.user_id` is NULL — the pair `images_press_kit_has_one_owner` holds —
+  # so reading that column alone left the kind takedown-ready and
+  # un-reportable: `can_report?/2` refuses a nil owner, and #2084 measured
+  # exactly that. The answer is the organization-post clause above, the same
+  # member for the same reason: the page's accountability must not move from
+  # person to person with each upload, and `uploader_user_id` cannot be it —
+  # it is nulled when that account goes.
+  #
+  # Matched on the **column**, never on a preloaded `:organization`: half the
+  # callers hand a bare row over straight from a query.
+  defp owner_id(%Image{user_id: nil, organization_id: id}) when is_binary(id),
+    do: Organizations.accountable_user_id(id)
+
   # A picture with no member owner is one of the kinds #2015 brings into the
-  # table (a post photo, an organization logo). There is nobody to strike and
-  # no member row to clear, so `can_report?/2` refuses it rather than guessing.
+  # table (a post photo, an organization logo), or a review's cover. There is
+  # nobody to strike and no member row to clear, so `can_report?/2` refuses it
+  # rather than guessing.
   defp owner_id(%Image{user_id: user_id}), do: user_id
 
   defp snapshot(%Post{body: body}), do: body
@@ -2337,6 +2384,16 @@ defmodule Vutuv.Moderation do
   # case opened on such a row would raise the moment an admin upheld it. Those
   # keep the affordance they had before the row existed: reporting the post,
   # the posting or the page the picture sits on.
+  # A press picture (issue #2089) adds the visibility half back, which the two
+  # profile kinds never needed: an avatar is as public as the profile it sits
+  # on, while a press picture can be waiting for the AI gate, held by an earlier
+  # case, or on a page that is not on the public site — and none of those is
+  # something a reporter has seen. Reporting one is then either pointless (it is
+  # already off the site) or an oracle for a row id, so it answers 404 exactly
+  # as the public notice form does for the same picture.
+  defp reportable_by?(reporter, %Image{kind: "press_kit"} = image),
+    do: Images.takedown_ready?(image) and PressKit.visible_to?(image, reporter)
+
   defp reportable_by?(_reporter, %Image{} = image), do: Images.takedown_ready?(image)
 
   defp reportable_by?(reporter, %JobPosting{} = posting),

--- a/lib/vutuv/moderation/content_url.ex
+++ b/lib/vutuv/moderation/content_url.ex
@@ -35,10 +35,12 @@ defmodule Vutuv.Moderation.ContentUrl do
   alias Vutuv.Accounts.User
   alias Vutuv.Fediverse
   alias Vutuv.Images
+  alias Vutuv.Images.Image
   alias Vutuv.Jobs
   alias Vutuv.Moderation
   alias Vutuv.Organizations
   alias Vutuv.Posts
+  alias Vutuv.PressKit
   alias Vutuv.Repo
   alias Vutuv.UUIDv7
   alias Vutuv.Videos
@@ -125,6 +127,15 @@ defmodule Vutuv.Moderation.ContentUrl do
   defp from_segments(["post_videos", token, _file]),
     do: post_of(Videos.get_video_by_token(token))
 
+  # A press photo or a logo variant (issue #2089), by any of the four addresses
+  # it has: the served versions, the stand-in, the download and a logo's PNG all
+  # hang off one path shape, and what a journalist copies is whichever of them
+  # their browser gave them. Unlike a post's photo the **picture** is the
+  # reportable thing here — it is published on its own, for redistribution, and
+  # the freeze takes exactly it offline.
+  defp from_segments(["system", "press_kit", token | _rest]),
+    do: visible_press_picture(token)
+
   # A profile picture or cover, by two of the three addresses one has. The
   # served files sit in an id-scoped public tree (`/avatars/<user id>/…`),
   # which is what a "copy image address" hands over; the third spelling,
@@ -133,7 +144,14 @@ defmodule Vutuv.Moderation.ContentUrl do
   defp from_segments(["avatars", user_id | _rest]), do: visible_image(user_id, "avatar")
   defp from_segments(["covers", user_id | _rest]), do: visible_image(user_id, "cover")
 
-  defp from_segments(["organizations", slug]),
+  # A page, by its own address or by any deeper path under it — its press
+  # section, its jobs, its followers all still name the page, which is the
+  # reportable thing there. The twin of the `[handle | _rest]` clause below, and
+  # what makes a pasted `/organizations/acme/press` a notice about the page
+  # rather than the "correct address, nobody's content" a site page gets
+  # (issue #2089). The post permalink above is the exception, and it is above
+  # for that reason.
+  defp from_segments(["organizations", slug | _rest]),
     do: ok_or_nil(Organizations.fetch_visible_organization(slug, nil))
 
   defp from_segments(["jobs", slug]), do: ok_or_nil(Jobs.fetch_visible_job_posting(slug, nil))
@@ -209,6 +227,18 @@ defmodule Vutuv.Moderation.ContentUrl do
   # reachable through the address the old file had. A picture another case
   # already holds is not offered either — it is off the site, and reporting it
   # again would say the notice did something it did not.
+  # Only a picture an anonymous visitor can already fetch, which is the whole
+  # module's rule and here also the freeze's: a picture a case already took down
+  # answers 404 at every one of its addresses, so resolving it would tell a
+  # stranger it exists. `visible_to?/2` with no viewer is that question,
+  # released picture and visible owner included.
+  defp visible_press_picture(token) do
+    case PressKit.get_by_token(token) do
+      %Image{} = image -> if PressKit.visible_to?(image, nil), do: image
+      nil -> nil
+    end
+  end
+
   defp visible_image(nil, _kind), do: nil
 
   defp visible_image(%User{} = owner, kind) do

--- a/lib/vutuv/moderation/report.ex
+++ b/lib/vutuv/moderation/report.ex
@@ -156,10 +156,11 @@ defmodule Vutuv.Moderation.Report do
   def categories_for(_type), do: @categories
 
   @doc """
-  Builds a report changeset. `content_type` (the wire string) restricts the
-  accepted categories to the ones that type actually offers, so a crafted POST
-  can't slip an off-type category (e.g. `misleading_job` on a profile report)
-  past the form — the same `categories_for/1` gate the form renders from.
+  Builds a report changeset. `offered` is the list of categories this content
+  really offers (`Vutuv.Moderation.report_categories/1`, the same list the form
+  renders from), so a crafted POST can't slip an off-type category past it — a
+  `misleading_job` on a profile report, or a `spam` on a profile picture, which
+  its shelf-mate the press picture does offer.
 
   Every message is a whole sentence addressed to the reporter, because the
   report form has no per-field error slots and shows them as one banner. They
@@ -174,14 +175,14 @@ defmodule Vutuv.Moderation.Report do
   gave a copyright notice its demand twice, in two different wordings, in a
   banner that joins every message into one line.
   """
-  def changeset(report, params \\ %{}, content_type \\ nil, opts \\ []) do
+  def changeset(report, params \\ %{}, offered \\ @categories, opts \\ []) do
     pick_one = "Please pick a category."
 
     report
     |> cast(params, [:category, :note, :good_faith?])
     |> update_change(:note, &String.trim/1)
     |> validate_required([:category], message: pick_one)
-    |> validate_inclusion(:category, categories_for(content_type), message: pick_one)
+    |> validate_inclusion(:category, offered, message: pick_one)
     |> validate_length(:note, max: @max_note_length, message: "Your note is too long.")
     |> validate_full_notice(Keyword.get(opts, :full_notice?, false))
     |> record_good_faith()
@@ -209,9 +210,9 @@ defmodule Vutuv.Moderation.Report do
   the name and the address are required, because the notice is worth nothing to
   an admin without a way back to the person who sent it.
   """
-  def outside_changeset(report, params, content_type) do
+  def outside_changeset(report, params, offered) do
     report
-    |> changeset(params, content_type, full_notice?: true)
+    |> changeset(params, offered, full_notice?: true)
     |> cast(params, [:reporter_name, :reporter_email])
     # Collapsed to ONE line where it is written, not where it is rendered. The
     # name is the only stranger-controlled string this app puts into running

--- a/lib/vutuv/organizations.ex
+++ b/lib/vutuv/organizations.ex
@@ -1590,6 +1590,25 @@ defmodule Vutuv.Organizations do
   end
 
   @doc """
+  The one member who answers for what this page publishes — whoever claimed it —
+  or `nil` once that account is gone (`created_by_user_id` is `nilify_all`).
+
+  The accountability question, not the permission one: `Vutuv.Moderation` carries
+  its strike ladder on a single `users` row, so a report against a page's post
+  (#1334) or its press picture (#2089) is owned by this member and by nobody
+  else — the page's content is the page's, and its accountability must not move
+  from person to person with each publisher. A page with no claimer left has
+  nobody to strike, so such a report is refused and only an admin freeze can act.
+
+  Takes either the page or its id, because half the callers hold a loaded row
+  and reading a column off it should not cost a query.
+  """
+  def accountable_user_id(%Organization{created_by_user_id: user_id}), do: user_id
+
+  def accountable_user_id(id) when is_binary(id),
+    do: Repo.one(from(o in Organization, where: o.id == ^id, select: o.created_by_user_id))
+
+  @doc """
   The members who may manage `organization`'s domains, oldest role first. The
   claim wizard makes the creator an owner, so this is never empty for a page
   that went through it.

--- a/lib/vutuv/press_kit.ex
+++ b/lib/vutuv/press_kit.ex
@@ -353,19 +353,26 @@ defmodule Vutuv.PressKit do
 
   defp privileged?(_owner, _viewer), do: false
 
-  # The owner of a press picture: whichever half of the pair the row names.
-  # Takes the preload when a caller remembered one and looks it up when nobody
-  # did — half the callers hand over a bare row straight from a query, and an
-  # answer that depends on whether somebody remembered a preload is not an
-  # answer.
-  defp owner(%Image{user: %User{} = user}), do: user
-  defp owner(%Image{organization: %Organization{} = organization}), do: organization
-  defp owner(%Image{user_id: id}) when is_binary(id), do: Repo.get(User, id)
+  @doc """
+  The owner of a press picture — the member or the page — or `nil`.
 
-  defp owner(%Image{organization_id: id}) when is_binary(id),
+  Takes the preload when a caller remembered one and looks it up when nobody
+  did: half the callers hand over a bare row straight from a query, and an
+  answer that depends on whether somebody remembered a preload is not an
+  answer. Matched on the **column** rather than on the association for the same
+  reason.
+
+  Public since #2089, where a surface has to ask the owner a second question
+  (may this reader be offered a Report control) about a shelf it already holds.
+  """
+  def owner(%Image{user: %User{} = user}), do: user
+  def owner(%Image{organization: %Organization{} = organization}), do: organization
+  def owner(%Image{user_id: id}) when is_binary(id), do: Repo.get(User, id)
+
+  def owner(%Image{organization_id: id}) when is_binary(id),
     do: Organizations.get_organization(id)
 
-  defp owner(%Image{}), do: nil
+  def owner(%Image{}), do: nil
 
   # The owner a whole shelf was read for, put on every row of it: the caller
   # already holds the record, so `owner/1` below never has to go and fetch it
@@ -421,6 +428,26 @@ defmodule Vutuv.PressKit do
       LowBandwidth.on?() -> url(image, "large")
       true -> url(image, "xl")
     end
+  end
+
+  @doc """
+  The version a **human outside this kit** is shown the picture at, or `nil`
+  when there is nothing anybody could be shown yet (issue #2089).
+
+  One name for the two places a press picture is looked at rather than used: the
+  report form, the two moderation case pages (through
+  `Vutuv.Images.preview_url/1`, which routes every kind's preview through the
+  context that owns it), and the address a Report link hands the public notice
+  form. Both shelves derive a `large`, so one version answers for a photo and
+  for a logo variant.
+
+  `visible_to?/2` with **no viewer** is the gate, because every byte here goes
+  through the authorizing proxy: a URL only a signed-in somebody could fetch
+  would be a broken image on a form, and an address the notice form cannot
+  resolve. A held or frozen picture therefore has no preview at all.
+  """
+  def preview_url(%Image{} = image) do
+    if visible_to?(image, nil), do: url(image, "large")
   end
 
   @doc "The URL the file itself is handed over at: the cleaned photo, or a logo's vector."

--- a/lib/vutuv/uploaders/press_kit_store.ex
+++ b/lib/vutuv/uploaders/press_kit_store.ex
@@ -165,6 +165,22 @@ defmodule Vutuv.PressKitStore do
   def version_path(_token, _version), do: nil
 
   @doc """
+  The same version while the picture is **held** by a copyright freeze, or `nil`
+  (issue #2089).
+
+  A frozen picture is out of every tree the proxy serves from, so this is the
+  only way an admin can look at what the claim is about — and the name is this
+  module's, not the hold's: `Vutuv.Uploads.held_version_path/3` globs for the
+  profile kinds' fingerprinted and legacy names, and a press picture's file is
+  called `large.avif` and matches neither.
+  """
+  def held_version_path(%ImageRow{id: id, token: token}, version)
+      when is_binary(id) and is_binary(token) and version in @all_versions,
+      do: Vutuv.Uploads.held_file_path(id, "#{version}#{Spec.served_ext()}")
+
+  def held_version_path(_image, _version), do: nil
+
+  @doc """
   Where this picture's stand-in lives (`Vutuv.Moderation.Pixelation`). The path
   is built whether or not the file is there — `Pixelation.stands_in?/2` is what
   asks that, because a missing stand-in is an ordinary state (a settled scan, a

--- a/lib/vutuv/uploads.ex
+++ b/lib/vutuv/uploads.ex
@@ -225,6 +225,17 @@ defmodule Vutuv.Uploads do
 
   def held_version_path(_image_id, _version, _fingerprint), do: nil
 
+  @doc """
+  The on-disk path of one held file by the **name it has**, or `nil`.
+
+  For a kind whose served files are named by version alone inside a directory of
+  their own (`press_kit/<token>/large.avif`, issue #2089): neither naming scheme
+  `held_version_path/3` globs for is on disk there, so the store that owns the
+  name asks for it. Every slot again, for the same reason.
+  """
+  def held_file_path(image_id, filename) when is_binary(image_id) and is_binary(filename),
+    do: first_match(hold_dir(image_id), filename)
+
   # Every slot, not just `served/`: a picture frozen while the AI gate still had
   # it keeps its versions under `quarantine/`. The private original stays out of
   # reach — it is never shown to anybody, and neither glob matches its

--- a/lib/vutuv_web/components/press_kit_components.ex
+++ b/lib/vutuv_web/components/press_kit_components.ex
@@ -65,7 +65,9 @@ defmodule VutuvWeb.PressKitComponents do
   import VutuvWeb.UI
 
   alias Vutuv.Images.Image
+  alias Vutuv.Moderation
   alias Vutuv.PressKit
+  alias VutuvWeb.AgentDocs
   alias VutuvWeb.Markdown
   alias VutuvWeb.PostComponents
 
@@ -190,6 +192,7 @@ defmodule VutuvWeb.PressKitComponents do
           data-photo-download={cell.photo[:download]}
           data-photo-license={cell.photo[:license]}
           data-photo-position={cell.photo[:position]}
+          data-photo-report={cell.report}
         >
           <.press_tile image={cell.image} held={cell.held} class="h-full w-full object-cover" />
           <span
@@ -267,11 +270,12 @@ defmodule VutuvWeb.PressKitComponents do
         data-photo-download={@view.photo[:download]}
         data-photo-license={@view.photo[:license]}
         data-photo-position={@view.photo[:position]}
+        data-photo-report={@view.report}
       >
         <.press_tile image={@view.image} held={@view.held} class="block h-auto w-full" />
       </a>
 
-      <.press_meta image={@view.image} />
+      <.press_meta image={@view.image} report={@view.report} />
       <.press_download :if={@view.photo} href={PressKit.download_url(@view.image)}>
         {gettext("Download photo")}
       </.press_download>
@@ -313,7 +317,7 @@ defmodule VutuvWeb.PressKitComponents do
         {variant_label(@view.image)}
       </p>
 
-      <.press_meta image={@view.image} />
+      <.press_meta image={@view.image} report={@view.report} />
 
       <div :if={@view.photo} class="flex flex-wrap gap-2">
         <.press_download href={PressKit.download_url(@view.image)}>
@@ -340,17 +344,64 @@ defmodule VutuvWeb.PressKitComponents do
   def views(images, viewer) do
     shown = Enum.map(images, &{&1, PressKit.visible_to?(&1, viewer)})
     visible = Enum.count(shown, &elem(&1, 1))
+    scope = report_scope(images, viewer)
 
     {views, _next} =
       Enum.map_reduce(shown, 0, fn
         {image, true}, next ->
-          {%{image: image, held: false, photo: photo_data(image, next, visible)}, next + 1}
+          {%{
+             image: image,
+             held: false,
+             photo: photo_data(image, next, visible),
+             report: report_href(image, scope)
+           }, next + 1}
 
         {image, false}, next ->
-          {%{image: image, held: PressKit.pixelated_url(image) || :none, photo: nil}, next}
+          {%{image: image, held: PressKit.pixelated_url(image) || :none, photo: nil, report: nil},
+           next}
       end)
 
     views
+  end
+
+  # Where a Report control on this picture goes, or `nil` when this reader is
+  # offered none (issue #2089).
+  #
+  # Two addresses, because a press kit is published *at* people who mostly have
+  # no account here: a signed-in member files in-app, and everybody else gets
+  # the public notice form with the picture's own address already filled in.
+  # The notice form takes a pasted address, so the link hands it one, absolute —
+  # that is what `Vutuv.Moderation.ContentUrl` parses back.
+  defp report_href(%Image{}, nil), do: nil
+
+  defp report_href(%Image{} = image, :public),
+    do: ~p"/system/report?#{[url: AgentDocs.abs_url(PressKit.preview_url(image))]}"
+
+  defp report_href(%Image{} = image, {:member, return_to}),
+    do: image_report_path(image.id, return_to)
+
+  # Asked **once per shelf**, not once per picture: every question here is about
+  # the owner, and every picture on a shelf has the same one. The first row is
+  # therefore as good as all of them.
+  #
+  # None of it is a query for an anonymous reader: the shelf arrived with its
+  # owner on every row (`public_shelves/2`), `manageable_by?/2` answers a
+  # viewerless call from a clause, and "is there anybody to hold accountable"
+  # is asked of the **owner** rather than of the picture, which is a column on
+  # a row already in memory. A signed-in reader on a page's kit pays one role
+  # read for it.
+  defp report_scope([], _viewer), do: nil
+
+  defp report_scope([%Image{} = image | _rest], viewer) do
+    owner = PressKit.owner(image)
+
+    cond do
+      is_nil(owner) -> nil
+      PressKit.manageable_by?(owner, viewer) -> nil
+      not Moderation.reportable?(owner) -> nil
+      is_nil(viewer) -> :public
+      true -> {:member, PressKit.page_path(owner)}
+    end
   end
 
   @doc """
@@ -400,9 +451,14 @@ defmodule VutuvWeb.PressKitComponents do
     }
   end
 
-  # The caption, the credit and the two file facts, in the one order both
-  # entries show them.
+  # The caption, the credit, the two file facts and — last, quiet, and a plain
+  # link rather than a control — the way to report the picture. It rides this
+  # line rather than standing beside the Download button on purpose: a press
+  # kit is published for people to take, and the one act nobody should have to
+  # hunt for still must not sit at the same weight as the act the page exists
+  # for.
   attr(:image, :any, required: true)
+  attr(:report, :any, default: nil)
 
   defp press_meta(assigns) do
     ~H"""
@@ -415,6 +471,15 @@ defmodule VutuvWeb.PressKitComponents do
       <span :if={present?(@image.credit)} data-press-credit>{@image.credit}</span>
       <span :if={present?(@image.credit)} aria-hidden="true">·</span>
       <span data-press-facts>{facts_line(@image)}</span>
+      <span :if={@report} aria-hidden="true">·</span>
+      <a
+        :if={@report}
+        href={@report}
+        class="underline underline-offset-2 hover:text-slate-700 dark:hover:text-slate-200"
+        data-press-report
+      >
+        {gettext("Report this picture")}
+      </a>
     </p>
     """
   end

--- a/lib/vutuv_web/components/ui.ex
+++ b/lib/vutuv_web/components/ui.ex
@@ -3247,6 +3247,7 @@ defmodule VutuvWeb.UI do
       data-label-prev={gettext("Previous photo")}
       data-label-next={gettext("Next photo")}
       data-label-download={gettext("Download the original")}
+      data-label-report={gettext("Report this picture")}
       {@rest}
     >
       {render_slot(@inner_block)}
@@ -3566,6 +3567,19 @@ defmodule VutuvWeb.UI do
       gettext("only %{account}", account: filter.account)
     end
   end
+
+  @doc """
+  The in-app report form's URL for one picture, coming back to `return_to`.
+
+  One owner for the address, because two surfaces name it: a profile picture
+  from the ⋯ menu (issue #2012, through `VutuvWeb.UserHTML.image_report_path/2`,
+  which knows the profile is where a reporter comes back to) and a press photo
+  or logo variant from its section page (issue #2089). A picture is reported by
+  the `images` row's id — never by its owner's — because it is reported in its
+  own right.
+  """
+  def image_report_path(image_id, return_to),
+    do: ~p"/reports/new?#{[type: "image", id: image_id, return_to: return_to]}"
 
   @doc """
   Compact display form for counted numbers, used site-wide wherever a count is

--- a/lib/vutuv_web/controllers/public_report_controller.ex
+++ b/lib/vutuv_web/controllers/public_report_controller.ex
@@ -51,8 +51,15 @@ defmodule VutuvWeb.PublicReportController do
   alias VutuvWeb.ErrorHelpers
   alias VutuvWeb.RateLimit
 
-  def new(conn, _params) do
-    render_form(conn, %Report{}, "", Report.categories(), [])
+  # `url` prefills the address field, so a Report link on a page can hand the
+  # form the picture it is about (issue #2089) instead of asking a journalist to
+  # copy it. It is nothing but a value in a text input — the resolve, the rate
+  # limit and every check happen on the POST, exactly as they do for a typed
+  # address — and it is capped so a crafted link cannot turn the field into a
+  # wall of text.
+  def new(conn, params) do
+    url = params |> Map.get("url", "") |> to_string() |> String.slice(0, 2_000)
+    render_form(conn, %Report{}, url, Report.categories(), [])
   end
 
   def create(conn, %{"report" => params}) when is_map(params) do
@@ -190,7 +197,7 @@ defmodule VutuvWeb.PublicReportController do
         |> render_form(
           struct_from(params),
           url,
-          Report.categories_for(type),
+          Moderation.report_categories(content),
           ErrorHelpers.changeset_messages(changeset)
         )
     end

--- a/lib/vutuv_web/controllers/report_controller.ex
+++ b/lib/vutuv_web/controllers/report_controller.ex
@@ -52,6 +52,10 @@ defmodule VutuvWeb.ReportController do
 
     defaults = [
       page_title: gettext("Report content"),
+      # Off the row, not off the wire string: a press picture offers `spam` and
+      # a profile picture does not, and this is the same list the changeset
+      # validates against (issue #2089).
+      categories: Moderation.report_categories(content),
       preview: preview(content),
       # A picture is the one reportable thing whose preview cannot be a
       # sentence: a rights holder has to see WHICH picture this is before they
@@ -171,7 +175,23 @@ defmodule VutuvWeb.ReportController do
   defp preview(%Vutuv.Jobs.JobPosting{} = posting), do: clip(posting.title)
 
   defp preview(%Image{kind: "cover"}), do: gettext("Cover photo")
+
+  # A press picture is one of many, so the shelf alone would not tell the
+  # reporter which one they are about to file a notice on. The variant label
+  # (`alt`) rides along where the owner wrote one; the picture itself is above
+  # this line anyway, which is what `preview_image/1` is for.
+  defp preview(%Image{kind: "press_kit"} = image) do
+    [press_kit_label(image), image.alt]
+    |> Enum.reject(&(&1 in [nil, ""]))
+    |> Enum.join(" - ")
+    |> clip()
+  end
+
   defp preview(%Image{}), do: gettext("Profile picture")
+
+  defp press_kit_label(%Image{} = image) do
+    if Image.logo?(image), do: gettext("Logo variant"), else: gettext("Press photo")
+  end
 
   # The picture itself, for the report form — through `Vutuv.Images`, which
   # owns kind → uploader, so a picture already held by another case (or still

--- a/lib/vutuv_web/templates/report/new.html.heex
+++ b/lib/vutuv_web/templates/report/new.html.heex
@@ -95,7 +95,7 @@
       <fieldset class="space-y-2">
         <legend class="sr-only">{gettext("Why are you reporting this?")}</legend>
         <label
-          :for={category <- Report.categories_for(@content_type)}
+          :for={category <- @categories}
           class="flex cursor-pointer items-start gap-3 rounded-lg border border-slate-200 p-3 transition hover:border-brand-400 has-checked:border-brand-500 has-checked:bg-brand-50 dark:border-slate-700 dark:hover:border-brand-500 dark:has-checked:bg-brand-800/30"
         >
           <input
@@ -123,7 +123,7 @@
             {gettext("Anything our admins should know? (optional)")}
           </span>
           <span
-            :if={copyright_offered?(@content_type)}
+            :if={copyright_offered?(@categories)}
             class="hidden group-has-[.report-copyright-choice:checked]:inline"
           >
             {gettext("Which work is it, and where can the original be seen? (required)")}
@@ -138,7 +138,7 @@
       </label>
 
       <.good_faith_declaration
-        :if={copyright_offered?(@content_type)}
+        :if={copyright_offered?(@categories)}
         id="report-good-faith"
         class="mt-4 hidden group-has-[.report-copyright-choice:checked]:flex"
         checked={@report.good_faith?}

--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -253,14 +253,14 @@ the resulting ~200px rail width. --%>
               <:item
                 :if={reportable_avatar}
                 id="report-avatar"
-                href={image_report_path(@user, reportable_avatar.id)}
+                href={image_report_path(reportable_avatar.id, "/#{@user.username}")}
               >
                 {gettext("Report the profile picture")}
               </:item>
               <:item
                 :if={reportable_cover}
                 id="report-cover"
-                href={image_report_path(@user, reportable_cover.id)}
+                href={image_report_path(reportable_cover.id, "/#{@user.username}")}
               >
                 {gettext("Report the cover photo")}
               </:item>

--- a/lib/vutuv_web/views/report_html.ex
+++ b/lib/vutuv_web/views/report_html.ex
@@ -179,7 +179,11 @@ defmodule VutuvWeb.ReportHTML do
         "A report from somebody with a good record hides the reported content automatically, the moment it arrives."
       )
 
-  @doc "Whether this content type's form carries the copyright notice at all."
-  def copyright_offered?(content_type),
-    do: Report.copyright_category() in Report.categories_for(content_type)
+  @doc """
+  Whether this form carries the copyright notice at all — asked of the category
+  list the form is rendering, not of the content type: a press picture and a
+  profile picture are one type with two lists (issue #2089).
+  """
+  def copyright_offered?(categories),
+    do: Report.copyright_category() in categories
 end

--- a/lib/vutuv_web/views/user_html.ex
+++ b/lib/vutuv_web/views/user_html.ex
@@ -301,16 +301,6 @@ defmodule VutuvWeb.UserHTML do
   def member_since(_user), do: nil
 
   @doc """
-  The report form's URL for one of this member's pictures (issue #2012). The id
-  is the `images` row's, not the member's: a picture is reported in its own
-  right, so a rights holder no longer has to report the whole profile to get a
-  stolen photo taken down.
-  """
-  def image_report_path(user, image_id) do
-    ~p"/reports/new?#{[type: "image", id: image_id, return_to: "/#{user.username}"]}"
-  end
-
-  @doc """
   The "Member since" line (calendar icon + label). Rendered in two spots on the
   profile: right-aligned on the counts row, or moved up under the work line
   when the account has no followers and no following. `class` positions it.

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -15,8 +15,8 @@ msgstr "Language: de\n"
 msgid "About us"
 msgstr "Impressum"
 
-#: lib/vutuv_web/components/ui.ex:4972
-#: lib/vutuv_web/components/ui.ex:4977
+#: lib/vutuv_web/components/ui.ex:4973
+#: lib/vutuv_web/components/ui.ex:4978
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:729
 #: lib/vutuv_web/live/organization_live/domains.ex:287
@@ -62,7 +62,7 @@ msgstr "Eine Adresse wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:77
 #: lib/vutuv_web/agent_docs/text.ex:72
-#: lib/vutuv_web/components/ui.ex:5320
+#: lib/vutuv_web/components/ui.ex:5321
 #: lib/vutuv_web/controllers/address_controller.ex:22
 #: lib/vutuv_web/controllers/address_controller.ex:37
 #: lib/vutuv_web/controllers/address_controller.ex:84
@@ -81,8 +81,8 @@ msgstr "Adressen"
 msgid "Already a member? Sign in here."
 msgstr "Schon ein Mitglied? Einloggen."
 
-#: lib/vutuv_web/components/ui.ex:4763
-#: lib/vutuv_web/components/ui.ex:4862
+#: lib/vutuv_web/components/ui.ex:4764
+#: lib/vutuv_web/components/ui.ex:4863
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:709
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:841
@@ -110,7 +110,7 @@ msgid "Birthday"
 msgstr "Geburtstag"
 
 #: lib/vutuv_web/components/saved_search_components.ex:104
-#: lib/vutuv_web/components/ui.ex:4757
+#: lib/vutuv_web/components/ui.ex:4758
 #: lib/vutuv_web/components/video_components.ex:281
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:210
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
@@ -165,7 +165,7 @@ msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
 #: lib/vutuv_web/components/post_components.ex:4435
-#: lib/vutuv_web/components/ui.ex:4864
+#: lib/vutuv_web/components/ui.ex:4865
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:657
@@ -213,7 +213,7 @@ msgid "Download"
 msgstr "Download"
 
 #: lib/vutuv_web/components/post_components.ex:4400
-#: lib/vutuv_web/components/ui.ex:4855
+#: lib/vutuv_web/components/ui.ex:4856
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
@@ -288,7 +288,7 @@ msgstr "E-Mail-Adresse eingeben"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:5284
+#: lib/vutuv_web/components/ui.ex:5285
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -617,7 +617,7 @@ msgstr "Provider"
 msgid "Public"
 msgstr "Öffentlich"
 
-#: lib/vutuv_web/components/ui.ex:4756
+#: lib/vutuv_web/components/ui.ex:4757
 #: lib/vutuv_web/live/organization_live/edit.ex:376
 #: lib/vutuv_web/live/post_live/composer.ex:2201
 #: lib/vutuv_web/live/press_kit_live.ex:795
@@ -795,7 +795,7 @@ msgstr "Profil aktualisiert."
 msgid "User verified successfully."
 msgstr "User wurde verifiziert."
 
-#: lib/vutuv_web/components/ui.ex:5269
+#: lib/vutuv_web/components/ui.ex:5270
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:832
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
@@ -856,14 +856,14 @@ msgstr "Benutzer"
 msgid "vCard"
 msgstr "vCard"
 
-#: lib/vutuv_web/components/ui.ex:4925
+#: lib/vutuv_web/components/ui.ex:4926
 #: lib/vutuv_web/templates/user/show.html.heex:1019
 #: lib/vutuv_web/templates/user/show.html.heex:1042
 #, elixir-autogen
 msgid "View All"
 msgstr "Alle anzeigen"
 
-#: lib/vutuv_web/components/ui.ex:5443
+#: lib/vutuv_web/components/ui.ex:5444
 #: lib/vutuv_web/controllers/settings_controller.ex:175
 #: lib/vutuv_web/live/job_posting_live/form.ex:818
 #: lib/vutuv_web/live/organization_live/edit.ex:339
@@ -1378,7 +1378,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:602
 #: lib/vutuv_web/agent_docs/text.ex:868
-#: lib/vutuv_web/components/ui.ex:5305
+#: lib/vutuv_web/components/ui.ex:5306
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1767,7 +1767,7 @@ msgid "Network"
 msgstr "Netzwerk"
 
 #: lib/vutuv_web/components/post_components.ex:487
-#: lib/vutuv_web/components/ui.ex:4974
+#: lib/vutuv_web/components/ui.ex:4975
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:804
@@ -1783,7 +1783,7 @@ msgid "Nothing new yet."
 msgstr "Noch nichts Neues."
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:5342
+#: lib/vutuv_web/components/ui.ex:5343
 #: lib/vutuv_web/controllers/page_controller.ex:214
 #: lib/vutuv_web/live/notification_live/index.ex:154
 #: lib/vutuv_web/live/notification_live/index.ex:440
@@ -1928,14 +1928,14 @@ msgstr "ist jetzt mit Ihnen vernetzt."
 msgid "started following you."
 msgstr "folgt Ihnen jetzt."
 
-#: lib/vutuv_web/components/ui.ex:4231
-#: lib/vutuv_web/components/ui.ex:4376
+#: lib/vutuv_web/components/ui.ex:4232
+#: lib/vutuv_web/components/ui.ex:4377
 #: lib/vutuv_web/live/import_connections_live.ex:638
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr "Seitennavigation"
 
-#: lib/vutuv_web/components/ui.ex:4999
+#: lib/vutuv_web/components/ui.ex:5000
 #: lib/vutuv_web/live/organization_live/activity.ex:159
 #: lib/vutuv_web/live/organization_live/feed.ex:258
 #: lib/vutuv_web/live/organization_live/show.ex:810
@@ -1950,7 +1950,7 @@ msgstr ""
 "Die Adresse selbst kann nicht geändert werden. Um eine andere zu verwenden, "
 "legen Sie sie als neue E-Mail-Adresse an und löschen Sie diese hier."
 
-#: lib/vutuv_web/components/ui.ex:4766
+#: lib/vutuv_web/components/ui.ex:4767
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr "Eintrag löschen"
@@ -1995,12 +1995,12 @@ msgstr "Titelbild hinzufügen"
 msgid "Add cover photo"
 msgstr "Titelbild hinzufügen"
 
-#: lib/vutuv_web/components/ui.ex:3662
+#: lib/vutuv_web/components/ui.ex:3663
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr "April"
 
-#: lib/vutuv_web/components/ui.ex:3666
+#: lib/vutuv_web/components/ui.ex:3667
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr "August"
@@ -2015,7 +2015,7 @@ msgstr "Titelbild ändern"
 msgid "Change cover photo"
 msgstr "Titelbild ändern"
 
-#: lib/vutuv_web/controllers/report_controller.ex:173
+#: lib/vutuv_web/controllers/report_controller.ex:177
 #: lib/vutuv_web/templates/user/edit.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "Cover photo"
@@ -2026,37 +2026,37 @@ msgstr "Titelbild"
 msgid "Cover photo of %{name}"
 msgstr "Titelbild von %{name}"
 
-#: lib/vutuv_web/components/ui.ex:3670
+#: lib/vutuv_web/components/ui.ex:3671
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr "Dezember"
 
-#: lib/vutuv_web/components/ui.ex:3660
+#: lib/vutuv_web/components/ui.ex:3661
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr "Februar"
 
-#: lib/vutuv_web/components/ui.ex:3659
+#: lib/vutuv_web/components/ui.ex:3660
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr "Januar"
 
-#: lib/vutuv_web/components/ui.ex:3665
+#: lib/vutuv_web/components/ui.ex:3666
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr "Juli"
 
-#: lib/vutuv_web/components/ui.ex:3664
+#: lib/vutuv_web/components/ui.ex:3665
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr "Juni"
 
-#: lib/vutuv_web/components/ui.ex:3661
+#: lib/vutuv_web/components/ui.ex:3662
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr "März"
 
-#: lib/vutuv_web/components/ui.ex:3663
+#: lib/vutuv_web/components/ui.ex:3664
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr "Mai"
@@ -2071,17 +2071,17 @@ msgstr "Mitglied seit %{month} %{year}"
 msgid "Member since %{year}"
 msgstr "Mitglied seit %{year}"
 
-#: lib/vutuv_web/components/ui.ex:3669
+#: lib/vutuv_web/components/ui.ex:3670
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr "November"
 
-#: lib/vutuv_web/components/ui.ex:3668
+#: lib/vutuv_web/components/ui.ex:3669
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr "Oktober"
 
-#: lib/vutuv_web/components/ui.ex:3667
+#: lib/vutuv_web/components/ui.ex:3668
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr "September"
@@ -2319,7 +2319,7 @@ msgstr "Zu viele Dateien."
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
-#: lib/vutuv_web/components/ui.ex:5687
+#: lib/vutuv_web/components/ui.ex:5688
 #: lib/vutuv_web/live/shell_live.ex:1582
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2363,7 +2363,7 @@ msgstr "Personen, die Ihnen nicht folgen"
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
 
-#: lib/vutuv_web/components/ui.ex:3758
+#: lib/vutuv_web/components/ui.ex:3759
 #: lib/vutuv_web/views/post_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "unknown"
@@ -2404,7 +2404,7 @@ msgstr "Alle Beiträge"
 
 #: lib/vutuv_web/components/post_components.ex:2181
 #: lib/vutuv_web/components/post_components.ex:6792
-#: lib/vutuv_web/components/ui.ex:4298
+#: lib/vutuv_web/components/ui.ex:4299
 #: lib/vutuv_web/views/user_html.ex:486
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2423,7 +2423,7 @@ msgstr "Lesezeichen"
 
 #: lib/vutuv_web/components/post_components.ex:2125
 #: lib/vutuv_web/components/post_components.ex:7033
-#: lib/vutuv_web/components/ui.ex:4284
+#: lib/vutuv_web/components/ui.ex:4285
 #: lib/vutuv_web/notification_line.ex:317
 #: lib/vutuv_web/views/user_html.ex:496
 #, elixir-autogen, elixir-format
@@ -2631,7 +2631,7 @@ msgstr "Mitglied nicht gefunden."
 msgid "No conversations yet."
 msgstr "Noch keine Unterhaltungen."
 
-#: lib/vutuv_web/components/ui.ex:3370
+#: lib/vutuv_web/components/ui.ex:3371
 #: lib/vutuv_web/live/message_live/index.ex:760
 #, elixir-autogen, elixir-format
 msgid "Online"
@@ -2781,8 +2781,8 @@ msgstr "Berufserfahrung hinzufügen"
 msgid "Write your first post"
 msgstr "Ersten Beitrag schreiben"
 
-#: lib/vutuv_web/components/ui.ex:4464
-#: lib/vutuv_web/components/ui.ex:4927
+#: lib/vutuv_web/components/ui.ex:4465
+#: lib/vutuv_web/components/ui.ex:4928
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:109
@@ -3173,7 +3173,7 @@ msgstr "Eröffnet"
 msgid "Owner"
 msgstr "Besitzer"
 
-#: lib/vutuv_web/components/ui.ex:5263
+#: lib/vutuv_web/components/ui.ex:5264
 #: lib/vutuv_web/live/shell_live.ex:1373
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3206,7 +3206,7 @@ msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 msgid "Report"
 msgstr "Melden"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:255
+#: lib/vutuv_web/controllers/public_report_controller.ex:262
 #: lib/vutuv_web/controllers/report_controller.ex:54
 #: lib/vutuv_web/templates/layout/app.html.heex:131
 #: lib/vutuv_web/templates/page/legal.html.heex:42
@@ -3288,7 +3288,7 @@ msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 "Meldungen sind anonym; wir verraten nie, wer gemeldet hat. Unsere Regeln:"
 
-#: lib/vutuv_web/components/ui.ex:4146
+#: lib/vutuv_web/components/ui.ex:4147
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:784
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -3368,7 +3368,7 @@ msgstr "Zielt auf eine Person, würdigt sie herab oder bedroht sie."
 msgid "Tell us more in the note below."
 msgstr "Beschreiben Sie es in der Notiz unten genauer."
 
-#: lib/vutuv_web/controllers/report_controller.ex:157
+#: lib/vutuv_web/controllers/report_controller.ex:161
 #, elixir-autogen, elixir-format
 msgid "Thank you for your report. We take it from here."
 msgstr "Danke für Ihre Meldung. Wir übernehmen ab hier."
@@ -3484,12 +3484,12 @@ msgstr ""
 "Ablehnungen in einem Jahr verlieren das sofortige Einfrieren; ihre Meldungen"
 " markieren nur noch zur Prüfung."
 
-#: lib/vutuv_web/controllers/report_controller.ex:89
+#: lib/vutuv_web/controllers/report_controller.ex:93
 #, elixir-autogen, elixir-format
 msgid "You already reported this. Our team is on it."
 msgstr "Sie haben das bereits gemeldet. Unser Team kümmert sich darum."
 
-#: lib/vutuv_web/controllers/report_controller.ex:95
+#: lib/vutuv_web/controllers/report_controller.ex:99
 #, elixir-autogen, elixir-format
 msgid "You cannot report your own content."
 msgstr "Eigene Inhalte können Sie nicht melden."
@@ -4406,12 +4406,12 @@ msgstr "Buchbar bis einschließlich %{last}."
 msgid "Bookings are open through %{last}. Next available day: %{day}"
 msgstr "Buchbar bis einschließlich %{last}. Nächster freier Tag: %{day}"
 
-#: lib/vutuv_web/components/ui.ex:3705
+#: lib/vutuv_web/components/ui.ex:3706
 #, elixir-autogen, elixir-format
 msgid "Fr"
 msgstr "Fr"
 
-#: lib/vutuv_web/components/ui.ex:3701
+#: lib/vutuv_web/components/ui.ex:3702
 #, elixir-autogen, elixir-format
 msgid "Mo"
 msgstr "Mo"
@@ -4423,27 +4423,27 @@ msgstr ""
 "Eine Anzeige pro Kalendertag: Wählen Sie einen freien Tag im Kalender; "
 "durchgestrichene Tage sind bereits vergeben."
 
-#: lib/vutuv_web/components/ui.ex:3706
+#: lib/vutuv_web/components/ui.ex:3707
 #, elixir-autogen, elixir-format
 msgid "Sa"
 msgstr "Sa"
 
-#: lib/vutuv_web/components/ui.ex:3707
+#: lib/vutuv_web/components/ui.ex:3708
 #, elixir-autogen, elixir-format
 msgid "Su"
 msgstr "So"
 
-#: lib/vutuv_web/components/ui.ex:3704
+#: lib/vutuv_web/components/ui.ex:3705
 #, elixir-autogen, elixir-format
 msgid "Th"
 msgstr "Do"
 
-#: lib/vutuv_web/components/ui.ex:3702
+#: lib/vutuv_web/components/ui.ex:3703
 #, elixir-autogen, elixir-format
 msgid "Tu"
 msgstr "Di"
 
-#: lib/vutuv_web/components/ui.ex:3703
+#: lib/vutuv_web/components/ui.ex:3704
 #, elixir-autogen, elixir-format
 msgid "We"
 msgstr "Mi"
@@ -4587,7 +4587,7 @@ msgstr ""
 "beide Richtungen unterbunden. Eine Aufhebung der Blockierung stellt das "
 "Entfernte nicht wieder her."
 
-#: lib/vutuv_web/components/ui.ex:5447
+#: lib/vutuv_web/components/ui.ex:5448
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -5410,7 +5410,7 @@ msgstr "API-Token (%{date})"
 msgid "API documentation"
 msgstr "API-Dokumentation"
 
-#: lib/vutuv_web/components/ui.ex:5497
+#: lib/vutuv_web/components/ui.ex:5498
 #: lib/vutuv_web/controllers/settings_controller.ex:161
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:517
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5494,10 +5494,10 @@ msgstr "Tastaturkürzel"
 msgid "Navigation"
 msgstr "Navigation"
 
-#: lib/vutuv_web/components/ui.ex:5594
-#: lib/vutuv_web/components/ui.ex:5599
-#: lib/vutuv_web/components/ui.ex:5678
-#: lib/vutuv_web/components/ui.ex:5742
+#: lib/vutuv_web/components/ui.ex:5595
+#: lib/vutuv_web/components/ui.ex:5600
+#: lib/vutuv_web/components/ui.ex:5679
+#: lib/vutuv_web/components/ui.ex:5743
 #: lib/vutuv_web/controllers/settings_controller.ex:68
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5615,7 +5615,7 @@ msgstr "Art der E-Mail-Adresse"
 msgid "About you"
 msgstr "Über Sie"
 
-#: lib/vutuv_web/components/ui.ex:5467
+#: lib/vutuv_web/components/ui.ex:5468
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:262
@@ -5637,7 +5637,7 @@ msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 "Laden Sie alles herunter, was vutuv über Sie speichert, als eine Datei."
 
-#: lib/vutuv_web/components/ui.ex:5312
+#: lib/vutuv_web/components/ui.ex:5313
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5672,7 +5672,7 @@ msgstr "Persönliche Tokens für die vutuv-API."
 msgid "Photos"
 msgstr "Fotos"
 
-#: lib/vutuv_web/components/ui.ex:5441
+#: lib/vutuv_web/components/ui.ex:5442
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #, elixir-autogen, elixir-format
 msgid "Privacy"
@@ -5787,7 +5787,7 @@ msgstr "@%{slug} folgt Ihnen jetzt auf vutuv"
 msgid "Apps"
 msgstr "Apps"
 
-#: lib/vutuv_web/components/ui.ex:5490
+#: lib/vutuv_web/components/ui.ex:5491
 #: lib/vutuv_web/controllers/settings_controller.ex:185
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -5995,21 +5995,21 @@ msgid "Sort"
 msgstr "Sortieren"
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/components/ui.ex:3774
+#: lib/vutuv_web/components/ui.ex:3775
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] "vor %{count} Tag"
 msgstr[1] "vor %{count} Tagen"
 
-#: lib/vutuv_web/components/ui.ex:3773
+#: lib/vutuv_web/components/ui.ex:3774
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] "vor %{count} Stunde"
 msgstr[1] "vor %{count} Stunden"
 
-#: lib/vutuv_web/components/ui.ex:3772
+#: lib/vutuv_web/components/ui.ex:3773
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
@@ -6078,7 +6078,7 @@ msgstr ""
 "Das ist die erste Anmeldung, die wir von diesem Gerät oder Browser gesehen "
 "haben."
 
-#: lib/vutuv_web/components/ui.ex:3771
+#: lib/vutuv_web/components/ui.ex:3772
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr "gerade eben"
@@ -7471,13 +7471,13 @@ msgstr "Ihre Mitglieder werden zu dieser hinzugefügt (Vereinigung)."
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr "Seite %{page} von %{pages}, %{total} gesamt"
 
-#: lib/vutuv_web/components/ui.ex:4240
+#: lib/vutuv_web/components/ui.ex:4241
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Zurück"
 
-#: lib/vutuv_web/components/ui.ex:4252
+#: lib/vutuv_web/components/ui.ex:4253
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1180
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -8285,7 +8285,7 @@ msgstr "PIN abgelaufen"
 msgid "PIN registered"
 msgstr "PIN-registriert"
 
-#: lib/vutuv_web/components/ui.ex:4243
+#: lib/vutuv_web/components/ui.ex:4244
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr "Seite %{page} von %{pages}"
@@ -8424,7 +8424,7 @@ msgstr "Abschluss"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:5288
+#: lib/vutuv_web/components/ui.ex:5289
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8484,7 +8484,7 @@ msgstr ""
 " was Sie nicht übernehmen möchten. Einträge, die bereits in Ihrem Profil "
 "stehen, sind für Sie abgewählt."
 
-#: lib/vutuv_web/components/ui.ex:5478
+#: lib/vutuv_web/components/ui.ex:5479
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Import"
@@ -8513,7 +8513,7 @@ msgstr "%{items} importiert."
 msgid "Nothing new to import."
 msgstr "Nichts Neues zu importieren."
 
-#: lib/vutuv_web/components/ui.ex:5316
+#: lib/vutuv_web/components/ui.ex:5317
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8610,7 +8610,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr "Zu viele Importe. Bitte versuchen Sie es in Kürze erneut."
 
-#: lib/vutuv_web/components/ui.ex:4509
+#: lib/vutuv_web/components/ui.ex:4510
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8704,13 +8704,13 @@ msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 "Ziehen Sie Ihre ZIP-Datei hierher oder klicken Sie, um eine auszuwählen."
 
-#: lib/vutuv_web/components/ui.ex:5265
+#: lib/vutuv_web/components/ui.ex:5266
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr "Basisdaten & Fotos"
 
-#: lib/vutuv_web/components/ui.ex:5410
+#: lib/vutuv_web/components/ui.ex:5411
 #: lib/vutuv_web/controllers/settings_controller.ex:129
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8722,7 +8722,7 @@ msgstr "Sprache & Anzeige"
 msgid "More profile sections"
 msgstr "Weitere Profil-Bereiche"
 
-#: lib/vutuv_web/components/ui.ex:5469
+#: lib/vutuv_web/components/ui.ex:5470
 #: lib/vutuv_web/controllers/settings_controller.ex:112
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8732,7 +8732,7 @@ msgstr "Weitere Profil-Bereiche"
 msgid "Sign-in & security"
 msgstr "Anmeldung & Sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:5482
+#: lib/vutuv_web/components/ui.ex:5483
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8963,7 +8963,7 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/agent_docs/text.ex:670
 #: lib/vutuv_web/components/organization_components.ex:285
 #: lib/vutuv_web/components/ui.ex:1807
-#: lib/vutuv_web/components/ui.ex:5459
+#: lib/vutuv_web/components/ui.ex:5460
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:366
 #: lib/vutuv_web/controllers/settings_controller.ex:433
@@ -9957,7 +9957,7 @@ msgstr "Zertifikate"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:5292
+#: lib/vutuv_web/components/ui.ex:5293
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -10160,13 +10160,13 @@ msgstr "Dauerhafter Profillink"
 msgid "Dismiss"
 msgstr "Schließen"
 
-#: lib/vutuv_web/components/ui.ex:3897
+#: lib/vutuv_web/components/ui.ex:3898
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr "Kopiert"
 
-#: lib/vutuv_web/components/ui.ex:3896
-#: lib/vutuv_web/components/ui.ex:3904
+#: lib/vutuv_web/components/ui.ex:3897
+#: lib/vutuv_web/components/ui.ex:3905
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Kopieren"
@@ -10308,7 +10308,7 @@ msgstr ""
 msgid "Spam"
 msgstr "Spam"
 
-#: lib/vutuv_web/controllers/report_controller.ex:145
+#: lib/vutuv_web/controllers/report_controller.ex:149
 #, elixir-autogen, elixir-format
 msgid "Thank you for your report. Our moderators have been notified and will review this account."
 msgstr ""
@@ -10326,7 +10326,7 @@ msgstr "deaktiviert"
 msgid "deleted"
 msgstr "gelöscht"
 
-#: lib/vutuv_web/controllers/report_controller.ex:132
+#: lib/vutuv_web/controllers/report_controller.ex:136
 #, elixir-autogen, elixir-format
 msgid "To protect you, the connection between you and the reported member is paused - no contact in either direction, including messages. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -11580,12 +11580,12 @@ msgstr "Stellen Sie diese Datei bereit unter:"
 msgid "State / region (optional)"
 msgstr "Bundesland / Region (optional)"
 
-#: lib/vutuv_web/components/ui.ex:4596
+#: lib/vutuv_web/components/ui.ex:4597
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr "Dieser Dateityp ist nicht erlaubt."
 
-#: lib/vutuv_web/components/ui.ex:4598
+#: lib/vutuv_web/components/ui.ex:4599
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr "Der Upload ist fehlgeschlagen."
@@ -12305,7 +12305,7 @@ msgstr "Organisation wieder freigegeben."
 #: lib/vutuv_web/agent_docs/markdown.ex:524
 #: lib/vutuv_web/agent_docs/organization_doc.ex:138
 #: lib/vutuv_web/agent_docs/text.ex:480
-#: lib/vutuv_web/components/ui.ex:5486
+#: lib/vutuv_web/components/ui.ex:5487
 #: lib/vutuv_web/controllers/settings_controller.ex:222
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
@@ -13532,7 +13532,7 @@ msgstr "Suche speichern"
 msgid "Saved search deleted."
 msgstr "Gespeicherte Suche gelöscht."
 
-#: lib/vutuv_web/components/ui.ex:5395
+#: lib/vutuv_web/components/ui.ex:5396
 #: lib/vutuv_web/controllers/settings_controller.ex:629
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -14004,7 +14004,7 @@ msgstr ""
 "Personen tauchen in Ihren Vorschlägen auf. Einem Tag folgen Sie auf seiner "
 "Seite."
 
-#: lib/vutuv_web/components/ui.ex:5378
+#: lib/vutuv_web/components/ui.ex:5379
 #: lib/vutuv_web/controllers/settings_controller.ex:643
 #: lib/vutuv_web/live/post_live/feed.ex:710
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -14081,7 +14081,7 @@ msgstr "Messenger wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:69
 #: lib/vutuv_web/agent_docs/text.ex:64
-#: lib/vutuv_web/components/ui.ex:5335
+#: lib/vutuv_web/components/ui.ex:5336
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -14109,14 +14109,14 @@ msgstr "Messenger von %{name}"
 msgid "Select a messenger"
 msgstr "Messenger auswählen"
 
-#: lib/vutuv_web/components/ui.ex:4681
+#: lib/vutuv_web/components/ui.ex:4682
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] "Meinen Follower darüber informieren"
 msgstr[1] "Meine %{formatted} Follower darüber informieren"
 
-#: lib/vutuv_web/components/ui.ex:4691
+#: lib/vutuv_web/components/ui.ex:4692
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr "Die Benachrichtigung enthält einen Link zu diesem Eintrag. Es wird keine E-Mail verschickt, und das passiert nur bei neuen Einträgen."
@@ -14299,7 +14299,7 @@ msgid_plural "%{formatted} new notifications"
 msgstr[0] "%{formatted} neue Mitteilung"
 msgstr[1] "%{formatted} neue Mitteilungen"
 
-#: lib/vutuv_web/components/ui.ex:3678
+#: lib/vutuv_web/components/ui.ex:3679
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr "%{day}. %{month} %{year}"
@@ -14885,7 +14885,7 @@ msgstr "Blenden Sie Beiträge aus Ihrem Feed aus, die ein Tag tragen oder ein Wo
 msgid "Match whole words only (word/phrase)"
 msgstr "Nur ganze Wörter treffen (Wort/Phrase)"
 
-#: lib/vutuv_web/components/ui.ex:5349
+#: lib/vutuv_web/components/ui.ex:5350
 #: lib/vutuv_web/controllers/settings_controller.ex:773
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -15521,252 +15521,252 @@ msgstr "Ihr Server"
 msgid "moved to %{address}"
 msgstr "umgezogen nach %{address}"
 
-#: lib/vutuv_web/components/ui.ex:5266
+#: lib/vutuv_web/components/ui.ex:5267
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr "Name, Foto, Titelbild, Kurzbeschreibung"
 
-#: lib/vutuv_web/components/ui.ex:5271
+#: lib/vutuv_web/components/ui.ex:5272
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr "handle spitzname nutzername umbenennen slug profiladresse url erwähnung"
 
-#: lib/vutuv_web/components/ui.ex:5285
+#: lib/vutuv_web/components/ui.ex:5286
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr "Die Stationen in Ihrem Lebenslauf"
 
-#: lib/vutuv_web/components/ui.ex:5286
+#: lib/vutuv_web/components/ui.ex:5287
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr "lebenslauf cv karriere beruf arbeitgeber position stelle job firma"
 
-#: lib/vutuv_web/components/ui.ex:5289
+#: lib/vutuv_web/components/ui.ex:5290
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr "Schulen, Hochschulen, Abschlüsse"
 
-#: lib/vutuv_web/components/ui.ex:5290
+#: lib/vutuv_web/components/ui.ex:5291
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr "lebenslauf studium schule universität hochschule abschluss ausbildung"
 
-#: lib/vutuv_web/components/ui.ex:5293
+#: lib/vutuv_web/components/ui.ex:5294
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr "Nachweise, mit Belegdokumenten"
 
-#: lib/vutuv_web/components/ui.ex:5294
+#: lib/vutuv_web/components/ui.ex:5295
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr "zertifikat lizenz urkunde diplom nachweis beleg auszeichnung dokument"
 
-#: lib/vutuv_web/components/ui.ex:5301
+#: lib/vutuv_web/components/ui.ex:5302
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr "Sprachkenntnisse"
 
-#: lib/vutuv_web/components/ui.ex:5302
+#: lib/vutuv_web/components/ui.ex:5303
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr "Die Sprachen, die Sie sprechen"
 
-#: lib/vutuv_web/components/ui.ex:5303
+#: lib/vutuv_web/components/ui.ex:5304
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr "sprache sprachen sprechen fließend muttersprache verhandlungssicher"
 
-#: lib/vutuv_web/components/ui.ex:5306
+#: lib/vutuv_web/components/ui.ex:5307
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr "Die Themen, für die Sie bekannt sind"
 
-#: lib/vutuv_web/components/ui.ex:5307
+#: lib/vutuv_web/components/ui.ex:5308
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr "fähigkeit kenntnis thema stichwort schlagwort expertise empfehlung"
 
-#: lib/vutuv_web/components/ui.ex:5487
+#: lib/vutuv_web/components/ui.ex:5488
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr "Organisationsseiten, die Sie verwalten"
 
-#: lib/vutuv_web/components/ui.ex:5488
+#: lib/vutuv_web/components/ui.ex:5489
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr "firma unternehmen arbeitgeber betrieb organisation seite"
 
-#: lib/vutuv_web/components/ui.ex:5310
+#: lib/vutuv_web/components/ui.ex:5311
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr "Kontaktdaten"
 
-#: lib/vutuv_web/components/ui.ex:5313
+#: lib/vutuv_web/components/ui.ex:5314
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr "Wo wir Sie erreichen, und welche Adresse öffentlich ist"
 
-#: lib/vutuv_web/components/ui.ex:5314
+#: lib/vutuv_web/components/ui.ex:5315
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr "mail e-mail email adresse hauptadresse primär"
 
-#: lib/vutuv_web/components/ui.ex:5317
+#: lib/vutuv_web/components/ui.ex:5318
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr "Festnetz, Mobil, Fax"
 
-#: lib/vutuv_web/components/ui.ex:5318
+#: lib/vutuv_web/components/ui.ex:5319
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr "telefon handy mobil festnetz fax nummer rufnummer"
 
-#: lib/vutuv_web/components/ui.ex:5321
+#: lib/vutuv_web/components/ui.ex:5322
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr "Postanschriften auf Ihrem Profil"
 
-#: lib/vutuv_web/components/ui.ex:5322
+#: lib/vutuv_web/components/ui.ex:5323
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr "straße stadt ort postleitzahl plz land anschrift karte"
 
-#: lib/vutuv_web/components/ui.ex:5324
+#: lib/vutuv_web/components/ui.ex:5325
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr "Webseiten & Links"
 
-#: lib/vutuv_web/components/ui.ex:5325
+#: lib/vutuv_web/components/ui.ex:5326
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr "Ihre Homepage und weitere Links"
 
-#: lib/vutuv_web/components/ui.ex:5326
+#: lib/vutuv_web/components/ui.ex:5327
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr "url webseite website homepage blog link verifizieren bestätigen rel=me"
 
-#: lib/vutuv_web/components/ui.ex:5328
+#: lib/vutuv_web/components/ui.ex:5329
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr "Social-Media-Profile"
 
-#: lib/vutuv_web/components/ui.ex:5329
+#: lib/vutuv_web/components/ui.ex:5330
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr "Mastodon, Bluesky, GitHub und die anderen"
 
-#: lib/vutuv_web/components/ui.ex:5331
+#: lib/vutuv_web/components/ui.ex:5332
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr "mastodon bluesky github gitlab codeberg linkedin x twitter instagram soziale netzwerke"
 
-#: lib/vutuv_web/components/ui.ex:5336
+#: lib/vutuv_web/components/ui.ex:5337
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr "Signal, Threema, Matrix und die anderen"
 
-#: lib/vutuv_web/components/ui.ex:5337
+#: lib/vutuv_web/components/ui.ex:5338
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr "signal threema matrix xmpp telegram whatsapp chat messenger nachrichten"
 
-#: lib/vutuv_web/components/ui.ex:5340
+#: lib/vutuv_web/components/ui.ex:5341
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr "Mitteilungen & Feed"
 
-#: lib/vutuv_web/components/ui.ex:5343
+#: lib/vutuv_web/components/ui.ex:5344
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr "Welche E-Mails wir schicken, und was die Glocke meldet"
 
-#: lib/vutuv_web/components/ui.ex:5350
+#: lib/vutuv_web/components/ui.ex:5351
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr "Beiträge aus Ihrem Feed heraushalten"
 
-#: lib/vutuv_web/components/ui.ex:5351
+#: lib/vutuv_web/components/ui.ex:5352
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr "stummschalten ausblenden verbergen filter wort begriff tag feed blockieren"
 
-#: lib/vutuv_web/components/ui.ex:5379
+#: lib/vutuv_web/components/ui.ex:5380
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr "Themen, deren Beiträge in Ihrem Feed landen"
 
-#: lib/vutuv_web/components/ui.ex:5380
+#: lib/vutuv_web/components/ui.ex:5381
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr "tag thema abonnieren folgen feed"
 
-#: lib/vutuv_web/components/ui.ex:5396
+#: lib/vutuv_web/components/ui.ex:5397
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr "Job- und Personensuchen, die Ihnen neue Treffer mailen"
 
-#: lib/vutuv_web/components/ui.ex:5397
+#: lib/vutuv_web/components/ui.ex:5398
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr "job stelle stellenangebot suchauftrag suche alarm benachrichtigung merkliste"
 
-#: lib/vutuv_web/components/ui.ex:5444
+#: lib/vutuv_web/components/ui.ex:5445
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr "Suchmaschinen, KI, Online-Status"
 
-#: lib/vutuv_web/components/ui.ex:5445
+#: lib/vutuv_web/components/ui.ex:5446
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr "privatsphäre datenschutz google suchmaschine ki ai llm crawler noindex online punkt öffentlich sichtbar"
 
-#: lib/vutuv_web/components/ui.ex:5448
+#: lib/vutuv_web/components/ui.ex:5449
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr "Personen, die nicht mit Ihnen interagieren können"
 
-#: lib/vutuv_web/components/ui.ex:5449
+#: lib/vutuv_web/components/ui.ex:5450
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr "blockieren sperren bannen stummschalten melden missbrauch belästigung"
 
-#: lib/vutuv_web/components/ui.ex:5470
+#: lib/vutuv_web/components/ui.ex:5471
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr "Passkeys, angemeldete Geräte, Anmeldecodes"
 
-#: lib/vutuv_web/components/ui.ex:5471
+#: lib/vutuv_web/components/ui.ex:5472
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr "passwort kennwort anmelden abmelden login logout sitzung gerät passkey totp 2fa pin sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:5479
+#: lib/vutuv_web/components/ui.ex:5480
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr "Ihre Daten von LinkedIn übernehmen"
 
-#: lib/vutuv_web/components/ui.ex:5480
+#: lib/vutuv_web/components/ui.ex:5481
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr "linkedin hochladen zip übernehmen importieren umzug"
 
-#: lib/vutuv_web/components/ui.ex:5483
+#: lib/vutuv_web/components/ui.ex:5484
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr "Alles herunterladen, was wir über Sie speichern"
 
-#: lib/vutuv_web/components/ui.ex:5484
+#: lib/vutuv_web/components/ui.ex:5485
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr "herunterladen download dsgvo gdpr daten sicherung json lebenslauf auskunft"
 
-#: lib/vutuv_web/components/ui.ex:5498
+#: lib/vutuv_web/components/ui.ex:5499
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr "Ihr Konto und alles darauf entfernen"
 
-#: lib/vutuv_web/components/ui.ex:5499
+#: lib/vutuv_web/components/ui.ex:5500
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr "löschen entfernen schließen kündigen beenden verlassen"
@@ -16243,7 +16243,7 @@ msgstr "API-Token erstellt"
 msgid "Access token revoked"
 msgstr "API-Token widerrufen"
 
-#: lib/vutuv_web/components/ui.ex:5473
+#: lib/vutuv_web/components/ui.ex:5474
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -16588,7 +16588,7 @@ msgstr "Was sich an einem Konto geändert hat, wann, von wo und wie es bestätig
 msgid "What changed on your account, and exactly when."
 msgstr "Was sich an Ihrem Konto geändert hat, und wann genau."
 
-#: lib/vutuv_web/components/ui.ex:5474
+#: lib/vutuv_web/components/ui.ex:5475
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr "Was sich an Ihrem Konto geändert hat, und wann"
@@ -16624,7 +16624,7 @@ msgstr "durch den Betreiber"
 msgid "from a signed-in session"
 msgstr "aus einer angemeldeten Sitzung"
 
-#: lib/vutuv_web/components/ui.ex:5476
+#: lib/vutuv_web/components/ui.ex:5477
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr "protokoll verlauf historie chronik audit sicherheit war ich das wer hat wann geaendert geändert log"
@@ -16826,13 +16826,13 @@ msgid "Open Fediverse settings"
 msgstr "Fediverse-Einstellungen öffnen"
 
 #: lib/vutuv_web/components/post_components.ex:5364
-#: lib/vutuv_web/components/press_kit_components.ex:399
+#: lib/vutuv_web/components/press_kit_components.ex:452
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
 #: lib/vutuv_web/components/post_components.ex:5592
-#: lib/vutuv_web/components/press_kit_components.ex:469
+#: lib/vutuv_web/components/press_kit_components.ex:536
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
@@ -17149,7 +17149,7 @@ msgstr "Ein Konto in einem anderen Netzwerk"
 msgid "Cancel request"
 msgstr "Anfrage zurückziehen"
 
-#: lib/vutuv_web/components/ui.ex:5460
+#: lib/vutuv_web/components/ui.ex:5461
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr "Konten auf Mastodon folgen, und von dort gefolgt werden"
@@ -17352,7 +17352,7 @@ msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, desh
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr "Ihr Konto ist derzeit gesperrt, deshalb geht nichts von Ihnen an andere Netzwerke und Sie können dort niemandem folgen. Das endet von selbst, sobald die Sperre abläuft."
 
-#: lib/vutuv_web/components/ui.ex:5462
+#: lib/vutuv_web/components/ui.ex:5463
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr "mastodon activitypub foederation federation follower folgen folge umzug migration entferntes konto"
@@ -18442,7 +18442,7 @@ msgstr "Arbeitszeugnis aktualisiert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:54
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:5296
+#: lib/vutuv_web/components/ui.ex:5297
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -18637,7 +18637,7 @@ msgstr "In der Warteschlange, Ihres ist als Nächstes dran."
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr "Sie haben den Text nach dieser Prüfung geändert. Sie beschreibt die frühere Fassung."
 
-#: lib/vutuv_web/components/ui.ex:5297
+#: lib/vutuv_web/components/ui.ex:5298
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr "Ihre Arbeitszeugnisse, privat bis Sie sie veröffentlichen"
@@ -18648,7 +18648,7 @@ msgstr "Ihre Arbeitszeugnisse, privat bis Sie sie veröffentlichen"
 msgid "Zwischenzeugnis"
 msgstr "Zwischenzeugnis"
 
-#: lib/vutuv_web/components/ui.ex:5299
+#: lib/vutuv_web/components/ui.ex:5300
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr "arbeitszeugnis zeugnis referenz beurteilung arbeitgeber bewertung prüfung"
@@ -18903,7 +18903,7 @@ msgstr "Datei hierher ziehen oder eine auswählen"
 msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr "PDF, JPG, PNG oder WebP, bis %{limit}"
 
-#: lib/vutuv_web/components/ui.ex:4582
+#: lib/vutuv_web/components/ui.ex:4583
 #: lib/vutuv_web/live/press_kit_live.ex:382
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
@@ -19234,7 +19234,7 @@ msgstr ""
 "Anteile bezogen auf die %{answered} Mitglieder mit Angabe. %{unanswered} ohne "
 "Angabe."
 
-#: lib/vutuv_web/components/ui.ex:5267
+#: lib/vutuv_web/components/ui.ex:5268
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr "avatar profilbild portrait foto bild geburtstag geburtsdatum geschlecht über mich"
@@ -19330,7 +19330,7 @@ msgstr "Ebenfalls löschen"
 msgid "Always keep"
 msgstr "Immer behalten"
 
-#: lib/vutuv_web/components/ui.ex:5453
+#: lib/vutuv_web/components/ui.ex:5454
 #: lib/vutuv_web/controllers/settings_controller.ex:256
 #: lib/vutuv_web/controllers/settings_controller.ex:335
 #: lib/vutuv_web/controllers/settings_controller.ex:347
@@ -19427,7 +19427,7 @@ msgstr "Fotobeiträge behalten"
 msgid "Keep posts that did well"
 msgstr "Beiträge behalten, die gut liefen"
 
-#: lib/vutuv_web/components/ui.ex:5455
+#: lib/vutuv_web/components/ui.ex:5456
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr "Ihre Beiträge nach einer selbst gewählten Zeit auslaufen lassen"
@@ -19536,7 +19536,7 @@ msgstr "Sie können vorher alles herunterladen, was Sie hier haben:"
 msgid "Your rule"
 msgstr "Ihre Regel"
 
-#: lib/vutuv_web/components/ui.ex:5457
+#: lib/vutuv_web/components/ui.ex:5458
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr "löschen entfernen beiträge alter alt ablaufen verfallen automatisch aufräumen aufbewahrung"
@@ -20828,7 +20828,7 @@ msgid "Feed language settings reset to the site defaults."
 msgstr "Feed-Spracheinstellungen auf die Website-Vorgaben zurückgesetzt."
 
 #: lib/vutuv_web/components/post_components.ex:5877
-#: lib/vutuv_web/components/ui.ex:5371
+#: lib/vutuv_web/components/ui.ex:5372
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
 #: lib/vutuv_web/templates/settings/preferences.html.heex:187
@@ -21039,7 +21039,7 @@ msgstr "Damit können Sie sich von einer Mastodon-kompatiblen App aus bei diesem
 msgid "Mastodon app access changed"
 msgstr "Mastodon-App-Zugriff geändert"
 
-#: lib/vutuv_web/components/ui.ex:5491
+#: lib/vutuv_web/components/ui.ex:5492
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr "Mastodon-Apps, verbundene Apps und Zugriffstoken"
@@ -21085,7 +21085,7 @@ msgstr "Wer etwas geschrieben hat, wird weiter festgehalten, das Team kann also 
 msgid "Your account is then %{handle}."
 msgstr "Dein Konto heißt dann %{handle}."
 
-#: lib/vutuv_web/components/ui.ex:5493
+#: lib/vutuv_web/components/ui.ex:5494
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr "api token oauth entwickler verbunden drittanbieter schnittstelle mastodon app handy telefon client ivory tusky ice cubes anmelden"
@@ -21120,7 +21120,7 @@ msgstr "Bekannte aus LinkedIn finden"
 msgid "Find your LinkedIn contacts"
 msgstr "Ihre LinkedIn-Kontakte finden"
 
-#: lib/vutuv_web/components/ui.ex:5387
+#: lib/vutuv_web/components/ui.ex:5388
 #: lib/vutuv_web/live/import_connections_live.ex:64
 #: lib/vutuv_web/templates/import/new.html.heex:37
 #, elixir-autogen, elixir-format
@@ -21228,7 +21228,7 @@ msgstr "Nach Namen suchen"
 msgid "See which of them are already on vutuv"
 msgstr "Sehen Sie, wer davon schon auf vutuv ist"
 
-#: lib/vutuv_web/components/ui.ex:5389
+#: lib/vutuv_web/components/ui.ex:5390
 #, elixir-autogen, elixir-format
 msgid "See which of your LinkedIn contacts are already on vutuv"
 msgstr "Sehen, wer aus Ihren LinkedIn-Kontakten schon auf vutuv ist"
@@ -21300,7 +21300,7 @@ msgstr "Ihre Kontakte auf vutuv"
 msgid "Your export also lists your LinkedIn contacts."
 msgstr "Ihr Export enthält auch Ihre LinkedIn-Kontakte."
 
-#: lib/vutuv_web/components/ui.ex:5391
+#: lib/vutuv_web/components/ui.ex:5392
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
 msgstr "linkedin kontakte verbindungen adressbuch bekannte kollegen finden folgen zip import netzwerk"
@@ -21557,7 +21557,7 @@ msgstr "Wenn etwas eintrifft, während vutuv in einem Tab offen ist, den Sie ger
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr "Sie haben Browser-Benachrichtigungen eingeschaltet. Dieser Browser wurde noch nicht um Erlaubnis gebeten."
 
-#: lib/vutuv_web/components/ui.ex:5345
+#: lib/vutuv_web/components/ui.ex:5346
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr "e-mail email mail abbestellen abmelden newsletter glocke benachrichtigung weniger ruhe browser desktop popup push hinweis mitteilung"
@@ -21789,26 +21789,26 @@ msgstr "Wird in Ihrem Feed ausgeblendet."
 msgid "Shown in the language it was written in."
 msgstr "Wird in der Sprache gezeigt, in der es geschrieben wurde."
 
-#: lib/vutuv_web/components/ui.ex:5372
+#: lib/vutuv_web/components/ui.ex:5373
 #, elixir-autogen, elixir-format
 msgid "Which languages reach you, and what happens to the rest"
 msgstr "Welche Sprachen Sie erreichen und was mit dem Rest geschieht"
 
-#: lib/vutuv_web/components/ui.ex:5374
+#: lib/vutuv_web/components/ui.ex:5375
 #, elixir-autogen, elixir-format
 msgid "language translate translation german english original hide foreign rank order sprache übersetzen fremdsprache reihenfolge"
 msgstr ""
 "sprache übersetzen übersetzung deutsch englisch original ausblenden "
 "fremdsprache reihenfolge rang feed language translate"
 
-#: lib/vutuv_web/components/ui.ex:5412
+#: lib/vutuv_web/components/ui.ex:5413
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, maps, how posts are shortened"
 msgstr ""
 "Anzeigesprache, Datumsformat und Zeitzone, Karten, wie Beiträge gekürzt "
 "werden"
 
-#: lib/vutuv_web/components/ui.ex:5416
+#: lib/vutuv_web/components/ui.ex:5417
 #, elixir-autogen, elixir-format
 msgid "german english locale map font length hyphenation übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr ""
@@ -22302,7 +22302,7 @@ msgstr ""
 "Ihre Organisationsseite wurde aktualisiert, aber dieses Bild konnte nicht als "
 "Logo verwendet werden. Bitte wählen Sie ein anderes."
 
-#: lib/vutuv_web/components/ui.ex:4588
+#: lib/vutuv_web/components/ui.ex:4589
 #, elixir-autogen, elixir-format
 msgid "You can upload one file at a time."
 msgid_plural "You can upload at most %{count} files at a time."
@@ -22500,7 +22500,7 @@ msgstr "Bleibt das Account-Feld leer, gilt die Regel für alle; %{example} grenz
 msgid "Only these accounts (empty = all) …"
 msgstr "Nur diese Accounts (leer = alle) …"
 
-#: lib/vutuv_web/components/ui.ex:3566
+#: lib/vutuv_web/components/ui.ex:3567
 #, elixir-autogen, elixir-format
 msgid "only %{account}"
 msgstr "nur %{account}"
@@ -22742,7 +22742,7 @@ msgstr "Von diesem Beitrag bleibt nichts übrig."
 msgid "Replace with"
 msgstr "Ersetzen durch"
 
-#: lib/vutuv_web/components/ui.ex:5364
+#: lib/vutuv_web/components/ui.ex:5365
 #, elixir-autogen, elixir-format
 msgid "Rewrite what an account's posts say, for you alone"
 msgstr "Text in den Beiträgen eines Kontos umschreiben, nur für Sie"
@@ -22760,7 +22760,7 @@ msgstr "Regeln, die den Text der Beiträge eines Kontos umschreiben, bevor Sie i
 #: lib/vutuv_web/components/post_components.ex:1452
 #: lib/vutuv_web/components/post_components.ex:3402
 #: lib/vutuv_web/components/post_components.ex:4496
-#: lib/vutuv_web/components/ui.ex:5363
+#: lib/vutuv_web/components/ui.ex:5364
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
 #: lib/vutuv_web/live/post_rewrites_live.ex:264
@@ -22816,12 +22816,12 @@ msgstr "Ihre gespeicherten Regeln ändern diesen Beitrag von %{who} wie gezeigt.
 msgid "\\1 puts back what the first (…) group matched, \\0 the whole match."
 msgstr "\\1 setzt ein, was die erste (…)-Gruppe getroffen hat, \\0 den ganzen Treffer."
 
-#: lib/vutuv_web/components/ui.ex:5365
+#: lib/vutuv_web/components/ui.ex:5366
 #, elixir-autogen, elixir-format
 msgid "regex regular expression rewrite replace footer signature strip"
 msgstr "regex regulärer ausdruck umschreiben ersetzen fußzeile signatur entfernen suchen"
 
-#: lib/vutuv_web/components/ui.ex:5434
+#: lib/vutuv_web/components/ui.ex:5435
 #, elixir-autogen, elixir-format
 msgid "Smaller pictures and a plain composer on a slow connection"
 msgstr "Kleinere Bilder und ein einfacher Editor bei langsamer Verbindung"
@@ -22831,12 +22831,12 @@ msgstr "Kleinere Bilder und ein einfacher Editor bei langsamer Verbindung"
 msgid "That endorsement is not possible."
 msgstr "Diese Empfehlung ist nicht möglich."
 
-#: lib/vutuv_web/components/ui.ex:5436
+#: lib/vutuv_web/components/ui.ex:5437
 #, elixir-autogen, elixir-format
 msgid "bandwidth slow internet mobile data saving saver volume metered compression pictures images screenshots editor langsam daten sparen datensparmodus volumen schmalband komprimierung bilder"
 msgstr "bandbreite langsam internet mobil daten sparen datensparmodus volumen schmalband komprimierung bilder fotos screenshots editor bandwidth slow data saving"
 
-#: lib/vutuv_web/components/ui.ex:5408
+#: lib/vutuv_web/components/ui.ex:5409
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr "Darstellung"
@@ -23316,7 +23316,7 @@ msgstr "Ein Fediverse-Konto, das hier mehreren Profilen folgt, zählt trotzdem a
 msgid "Accounts whose posts stay out of your feed, and accounts whose reposts do. This list is yours alone: it is never shared and nobody is told they are on it."
 msgstr "Konten, deren Beiträge nicht in Ihrem Feed erscheinen, und Konten, deren Reposts Sie ausgeblendet haben. Diese Liste gehört Ihnen allein: sie wird nie geteilt, und niemand erfährt, dass er darauf steht."
 
-#: lib/vutuv_web/components/ui.ex:5357
+#: lib/vutuv_web/components/ui.ex:5358
 #, elixir-autogen, elixir-format
 msgid "Accounts you have silenced, and whose reposts you hide"
 msgstr "Konten, die Sie stummgeschaltet haben, und deren Reposts Sie ausblenden"
@@ -23342,7 +23342,7 @@ msgstr "Suchen Sie stattdessen nach Wörtern, Wendungen oder Tags?"
 msgid "Mute everything"
 msgstr "Ganz stummschalten"
 
-#: lib/vutuv_web/components/ui.ex:5356
+#: lib/vutuv_web/components/ui.ex:5357
 #: lib/vutuv_web/controllers/settings_controller.ex:713
 #: lib/vutuv_web/templates/settings/mutes.html.heex:1
 #: lib/vutuv_web/templates/settings/mutes.html.heex:3
@@ -23386,7 +23386,7 @@ msgstr "Sie haben noch niemanden stummgeschaltet."
 msgid "You mute an account where you meet it: the ⋯ menu on any of its posts, or its own page. Muting works whether or not you follow them."
 msgstr "Stummschalten können Sie ein Konto dort, wo Sie ihm begegnen: im ⋯-Menü eines seiner Beiträge oder auf seiner eigenen Seite. Das geht auch bei Konten, denen Sie nicht folgen."
 
-#: lib/vutuv_web/components/ui.ex:5359
+#: lib/vutuv_web/components/ui.ex:5360
 #, elixir-autogen, elixir-format
 msgid "mute unmute hide account reposts boosts feed stumm stummschalten ausblenden konto"
 msgstr "stumm stummschalten stummschaltung ausblenden verbergen konto account reposts boosts feed"
@@ -23486,7 +23486,7 @@ msgstr "Die Länge Ihres Feeds folgt wieder der Voreinstellung."
 msgid "Feed settings saved."
 msgstr "Feed-Einstellungen gespeichert."
 
-#: lib/vutuv_web/components/ui.ex:5427
+#: lib/vutuv_web/components/ui.ex:5428
 #, elixir-autogen, elixir-format
 msgid "How many load at once, and how many “Load more” adds"
 msgstr "Wie viele auf einmal geladen werden und wie viele „Mehr laden“ ergänzt"
@@ -23496,7 +23496,7 @@ msgstr "Wie viele auf einmal geladen werden und wie viele „Mehr laden“ ergä
 msgid "How many posts your feed shows before the “Load more” button, and how many that button adds. More posts mean a longer wait for the page."
 msgstr "Wie viele Beiträge Ihr Feed vor dem Knopf „Mehr laden“ zeigt und wie viele dieser Knopf ergänzt. Mehr Beiträge bedeuten eine längere Wartezeit auf die Seite."
 
-#: lib/vutuv_web/components/ui.ex:5426
+#: lib/vutuv_web/components/ui.ex:5427
 #: lib/vutuv_web/controllers/settings_controller.ex:963
 #: lib/vutuv_web/templates/settings/feed.html.heex:12
 #, elixir-autogen, elixir-format
@@ -23519,7 +23519,7 @@ msgstr "Beiträge pro Seite"
 msgid "You can change this under the feed itself as well, right below the “Load more” button."
 msgstr "Sie können das auch direkt im Feed ändern, gleich unter „Mehr laden“."
 
-#: lib/vutuv_web/components/ui.ex:5429
+#: lib/vutuv_web/components/ui.ex:5430
 #, elixir-autogen, elixir-format
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr "feed länge seitengröße beiträge anzahl menge mehr laden scrollen blättern seite umfang page size posts number load more"
@@ -23943,7 +23943,7 @@ msgstr "Neue Mitteilungen"
 msgid "Neither your profile picture nor your cover photo was replaced: a report about them is still open. Open the case to remove the picture or to say that it is yours."
 msgstr "Weder Ihr Profilbild noch Ihr Titelbild wurde ersetzt: Eine Meldung dazu ist noch offen. Öffnen Sie den Fall, um das Bild zu entfernen oder zu sagen, dass es Ihres ist."
 
-#: lib/vutuv_web/controllers/report_controller.ex:174
+#: lib/vutuv_web/controllers/report_controller.ex:190
 #, elixir-autogen, elixir-format
 msgid "Profile picture"
 msgstr "Profilbild"
@@ -24028,7 +24028,7 @@ msgstr ""
 "Bei einer Meldung wegen Urheberrechts geht das Bild sofort offline; jede "
 "andere Meldung geht an unsere Admins, das Bild bleibt sichtbar."
 
-#: lib/vutuv_web/controllers/report_controller.ex:151
+#: lib/vutuv_web/controllers/report_controller.ex:155
 #, elixir-autogen, elixir-format
 msgid "Thank you for your report. Our moderators have been notified and will review this picture."
 msgstr ""
@@ -24066,8 +24066,8 @@ msgstr "Adresse der Seite"
 msgid "Confirm the report"
 msgstr "Meldung bestätigen"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:91
-#: lib/vutuv_web/controllers/public_report_controller.ex:111
+#: lib/vutuv_web/controllers/public_report_controller.ex:98
+#: lib/vutuv_web/controllers/public_report_controller.ex:118
 #: lib/vutuv_web/templates/public_report/confirm.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Confirm your report"
@@ -24119,8 +24119,8 @@ msgstr "Externer Melder hat seine Adresse bestätigt"
 msgid "Please confirm your report"
 msgstr "Bitte bestätigen Sie Ihre Meldung"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:88
-#: lib/vutuv_web/controllers/public_report_controller.ex:116
+#: lib/vutuv_web/controllers/public_report_controller.ex:95
+#: lib/vutuv_web/controllers/public_report_controller.ex:123
 #, elixir-autogen, elixir-format
 msgid "Report confirmed"
 msgstr "Meldung bestätigt"
@@ -24135,7 +24135,7 @@ msgstr "Inhalt auf dieser Seite melden"
 msgid "Report filed from outside"
 msgstr "Meldung von außerhalb eingegangen"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:171
+#: lib/vutuv_web/controllers/public_report_controller.ex:178
 #, elixir-autogen, elixir-format
 msgid "Report sent"
 msgstr "Meldung abgeschickt"
@@ -24150,7 +24150,7 @@ msgstr "Inhalte auf dieser Seite melden"
 msgid "Thank you - your report is with our admins"
 msgstr "Danke, Ihre Meldung liegt bei unseren Admins"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:133
+#: lib/vutuv_web/controllers/public_report_controller.ex:140
 #, elixir-autogen, elixir-format
 msgid "That address is not on this site. We can only act on content published here."
 msgstr "Diese Adresse gehört nicht zu dieser Seite. Wir können nur bei Inhalten tätig werden, die hier veröffentlicht sind."
@@ -24165,7 +24165,7 @@ msgstr "Der Beitrag, das Bild, das Video, das Profil, die Seite oder die Stellen
 msgid "The report by %{email} was a deliberate weapon (that address loses our trust)"
 msgstr "Die Meldung von %{email} war eine gezielte Waffe (diese Adresse verliert unser Vertrauen)"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:232
+#: lib/vutuv_web/controllers/public_report_controller.ex:239
 #, elixir-autogen, elixir-format
 msgid "We could not find that page. Please check the address."
 msgstr "Wir konnten diese Seite nicht finden. Bitte prüfen Sie die Adresse."
@@ -24180,7 +24180,7 @@ msgstr "Wir haben eine E-Mail an %{email} geschickt."
 msgid "What is wrong with it?"
 msgstr "Was stimmt damit nicht?"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:176
+#: lib/vutuv_web/controllers/public_report_controller.ex:183
 #, elixir-autogen, elixir-format
 msgid "You already sent us this report. Please use the confirmation link in the email we sent you."
 msgstr "Diese Meldung haben Sie uns bereits geschickt. Bitte nutzen Sie den Bestätigungslink aus unserer E-Mail."
@@ -24195,7 +24195,7 @@ msgstr "Sie brauchen kein Konto. Sagen Sie uns, um welche Seite es geht und was 
 msgid "You do not need to do anything else."
 msgstr "Mehr müssen Sie nicht tun."
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:72
+#: lib/vutuv_web/controllers/public_report_controller.ex:79
 #, elixir-autogen, elixir-format
 msgid "You have sent us a lot of reports just now. Please try again later."
 msgstr "Sie haben uns gerade sehr viele Meldungen geschickt. Bitte versuchen Sie es später noch einmal."
@@ -24261,8 +24261,8 @@ msgstr "Meldung verworfen: die Adresse wurde nie bestätigt"
 msgid "Send the report again"
 msgstr "Meldung erneut senden"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:99
-#: lib/vutuv_web/controllers/public_report_controller.ex:121
+#: lib/vutuv_web/controllers/public_report_controller.ex:106
+#: lib/vutuv_web/controllers/public_report_controller.ex:128
 #: lib/vutuv_web/templates/public_report/expired.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "This link has expired"
@@ -24458,7 +24458,7 @@ msgstr "Melden Sie ehrlich. Wer meldet, um jemandem zu schaden, verstößt gegen
 msgid "Texts, photos and videos belong to whoever made them. Post your own work, or work you have permission to use. A rights holder can report content here without an account, through {form}; such a complaint is decided by one of our admins, and an edit does not settle it."
 msgstr "Texte, Fotos und Videos gehören denen, die sie gemacht haben. Veröffentlichen Sie eigene Werke oder solche, für die Sie die Erlaubnis haben. Rechteinhaber können Inhalte auch ohne Konto melden, über {form}; über eine solche Meldung entscheidet einer unserer Admins, und eine Korrektur erledigt sie nicht."
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:143
+#: lib/vutuv_web/controllers/public_report_controller.ex:150
 #, elixir-autogen, elixir-format
 msgid "That address is one of our own pages, not content somebody published here, so there is nothing on it we could act on. Please paste the address of the post, picture, video, profile or job posting itself."
 msgstr "Diese Adresse gehört zu einer unserer eigenen Seiten und nicht zu einem Inhalt, den jemand hier veröffentlicht hat; dort gibt es also nichts, wogegen wir vorgehen könnten. Bitte fügen Sie die Adresse des Beitrags, des Bildes, des Videos, des Profils oder der Stellenanzeige selbst ein."
@@ -24484,7 +24484,7 @@ msgid "“%{note}”"
 msgstr "„%{note}“"
 
 #: lib/vutuv_web/components/post_components.ex:5236
-#: lib/vutuv_web/components/press_kit_components.ex:207
+#: lib/vutuv_web/components/press_kit_components.ex:209
 #, elixir-autogen, elixir-format
 msgid "Show these photos larger"
 msgstr "Fotos vergrößern"
@@ -24554,7 +24554,7 @@ msgstr "Bildnachweis"
 msgid "Dark"
 msgstr "Dunkel"
 
-#: lib/vutuv_web/components/ui.ex:5278
+#: lib/vutuv_web/components/ui.ex:5279
 #, elixir-autogen, elixir-format
 msgid "Files a journalist may download and print"
 msgstr "Dateien, die eine Redaktion herunterladen und drucken darf"
@@ -24579,6 +24579,7 @@ msgstr "Ich habe die Rechte an dieser Datei und gebe sie zur redaktionellen Nutz
 msgid "Light"
 msgstr "Hell"
 
+#: lib/vutuv_web/controllers/report_controller.ex:193
 #: lib/vutuv_web/live/press_kit_live.ex:1006
 #, elixir-autogen, elixir-format
 msgid "Logo variant"
@@ -24628,6 +24629,7 @@ msgstr "Bild entfernt."
 msgid "Please confirm the rights first, then choose the file."
 msgstr "Bitte bestätigen Sie zuerst die Rechte und wählen Sie dann die Datei."
 
+#: lib/vutuv_web/controllers/report_controller.ex:193
 #: lib/vutuv_web/live/press_kit_live.ex:1006
 #, elixir-autogen, elixir-format
 msgid "Press photo"
@@ -24641,7 +24643,7 @@ msgstr "Pressefoto"
 msgid "Press photos"
 msgstr "Pressefotos"
 
-#: lib/vutuv_web/components/ui.ex:5277
+#: lib/vutuv_web/components/ui.ex:5278
 #: lib/vutuv_web/live/press_kit_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Press photos & logos"
@@ -24712,7 +24714,7 @@ msgstr "Sie können dieser Pressemappe kein Bild hinzufügen."
 msgid "Your logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
 msgstr "Ihr Logo als Datei, eine Kachel je Variante. Eine Druckerei fragt nach einem Vektor (SVG), alle anderen können ein PNG öffnen."
 
-#: lib/vutuv_web/components/ui.ex:5280
+#: lib/vutuv_web/components/ui.ex:5281
 #, elixir-autogen, elixir-format
 msgid "press kit media journalist photographer download original print logo svg credit copyright presse pressemappe fotos logo herunterladen bildnachweis"
 msgstr "pressemappe presse medien redaktion journalist fotograf download original druck logo svg bildnachweis urheberrecht pressefotos herunterladen press kit"
@@ -24722,24 +24724,24 @@ msgstr "pressemappe presse medien redaktion journalist fotograf download origina
 msgid "Ready-made buttons and badges"
 msgstr "Fertige Buttons und Badges"
 
-#: lib/vutuv_web/components/ui.ex:3619
+#: lib/vutuv_web/components/ui.ex:3620
 #, elixir-autogen, elixir-format
 msgid "%{count} byte"
 msgid_plural "%{count} bytes"
 msgstr[0] "%{count} Byte"
 msgstr[1] "%{count} Bytes"
 
-#: lib/vutuv_web/components/press_kit_components.ex:99
+#: lib/vutuv_web/components/press_kit_components.ex:100
 #, elixir-autogen, elixir-format
 msgid "Add press photos"
 msgstr "Pressefotos hinzufügen"
 
-#: lib/vutuv_web/components/press_kit_components.ex:117
+#: lib/vutuv_web/components/press_kit_components.ex:118
 #, elixir-autogen, elixir-format
 msgid "All press material"
 msgstr "Alle Pressematerialien"
 
-#: lib/vutuv_web/components/press_kit_components.ex:173
+#: lib/vutuv_web/components/press_kit_components.ex:174
 #, elixir-autogen, elixir-format
 msgid "All press photos"
 msgstr "Alle Pressefotos"
@@ -24750,18 +24752,18 @@ msgstr "Alle Pressefotos"
 msgid "Credit: %{credit}"
 msgstr "Bildnachweis: %{credit}"
 
-#: lib/vutuv_web/components/press_kit_components.ex:320
 #: lib/vutuv_web/components/press_kit_components.ex:323
+#: lib/vutuv_web/components/press_kit_components.ex:326
 #, elixir-autogen, elixir-format
 msgid "Download %{format}"
 msgstr "%{format} herunterladen"
 
-#: lib/vutuv_web/components/press_kit_components.ex:276
+#: lib/vutuv_web/components/press_kit_components.ex:279
 #, elixir-autogen, elixir-format
 msgid "Download photo"
 msgstr "Foto herunterladen"
 
-#: lib/vutuv/press_kit.ex:496
+#: lib/vutuv/press_kit.ex:503
 #, elixir-autogen, elixir-format
 msgid "Free for editorial use with credit."
 msgstr "Zur freien redaktionellen Verwendung mit Bildnachweis."
@@ -24776,7 +24778,7 @@ msgstr "PNG-Fassung"
 #: lib/vutuv_web/agent_docs/text.ex:57
 #: lib/vutuv_web/agent_docs/text.ex:257
 #: lib/vutuv_web/components/organization_components.ex:262
-#: lib/vutuv_web/components/press_kit_components.ex:97
+#: lib/vutuv_web/components/press_kit_components.ex:98
 #: lib/vutuv_web/live/organization_live/show.ex:168
 #: lib/vutuv_web/views/press_kit_html.ex:28
 #: lib/vutuv_web/views/press_kit_html.ex:46
@@ -24835,3 +24837,9 @@ msgstr "Logo dieser Seite verwenden"
 #, elixir-autogen, elixir-format
 msgid "What a journalist writing about this page may download: photos in print quality and its logo as a file. Everything here is public and free for editorial use as long as the credit is shown."
 msgstr "Was eine Redaktion, die über diese Seite schreibt, herunterladen darf: Fotos in Druckqualität und das Logo als Datei. Alles hier ist öffentlich und zur redaktionellen Nutzung frei, solange der Bildnachweis genannt wird."
+
+#: lib/vutuv_web/components/press_kit_components.ex:483
+#: lib/vutuv_web/components/ui.ex:3250
+#, elixir-autogen, elixir-format
+msgid "Report this picture"
+msgstr "Dieses Bild melden"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -17,8 +17,8 @@ msgstr ""
 msgid "About us"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4972
-#: lib/vutuv_web/components/ui.ex:4977
+#: lib/vutuv_web/components/ui.ex:4973
+#: lib/vutuv_web/components/ui.ex:4978
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:729
 #: lib/vutuv_web/live/organization_live/domains.ex:287
@@ -64,7 +64,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:77
 #: lib/vutuv_web/agent_docs/text.ex:72
-#: lib/vutuv_web/components/ui.ex:5320
+#: lib/vutuv_web/components/ui.ex:5321
 #: lib/vutuv_web/controllers/address_controller.ex:22
 #: lib/vutuv_web/controllers/address_controller.ex:37
 #: lib/vutuv_web/controllers/address_controller.ex:84
@@ -83,8 +83,8 @@ msgstr ""
 msgid "Already a member? Sign in here."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4763
-#: lib/vutuv_web/components/ui.ex:4862
+#: lib/vutuv_web/components/ui.ex:4764
+#: lib/vutuv_web/components/ui.ex:4863
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:709
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:841
@@ -112,7 +112,7 @@ msgid "Birthday"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:104
-#: lib/vutuv_web/components/ui.ex:4757
+#: lib/vutuv_web/components/ui.ex:4758
 #: lib/vutuv_web/components/video_components.ex:281
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:210
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
@@ -165,7 +165,7 @@ msgid "Couldn't follow back to %{name}."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:4435
-#: lib/vutuv_web/components/ui.ex:4864
+#: lib/vutuv_web/components/ui.ex:4865
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:657
@@ -213,7 +213,7 @@ msgid "Download"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:4400
-#: lib/vutuv_web/components/ui.ex:4855
+#: lib/vutuv_web/components/ui.ex:4856
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
@@ -288,7 +288,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:5284
+#: lib/vutuv_web/components/ui.ex:5285
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -617,7 +617,7 @@ msgstr ""
 msgid "Public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4756
+#: lib/vutuv_web/components/ui.ex:4757
 #: lib/vutuv_web/live/organization_live/edit.ex:376
 #: lib/vutuv_web/live/post_live/composer.ex:2201
 #: lib/vutuv_web/live/press_kit_live.ex:795
@@ -793,7 +793,7 @@ msgstr ""
 msgid "User verified successfully."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5269
+#: lib/vutuv_web/components/ui.ex:5270
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:832
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
@@ -854,14 +854,14 @@ msgstr ""
 msgid "vCard"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4925
+#: lib/vutuv_web/components/ui.ex:4926
 #: lib/vutuv_web/templates/user/show.html.heex:1019
 #: lib/vutuv_web/templates/user/show.html.heex:1042
 #, elixir-autogen
 msgid "View All"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5443
+#: lib/vutuv_web/components/ui.ex:5444
 #: lib/vutuv_web/controllers/settings_controller.ex:175
 #: lib/vutuv_web/live/job_posting_live/form.ex:818
 #: lib/vutuv_web/live/organization_live/edit.ex:339
@@ -1356,7 +1356,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:602
 #: lib/vutuv_web/agent_docs/text.ex:868
-#: lib/vutuv_web/components/ui.ex:5305
+#: lib/vutuv_web/components/ui.ex:5306
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1737,7 +1737,7 @@ msgid "Network"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:487
-#: lib/vutuv_web/components/ui.ex:4974
+#: lib/vutuv_web/components/ui.ex:4975
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:804
@@ -1753,7 +1753,7 @@ msgid "Nothing new yet."
 msgstr ""
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:5342
+#: lib/vutuv_web/components/ui.ex:5343
 #: lib/vutuv_web/controllers/page_controller.ex:214
 #: lib/vutuv_web/live/notification_live/index.ex:154
 #: lib/vutuv_web/live/notification_live/index.ex:440
@@ -1892,14 +1892,14 @@ msgstr ""
 msgid "started following you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4231
-#: lib/vutuv_web/components/ui.ex:4376
+#: lib/vutuv_web/components/ui.ex:4232
+#: lib/vutuv_web/components/ui.ex:4377
 #: lib/vutuv_web/live/import_connections_live.ex:638
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4999
+#: lib/vutuv_web/components/ui.ex:5000
 #: lib/vutuv_web/live/organization_live/activity.ex:159
 #: lib/vutuv_web/live/organization_live/feed.ex:258
 #: lib/vutuv_web/live/organization_live/show.ex:810
@@ -1912,7 +1912,7 @@ msgstr ""
 msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4766
+#: lib/vutuv_web/components/ui.ex:4767
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
@@ -1957,12 +1957,12 @@ msgstr ""
 msgid "Add cover photo"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3662
+#: lib/vutuv_web/components/ui.ex:3663
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3666
+#: lib/vutuv_web/components/ui.ex:3667
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr ""
@@ -1977,7 +1977,7 @@ msgstr ""
 msgid "Change cover photo"
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:173
+#: lib/vutuv_web/controllers/report_controller.ex:177
 #: lib/vutuv_web/templates/user/edit.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "Cover photo"
@@ -1988,37 +1988,37 @@ msgstr ""
 msgid "Cover photo of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3670
+#: lib/vutuv_web/components/ui.ex:3671
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3660
+#: lib/vutuv_web/components/ui.ex:3661
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3659
+#: lib/vutuv_web/components/ui.ex:3660
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3665
+#: lib/vutuv_web/components/ui.ex:3666
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3664
+#: lib/vutuv_web/components/ui.ex:3665
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3661
+#: lib/vutuv_web/components/ui.ex:3662
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3663
+#: lib/vutuv_web/components/ui.ex:3664
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr ""
@@ -2033,17 +2033,17 @@ msgstr ""
 msgid "Member since %{year}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3669
+#: lib/vutuv_web/components/ui.ex:3670
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3668
+#: lib/vutuv_web/components/ui.ex:3669
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3667
+#: lib/vutuv_web/components/ui.ex:3668
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr ""
@@ -2277,7 +2277,7 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5687
+#: lib/vutuv_web/components/ui.ex:5688
 #: lib/vutuv_web/live/shell_live.ex:1582
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2321,7 +2321,7 @@ msgstr ""
 msgid "people you don't follow"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3758
+#: lib/vutuv_web/components/ui.ex:3759
 #: lib/vutuv_web/views/post_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "unknown"
@@ -2362,7 +2362,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2181
 #: lib/vutuv_web/components/post_components.ex:6792
-#: lib/vutuv_web/components/ui.ex:4298
+#: lib/vutuv_web/components/ui.ex:4299
 #: lib/vutuv_web/views/user_html.ex:486
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2381,7 +2381,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2125
 #: lib/vutuv_web/components/post_components.ex:7033
-#: lib/vutuv_web/components/ui.ex:4284
+#: lib/vutuv_web/components/ui.ex:4285
 #: lib/vutuv_web/notification_line.ex:317
 #: lib/vutuv_web/views/user_html.ex:496
 #, elixir-autogen, elixir-format
@@ -2589,7 +2589,7 @@ msgstr ""
 msgid "No conversations yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3370
+#: lib/vutuv_web/components/ui.ex:3371
 #: lib/vutuv_web/live/message_live/index.ex:760
 #, elixir-autogen, elixir-format
 msgid "Online"
@@ -2737,8 +2737,8 @@ msgstr ""
 msgid "Write your first post"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4464
-#: lib/vutuv_web/components/ui.ex:4927
+#: lib/vutuv_web/components/ui.ex:4465
+#: lib/vutuv_web/components/ui.ex:4928
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:109
@@ -3111,7 +3111,7 @@ msgstr ""
 msgid "Owner"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5263
+#: lib/vutuv_web/components/ui.ex:5264
 #: lib/vutuv_web/live/shell_live.ex:1373
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3144,7 +3144,7 @@ msgstr ""
 msgid "Report"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:255
+#: lib/vutuv_web/controllers/public_report_controller.ex:262
 #: lib/vutuv_web/controllers/report_controller.ex:54
 #: lib/vutuv_web/templates/layout/app.html.heex:131
 #: lib/vutuv_web/templates/page/legal.html.heex:42
@@ -3223,7 +3223,7 @@ msgstr ""
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4146
+#: lib/vutuv_web/components/ui.ex:4147
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:784
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -3296,7 +3296,7 @@ msgstr ""
 msgid "Tell us more in the note below."
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:157
+#: lib/vutuv_web/controllers/report_controller.ex:161
 #, elixir-autogen, elixir-format
 msgid "Thank you for your report. We take it from here."
 msgstr ""
@@ -3399,12 +3399,12 @@ msgstr ""
 msgid "Worst offenders first. Reporters with abusive reports or three rejections in a year lose the instant freeze; their reports only flag for review."
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:89
+#: lib/vutuv_web/controllers/report_controller.ex:93
 #, elixir-autogen, elixir-format
 msgid "You already reported this. Our team is on it."
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:95
+#: lib/vutuv_web/controllers/report_controller.ex:99
 #, elixir-autogen, elixir-format
 msgid "You cannot report your own content."
 msgstr ""
@@ -4269,12 +4269,12 @@ msgstr ""
 msgid "Bookings are open through %{last}. Next available day: %{day}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3705
+#: lib/vutuv_web/components/ui.ex:3706
 #, elixir-autogen, elixir-format
 msgid "Fr"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3701
+#: lib/vutuv_web/components/ui.ex:3702
 #, elixir-autogen, elixir-format
 msgid "Mo"
 msgstr ""
@@ -4284,27 +4284,27 @@ msgstr ""
 msgid "One ad per calendar day: pick a free day in the calendar; struck-through days are already booked."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3706
+#: lib/vutuv_web/components/ui.ex:3707
 #, elixir-autogen, elixir-format
 msgid "Sa"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3707
+#: lib/vutuv_web/components/ui.ex:3708
 #, elixir-autogen, elixir-format
 msgid "Su"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3704
+#: lib/vutuv_web/components/ui.ex:3705
 #, elixir-autogen, elixir-format
 msgid "Th"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3702
+#: lib/vutuv_web/components/ui.ex:3703
 #, elixir-autogen, elixir-format
 msgid "Tu"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3703
+#: lib/vutuv_web/components/ui.ex:3704
 #, elixir-autogen, elixir-format
 msgid "We"
 msgstr ""
@@ -4436,7 +4436,7 @@ msgstr ""
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5447
+#: lib/vutuv_web/components/ui.ex:5448
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -5203,7 +5203,7 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5497
+#: lib/vutuv_web/components/ui.ex:5498
 #: lib/vutuv_web/controllers/settings_controller.ex:161
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:517
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5282,10 +5282,10 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5594
-#: lib/vutuv_web/components/ui.ex:5599
-#: lib/vutuv_web/components/ui.ex:5678
-#: lib/vutuv_web/components/ui.ex:5742
+#: lib/vutuv_web/components/ui.ex:5595
+#: lib/vutuv_web/components/ui.ex:5600
+#: lib/vutuv_web/components/ui.ex:5679
+#: lib/vutuv_web/components/ui.ex:5743
 #: lib/vutuv_web/controllers/settings_controller.ex:68
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5403,7 +5403,7 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5467
+#: lib/vutuv_web/components/ui.ex:5468
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:262
@@ -5424,7 +5424,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5312
+#: lib/vutuv_web/components/ui.ex:5313
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5459,7 +5459,7 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5441
+#: lib/vutuv_web/components/ui.ex:5442
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #, elixir-autogen, elixir-format
 msgid "Privacy"
@@ -5572,7 +5572,7 @@ msgstr ""
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5490
+#: lib/vutuv_web/components/ui.ex:5491
 #: lib/vutuv_web/controllers/settings_controller.ex:185
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -5776,21 +5776,21 @@ msgid "Sort"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/components/ui.ex:3774
+#: lib/vutuv_web/components/ui.ex:3775
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3773
+#: lib/vutuv_web/components/ui.ex:3774
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3772
+#: lib/vutuv_web/components/ui.ex:3773
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
@@ -5857,7 +5857,7 @@ msgstr ""
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3771
+#: lib/vutuv_web/components/ui.ex:3772
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
@@ -7182,13 +7182,13 @@ msgstr ""
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4240
+#: lib/vutuv_web/components/ui.ex:4241
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4252
+#: lib/vutuv_web/components/ui.ex:4253
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1180
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7941,7 +7941,7 @@ msgstr ""
 msgid "PIN registered"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4243
+#: lib/vutuv_web/components/ui.ex:4244
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr ""
@@ -8071,7 +8071,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:5288
+#: lib/vutuv_web/components/ui.ex:5289
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8126,7 +8126,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5478
+#: lib/vutuv_web/components/ui.ex:5479
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8155,7 +8155,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5316
+#: lib/vutuv_web/components/ui.ex:5317
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8249,7 +8249,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4509
+#: lib/vutuv_web/components/ui.ex:4510
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8324,13 +8324,13 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5265
+#: lib/vutuv_web/components/ui.ex:5266
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5410
+#: lib/vutuv_web/components/ui.ex:5411
 #: lib/vutuv_web/controllers/settings_controller.ex:129
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8342,7 +8342,7 @@ msgstr ""
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5469
+#: lib/vutuv_web/components/ui.ex:5470
 #: lib/vutuv_web/controllers/settings_controller.ex:112
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8352,7 +8352,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5482
+#: lib/vutuv_web/components/ui.ex:5483
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8558,7 +8558,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:670
 #: lib/vutuv_web/components/organization_components.ex:285
 #: lib/vutuv_web/components/ui.ex:1807
-#: lib/vutuv_web/components/ui.ex:5459
+#: lib/vutuv_web/components/ui.ex:5460
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:366
 #: lib/vutuv_web/controllers/settings_controller.ex:433
@@ -9502,7 +9502,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:5292
+#: lib/vutuv_web/components/ui.ex:5293
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -9698,13 +9698,13 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3897
+#: lib/vutuv_web/components/ui.ex:3898
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3896
-#: lib/vutuv_web/components/ui.ex:3904
+#: lib/vutuv_web/components/ui.ex:3897
+#: lib/vutuv_web/components/ui.ex:3905
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
@@ -9837,7 +9837,7 @@ msgstr ""
 msgid "Spam"
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:145
+#: lib/vutuv_web/controllers/report_controller.ex:149
 #, elixir-autogen, elixir-format
 msgid "Thank you for your report. Our moderators have been notified and will review this account."
 msgstr ""
@@ -9853,7 +9853,7 @@ msgstr ""
 msgid "deleted"
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:132
+#: lib/vutuv_web/controllers/report_controller.ex:136
 #, elixir-autogen, elixir-format
 msgid "To protect you, the connection between you and the reported member is paused - no contact in either direction, including messages. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -10998,12 +10998,12 @@ msgstr ""
 msgid "State / region (optional)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4596
+#: lib/vutuv_web/components/ui.ex:4597
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4598
+#: lib/vutuv_web/components/ui.ex:4599
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr ""
@@ -11686,7 +11686,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:524
 #: lib/vutuv_web/agent_docs/organization_doc.ex:138
 #: lib/vutuv_web/agent_docs/text.ex:480
-#: lib/vutuv_web/components/ui.ex:5486
+#: lib/vutuv_web/components/ui.ex:5487
 #: lib/vutuv_web/controllers/settings_controller.ex:222
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
@@ -12895,7 +12895,7 @@ msgstr ""
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5395
+#: lib/vutuv_web/components/ui.ex:5396
 #: lib/vutuv_web/controllers/settings_controller.ex:629
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13353,7 +13353,7 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5378
+#: lib/vutuv_web/components/ui.ex:5379
 #: lib/vutuv_web/controllers/settings_controller.ex:643
 #: lib/vutuv_web/live/post_live/feed.ex:710
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -13428,7 +13428,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:69
 #: lib/vutuv_web/agent_docs/text.ex:64
-#: lib/vutuv_web/components/ui.ex:5335
+#: lib/vutuv_web/components/ui.ex:5336
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -13456,14 +13456,14 @@ msgstr ""
 msgid "Select a messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4681
+#: lib/vutuv_web/components/ui.ex:4682
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:4691
+#: lib/vutuv_web/components/ui.ex:4692
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
@@ -13646,7 +13646,7 @@ msgid_plural "%{formatted} new notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3678
+#: lib/vutuv_web/components/ui.ex:3679
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr ""
@@ -14216,7 +14216,7 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5349
+#: lib/vutuv_web/components/ui.ex:5350
 #: lib/vutuv_web/controllers/settings_controller.ex:773
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -14850,252 +14850,252 @@ msgstr ""
 msgid "moved to %{address}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5266
+#: lib/vutuv_web/components/ui.ex:5267
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5271
+#: lib/vutuv_web/components/ui.ex:5272
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5285
+#: lib/vutuv_web/components/ui.ex:5286
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5286
+#: lib/vutuv_web/components/ui.ex:5287
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5289
+#: lib/vutuv_web/components/ui.ex:5290
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5290
+#: lib/vutuv_web/components/ui.ex:5291
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5293
+#: lib/vutuv_web/components/ui.ex:5294
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5294
+#: lib/vutuv_web/components/ui.ex:5295
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5301
+#: lib/vutuv_web/components/ui.ex:5302
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5302
+#: lib/vutuv_web/components/ui.ex:5303
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5303
+#: lib/vutuv_web/components/ui.ex:5304
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5306
+#: lib/vutuv_web/components/ui.ex:5307
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5307
+#: lib/vutuv_web/components/ui.ex:5308
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5487
+#: lib/vutuv_web/components/ui.ex:5488
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5488
+#: lib/vutuv_web/components/ui.ex:5489
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5310
+#: lib/vutuv_web/components/ui.ex:5311
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5313
+#: lib/vutuv_web/components/ui.ex:5314
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5314
+#: lib/vutuv_web/components/ui.ex:5315
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5317
+#: lib/vutuv_web/components/ui.ex:5318
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5318
+#: lib/vutuv_web/components/ui.ex:5319
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5321
+#: lib/vutuv_web/components/ui.ex:5322
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5322
+#: lib/vutuv_web/components/ui.ex:5323
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5324
+#: lib/vutuv_web/components/ui.ex:5325
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5325
+#: lib/vutuv_web/components/ui.ex:5326
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5326
+#: lib/vutuv_web/components/ui.ex:5327
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5328
+#: lib/vutuv_web/components/ui.ex:5329
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5329
+#: lib/vutuv_web/components/ui.ex:5330
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5331
+#: lib/vutuv_web/components/ui.ex:5332
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5336
+#: lib/vutuv_web/components/ui.ex:5337
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5337
+#: lib/vutuv_web/components/ui.ex:5338
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5340
+#: lib/vutuv_web/components/ui.ex:5341
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5343
+#: lib/vutuv_web/components/ui.ex:5344
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5350
+#: lib/vutuv_web/components/ui.ex:5351
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5351
+#: lib/vutuv_web/components/ui.ex:5352
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5379
+#: lib/vutuv_web/components/ui.ex:5380
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5380
+#: lib/vutuv_web/components/ui.ex:5381
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5396
+#: lib/vutuv_web/components/ui.ex:5397
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5397
+#: lib/vutuv_web/components/ui.ex:5398
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5444
+#: lib/vutuv_web/components/ui.ex:5445
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5445
+#: lib/vutuv_web/components/ui.ex:5446
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5448
+#: lib/vutuv_web/components/ui.ex:5449
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5449
+#: lib/vutuv_web/components/ui.ex:5450
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5470
+#: lib/vutuv_web/components/ui.ex:5471
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5471
+#: lib/vutuv_web/components/ui.ex:5472
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5479
+#: lib/vutuv_web/components/ui.ex:5480
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5480
+#: lib/vutuv_web/components/ui.ex:5481
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5483
+#: lib/vutuv_web/components/ui.ex:5484
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5484
+#: lib/vutuv_web/components/ui.ex:5485
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5498
+#: lib/vutuv_web/components/ui.ex:5499
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5499
+#: lib/vutuv_web/components/ui.ex:5500
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr ""
@@ -15554,7 +15554,7 @@ msgstr ""
 msgid "Access token revoked"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5473
+#: lib/vutuv_web/components/ui.ex:5474
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -15899,7 +15899,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5474
+#: lib/vutuv_web/components/ui.ex:5475
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr ""
@@ -15935,7 +15935,7 @@ msgstr ""
 msgid "from a signed-in session"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5476
+#: lib/vutuv_web/components/ui.ex:5477
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -16131,13 +16131,13 @@ msgid "Open Fediverse settings"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:5364
-#: lib/vutuv_web/components/press_kit_components.ex:399
+#: lib/vutuv_web/components/press_kit_components.ex:452
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:5592
-#: lib/vutuv_web/components/press_kit_components.ex:469
+#: lib/vutuv_web/components/press_kit_components.ex:536
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16445,7 +16445,7 @@ msgstr ""
 msgid "Cancel request"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5460
+#: lib/vutuv_web/components/ui.ex:5461
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
@@ -16648,7 +16648,7 @@ msgstr ""
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5462
+#: lib/vutuv_web/components/ui.ex:5463
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
@@ -17720,7 +17720,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:54
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:5296
+#: lib/vutuv_web/components/ui.ex:5297
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -17915,7 +17915,7 @@ msgstr ""
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5297
+#: lib/vutuv_web/components/ui.ex:5298
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr ""
@@ -17926,7 +17926,7 @@ msgstr ""
 msgid "Zwischenzeugnis"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5299
+#: lib/vutuv_web/components/ui.ex:5300
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr ""
@@ -18181,7 +18181,7 @@ msgstr ""
 msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4582
+#: lib/vutuv_web/components/ui.ex:4583
 #: lib/vutuv_web/live/press_kit_live.ex:382
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
@@ -18498,7 +18498,7 @@ msgstr ""
 msgid "Shares are of the %{answered} members who answered. %{unanswered} gave no answer."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5267
+#: lib/vutuv_web/components/ui.ex:5268
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr ""
@@ -18594,7 +18594,7 @@ msgstr ""
 msgid "Always keep"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5453
+#: lib/vutuv_web/components/ui.ex:5454
 #: lib/vutuv_web/controllers/settings_controller.ex:256
 #: lib/vutuv_web/controllers/settings_controller.ex:335
 #: lib/vutuv_web/controllers/settings_controller.ex:347
@@ -18691,7 +18691,7 @@ msgstr ""
 msgid "Keep posts that did well"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5455
+#: lib/vutuv_web/components/ui.ex:5456
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr ""
@@ -18800,7 +18800,7 @@ msgstr ""
 msgid "Your rule"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5457
+#: lib/vutuv_web/components/ui.ex:5458
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
@@ -20073,7 +20073,7 @@ msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:5877
-#: lib/vutuv_web/components/ui.ex:5371
+#: lib/vutuv_web/components/ui.ex:5372
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
 #: lib/vutuv_web/templates/settings/preferences.html.heex:187
@@ -20284,7 +20284,7 @@ msgstr ""
 msgid "Mastodon app access changed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5491
+#: lib/vutuv_web/components/ui.ex:5492
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr ""
@@ -20330,7 +20330,7 @@ msgstr ""
 msgid "Your account is then %{handle}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5493
+#: lib/vutuv_web/components/ui.ex:5494
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr ""
@@ -20365,7 +20365,7 @@ msgstr ""
 msgid "Find your LinkedIn contacts"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5387
+#: lib/vutuv_web/components/ui.ex:5388
 #: lib/vutuv_web/live/import_connections_live.ex:64
 #: lib/vutuv_web/templates/import/new.html.heex:37
 #, elixir-autogen, elixir-format
@@ -20473,7 +20473,7 @@ msgstr ""
 msgid "See which of them are already on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5389
+#: lib/vutuv_web/components/ui.ex:5390
 #, elixir-autogen, elixir-format
 msgid "See which of your LinkedIn contacts are already on vutuv"
 msgstr ""
@@ -20545,7 +20545,7 @@ msgstr ""
 msgid "Your export also lists your LinkedIn contacts."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5391
+#: lib/vutuv_web/components/ui.ex:5392
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
 msgstr ""
@@ -20802,7 +20802,7 @@ msgstr ""
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5345
+#: lib/vutuv_web/components/ui.ex:5346
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr ""
@@ -21023,22 +21023,22 @@ msgstr ""
 msgid "Shown in the language it was written in."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5372
+#: lib/vutuv_web/components/ui.ex:5373
 #, elixir-autogen, elixir-format
 msgid "Which languages reach you, and what happens to the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5374
+#: lib/vutuv_web/components/ui.ex:5375
 #, elixir-autogen, elixir-format
 msgid "language translate translation german english original hide foreign rank order sprache übersetzen fremdsprache reihenfolge"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5412
+#: lib/vutuv_web/components/ui.ex:5413
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, maps, how posts are shortened"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5416
+#: lib/vutuv_web/components/ui.ex:5417
 #, elixir-autogen, elixir-format
 msgid "german english locale map font length hyphenation übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr ""
@@ -21517,7 +21517,7 @@ msgstr ""
 msgid "Your organization page was updated, but that picture could not be used as a logo. Please pick another one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4588
+#: lib/vutuv_web/components/ui.ex:4589
 #, elixir-autogen, elixir-format
 msgid "You can upload one file at a time."
 msgid_plural "You can upload at most %{count} files at a time."
@@ -21715,7 +21715,7 @@ msgstr ""
 msgid "Only these accounts (empty = all) …"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3566
+#: lib/vutuv_web/components/ui.ex:3567
 #, elixir-autogen, elixir-format
 msgid "only %{account}"
 msgstr ""
@@ -21957,7 +21957,7 @@ msgstr ""
 msgid "Replace with"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5364
+#: lib/vutuv_web/components/ui.ex:5365
 #, elixir-autogen, elixir-format
 msgid "Rewrite what an account's posts say, for you alone"
 msgstr ""
@@ -21975,7 +21975,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1452
 #: lib/vutuv_web/components/post_components.ex:3402
 #: lib/vutuv_web/components/post_components.ex:4496
-#: lib/vutuv_web/components/ui.ex:5363
+#: lib/vutuv_web/components/ui.ex:5364
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
 #: lib/vutuv_web/live/post_rewrites_live.ex:264
@@ -22031,12 +22031,12 @@ msgstr ""
 msgid "\\1 puts back what the first (…) group matched, \\0 the whole match."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5365
+#: lib/vutuv_web/components/ui.ex:5366
 #, elixir-autogen, elixir-format
 msgid "regex regular expression rewrite replace footer signature strip"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5434
+#: lib/vutuv_web/components/ui.ex:5435
 #, elixir-autogen, elixir-format
 msgid "Smaller pictures and a plain composer on a slow connection"
 msgstr ""
@@ -22046,12 +22046,12 @@ msgstr ""
 msgid "That endorsement is not possible."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5436
+#: lib/vutuv_web/components/ui.ex:5437
 #, elixir-autogen, elixir-format
 msgid "bandwidth slow internet mobile data saving saver volume metered compression pictures images screenshots editor langsam daten sparen datensparmodus volumen schmalband komprimierung bilder"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5408
+#: lib/vutuv_web/components/ui.ex:5409
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr ""
@@ -22531,7 +22531,7 @@ msgstr ""
 msgid "Accounts whose posts stay out of your feed, and accounts whose reposts do. This list is yours alone: it is never shared and nobody is told they are on it."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5357
+#: lib/vutuv_web/components/ui.ex:5358
 #, elixir-autogen, elixir-format
 msgid "Accounts you have silenced, and whose reposts you hide"
 msgstr ""
@@ -22557,7 +22557,7 @@ msgstr ""
 msgid "Mute everything"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5356
+#: lib/vutuv_web/components/ui.ex:5357
 #: lib/vutuv_web/controllers/settings_controller.ex:713
 #: lib/vutuv_web/templates/settings/mutes.html.heex:1
 #: lib/vutuv_web/templates/settings/mutes.html.heex:3
@@ -22601,7 +22601,7 @@ msgstr ""
 msgid "You mute an account where you meet it: the ⋯ menu on any of its posts, or its own page. Muting works whether or not you follow them."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5359
+#: lib/vutuv_web/components/ui.ex:5360
 #, elixir-autogen, elixir-format
 msgid "mute unmute hide account reposts boosts feed stumm stummschalten ausblenden konto"
 msgstr ""
@@ -22701,7 +22701,7 @@ msgstr ""
 msgid "Feed settings saved."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5427
+#: lib/vutuv_web/components/ui.ex:5428
 #, elixir-autogen, elixir-format
 msgid "How many load at once, and how many “Load more” adds"
 msgstr ""
@@ -22711,7 +22711,7 @@ msgstr ""
 msgid "How many posts your feed shows before the “Load more” button, and how many that button adds. More posts mean a longer wait for the page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5426
+#: lib/vutuv_web/components/ui.ex:5427
 #: lib/vutuv_web/controllers/settings_controller.ex:963
 #: lib/vutuv_web/templates/settings/feed.html.heex:12
 #, elixir-autogen, elixir-format
@@ -22734,7 +22734,7 @@ msgstr ""
 msgid "You can change this under the feed itself as well, right below the “Load more” button."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5429
+#: lib/vutuv_web/components/ui.ex:5430
 #, elixir-autogen, elixir-format
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr ""
@@ -23120,7 +23120,7 @@ msgstr ""
 msgid "Neither your profile picture nor your cover photo was replaced: a report about them is still open. Open the case to remove the picture or to say that it is yours."
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:174
+#: lib/vutuv_web/controllers/report_controller.ex:190
 #, elixir-autogen, elixir-format
 msgid "Profile picture"
 msgstr ""
@@ -23203,7 +23203,7 @@ msgstr ""
 msgid "A picture goes offline right away for a copyright notice; every other report goes to our admins with the picture left where it is."
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:151
+#: lib/vutuv_web/controllers/report_controller.ex:155
 #, elixir-autogen, elixir-format
 msgid "Thank you for your report. Our moderators have been notified and will review this picture."
 msgstr ""
@@ -23233,8 +23233,8 @@ msgstr ""
 msgid "Confirm the report"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:91
-#: lib/vutuv_web/controllers/public_report_controller.ex:111
+#: lib/vutuv_web/controllers/public_report_controller.ex:98
+#: lib/vutuv_web/controllers/public_report_controller.ex:118
 #: lib/vutuv_web/templates/public_report/confirm.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Confirm your report"
@@ -23286,8 +23286,8 @@ msgstr ""
 msgid "Please confirm your report"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:88
-#: lib/vutuv_web/controllers/public_report_controller.ex:116
+#: lib/vutuv_web/controllers/public_report_controller.ex:95
+#: lib/vutuv_web/controllers/public_report_controller.ex:123
 #, elixir-autogen, elixir-format
 msgid "Report confirmed"
 msgstr ""
@@ -23302,7 +23302,7 @@ msgstr ""
 msgid "Report filed from outside"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:171
+#: lib/vutuv_web/controllers/public_report_controller.ex:178
 #, elixir-autogen, elixir-format
 msgid "Report sent"
 msgstr ""
@@ -23317,7 +23317,7 @@ msgstr ""
 msgid "Thank you - your report is with our admins"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:133
+#: lib/vutuv_web/controllers/public_report_controller.ex:140
 #, elixir-autogen, elixir-format
 msgid "That address is not on this site. We can only act on content published here."
 msgstr ""
@@ -23332,7 +23332,7 @@ msgstr ""
 msgid "The report by %{email} was a deliberate weapon (that address loses our trust)"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:232
+#: lib/vutuv_web/controllers/public_report_controller.ex:239
 #, elixir-autogen, elixir-format
 msgid "We could not find that page. Please check the address."
 msgstr ""
@@ -23347,7 +23347,7 @@ msgstr ""
 msgid "What is wrong with it?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:176
+#: lib/vutuv_web/controllers/public_report_controller.ex:183
 #, elixir-autogen, elixir-format
 msgid "You already sent us this report. Please use the confirmation link in the email we sent you."
 msgstr ""
@@ -23362,7 +23362,7 @@ msgstr ""
 msgid "You do not need to do anything else."
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:72
+#: lib/vutuv_web/controllers/public_report_controller.ex:79
 #, elixir-autogen, elixir-format
 msgid "You have sent us a lot of reports just now. Please try again later."
 msgstr ""
@@ -23428,8 +23428,8 @@ msgstr ""
 msgid "Send the report again"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:99
-#: lib/vutuv_web/controllers/public_report_controller.ex:121
+#: lib/vutuv_web/controllers/public_report_controller.ex:106
+#: lib/vutuv_web/controllers/public_report_controller.ex:128
 #: lib/vutuv_web/templates/public_report/expired.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "This link has expired"
@@ -23625,7 +23625,7 @@ msgstr ""
 msgid "Texts, photos and videos belong to whoever made them. Post your own work, or work you have permission to use. A rights holder can report content here without an account, through {form}; such a complaint is decided by one of our admins, and an edit does not settle it."
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:143
+#: lib/vutuv_web/controllers/public_report_controller.ex:150
 #, elixir-autogen, elixir-format
 msgid "That address is one of our own pages, not content somebody published here, so there is nothing on it we could act on. Please paste the address of the post, picture, video, profile or job posting itself."
 msgstr ""
@@ -23651,7 +23651,7 @@ msgid "“%{note}”"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:5236
-#: lib/vutuv_web/components/press_kit_components.ex:207
+#: lib/vutuv_web/components/press_kit_components.ex:209
 #, elixir-autogen, elixir-format
 msgid "Show these photos larger"
 msgstr ""
@@ -23721,7 +23721,7 @@ msgstr ""
 msgid "Dark"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5278
+#: lib/vutuv_web/components/ui.ex:5279
 #, elixir-autogen, elixir-format
 msgid "Files a journalist may download and print"
 msgstr ""
@@ -23746,6 +23746,7 @@ msgstr ""
 msgid "Light"
 msgstr ""
 
+#: lib/vutuv_web/controllers/report_controller.ex:193
 #: lib/vutuv_web/live/press_kit_live.ex:1006
 #, elixir-autogen, elixir-format
 msgid "Logo variant"
@@ -23795,6 +23796,7 @@ msgstr ""
 msgid "Please confirm the rights first, then choose the file."
 msgstr ""
 
+#: lib/vutuv_web/controllers/report_controller.ex:193
 #: lib/vutuv_web/live/press_kit_live.ex:1006
 #, elixir-autogen, elixir-format
 msgid "Press photo"
@@ -23808,7 +23810,7 @@ msgstr ""
 msgid "Press photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5277
+#: lib/vutuv_web/components/ui.ex:5278
 #: lib/vutuv_web/live/press_kit_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Press photos & logos"
@@ -23879,7 +23881,7 @@ msgstr ""
 msgid "Your logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5280
+#: lib/vutuv_web/components/ui.ex:5281
 #, elixir-autogen, elixir-format
 msgid "press kit media journalist photographer download original print logo svg credit copyright presse pressemappe fotos logo herunterladen bildnachweis"
 msgstr ""
@@ -23889,24 +23891,24 @@ msgstr ""
 msgid "Ready-made buttons and badges"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3619
+#: lib/vutuv_web/components/ui.ex:3620
 #, elixir-autogen, elixir-format
 msgid "%{count} byte"
 msgid_plural "%{count} bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/press_kit_components.ex:99
+#: lib/vutuv_web/components/press_kit_components.ex:100
 #, elixir-autogen, elixir-format
 msgid "Add press photos"
 msgstr ""
 
-#: lib/vutuv_web/components/press_kit_components.ex:117
+#: lib/vutuv_web/components/press_kit_components.ex:118
 #, elixir-autogen, elixir-format
 msgid "All press material"
 msgstr ""
 
-#: lib/vutuv_web/components/press_kit_components.ex:173
+#: lib/vutuv_web/components/press_kit_components.ex:174
 #, elixir-autogen, elixir-format
 msgid "All press photos"
 msgstr ""
@@ -23917,18 +23919,18 @@ msgstr ""
 msgid "Credit: %{credit}"
 msgstr ""
 
-#: lib/vutuv_web/components/press_kit_components.ex:320
 #: lib/vutuv_web/components/press_kit_components.ex:323
+#: lib/vutuv_web/components/press_kit_components.ex:326
 #, elixir-autogen, elixir-format
 msgid "Download %{format}"
 msgstr ""
 
-#: lib/vutuv_web/components/press_kit_components.ex:276
+#: lib/vutuv_web/components/press_kit_components.ex:279
 #, elixir-autogen, elixir-format
 msgid "Download photo"
 msgstr ""
 
-#: lib/vutuv/press_kit.ex:496
+#: lib/vutuv/press_kit.ex:503
 #, elixir-autogen, elixir-format
 msgid "Free for editorial use with credit."
 msgstr ""
@@ -23943,7 +23945,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:57
 #: lib/vutuv_web/agent_docs/text.ex:257
 #: lib/vutuv_web/components/organization_components.ex:262
-#: lib/vutuv_web/components/press_kit_components.ex:97
+#: lib/vutuv_web/components/press_kit_components.ex:98
 #: lib/vutuv_web/live/organization_live/show.ex:168
 #: lib/vutuv_web/views/press_kit_html.ex:28
 #: lib/vutuv_web/views/press_kit_html.ex:46
@@ -24001,4 +24003,10 @@ msgstr ""
 #: lib/vutuv_web/live/press_kit_live.ex:468
 #, elixir-autogen, elixir-format
 msgid "What a journalist writing about this page may download: photos in print quality and its logo as a file. Everything here is public and free for editorial use as long as the credit is shown."
+msgstr ""
+
+#: lib/vutuv_web/components/press_kit_components.ex:483
+#: lib/vutuv_web/components/ui.ex:3250
+#, elixir-autogen, elixir-format
+msgid "Report this picture"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -15,8 +15,8 @@ msgstr "Language: en\n"
 msgid "About us"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4972
-#: lib/vutuv_web/components/ui.ex:4977
+#: lib/vutuv_web/components/ui.ex:4973
+#: lib/vutuv_web/components/ui.ex:4978
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:729
 #: lib/vutuv_web/live/organization_live/domains.ex:287
@@ -62,7 +62,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:77
 #: lib/vutuv_web/agent_docs/text.ex:72
-#: lib/vutuv_web/components/ui.ex:5320
+#: lib/vutuv_web/components/ui.ex:5321
 #: lib/vutuv_web/controllers/address_controller.ex:22
 #: lib/vutuv_web/controllers/address_controller.ex:37
 #: lib/vutuv_web/controllers/address_controller.ex:84
@@ -81,8 +81,8 @@ msgstr ""
 msgid "Already a member? Sign in here."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4763
-#: lib/vutuv_web/components/ui.ex:4862
+#: lib/vutuv_web/components/ui.ex:4764
+#: lib/vutuv_web/components/ui.ex:4863
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:709
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:841
@@ -110,7 +110,7 @@ msgid "Birthday"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:104
-#: lib/vutuv_web/components/ui.ex:4757
+#: lib/vutuv_web/components/ui.ex:4758
 #: lib/vutuv_web/components/video_components.ex:281
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:210
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
@@ -163,7 +163,7 @@ msgid "Couldn't follow back to %{name}."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:4435
-#: lib/vutuv_web/components/ui.ex:4864
+#: lib/vutuv_web/components/ui.ex:4865
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:657
@@ -211,7 +211,7 @@ msgid "Download"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:4400
-#: lib/vutuv_web/components/ui.ex:4855
+#: lib/vutuv_web/components/ui.ex:4856
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
@@ -286,7 +286,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:5284
+#: lib/vutuv_web/components/ui.ex:5285
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -615,7 +615,7 @@ msgstr ""
 msgid "Public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4756
+#: lib/vutuv_web/components/ui.ex:4757
 #: lib/vutuv_web/live/organization_live/edit.ex:376
 #: lib/vutuv_web/live/post_live/composer.ex:2201
 #: lib/vutuv_web/live/press_kit_live.ex:795
@@ -791,7 +791,7 @@ msgstr ""
 msgid "User verified successfully."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5269
+#: lib/vutuv_web/components/ui.ex:5270
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:832
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
@@ -852,14 +852,14 @@ msgstr ""
 msgid "vCard"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4925
+#: lib/vutuv_web/components/ui.ex:4926
 #: lib/vutuv_web/templates/user/show.html.heex:1019
 #: lib/vutuv_web/templates/user/show.html.heex:1042
 #, elixir-autogen
 msgid "View All"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5443
+#: lib/vutuv_web/components/ui.ex:5444
 #: lib/vutuv_web/controllers/settings_controller.ex:175
 #: lib/vutuv_web/live/job_posting_live/form.ex:818
 #: lib/vutuv_web/live/organization_live/edit.ex:339
@@ -1354,7 +1354,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:602
 #: lib/vutuv_web/agent_docs/text.ex:868
-#: lib/vutuv_web/components/ui.ex:5305
+#: lib/vutuv_web/components/ui.ex:5306
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1735,7 +1735,7 @@ msgid "Network"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:487
-#: lib/vutuv_web/components/ui.ex:4974
+#: lib/vutuv_web/components/ui.ex:4975
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:804
@@ -1751,7 +1751,7 @@ msgid "Nothing new yet."
 msgstr ""
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:5342
+#: lib/vutuv_web/components/ui.ex:5343
 #: lib/vutuv_web/controllers/page_controller.ex:214
 #: lib/vutuv_web/live/notification_live/index.ex:154
 #: lib/vutuv_web/live/notification_live/index.ex:440
@@ -1890,14 +1890,14 @@ msgstr ""
 msgid "started following you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4231
-#: lib/vutuv_web/components/ui.ex:4376
+#: lib/vutuv_web/components/ui.ex:4232
+#: lib/vutuv_web/components/ui.ex:4377
 #: lib/vutuv_web/live/import_connections_live.ex:638
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4999
+#: lib/vutuv_web/components/ui.ex:5000
 #: lib/vutuv_web/live/organization_live/activity.ex:159
 #: lib/vutuv_web/live/organization_live/feed.ex:258
 #: lib/vutuv_web/live/organization_live/show.ex:810
@@ -1910,7 +1910,7 @@ msgstr ""
 msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4766
+#: lib/vutuv_web/components/ui.ex:4767
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
@@ -1955,12 +1955,12 @@ msgstr ""
 msgid "Add cover photo"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3662
+#: lib/vutuv_web/components/ui.ex:3663
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3666
+#: lib/vutuv_web/components/ui.ex:3667
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr ""
@@ -1975,7 +1975,7 @@ msgstr ""
 msgid "Change cover photo"
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:173
+#: lib/vutuv_web/controllers/report_controller.ex:177
 #: lib/vutuv_web/templates/user/edit.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "Cover photo"
@@ -1986,37 +1986,37 @@ msgstr ""
 msgid "Cover photo of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3670
+#: lib/vutuv_web/components/ui.ex:3671
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3660
+#: lib/vutuv_web/components/ui.ex:3661
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3659
+#: lib/vutuv_web/components/ui.ex:3660
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3665
+#: lib/vutuv_web/components/ui.ex:3666
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3664
+#: lib/vutuv_web/components/ui.ex:3665
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3661
+#: lib/vutuv_web/components/ui.ex:3662
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3663
+#: lib/vutuv_web/components/ui.ex:3664
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr ""
@@ -2031,17 +2031,17 @@ msgstr ""
 msgid "Member since %{year}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3669
+#: lib/vutuv_web/components/ui.ex:3670
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3668
+#: lib/vutuv_web/components/ui.ex:3669
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3667
+#: lib/vutuv_web/components/ui.ex:3668
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr ""
@@ -2275,7 +2275,7 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5687
+#: lib/vutuv_web/components/ui.ex:5688
 #: lib/vutuv_web/live/shell_live.ex:1582
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2319,7 +2319,7 @@ msgstr ""
 msgid "people you don't follow"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3758
+#: lib/vutuv_web/components/ui.ex:3759
 #: lib/vutuv_web/views/post_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "unknown"
@@ -2360,7 +2360,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2181
 #: lib/vutuv_web/components/post_components.ex:6792
-#: lib/vutuv_web/components/ui.ex:4298
+#: lib/vutuv_web/components/ui.ex:4299
 #: lib/vutuv_web/views/user_html.ex:486
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2379,7 +2379,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2125
 #: lib/vutuv_web/components/post_components.ex:7033
-#: lib/vutuv_web/components/ui.ex:4284
+#: lib/vutuv_web/components/ui.ex:4285
 #: lib/vutuv_web/notification_line.ex:317
 #: lib/vutuv_web/views/user_html.ex:496
 #, elixir-autogen, elixir-format
@@ -2587,7 +2587,7 @@ msgstr ""
 msgid "No conversations yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3370
+#: lib/vutuv_web/components/ui.ex:3371
 #: lib/vutuv_web/live/message_live/index.ex:760
 #, elixir-autogen, elixir-format
 msgid "Online"
@@ -2735,8 +2735,8 @@ msgstr ""
 msgid "Write your first post"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4464
-#: lib/vutuv_web/components/ui.ex:4927
+#: lib/vutuv_web/components/ui.ex:4465
+#: lib/vutuv_web/components/ui.ex:4928
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:109
@@ -3109,7 +3109,7 @@ msgstr ""
 msgid "Owner"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5263
+#: lib/vutuv_web/components/ui.ex:5264
 #: lib/vutuv_web/live/shell_live.ex:1373
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3142,7 +3142,7 @@ msgstr ""
 msgid "Report"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:255
+#: lib/vutuv_web/controllers/public_report_controller.ex:262
 #: lib/vutuv_web/controllers/report_controller.ex:54
 #: lib/vutuv_web/templates/layout/app.html.heex:131
 #: lib/vutuv_web/templates/page/legal.html.heex:42
@@ -3221,7 +3221,7 @@ msgstr ""
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4146
+#: lib/vutuv_web/components/ui.ex:4147
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:784
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -3294,7 +3294,7 @@ msgstr ""
 msgid "Tell us more in the note below."
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:157
+#: lib/vutuv_web/controllers/report_controller.ex:161
 #, elixir-autogen, elixir-format
 msgid "Thank you for your report. We take it from here."
 msgstr ""
@@ -3397,12 +3397,12 @@ msgstr ""
 msgid "Worst offenders first. Reporters with abusive reports or three rejections in a year lose the instant freeze; their reports only flag for review."
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:89
+#: lib/vutuv_web/controllers/report_controller.ex:93
 #, elixir-autogen, elixir-format
 msgid "You already reported this. Our team is on it."
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:95
+#: lib/vutuv_web/controllers/report_controller.ex:99
 #, elixir-autogen, elixir-format
 msgid "You cannot report your own content."
 msgstr ""
@@ -4267,12 +4267,12 @@ msgstr ""
 msgid "Bookings are open through %{last}. Next available day: %{day}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3705
+#: lib/vutuv_web/components/ui.ex:3706
 #, elixir-autogen, elixir-format
 msgid "Fr"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3701
+#: lib/vutuv_web/components/ui.ex:3702
 #, elixir-autogen, elixir-format
 msgid "Mo"
 msgstr ""
@@ -4282,27 +4282,27 @@ msgstr ""
 msgid "One ad per calendar day: pick a free day in the calendar; struck-through days are already booked."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3706
+#: lib/vutuv_web/components/ui.ex:3707
 #, elixir-autogen, elixir-format
 msgid "Sa"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3707
+#: lib/vutuv_web/components/ui.ex:3708
 #, elixir-autogen, elixir-format
 msgid "Su"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3704
+#: lib/vutuv_web/components/ui.ex:3705
 #, elixir-autogen, elixir-format
 msgid "Th"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3702
+#: lib/vutuv_web/components/ui.ex:3703
 #, elixir-autogen, elixir-format
 msgid "Tu"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3703
+#: lib/vutuv_web/components/ui.ex:3704
 #, elixir-autogen, elixir-format
 msgid "We"
 msgstr ""
@@ -4434,7 +4434,7 @@ msgstr ""
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5447
+#: lib/vutuv_web/components/ui.ex:5448
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -5201,7 +5201,7 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5497
+#: lib/vutuv_web/components/ui.ex:5498
 #: lib/vutuv_web/controllers/settings_controller.ex:161
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:517
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5280,10 +5280,10 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5594
-#: lib/vutuv_web/components/ui.ex:5599
-#: lib/vutuv_web/components/ui.ex:5678
-#: lib/vutuv_web/components/ui.ex:5742
+#: lib/vutuv_web/components/ui.ex:5595
+#: lib/vutuv_web/components/ui.ex:5600
+#: lib/vutuv_web/components/ui.ex:5679
+#: lib/vutuv_web/components/ui.ex:5743
 #: lib/vutuv_web/controllers/settings_controller.ex:68
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5401,7 +5401,7 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5467
+#: lib/vutuv_web/components/ui.ex:5468
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:262
@@ -5422,7 +5422,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5312
+#: lib/vutuv_web/components/ui.ex:5313
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5457,7 +5457,7 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5441
+#: lib/vutuv_web/components/ui.ex:5442
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #, elixir-autogen, elixir-format
 msgid "Privacy"
@@ -5570,7 +5570,7 @@ msgstr ""
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5490
+#: lib/vutuv_web/components/ui.ex:5491
 #: lib/vutuv_web/controllers/settings_controller.ex:185
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -5774,21 +5774,21 @@ msgid "Sort"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/components/ui.ex:3774
+#: lib/vutuv_web/components/ui.ex:3775
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3773
+#: lib/vutuv_web/components/ui.ex:3774
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3772
+#: lib/vutuv_web/components/ui.ex:3773
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
@@ -5855,7 +5855,7 @@ msgstr ""
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3771
+#: lib/vutuv_web/components/ui.ex:3772
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
@@ -7180,13 +7180,13 @@ msgstr ""
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4240
+#: lib/vutuv_web/components/ui.ex:4241
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4252
+#: lib/vutuv_web/components/ui.ex:4253
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1180
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7939,7 +7939,7 @@ msgstr ""
 msgid "PIN registered"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4243
+#: lib/vutuv_web/components/ui.ex:4244
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr ""
@@ -8069,7 +8069,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:5288
+#: lib/vutuv_web/components/ui.ex:5289
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8124,7 +8124,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5478
+#: lib/vutuv_web/components/ui.ex:5479
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8153,7 +8153,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5316
+#: lib/vutuv_web/components/ui.ex:5317
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8247,7 +8247,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4509
+#: lib/vutuv_web/components/ui.ex:4510
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8322,13 +8322,13 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5265
+#: lib/vutuv_web/components/ui.ex:5266
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5410
+#: lib/vutuv_web/components/ui.ex:5411
 #: lib/vutuv_web/controllers/settings_controller.ex:129
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8340,7 +8340,7 @@ msgstr ""
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5469
+#: lib/vutuv_web/components/ui.ex:5470
 #: lib/vutuv_web/controllers/settings_controller.ex:112
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8350,7 +8350,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5482
+#: lib/vutuv_web/components/ui.ex:5483
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8556,7 +8556,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:670
 #: lib/vutuv_web/components/organization_components.ex:285
 #: lib/vutuv_web/components/ui.ex:1807
-#: lib/vutuv_web/components/ui.ex:5459
+#: lib/vutuv_web/components/ui.ex:5460
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:366
 #: lib/vutuv_web/controllers/settings_controller.ex:433
@@ -9500,7 +9500,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:5292
+#: lib/vutuv_web/components/ui.ex:5293
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -9696,13 +9696,13 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3897
+#: lib/vutuv_web/components/ui.ex:3898
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3896
-#: lib/vutuv_web/components/ui.ex:3904
+#: lib/vutuv_web/components/ui.ex:3897
+#: lib/vutuv_web/components/ui.ex:3905
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
@@ -9835,7 +9835,7 @@ msgstr ""
 msgid "Spam"
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:145
+#: lib/vutuv_web/controllers/report_controller.ex:149
 #, elixir-autogen, elixir-format
 msgid "Thank you for your report. Our moderators have been notified and will review this account."
 msgstr ""
@@ -9851,7 +9851,7 @@ msgstr ""
 msgid "deleted"
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:132
+#: lib/vutuv_web/controllers/report_controller.ex:136
 #, elixir-autogen, elixir-format
 msgid "To protect you, the connection between you and the reported member is paused - no contact in either direction, including messages. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -10996,12 +10996,12 @@ msgstr ""
 msgid "State / region (optional)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4596
+#: lib/vutuv_web/components/ui.ex:4597
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4598
+#: lib/vutuv_web/components/ui.ex:4599
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr ""
@@ -11684,7 +11684,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:524
 #: lib/vutuv_web/agent_docs/organization_doc.ex:138
 #: lib/vutuv_web/agent_docs/text.ex:480
-#: lib/vutuv_web/components/ui.ex:5486
+#: lib/vutuv_web/components/ui.ex:5487
 #: lib/vutuv_web/controllers/settings_controller.ex:222
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
@@ -12893,7 +12893,7 @@ msgstr ""
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5395
+#: lib/vutuv_web/components/ui.ex:5396
 #: lib/vutuv_web/controllers/settings_controller.ex:629
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13351,7 +13351,7 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5378
+#: lib/vutuv_web/components/ui.ex:5379
 #: lib/vutuv_web/controllers/settings_controller.ex:643
 #: lib/vutuv_web/live/post_live/feed.ex:710
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -13426,7 +13426,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:69
 #: lib/vutuv_web/agent_docs/text.ex:64
-#: lib/vutuv_web/components/ui.ex:5335
+#: lib/vutuv_web/components/ui.ex:5336
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -13454,14 +13454,14 @@ msgstr ""
 msgid "Select a messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4681
+#: lib/vutuv_web/components/ui.ex:4682
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:4691
+#: lib/vutuv_web/components/ui.ex:4692
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
@@ -13644,7 +13644,7 @@ msgid_plural "%{formatted} new notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3678
+#: lib/vutuv_web/components/ui.ex:3679
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr ""
@@ -14214,7 +14214,7 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5349
+#: lib/vutuv_web/components/ui.ex:5350
 #: lib/vutuv_web/controllers/settings_controller.ex:773
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -14848,252 +14848,252 @@ msgstr ""
 msgid "moved to %{address}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5266
+#: lib/vutuv_web/components/ui.ex:5267
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5271
+#: lib/vutuv_web/components/ui.ex:5272
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5285
+#: lib/vutuv_web/components/ui.ex:5286
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5286
+#: lib/vutuv_web/components/ui.ex:5287
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5289
+#: lib/vutuv_web/components/ui.ex:5290
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5290
+#: lib/vutuv_web/components/ui.ex:5291
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5293
+#: lib/vutuv_web/components/ui.ex:5294
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5294
+#: lib/vutuv_web/components/ui.ex:5295
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5301
+#: lib/vutuv_web/components/ui.ex:5302
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5302
+#: lib/vutuv_web/components/ui.ex:5303
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5303
+#: lib/vutuv_web/components/ui.ex:5304
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5306
+#: lib/vutuv_web/components/ui.ex:5307
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5307
+#: lib/vutuv_web/components/ui.ex:5308
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5487
+#: lib/vutuv_web/components/ui.ex:5488
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5488
+#: lib/vutuv_web/components/ui.ex:5489
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5310
+#: lib/vutuv_web/components/ui.ex:5311
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5313
+#: lib/vutuv_web/components/ui.ex:5314
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5314
+#: lib/vutuv_web/components/ui.ex:5315
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5317
+#: lib/vutuv_web/components/ui.ex:5318
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5318
+#: lib/vutuv_web/components/ui.ex:5319
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5321
+#: lib/vutuv_web/components/ui.ex:5322
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5322
+#: lib/vutuv_web/components/ui.ex:5323
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5324
+#: lib/vutuv_web/components/ui.ex:5325
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5325
+#: lib/vutuv_web/components/ui.ex:5326
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5326
+#: lib/vutuv_web/components/ui.ex:5327
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5328
+#: lib/vutuv_web/components/ui.ex:5329
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5329
+#: lib/vutuv_web/components/ui.ex:5330
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5331
+#: lib/vutuv_web/components/ui.ex:5332
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5336
+#: lib/vutuv_web/components/ui.ex:5337
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5337
+#: lib/vutuv_web/components/ui.ex:5338
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5340
+#: lib/vutuv_web/components/ui.ex:5341
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5343
+#: lib/vutuv_web/components/ui.ex:5344
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5350
+#: lib/vutuv_web/components/ui.ex:5351
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5351
+#: lib/vutuv_web/components/ui.ex:5352
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5379
+#: lib/vutuv_web/components/ui.ex:5380
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5380
+#: lib/vutuv_web/components/ui.ex:5381
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5396
+#: lib/vutuv_web/components/ui.ex:5397
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5397
+#: lib/vutuv_web/components/ui.ex:5398
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5444
+#: lib/vutuv_web/components/ui.ex:5445
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5445
+#: lib/vutuv_web/components/ui.ex:5446
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5448
+#: lib/vutuv_web/components/ui.ex:5449
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5449
+#: lib/vutuv_web/components/ui.ex:5450
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5470
+#: lib/vutuv_web/components/ui.ex:5471
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5471
+#: lib/vutuv_web/components/ui.ex:5472
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5479
+#: lib/vutuv_web/components/ui.ex:5480
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5480
+#: lib/vutuv_web/components/ui.ex:5481
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5483
+#: lib/vutuv_web/components/ui.ex:5484
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5484
+#: lib/vutuv_web/components/ui.ex:5485
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5498
+#: lib/vutuv_web/components/ui.ex:5499
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5499
+#: lib/vutuv_web/components/ui.ex:5500
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr ""
@@ -15552,7 +15552,7 @@ msgstr ""
 msgid "Access token revoked"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5473
+#: lib/vutuv_web/components/ui.ex:5474
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -15897,7 +15897,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5474
+#: lib/vutuv_web/components/ui.ex:5475
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr ""
@@ -15933,7 +15933,7 @@ msgstr ""
 msgid "from a signed-in session"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5476
+#: lib/vutuv_web/components/ui.ex:5477
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -16129,13 +16129,13 @@ msgid "Open Fediverse settings"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:5364
-#: lib/vutuv_web/components/press_kit_components.ex:399
+#: lib/vutuv_web/components/press_kit_components.ex:452
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:5592
-#: lib/vutuv_web/components/press_kit_components.ex:469
+#: lib/vutuv_web/components/press_kit_components.ex:536
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16443,7 +16443,7 @@ msgstr ""
 msgid "Cancel request"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5460
+#: lib/vutuv_web/components/ui.ex:5461
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
@@ -16646,7 +16646,7 @@ msgstr ""
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5462
+#: lib/vutuv_web/components/ui.ex:5463
 #, elixir-autogen, elixir-format, fuzzy
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
@@ -17718,7 +17718,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:54
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:5296
+#: lib/vutuv_web/components/ui.ex:5297
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -17913,7 +17913,7 @@ msgstr ""
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5297
+#: lib/vutuv_web/components/ui.ex:5298
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr ""
@@ -17924,7 +17924,7 @@ msgstr ""
 msgid "Zwischenzeugnis"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5299
+#: lib/vutuv_web/components/ui.ex:5300
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr ""
@@ -18179,7 +18179,7 @@ msgstr ""
 msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4582
+#: lib/vutuv_web/components/ui.ex:4583
 #: lib/vutuv_web/live/press_kit_live.ex:382
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
@@ -18496,7 +18496,7 @@ msgstr ""
 msgid "Shares are of the %{answered} members who answered. %{unanswered} gave no answer."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5267
+#: lib/vutuv_web/components/ui.ex:5268
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr ""
@@ -18592,7 +18592,7 @@ msgstr ""
 msgid "Always keep"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5453
+#: lib/vutuv_web/components/ui.ex:5454
 #: lib/vutuv_web/controllers/settings_controller.ex:256
 #: lib/vutuv_web/controllers/settings_controller.ex:335
 #: lib/vutuv_web/controllers/settings_controller.ex:347
@@ -18689,7 +18689,7 @@ msgstr ""
 msgid "Keep posts that did well"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5455
+#: lib/vutuv_web/components/ui.ex:5456
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr ""
@@ -18798,7 +18798,7 @@ msgstr ""
 msgid "Your rule"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5457
+#: lib/vutuv_web/components/ui.ex:5458
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
@@ -20071,7 +20071,7 @@ msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:5877
-#: lib/vutuv_web/components/ui.ex:5371
+#: lib/vutuv_web/components/ui.ex:5372
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
 #: lib/vutuv_web/templates/settings/preferences.html.heex:187
@@ -20282,7 +20282,7 @@ msgstr ""
 msgid "Mastodon app access changed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5491
+#: lib/vutuv_web/components/ui.ex:5492
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr ""
@@ -20328,7 +20328,7 @@ msgstr ""
 msgid "Your account is then %{handle}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5493
+#: lib/vutuv_web/components/ui.ex:5494
 #, elixir-autogen, elixir-format, fuzzy
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr ""
@@ -20363,7 +20363,7 @@ msgstr ""
 msgid "Find your LinkedIn contacts"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5387
+#: lib/vutuv_web/components/ui.ex:5388
 #: lib/vutuv_web/live/import_connections_live.ex:64
 #: lib/vutuv_web/templates/import/new.html.heex:37
 #, elixir-autogen, elixir-format, fuzzy
@@ -20471,7 +20471,7 @@ msgstr ""
 msgid "See which of them are already on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5389
+#: lib/vutuv_web/components/ui.ex:5390
 #, elixir-autogen, elixir-format
 msgid "See which of your LinkedIn contacts are already on vutuv"
 msgstr ""
@@ -20543,7 +20543,7 @@ msgstr ""
 msgid "Your export also lists your LinkedIn contacts."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5391
+#: lib/vutuv_web/components/ui.ex:5392
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
 msgstr ""
@@ -20800,7 +20800,7 @@ msgstr ""
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5345
+#: lib/vutuv_web/components/ui.ex:5346
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr ""
@@ -21021,22 +21021,22 @@ msgstr ""
 msgid "Shown in the language it was written in."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5372
+#: lib/vutuv_web/components/ui.ex:5373
 #, elixir-autogen, elixir-format
 msgid "Which languages reach you, and what happens to the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5374
+#: lib/vutuv_web/components/ui.ex:5375
 #, elixir-autogen, elixir-format
 msgid "language translate translation german english original hide foreign rank order sprache übersetzen fremdsprache reihenfolge"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5412
+#: lib/vutuv_web/components/ui.ex:5413
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, maps, how posts are shortened"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5416
+#: lib/vutuv_web/components/ui.ex:5417
 #, elixir-autogen, elixir-format
 msgid "german english locale map font length hyphenation übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr ""
@@ -21515,7 +21515,7 @@ msgstr ""
 msgid "Your organization page was updated, but that picture could not be used as a logo. Please pick another one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4588
+#: lib/vutuv_web/components/ui.ex:4589
 #, elixir-autogen, elixir-format
 msgid "You can upload one file at a time."
 msgid_plural "You can upload at most %{count} files at a time."
@@ -21713,7 +21713,7 @@ msgstr ""
 msgid "Only these accounts (empty = all) …"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3566
+#: lib/vutuv_web/components/ui.ex:3567
 #, elixir-autogen, elixir-format
 msgid "only %{account}"
 msgstr ""
@@ -21955,7 +21955,7 @@ msgstr ""
 msgid "Replace with"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5364
+#: lib/vutuv_web/components/ui.ex:5365
 #, elixir-autogen, elixir-format
 msgid "Rewrite what an account's posts say, for you alone"
 msgstr ""
@@ -21973,7 +21973,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1452
 #: lib/vutuv_web/components/post_components.ex:3402
 #: lib/vutuv_web/components/post_components.ex:4496
-#: lib/vutuv_web/components/ui.ex:5363
+#: lib/vutuv_web/components/ui.ex:5364
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
 #: lib/vutuv_web/live/post_rewrites_live.ex:264
@@ -22029,12 +22029,12 @@ msgstr ""
 msgid "\\1 puts back what the first (…) group matched, \\0 the whole match."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5365
+#: lib/vutuv_web/components/ui.ex:5366
 #, elixir-autogen, elixir-format
 msgid "regex regular expression rewrite replace footer signature strip"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5434
+#: lib/vutuv_web/components/ui.ex:5435
 #, elixir-autogen, elixir-format
 msgid "Smaller pictures and a plain composer on a slow connection"
 msgstr ""
@@ -22044,12 +22044,12 @@ msgstr ""
 msgid "That endorsement is not possible."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5436
+#: lib/vutuv_web/components/ui.ex:5437
 #, elixir-autogen, elixir-format
 msgid "bandwidth slow internet mobile data saving saver volume metered compression pictures images screenshots editor langsam daten sparen datensparmodus volumen schmalband komprimierung bilder"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5408
+#: lib/vutuv_web/components/ui.ex:5409
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr ""
@@ -22529,7 +22529,7 @@ msgstr ""
 msgid "Accounts whose posts stay out of your feed, and accounts whose reposts do. This list is yours alone: it is never shared and nobody is told they are on it."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5357
+#: lib/vutuv_web/components/ui.ex:5358
 #, elixir-autogen, elixir-format
 msgid "Accounts you have silenced, and whose reposts you hide"
 msgstr ""
@@ -22555,7 +22555,7 @@ msgstr ""
 msgid "Mute everything"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5356
+#: lib/vutuv_web/components/ui.ex:5357
 #: lib/vutuv_web/controllers/settings_controller.ex:713
 #: lib/vutuv_web/templates/settings/mutes.html.heex:1
 #: lib/vutuv_web/templates/settings/mutes.html.heex:3
@@ -22599,7 +22599,7 @@ msgstr ""
 msgid "You mute an account where you meet it: the ⋯ menu on any of its posts, or its own page. Muting works whether or not you follow them."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5359
+#: lib/vutuv_web/components/ui.ex:5360
 #, elixir-autogen, elixir-format
 msgid "mute unmute hide account reposts boosts feed stumm stummschalten ausblenden konto"
 msgstr ""
@@ -22699,7 +22699,7 @@ msgstr ""
 msgid "Feed settings saved."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5427
+#: lib/vutuv_web/components/ui.ex:5428
 #, elixir-autogen, elixir-format
 msgid "How many load at once, and how many “Load more” adds"
 msgstr ""
@@ -22709,7 +22709,7 @@ msgstr ""
 msgid "How many posts your feed shows before the “Load more” button, and how many that button adds. More posts mean a longer wait for the page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5426
+#: lib/vutuv_web/components/ui.ex:5427
 #: lib/vutuv_web/controllers/settings_controller.ex:963
 #: lib/vutuv_web/templates/settings/feed.html.heex:12
 #, elixir-autogen, elixir-format
@@ -22732,7 +22732,7 @@ msgstr ""
 msgid "You can change this under the feed itself as well, right below the “Load more” button."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5429
+#: lib/vutuv_web/components/ui.ex:5430
 #, elixir-autogen, elixir-format
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr ""
@@ -23118,7 +23118,7 @@ msgstr ""
 msgid "Neither your profile picture nor your cover photo was replaced: a report about them is still open. Open the case to remove the picture or to say that it is yours."
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:174
+#: lib/vutuv_web/controllers/report_controller.ex:190
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Profile picture"
 msgstr ""
@@ -23201,7 +23201,7 @@ msgstr ""
 msgid "A picture goes offline right away for a copyright notice; every other report goes to our admins with the picture left where it is."
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:151
+#: lib/vutuv_web/controllers/report_controller.ex:155
 #, elixir-autogen, elixir-format
 msgid "Thank you for your report. Our moderators have been notified and will review this picture."
 msgstr ""
@@ -23231,8 +23231,8 @@ msgstr ""
 msgid "Confirm the report"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:91
-#: lib/vutuv_web/controllers/public_report_controller.ex:111
+#: lib/vutuv_web/controllers/public_report_controller.ex:98
+#: lib/vutuv_web/controllers/public_report_controller.ex:118
 #: lib/vutuv_web/templates/public_report/confirm.html.heex:4
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Confirm your report"
@@ -23284,8 +23284,8 @@ msgstr ""
 msgid "Please confirm your report"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:88
-#: lib/vutuv_web/controllers/public_report_controller.ex:116
+#: lib/vutuv_web/controllers/public_report_controller.ex:95
+#: lib/vutuv_web/controllers/public_report_controller.ex:123
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report confirmed"
 msgstr ""
@@ -23300,7 +23300,7 @@ msgstr ""
 msgid "Report filed from outside"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:171
+#: lib/vutuv_web/controllers/public_report_controller.ex:178
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report sent"
 msgstr ""
@@ -23315,7 +23315,7 @@ msgstr ""
 msgid "Thank you - your report is with our admins"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:133
+#: lib/vutuv_web/controllers/public_report_controller.ex:140
 #, elixir-autogen, elixir-format
 msgid "That address is not on this site. We can only act on content published here."
 msgstr ""
@@ -23330,7 +23330,7 @@ msgstr ""
 msgid "The report by %{email} was a deliberate weapon (that address loses our trust)"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:232
+#: lib/vutuv_web/controllers/public_report_controller.ex:239
 #, elixir-autogen, elixir-format
 msgid "We could not find that page. Please check the address."
 msgstr ""
@@ -23345,7 +23345,7 @@ msgstr ""
 msgid "What is wrong with it?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:176
+#: lib/vutuv_web/controllers/public_report_controller.ex:183
 #, elixir-autogen, elixir-format
 msgid "You already sent us this report. Please use the confirmation link in the email we sent you."
 msgstr ""
@@ -23360,7 +23360,7 @@ msgstr ""
 msgid "You do not need to do anything else."
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:72
+#: lib/vutuv_web/controllers/public_report_controller.ex:79
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You have sent us a lot of reports just now. Please try again later."
 msgstr ""
@@ -23426,8 +23426,8 @@ msgstr ""
 msgid "Send the report again"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:99
-#: lib/vutuv_web/controllers/public_report_controller.ex:121
+#: lib/vutuv_web/controllers/public_report_controller.ex:106
+#: lib/vutuv_web/controllers/public_report_controller.ex:128
 #: lib/vutuv_web/templates/public_report/expired.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "This link has expired"
@@ -23623,7 +23623,7 @@ msgstr ""
 msgid "Texts, photos and videos belong to whoever made them. Post your own work, or work you have permission to use. A rights holder can report content here without an account, through {form}; such a complaint is decided by one of our admins, and an edit does not settle it."
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:143
+#: lib/vutuv_web/controllers/public_report_controller.ex:150
 #, elixir-autogen, elixir-format
 msgid "That address is one of our own pages, not content somebody published here, so there is nothing on it we could act on. Please paste the address of the post, picture, video, profile or job posting itself."
 msgstr ""
@@ -23649,7 +23649,7 @@ msgid "“%{note}”"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:5236
-#: lib/vutuv_web/components/press_kit_components.ex:207
+#: lib/vutuv_web/components/press_kit_components.ex:209
 #, elixir-autogen, elixir-format
 msgid "Show these photos larger"
 msgstr ""
@@ -23719,7 +23719,7 @@ msgstr ""
 msgid "Dark"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5278
+#: lib/vutuv_web/components/ui.ex:5279
 #, elixir-autogen, elixir-format
 msgid "Files a journalist may download and print"
 msgstr ""
@@ -23744,6 +23744,7 @@ msgstr ""
 msgid "Light"
 msgstr ""
 
+#: lib/vutuv_web/controllers/report_controller.ex:193
 #: lib/vutuv_web/live/press_kit_live.ex:1006
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Logo variant"
@@ -23793,6 +23794,7 @@ msgstr ""
 msgid "Please confirm the rights first, then choose the file."
 msgstr ""
 
+#: lib/vutuv_web/controllers/report_controller.ex:193
 #: lib/vutuv_web/live/press_kit_live.ex:1006
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Press photo"
@@ -23806,7 +23808,7 @@ msgstr ""
 msgid "Press photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5277
+#: lib/vutuv_web/components/ui.ex:5278
 #: lib/vutuv_web/live/press_kit_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Press photos & logos"
@@ -23877,7 +23879,7 @@ msgstr ""
 msgid "Your logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5280
+#: lib/vutuv_web/components/ui.ex:5281
 #, elixir-autogen, elixir-format
 msgid "press kit media journalist photographer download original print logo svg credit copyright presse pressemappe fotos logo herunterladen bildnachweis"
 msgstr ""
@@ -23887,24 +23889,24 @@ msgstr ""
 msgid "Ready-made buttons and badges"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3619
+#: lib/vutuv_web/components/ui.ex:3620
 #, elixir-autogen, elixir-format
 msgid "%{count} byte"
 msgid_plural "%{count} bytes"
 msgstr[0] "%{count} byte"
 msgstr[1] "%{count} bytes"
 
-#: lib/vutuv_web/components/press_kit_components.ex:99
+#: lib/vutuv_web/components/press_kit_components.ex:100
 #, elixir-autogen, elixir-format
 msgid "Add press photos"
 msgstr "Add press photos"
 
-#: lib/vutuv_web/components/press_kit_components.ex:117
+#: lib/vutuv_web/components/press_kit_components.ex:118
 #, elixir-autogen, elixir-format
 msgid "All press material"
 msgstr "All press material"
 
-#: lib/vutuv_web/components/press_kit_components.ex:173
+#: lib/vutuv_web/components/press_kit_components.ex:174
 #, elixir-autogen, elixir-format
 msgid "All press photos"
 msgstr "All press photos"
@@ -23915,18 +23917,18 @@ msgstr "All press photos"
 msgid "Credit: %{credit}"
 msgstr "Credit: %{credit}"
 
-#: lib/vutuv_web/components/press_kit_components.ex:320
 #: lib/vutuv_web/components/press_kit_components.ex:323
+#: lib/vutuv_web/components/press_kit_components.ex:326
 #, elixir-autogen, elixir-format
 msgid "Download %{format}"
 msgstr "Download %{format}"
 
-#: lib/vutuv_web/components/press_kit_components.ex:276
+#: lib/vutuv_web/components/press_kit_components.ex:279
 #, elixir-autogen, elixir-format
 msgid "Download photo"
 msgstr "Download photo"
 
-#: lib/vutuv/press_kit.ex:496
+#: lib/vutuv/press_kit.ex:503
 #, elixir-autogen, elixir-format
 msgid "Free for editorial use with credit."
 msgstr "Free for editorial use with credit."
@@ -23941,7 +23943,7 @@ msgstr "PNG version"
 #: lib/vutuv_web/agent_docs/text.ex:57
 #: lib/vutuv_web/agent_docs/text.ex:257
 #: lib/vutuv_web/components/organization_components.ex:262
-#: lib/vutuv_web/components/press_kit_components.ex:97
+#: lib/vutuv_web/components/press_kit_components.ex:98
 #: lib/vutuv_web/live/organization_live/show.ex:168
 #: lib/vutuv_web/views/press_kit_html.ex:28
 #: lib/vutuv_web/views/press_kit_html.ex:46
@@ -23999,4 +24001,10 @@ msgstr ""
 #: lib/vutuv_web/live/press_kit_live.ex:468
 #, elixir-autogen, elixir-format, fuzzy
 msgid "What a journalist writing about this page may download: photos in print quality and its logo as a file. Everything here is public and free for editorial use as long as the credit is shown."
+msgstr ""
+
+#: lib/vutuv_web/components/press_kit_components.ex:483
+#: lib/vutuv_web/components/ui.ex:3250
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Report this picture"
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -17,8 +17,8 @@ msgstr ""
 msgid "About us"
 msgstr "Note legali"
 
-#: lib/vutuv_web/components/ui.ex:4972
-#: lib/vutuv_web/components/ui.ex:4977
+#: lib/vutuv_web/components/ui.ex:4973
+#: lib/vutuv_web/components/ui.ex:4978
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:729
 #: lib/vutuv_web/live/organization_live/domains.ex:287
@@ -64,7 +64,7 @@ msgstr "Indirizzo aggiornato."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:77
 #: lib/vutuv_web/agent_docs/text.ex:72
-#: lib/vutuv_web/components/ui.ex:5320
+#: lib/vutuv_web/components/ui.ex:5321
 #: lib/vutuv_web/controllers/address_controller.ex:22
 #: lib/vutuv_web/controllers/address_controller.ex:37
 #: lib/vutuv_web/controllers/address_controller.ex:84
@@ -83,8 +83,8 @@ msgstr "Indirizzi"
 msgid "Already a member? Sign in here."
 msgstr "È già iscritto? Acceda qui."
 
-#: lib/vutuv_web/components/ui.ex:4763
-#: lib/vutuv_web/components/ui.ex:4862
+#: lib/vutuv_web/components/ui.ex:4764
+#: lib/vutuv_web/components/ui.ex:4863
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:709
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:841
@@ -112,7 +112,7 @@ msgid "Birthday"
 msgstr "Compleanno"
 
 #: lib/vutuv_web/components/saved_search_components.ex:104
-#: lib/vutuv_web/components/ui.ex:4757
+#: lib/vutuv_web/components/ui.ex:4758
 #: lib/vutuv_web/components/video_components.ex:281
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:210
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
@@ -165,7 +165,7 @@ msgid "Couldn't follow back to %{name}."
 msgstr "Non è stato possibile ricambiare il follow a %{name}."
 
 #: lib/vutuv_web/components/post_components.ex:4435
-#: lib/vutuv_web/components/ui.ex:4864
+#: lib/vutuv_web/components/ui.ex:4865
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:657
@@ -213,7 +213,7 @@ msgid "Download"
 msgstr "Scarica"
 
 #: lib/vutuv_web/components/post_components.ex:4400
-#: lib/vutuv_web/components/ui.ex:4855
+#: lib/vutuv_web/components/ui.ex:4856
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
@@ -288,7 +288,7 @@ msgstr "Inserisca il Suo indirizzo e-mail"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:5284
+#: lib/vutuv_web/components/ui.ex:5285
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -619,7 +619,7 @@ msgstr "Piattaforma"
 msgid "Public"
 msgstr "Pubblico"
 
-#: lib/vutuv_web/components/ui.ex:4756
+#: lib/vutuv_web/components/ui.ex:4757
 #: lib/vutuv_web/live/organization_live/edit.ex:376
 #: lib/vutuv_web/live/post_live/composer.ex:2201
 #: lib/vutuv_web/live/press_kit_live.ex:795
@@ -795,7 +795,7 @@ msgstr "Utente aggiornato."
 msgid "User verified successfully."
 msgstr "Utente verificato."
 
-#: lib/vutuv_web/components/ui.ex:5269
+#: lib/vutuv_web/components/ui.ex:5270
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:832
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
@@ -856,14 +856,14 @@ msgstr "Utenti"
 msgid "vCard"
 msgstr "vCard"
 
-#: lib/vutuv_web/components/ui.ex:4925
+#: lib/vutuv_web/components/ui.ex:4926
 #: lib/vutuv_web/templates/user/show.html.heex:1019
 #: lib/vutuv_web/templates/user/show.html.heex:1042
 #, elixir-autogen
 msgid "View All"
 msgstr "Mostra tutti"
 
-#: lib/vutuv_web/components/ui.ex:5443
+#: lib/vutuv_web/components/ui.ex:5444
 #: lib/vutuv_web/controllers/settings_controller.ex:175
 #: lib/vutuv_web/live/job_posting_live/form.ex:818
 #: lib/vutuv_web/live/organization_live/edit.ex:339
@@ -1379,7 +1379,7 @@ msgstr "URL dei tag"
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:602
 #: lib/vutuv_web/agent_docs/text.ex:868
-#: lib/vutuv_web/components/ui.ex:5305
+#: lib/vutuv_web/components/ui.ex:5306
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1767,7 +1767,7 @@ msgid "Network"
 msgstr "Rete"
 
 #: lib/vutuv_web/components/post_components.ex:487
-#: lib/vutuv_web/components/ui.ex:4974
+#: lib/vutuv_web/components/ui.ex:4975
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:804
@@ -1783,7 +1783,7 @@ msgid "Nothing new yet."
 msgstr "Ancora nessuna novità."
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:5342
+#: lib/vutuv_web/components/ui.ex:5343
 #: lib/vutuv_web/controllers/page_controller.ex:214
 #: lib/vutuv_web/live/notification_live/index.ex:154
 #: lib/vutuv_web/live/notification_live/index.ex:440
@@ -1928,14 +1928,14 @@ msgstr "ora è collegato con Lei."
 msgid "started following you."
 msgstr "ha iniziato a seguirla."
 
-#: lib/vutuv_web/components/ui.ex:4231
-#: lib/vutuv_web/components/ui.ex:4376
+#: lib/vutuv_web/components/ui.ex:4232
+#: lib/vutuv_web/components/ui.ex:4377
 #: lib/vutuv_web/live/import_connections_live.ex:638
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr "Paginazione"
 
-#: lib/vutuv_web/components/ui.ex:4999
+#: lib/vutuv_web/components/ui.ex:5000
 #: lib/vutuv_web/live/organization_live/activity.ex:159
 #: lib/vutuv_web/live/organization_live/feed.ex:258
 #: lib/vutuv_web/live/organization_live/show.ex:810
@@ -1950,7 +1950,7 @@ msgstr ""
 "L'indirizzo non può essere modificato. Per usarne un altro, lo aggiunga come"
 " nuovo indirizzo e-mail ed elimini questo."
 
-#: lib/vutuv_web/components/ui.ex:4766
+#: lib/vutuv_web/components/ui.ex:4767
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr "Elimina voce"
@@ -1995,12 +1995,12 @@ msgstr "Aggiungi un'immagine di copertina"
 msgid "Add cover photo"
 msgstr "Aggiungi immagine di copertina"
 
-#: lib/vutuv_web/components/ui.ex:3662
+#: lib/vutuv_web/components/ui.ex:3663
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr "Aprile"
 
-#: lib/vutuv_web/components/ui.ex:3666
+#: lib/vutuv_web/components/ui.ex:3667
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr "Agosto"
@@ -2015,7 +2015,7 @@ msgstr "Cambia copertina"
 msgid "Change cover photo"
 msgstr "Cambia immagine di copertina"
 
-#: lib/vutuv_web/controllers/report_controller.ex:173
+#: lib/vutuv_web/controllers/report_controller.ex:177
 #: lib/vutuv_web/templates/user/edit.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "Cover photo"
@@ -2026,37 +2026,37 @@ msgstr "Immagine di copertina"
 msgid "Cover photo of %{name}"
 msgstr "Immagine di copertina di %{name}"
 
-#: lib/vutuv_web/components/ui.ex:3670
+#: lib/vutuv_web/components/ui.ex:3671
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr "Dicembre"
 
-#: lib/vutuv_web/components/ui.ex:3660
+#: lib/vutuv_web/components/ui.ex:3661
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr "Febbraio"
 
-#: lib/vutuv_web/components/ui.ex:3659
+#: lib/vutuv_web/components/ui.ex:3660
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr "Gennaio"
 
-#: lib/vutuv_web/components/ui.ex:3665
+#: lib/vutuv_web/components/ui.ex:3666
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr "Luglio"
 
-#: lib/vutuv_web/components/ui.ex:3664
+#: lib/vutuv_web/components/ui.ex:3665
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr "Giugno"
 
-#: lib/vutuv_web/components/ui.ex:3661
+#: lib/vutuv_web/components/ui.ex:3662
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr "Marzo"
 
-#: lib/vutuv_web/components/ui.ex:3663
+#: lib/vutuv_web/components/ui.ex:3664
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr "Maggio"
@@ -2071,17 +2071,17 @@ msgstr "Membro da %{month} %{year}"
 msgid "Member since %{year}"
 msgstr "Membro dal %{year}"
 
-#: lib/vutuv_web/components/ui.ex:3669
+#: lib/vutuv_web/components/ui.ex:3670
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr "Novembre"
 
-#: lib/vutuv_web/components/ui.ex:3668
+#: lib/vutuv_web/components/ui.ex:3669
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr "Ottobre"
 
-#: lib/vutuv_web/components/ui.ex:3667
+#: lib/vutuv_web/components/ui.ex:3668
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr "Settembre"
@@ -2321,7 +2321,7 @@ msgstr "Troppi file."
 msgid "Upload failed."
 msgstr "Caricamento non riuscito."
 
-#: lib/vutuv_web/components/ui.ex:5687
+#: lib/vutuv_web/components/ui.ex:5688
 #: lib/vutuv_web/live/shell_live.ex:1582
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2365,7 +2365,7 @@ msgstr "persone che non La seguono"
 msgid "people you don't follow"
 msgstr "persone che non segue"
 
-#: lib/vutuv_web/components/ui.ex:3758
+#: lib/vutuv_web/components/ui.ex:3759
 #: lib/vutuv_web/views/post_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "unknown"
@@ -2406,7 +2406,7 @@ msgstr "Tutti i post"
 
 #: lib/vutuv_web/components/post_components.ex:2181
 #: lib/vutuv_web/components/post_components.ex:6792
-#: lib/vutuv_web/components/ui.ex:4298
+#: lib/vutuv_web/components/ui.ex:4299
 #: lib/vutuv_web/views/user_html.ex:486
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2425,7 +2425,7 @@ msgstr "Salvati"
 
 #: lib/vutuv_web/components/post_components.ex:2125
 #: lib/vutuv_web/components/post_components.ex:7033
-#: lib/vutuv_web/components/ui.ex:4284
+#: lib/vutuv_web/components/ui.ex:4285
 #: lib/vutuv_web/notification_line.ex:317
 #: lib/vutuv_web/views/user_html.ex:496
 #, elixir-autogen, elixir-format
@@ -2638,7 +2638,7 @@ msgstr "Membro non trovato."
 msgid "No conversations yet."
 msgstr "Ancora nessuna conversazione."
 
-#: lib/vutuv_web/components/ui.ex:3370
+#: lib/vutuv_web/components/ui.ex:3371
 #: lib/vutuv_web/live/message_live/index.ex:760
 #, elixir-autogen, elixir-format
 msgid "Online"
@@ -2788,8 +2788,8 @@ msgstr "Aggiungi un'esperienza lavorativa"
 msgid "Write your first post"
 msgstr "Scriva il Suo primo post"
 
-#: lib/vutuv_web/components/ui.ex:4464
-#: lib/vutuv_web/components/ui.ex:4927
+#: lib/vutuv_web/components/ui.ex:4465
+#: lib/vutuv_web/components/ui.ex:4928
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:109
@@ -3179,7 +3179,7 @@ msgstr "Aperto"
 msgid "Owner"
 msgstr "Proprietario"
 
-#: lib/vutuv_web/components/ui.ex:5263
+#: lib/vutuv_web/components/ui.ex:5264
 #: lib/vutuv_web/live/shell_live.ex:1373
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3212,7 +3212,7 @@ msgstr "Lo rimuova. La segnalazione si chiude, senza altre domande."
 msgid "Report"
 msgstr "Segnala"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:255
+#: lib/vutuv_web/controllers/public_report_controller.ex:262
 #: lib/vutuv_web/controllers/report_controller.ex:54
 #: lib/vutuv_web/templates/layout/app.html.heex:131
 #: lib/vutuv_web/templates/page/legal.html.heex:42
@@ -3295,7 +3295,7 @@ msgstr ""
 "Le segnalazioni sono anonime; non diciamo mai chi ha segnalato. Le nostre "
 "regole:"
 
-#: lib/vutuv_web/components/ui.ex:4146
+#: lib/vutuv_web/components/ui.ex:4147
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:784
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -3374,7 +3374,7 @@ msgstr "Prende di mira, umilia o minaccia una persona."
 msgid "Tell us more in the note below."
 msgstr "Ci dica di più nella nota qui sotto."
 
-#: lib/vutuv_web/controllers/report_controller.ex:157
+#: lib/vutuv_web/controllers/report_controller.ex:161
 #, elixir-autogen, elixir-format
 msgid "Thank you for your report. We take it from here."
 msgstr "Grazie per la segnalazione. Ce ne occupiamo noi."
@@ -3489,12 +3489,12 @@ msgstr ""
 "respingimenti in un anno perdono il blocco immediato: le loro segnalazioni "
 "si limitano a mettere il contenuto in esame."
 
-#: lib/vutuv_web/controllers/report_controller.ex:89
+#: lib/vutuv_web/controllers/report_controller.ex:93
 #, elixir-autogen, elixir-format
 msgid "You already reported this. Our team is on it."
 msgstr "Lo ha già segnalato. Ce ne stiamo occupando."
 
-#: lib/vutuv_web/controllers/report_controller.ex:95
+#: lib/vutuv_web/controllers/report_controller.ex:99
 #, elixir-autogen, elixir-format
 msgid "You cannot report your own content."
 msgstr "Non può segnalare i propri contenuti."
@@ -4417,12 +4417,12 @@ msgstr ""
 "Le prenotazioni sono aperte fino al %{last}. Prossimo giorno disponibile: "
 "%{day}"
 
-#: lib/vutuv_web/components/ui.ex:3705
+#: lib/vutuv_web/components/ui.ex:3706
 #, elixir-autogen, elixir-format
 msgid "Fr"
 msgstr "Ve"
 
-#: lib/vutuv_web/components/ui.ex:3701
+#: lib/vutuv_web/components/ui.ex:3702
 #, elixir-autogen, elixir-format
 msgid "Mo"
 msgstr "Lu"
@@ -4434,27 +4434,27 @@ msgstr ""
 "Una pubblicità al giorno: scelga un giorno libero nel calendario; i giorni "
 "barrati sono già prenotati."
 
-#: lib/vutuv_web/components/ui.ex:3706
+#: lib/vutuv_web/components/ui.ex:3707
 #, elixir-autogen, elixir-format
 msgid "Sa"
 msgstr "Sa"
 
-#: lib/vutuv_web/components/ui.ex:3707
+#: lib/vutuv_web/components/ui.ex:3708
 #, elixir-autogen, elixir-format
 msgid "Su"
 msgstr "Do"
 
-#: lib/vutuv_web/components/ui.ex:3704
+#: lib/vutuv_web/components/ui.ex:3705
 #, elixir-autogen, elixir-format
 msgid "Th"
 msgstr "Gi"
 
-#: lib/vutuv_web/components/ui.ex:3702
+#: lib/vutuv_web/components/ui.ex:3703
 #, elixir-autogen, elixir-format
 msgid "Tu"
 msgstr "Ma"
 
-#: lib/vutuv_web/components/ui.ex:3703
+#: lib/vutuv_web/components/ui.ex:3704
 #, elixir-autogen, elixir-format
 msgid "We"
 msgstr "Me"
@@ -4597,7 +4597,7 @@ msgstr ""
 " la vostra conversazione e impedisce ogni interazione in entrambe le "
 "direzioni. Sbloccare non ripristina ciò che è stato rimosso."
 
-#: lib/vutuv_web/components/ui.ex:5447
+#: lib/vutuv_web/components/ui.ex:5448
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -5405,7 +5405,7 @@ msgstr "Token API (%{date})"
 msgid "API documentation"
 msgstr "Documentazione dell'API"
 
-#: lib/vutuv_web/components/ui.ex:5497
+#: lib/vutuv_web/components/ui.ex:5498
 #: lib/vutuv_web/controllers/settings_controller.ex:161
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:517
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5488,10 +5488,10 @@ msgstr "Scorciatoie da tastiera"
 msgid "Navigation"
 msgstr "Navigazione"
 
-#: lib/vutuv_web/components/ui.ex:5594
-#: lib/vutuv_web/components/ui.ex:5599
-#: lib/vutuv_web/components/ui.ex:5678
-#: lib/vutuv_web/components/ui.ex:5742
+#: lib/vutuv_web/components/ui.ex:5595
+#: lib/vutuv_web/components/ui.ex:5600
+#: lib/vutuv_web/components/ui.ex:5679
+#: lib/vutuv_web/components/ui.ex:5743
 #: lib/vutuv_web/controllers/settings_controller.ex:68
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5609,7 +5609,7 @@ msgstr "Tipo di indirizzo e-mail"
 msgid "About you"
 msgstr "Su di Lei"
 
-#: lib/vutuv_web/components/ui.ex:5467
+#: lib/vutuv_web/components/ui.ex:5468
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:262
@@ -5630,7 +5630,7 @@ msgstr "Modifica"
 msgid "Download everything vutuv stores about you, as one file."
 msgstr "Scarichi in un unico file tutto ciò che vutuv conserva su di Lei."
 
-#: lib/vutuv_web/components/ui.ex:5312
+#: lib/vutuv_web/components/ui.ex:5313
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5665,7 +5665,7 @@ msgstr "Token personali per l'API di vutuv."
 msgid "Photos"
 msgstr "Foto"
 
-#: lib/vutuv_web/components/ui.ex:5441
+#: lib/vutuv_web/components/ui.ex:5442
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #, elixir-autogen, elixir-format
 msgid "Privacy"
@@ -5780,7 +5780,7 @@ msgstr "@%{slug} ha iniziato a seguirla su vutuv"
 msgid "Apps"
 msgstr "App"
 
-#: lib/vutuv_web/components/ui.ex:5490
+#: lib/vutuv_web/components/ui.ex:5491
 #: lib/vutuv_web/controllers/settings_controller.ex:185
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -5987,21 +5987,21 @@ msgid "Sort"
 msgstr "Ordina"
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/components/ui.ex:3774
+#: lib/vutuv_web/components/ui.ex:3775
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] "%{count} giorno fa"
 msgstr[1] "%{count} giorni fa"
 
-#: lib/vutuv_web/components/ui.ex:3773
+#: lib/vutuv_web/components/ui.ex:3774
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] "%{count} ora fa"
 msgstr[1] "%{count} ore fa"
 
-#: lib/vutuv_web/components/ui.ex:3772
+#: lib/vutuv_web/components/ui.ex:3773
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
@@ -6068,7 +6068,7 @@ msgstr "Questo dispositivo"
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr "È il primo accesso che vediamo da questo dispositivo o browser."
 
-#: lib/vutuv_web/components/ui.ex:3771
+#: lib/vutuv_web/components/ui.ex:3772
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr "adesso"
@@ -7459,13 +7459,13 @@ msgstr "I loro membri vengono aggiunti a questo (unione)."
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr "pagina %{page} di %{pages}, %{total} in totale"
 
-#: lib/vutuv_web/components/ui.ex:4240
+#: lib/vutuv_web/components/ui.ex:4241
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Precedente"
 
-#: lib/vutuv_web/components/ui.ex:4252
+#: lib/vutuv_web/components/ui.ex:4253
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1180
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -8271,7 +8271,7 @@ msgstr "PIN scaduto"
 msgid "PIN registered"
 msgstr "Registrato con PIN"
 
-#: lib/vutuv_web/components/ui.ex:4243
+#: lib/vutuv_web/components/ui.ex:4244
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr "Pagina %{page} di %{pages}"
@@ -8410,7 +8410,7 @@ msgstr "Titolo di studio"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:5288
+#: lib/vutuv_web/components/ui.ex:5289
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8469,7 +8469,7 @@ msgstr ""
 "Ecco cosa abbiamo trovato nella Sua esportazione. Tolga la spunta a ciò che "
 "non desidera. Le voci già presenti sul Suo profilo sono già senza spunta."
 
-#: lib/vutuv_web/components/ui.ex:5478
+#: lib/vutuv_web/components/ui.ex:5479
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importa"
@@ -8498,7 +8498,7 @@ msgstr "Importati: %{items}."
 msgid "Nothing new to import."
 msgstr "Nulla di nuovo da importare."
 
-#: lib/vutuv_web/components/ui.ex:5316
+#: lib/vutuv_web/components/ui.ex:5317
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8594,7 +8594,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr "Troppe importazioni. Riprovi tra poco."
 
-#: lib/vutuv_web/components/ui.ex:4509
+#: lib/vutuv_web/components/ui.ex:4510
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8684,13 +8684,13 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr "Trascini qui il Suo file ZIP, oppure prema per sceglierne uno."
 
-#: lib/vutuv_web/components/ui.ex:5265
+#: lib/vutuv_web/components/ui.ex:5266
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr "Dati di base e foto"
 
-#: lib/vutuv_web/components/ui.ex:5410
+#: lib/vutuv_web/components/ui.ex:5411
 #: lib/vutuv_web/controllers/settings_controller.ex:129
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8702,7 +8702,7 @@ msgstr "Lingua e visualizzazione"
 msgid "More profile sections"
 msgstr "Altre sezioni del profilo"
 
-#: lib/vutuv_web/components/ui.ex:5469
+#: lib/vutuv_web/components/ui.ex:5470
 #: lib/vutuv_web/controllers/settings_controller.ex:112
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8712,7 +8712,7 @@ msgstr "Altre sezioni del profilo"
 msgid "Sign-in & security"
 msgstr "Accesso e sicurezza"
 
-#: lib/vutuv_web/components/ui.ex:5482
+#: lib/vutuv_web/components/ui.ex:5483
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8937,7 +8937,7 @@ msgstr "La scriva in Amministrazione › Pagine legali"
 #: lib/vutuv_web/agent_docs/text.ex:670
 #: lib/vutuv_web/components/organization_components.ex:285
 #: lib/vutuv_web/components/ui.ex:1807
-#: lib/vutuv_web/components/ui.ex:5459
+#: lib/vutuv_web/components/ui.ex:5460
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:366
 #: lib/vutuv_web/controllers/settings_controller.ex:433
@@ -9924,7 +9924,7 @@ msgstr "Certificati"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:5292
+#: lib/vutuv_web/components/ui.ex:5293
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -10127,13 +10127,13 @@ msgstr "Link permanente al profilo"
 msgid "Dismiss"
 msgstr "Chiudi"
 
-#: lib/vutuv_web/components/ui.ex:3897
+#: lib/vutuv_web/components/ui.ex:3898
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr "Copiato"
 
-#: lib/vutuv_web/components/ui.ex:3896
-#: lib/vutuv_web/components/ui.ex:3904
+#: lib/vutuv_web/components/ui.ex:3897
+#: lib/vutuv_web/components/ui.ex:3905
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Copia"
@@ -10273,7 +10273,7 @@ msgstr "Ripristinare questo account perché il membro possa accedere di nuovo?"
 msgid "Spam"
 msgstr "Spam"
 
-#: lib/vutuv_web/controllers/report_controller.ex:145
+#: lib/vutuv_web/controllers/report_controller.ex:149
 #, elixir-autogen, elixir-format
 msgid "Thank you for your report. Our moderators have been notified and will review this account."
 msgstr ""
@@ -10291,7 +10291,7 @@ msgstr "disattivato"
 msgid "deleted"
 msgstr "eliminato"
 
-#: lib/vutuv_web/controllers/report_controller.ex:132
+#: lib/vutuv_web/controllers/report_controller.ex:136
 #, elixir-autogen, elixir-format
 msgid "To protect you, the connection between you and the reported member is paused - no contact in either direction, including messages. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -11547,12 +11547,12 @@ msgstr "Pubblichi questo file all'indirizzo:"
 msgid "State / region (optional)"
 msgstr "Provincia / regione (facoltativo)"
 
-#: lib/vutuv_web/components/ui.ex:4596
+#: lib/vutuv_web/components/ui.ex:4597
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr "Questo tipo di file non è ammesso."
 
-#: lib/vutuv_web/components/ui.ex:4598
+#: lib/vutuv_web/components/ui.ex:4599
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr "Il caricamento non è riuscito."
@@ -12286,7 +12286,7 @@ msgstr "Organizzazione sbloccata."
 #: lib/vutuv_web/agent_docs/markdown.ex:524
 #: lib/vutuv_web/agent_docs/organization_doc.ex:138
 #: lib/vutuv_web/agent_docs/text.ex:480
-#: lib/vutuv_web/components/ui.ex:5486
+#: lib/vutuv_web/components/ui.ex:5487
 #: lib/vutuv_web/controllers/settings_controller.ex:222
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
@@ -13563,7 +13563,7 @@ msgstr "Salva la ricerca"
 msgid "Saved search deleted."
 msgstr "Ricerca salvata eliminata."
 
-#: lib/vutuv_web/components/ui.ex:5395
+#: lib/vutuv_web/components/ui.ex:5396
 #: lib/vutuv_web/controllers/settings_controller.ex:629
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -14078,7 +14078,7 @@ msgstr ""
 "persone note per quel tag compaiono tra i Suoi suggerimenti. Segua un tag "
 "dalla sua pagina."
 
-#: lib/vutuv_web/components/ui.ex:5378
+#: lib/vutuv_web/components/ui.ex:5379
 #: lib/vutuv_web/controllers/settings_controller.ex:643
 #: lib/vutuv_web/live/post_live/feed.ex:710
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -14158,7 +14158,7 @@ msgstr "Messenger aggiornato."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:69
 #: lib/vutuv_web/agent_docs/text.ex:64
-#: lib/vutuv_web/components/ui.ex:5335
+#: lib/vutuv_web/components/ui.ex:5336
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -14186,14 +14186,14 @@ msgstr "Messenger di %{name}"
 msgid "Select a messenger"
 msgstr "Selezioni un messenger"
 
-#: lib/vutuv_web/components/ui.ex:4681
+#: lib/vutuv_web/components/ui.ex:4682
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] "Avvisa il mio follower"
 msgstr[1] "Avvisa i miei %{formatted} follower"
 
-#: lib/vutuv_web/components/ui.ex:4691
+#: lib/vutuv_web/components/ui.ex:4692
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
@@ -14383,7 +14383,7 @@ msgid_plural "%{formatted} new notifications"
 msgstr[0] "%{formatted} nuova notifica"
 msgstr[1] "%{formatted} nuove notifiche"
 
-#: lib/vutuv_web/components/ui.ex:3678
+#: lib/vutuv_web/components/ui.ex:3679
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr "%{day} %{month} %{year}"
@@ -15006,7 +15006,7 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr "Corrispondenza solo su parole intere (parola o frase)"
 
-#: lib/vutuv_web/components/ui.ex:5349
+#: lib/vutuv_web/components/ui.ex:5350
 #: lib/vutuv_web/controllers/settings_controller.ex:773
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -15711,259 +15711,259 @@ msgstr "Il Suo server"
 msgid "moved to %{address}"
 msgstr "spostato a %{address}"
 
-#: lib/vutuv_web/components/ui.ex:5266
+#: lib/vutuv_web/components/ui.ex:5267
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr "Nome, foto, immagine di copertina, descrizione breve"
 
-#: lib/vutuv_web/components/ui.ex:5271
+#: lib/vutuv_web/components/ui.ex:5272
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr "handle soprannome rinomina slug profilo indirizzo url menzione"
 
-#: lib/vutuv_web/components/ui.ex:5285
+#: lib/vutuv_web/components/ui.ex:5286
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr "Gli impieghi e i ruoli nel Suo CV"
 
-#: lib/vutuv_web/components/ui.ex:5286
+#: lib/vutuv_web/components/ui.ex:5287
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr "cv curriculum carriera datore di lavoro posizione qualifica azienda"
 
-#: lib/vutuv_web/components/ui.ex:5289
+#: lib/vutuv_web/components/ui.ex:5290
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr "Scuole, università, titoli di studio"
 
-#: lib/vutuv_web/components/ui.ex:5290
+#: lib/vutuv_web/components/ui.ex:5291
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr "cv curriculum studio studi scuola università laurea titolo"
 
-#: lib/vutuv_web/components/ui.ex:5293
+#: lib/vutuv_web/components/ui.ex:5294
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr "Credenziali, con documenti di prova"
 
-#: lib/vutuv_web/components/ui.ex:5294
+#: lib/vutuv_web/components/ui.ex:5295
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 "certificato abilitazione diploma credenziale riconoscimento prova documento"
 
-#: lib/vutuv_web/components/ui.ex:5301
+#: lib/vutuv_web/components/ui.ex:5302
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr "Competenze linguistiche"
 
-#: lib/vutuv_web/components/ui.ex:5302
+#: lib/vutuv_web/components/ui.ex:5303
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr "Le lingue che parla"
 
-#: lib/vutuv_web/components/ui.ex:5303
+#: lib/vutuv_web/components/ui.ex:5304
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr "lingua parlare parlata fluente madrelingua"
 
-#: lib/vutuv_web/components/ui.ex:5306
+#: lib/vutuv_web/components/ui.ex:5307
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr "Gli argomenti per cui è conosciuto"
 
-#: lib/vutuv_web/components/ui.ex:5307
+#: lib/vutuv_web/components/ui.ex:5308
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr "competenza argomento parola chiave esperienza conferma"
 
-#: lib/vutuv_web/components/ui.ex:5487
+#: lib/vutuv_web/components/ui.ex:5488
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr "Pagine aziendali che gestisce"
 
-#: lib/vutuv_web/components/ui.ex:5488
+#: lib/vutuv_web/components/ui.ex:5489
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr "azienda datore di lavoro impresa attività organizzazione pagina"
 
-#: lib/vutuv_web/components/ui.ex:5310
+#: lib/vutuv_web/components/ui.ex:5311
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr "Recapiti"
 
-#: lib/vutuv_web/components/ui.ex:5313
+#: lib/vutuv_web/components/ui.ex:5314
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr "Dove La raggiungiamo, e quale indirizzo è pubblico"
 
-#: lib/vutuv_web/components/ui.ex:5314
+#: lib/vutuv_web/components/ui.ex:5315
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr "posta e-mail indirizzo principale"
 
-#: lib/vutuv_web/components/ui.ex:5317
+#: lib/vutuv_web/components/ui.ex:5318
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr "Fisso, cellulare, fax"
 
-#: lib/vutuv_web/components/ui.ex:5318
+#: lib/vutuv_web/components/ui.ex:5319
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr "telefono cellulare fax numero"
 
-#: lib/vutuv_web/components/ui.ex:5321
+#: lib/vutuv_web/components/ui.ex:5322
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr "Indirizzi postali sul Suo profilo"
 
-#: lib/vutuv_web/components/ui.ex:5322
+#: lib/vutuv_web/components/ui.ex:5323
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr "via città cap paese posta mappa"
 
-#: lib/vutuv_web/components/ui.ex:5324
+#: lib/vutuv_web/components/ui.ex:5325
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr "Siti web e link"
 
-#: lib/vutuv_web/components/ui.ex:5325
+#: lib/vutuv_web/components/ui.ex:5326
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr "Il Suo sito e gli altri link"
 
-#: lib/vutuv_web/components/ui.ex:5326
+#: lib/vutuv_web/components/ui.ex:5327
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr "url sito web homepage blog link verifica rel=me"
 
-#: lib/vutuv_web/components/ui.ex:5328
+#: lib/vutuv_web/components/ui.ex:5329
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr "Profili sui social"
 
-#: lib/vutuv_web/components/ui.ex:5329
+#: lib/vutuv_web/components/ui.ex:5330
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr "Mastodon, Bluesky, GitHub e gli altri"
 
-#: lib/vutuv_web/components/ui.ex:5331
+#: lib/vutuv_web/components/ui.ex:5332
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 
-#: lib/vutuv_web/components/ui.ex:5336
+#: lib/vutuv_web/components/ui.ex:5337
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr "Signal, Threema, Matrix e gli altri"
 
-#: lib/vutuv_web/components/ui.ex:5337
+#: lib/vutuv_web/components/ui.ex:5338
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr "signal threema matrix xmpp telegram whatsapp chat messenger"
 
-#: lib/vutuv_web/components/ui.ex:5340
+#: lib/vutuv_web/components/ui.ex:5341
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr "Notifiche e feed"
 
-#: lib/vutuv_web/components/ui.ex:5343
+#: lib/vutuv_web/components/ui.ex:5344
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr "Quali e-mail inviamo, e cosa Le dice la campanella"
 
-#: lib/vutuv_web/components/ui.ex:5350
+#: lib/vutuv_web/components/ui.ex:5351
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr "Tenga dei post fuori dal Suo feed"
 
-#: lib/vutuv_web/components/ui.ex:5351
+#: lib/vutuv_web/components/ui.ex:5352
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr "silenzia blocca nascondi filtro parola chiave parola tag feed"
 
-#: lib/vutuv_web/components/ui.ex:5379
+#: lib/vutuv_web/components/ui.ex:5380
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr "Argomenti i cui post arrivano nel Suo feed"
 
-#: lib/vutuv_web/components/ui.ex:5380
+#: lib/vutuv_web/components/ui.ex:5381
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr "tag argomento iscriviti segui feed"
 
-#: lib/vutuv_web/components/ui.ex:5396
+#: lib/vutuv_web/components/ui.ex:5397
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 "Ricerche di lavoro e di persone che Le inviano per e-mail le nuove "
 "corrispondenze"
 
-#: lib/vutuv_web/components/ui.ex:5397
+#: lib/vutuv_web/components/ui.ex:5398
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr "lavoro avviso ricerca agente osservati"
 
-#: lib/vutuv_web/components/ui.ex:5444
+#: lib/vutuv_web/components/ui.ex:5445
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr "Motori di ricerca, IA, stato online"
 
-#: lib/vutuv_web/components/ui.ex:5445
+#: lib/vutuv_web/components/ui.ex:5446
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 "privacy google motore di ricerca ia llm crawler noindex online pallino "
 "pubblico"
 
-#: lib/vutuv_web/components/ui.ex:5448
+#: lib/vutuv_web/components/ui.ex:5449
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr "Persone che non possono interagire con Lei"
 
-#: lib/vutuv_web/components/ui.ex:5449
+#: lib/vutuv_web/components/ui.ex:5450
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr "blocca bandisci silenzia segnala abuso molestie stalker"
 
-#: lib/vutuv_web/components/ui.ex:5470
+#: lib/vutuv_web/components/ui.ex:5471
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr "Passkey, dispositivi connessi, codici di accesso"
 
-#: lib/vutuv_web/components/ui.ex:5471
+#: lib/vutuv_web/components/ui.ex:5472
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 "password accesso entrare uscire sessione dispositivo passkey totp 2fa pin"
 
-#: lib/vutuv_web/components/ui.ex:5479
+#: lib/vutuv_web/components/ui.ex:5480
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr "Porti i Suoi dati da LinkedIn"
 
-#: lib/vutuv_web/components/ui.ex:5480
+#: lib/vutuv_web/components/ui.ex:5481
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr "linkedin caricamento zip migrazione trasferimento"
 
-#: lib/vutuv_web/components/ui.ex:5483
+#: lib/vutuv_web/components/ui.ex:5484
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr "Scarichi tutto ciò che conserviamo su di Lei"
 
-#: lib/vutuv_web/components/ui.ex:5484
+#: lib/vutuv_web/components/ui.ex:5485
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr "download gdpr rgpd dati backup json cv"
 
-#: lib/vutuv_web/components/ui.ex:5498
+#: lib/vutuv_web/components/ui.ex:5499
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr "Rimuova il Suo account e tutto ciò che contiene"
 
-#: lib/vutuv_web/components/ui.ex:5499
+#: lib/vutuv_web/components/ui.ex:5500
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr "elimina rimuovi chiudi esci cancella abbandona"
@@ -16463,7 +16463,7 @@ msgstr "Token di accesso creato"
 msgid "Access token revoked"
 msgstr "Token di accesso revocato"
 
-#: lib/vutuv_web/components/ui.ex:5473
+#: lib/vutuv_web/components/ui.ex:5474
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -16822,7 +16822,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr "Cosa è cambiato sul Suo account, ed esattamente quando."
 
-#: lib/vutuv_web/components/ui.ex:5474
+#: lib/vutuv_web/components/ui.ex:5475
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr "Cosa è cambiato sul Suo account, e quando"
@@ -16858,7 +16858,7 @@ msgstr "da chi gestisce il sito"
 msgid "from a signed-in session"
 msgstr "da una sessione connessa"
 
-#: lib/vutuv_web/components/ui.ex:5476
+#: lib/vutuv_web/components/ui.ex:5477
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -17068,13 +17068,13 @@ msgid "Open Fediverse settings"
 msgstr "Apri le impostazioni del Fediverso"
 
 #: lib/vutuv_web/components/post_components.ex:5364
-#: lib/vutuv_web/components/press_kit_components.ex:399
+#: lib/vutuv_web/components/press_kit_components.ex:452
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} di %{total}"
 
 #: lib/vutuv_web/components/post_components.ex:5592
-#: lib/vutuv_web/components/press_kit_components.ex:469
+#: lib/vutuv_web/components/press_kit_components.ex:536
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "La foto è in fase di controllo"
@@ -17417,7 +17417,7 @@ msgstr "Un account su un'altra rete"
 msgid "Cancel request"
 msgstr "Annulla la richiesta"
 
-#: lib/vutuv_web/components/ui.ex:5460
+#: lib/vutuv_web/components/ui.ex:5461
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr "Segua account su Mastodon, e si faccia seguire da lì"
@@ -17653,7 +17653,7 @@ msgstr ""
 "reti e non può seguire nessuno lì. La sospensione decade da sé quando "
 "termina."
 
-#: lib/vutuv_web/components/ui.ex:5462
+#: lib/vutuv_web/components/ui.ex:5463
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
@@ -18836,7 +18836,7 @@ msgstr "Attestato di lavoro aggiornato."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:54
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:5296
+#: lib/vutuv_web/components/ui.ex:5297
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -19040,7 +19040,7 @@ msgstr ""
 "Ha modificato il testo dopo questa analisi. L'analisi descrive la versione "
 "precedente."
 
-#: lib/vutuv_web/components/ui.ex:5297
+#: lib/vutuv_web/components/ui.ex:5298
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr "I Suoi Arbeitszeugnisse, privati finché non li pubblica"
@@ -19051,7 +19051,7 @@ msgstr "I Suoi Arbeitszeugnisse, privati finché non li pubblica"
 msgid "Zwischenzeugnis"
 msgstr "Zwischenzeugnis"
 
-#: lib/vutuv_web/components/ui.ex:5299
+#: lib/vutuv_web/components/ui.ex:5300
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr ""
@@ -19327,7 +19327,7 @@ msgstr "Trascini qui il file, oppure ne scelga uno"
 msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr "PDF, JPG, PNG o WebP, fino a %{limit}"
 
-#: lib/vutuv_web/components/ui.ex:4582
+#: lib/vutuv_web/components/ui.ex:4583
 #: lib/vutuv_web/live/press_kit_live.ex:382
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
@@ -19682,7 +19682,7 @@ msgstr ""
 "Le percentuali si riferiscono ai %{answered} membri che hanno risposto. "
 "%{unanswered} non hanno risposto."
 
-#: lib/vutuv_web/components/ui.ex:5267
+#: lib/vutuv_web/components/ui.ex:5268
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr "immagine profilo ritratto foto compleanno genere su di me"
@@ -19784,7 +19784,7 @@ msgstr "Elimina anche"
 msgid "Always keep"
 msgstr "Conserva sempre"
 
-#: lib/vutuv_web/components/ui.ex:5453
+#: lib/vutuv_web/components/ui.ex:5454
 #: lib/vutuv_web/controllers/settings_controller.ex:256
 #: lib/vutuv_web/controllers/settings_controller.ex:335
 #: lib/vutuv_web/controllers/settings_controller.ex:347
@@ -19894,7 +19894,7 @@ msgstr "Conserva i post con foto"
 msgid "Keep posts that did well"
 msgstr "Conserva i post andati bene"
 
-#: lib/vutuv_web/components/ui.ex:5455
+#: lib/vutuv_web/components/ui.ex:5456
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr "Lasci scadere i Suoi post dopo un tempo che decide Lei"
@@ -20018,7 +20018,7 @@ msgstr "Prima può scaricare tutto ciò che ha qui:"
 msgid "Your rule"
 msgstr "La Sua regola"
 
-#: lib/vutuv_web/components/ui.ex:5457
+#: lib/vutuv_web/components/ui.ex:5458
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
@@ -21424,7 +21424,7 @@ msgstr ""
 "Impostazioni delle lingue del feed riportate ai valori predefiniti del sito."
 
 #: lib/vutuv_web/components/post_components.ex:5877
-#: lib/vutuv_web/components/ui.ex:5371
+#: lib/vutuv_web/components/ui.ex:5372
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
 #: lib/vutuv_web/templates/settings/preferences.html.heex:187
@@ -21666,7 +21666,7 @@ msgstr ""
 msgid "Mastodon app access changed"
 msgstr "Accesso delle app Mastodon modificato"
 
-#: lib/vutuv_web/components/ui.ex:5491
+#: lib/vutuv_web/components/ui.ex:5492
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr "App Mastodon, app collegate e token di accesso"
@@ -21722,7 +21722,7 @@ msgstr ""
 msgid "Your account is then %{handle}."
 msgstr "Il Suo account è allora %{handle}."
 
-#: lib/vutuv_web/components/ui.ex:5493
+#: lib/vutuv_web/components/ui.ex:5494
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr ""
@@ -21759,7 +21759,7 @@ msgstr "Trovi le persone che conosce da LinkedIn"
 msgid "Find your LinkedIn contacts"
 msgstr "Trovi i Suoi contatti LinkedIn"
 
-#: lib/vutuv_web/components/ui.ex:5387
+#: lib/vutuv_web/components/ui.ex:5388
 #: lib/vutuv_web/live/import_connections_live.ex:64
 #: lib/vutuv_web/templates/import/new.html.heex:37
 #, elixir-autogen, elixir-format
@@ -21873,7 +21873,7 @@ msgstr "Cerchi per nome"
 msgid "See which of them are already on vutuv"
 msgstr "Veda quali di loro sono già su vutuv"
 
-#: lib/vutuv_web/components/ui.ex:5389
+#: lib/vutuv_web/components/ui.ex:5390
 #, elixir-autogen, elixir-format
 msgid "See which of your LinkedIn contacts are already on vutuv"
 msgstr "Veda quali dei Suoi contatti LinkedIn sono già su vutuv"
@@ -21957,7 +21957,7 @@ msgstr "I Suoi contatti su vutuv"
 msgid "Your export also lists your LinkedIn contacts."
 msgstr "La Sua esportazione elenca anche i Suoi contatti LinkedIn."
 
-#: lib/vutuv_web/components/ui.ex:5391
+#: lib/vutuv_web/components/ui.ex:5392
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
 msgstr ""
@@ -22243,7 +22243,7 @@ msgstr ""
 "Ha attivato le notifiche del browser. A questo browser non è ancora stato "
 "chiesto il permesso."
 
-#: lib/vutuv_web/components/ui.ex:5345
+#: lib/vutuv_web/components/ui.ex:5346
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr ""
@@ -22477,22 +22477,22 @@ msgstr "Vengono nascosti dal Suo feed."
 msgid "Shown in the language it was written in."
 msgstr "Vengono mostrati nella lingua in cui sono stati scritti."
 
-#: lib/vutuv_web/components/ui.ex:5372
+#: lib/vutuv_web/components/ui.ex:5373
 #, elixir-autogen, elixir-format
 msgid "Which languages reach you, and what happens to the rest"
 msgstr "Quali lingue arrivano fino a Lei e cosa succede al resto"
 
-#: lib/vutuv_web/components/ui.ex:5374
+#: lib/vutuv_web/components/ui.ex:5375
 #, elixir-autogen, elixir-format
 msgid "language translate translation german english original hide foreign rank order sprache übersetzen fremdsprache reihenfolge"
 msgstr "lingua tradurre traduzione italiano tedesco inglese originale nascondere lingua straniera ordine priorità feed language translate sprache"
 
-#: lib/vutuv_web/components/ui.ex:5412
+#: lib/vutuv_web/components/ui.ex:5413
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, maps, how posts are shortened"
 msgstr "Lingua dell'interfaccia, formato della data e fuso orario, mappe, come vengono accorciati i post"
 
-#: lib/vutuv_web/components/ui.ex:5416
+#: lib/vutuv_web/components/ui.ex:5417
 #, elixir-autogen, elixir-format
 msgid "german english locale map font length hyphenation übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr "italiano tedesco inglese lingua mappa carattere lunghezza sillabazione fuso orario timezone utc data ora orologio 24 ore formato della data"
@@ -22981,7 +22981,7 @@ msgstr ""
 "La pagina della Sua organizzazione è stata aggiornata, ma non è stato "
 "possibile usare quell'immagine come logo. Ne scelga un'altra."
 
-#: lib/vutuv_web/components/ui.ex:4588
+#: lib/vutuv_web/components/ui.ex:4589
 #, elixir-autogen, elixir-format
 msgid "You can upload one file at a time."
 msgid_plural "You can upload at most %{count} files at a time."
@@ -23179,7 +23179,7 @@ msgstr "Lascia vuoto il campo degli account e la regola vale per tutti; %{exampl
 msgid "Only these accounts (empty = all) …"
 msgstr "Solo questi account (vuoto = tutti) …"
 
-#: lib/vutuv_web/components/ui.ex:3566
+#: lib/vutuv_web/components/ui.ex:3567
 #, elixir-autogen, elixir-format
 msgid "only %{account}"
 msgstr "solo %{account}"
@@ -23421,7 +23421,7 @@ msgstr "Di questo post non resta nulla."
 msgid "Replace with"
 msgstr "Sostituisci con"
 
-#: lib/vutuv_web/components/ui.ex:5364
+#: lib/vutuv_web/components/ui.ex:5365
 #, elixir-autogen, elixir-format
 msgid "Rewrite what an account's posts say, for you alone"
 msgstr "Riscrivere il testo dei post di un account, solo per Lei"
@@ -23439,7 +23439,7 @@ msgstr "Regole che riscrivono il testo dei post di un account prima che Lei li l
 #: lib/vutuv_web/components/post_components.ex:1452
 #: lib/vutuv_web/components/post_components.ex:3402
 #: lib/vutuv_web/components/post_components.ex:4496
-#: lib/vutuv_web/components/ui.ex:5363
+#: lib/vutuv_web/components/ui.ex:5364
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
 #: lib/vutuv_web/live/post_rewrites_live.ex:264
@@ -23495,12 +23495,12 @@ msgstr "Le Sue regole salvate modificano questo post di %{who} come mostrato."
 msgid "\\1 puts back what the first (…) group matched, \\0 the whole match."
 msgstr "\\1 reinserisce ciò che ha trovato il primo gruppo (…), \\0 l'intera corrispondenza."
 
-#: lib/vutuv_web/components/ui.ex:5365
+#: lib/vutuv_web/components/ui.ex:5366
 #, elixir-autogen, elixir-format
 msgid "regex regular expression rewrite replace footer signature strip"
 msgstr "regex espressione regolare riscrivere sostituire piè di pagina firma rimuovere cerca"
 
-#: lib/vutuv_web/components/ui.ex:5434
+#: lib/vutuv_web/components/ui.ex:5435
 #, elixir-autogen, elixir-format
 msgid "Smaller pictures and a plain composer on a slow connection"
 msgstr "Immagini più piccole e un editor semplice con una connessione lenta"
@@ -23510,12 +23510,12 @@ msgstr "Immagini più piccole e un editor semplice con una connessione lenta"
 msgid "That endorsement is not possible."
 msgstr "Questa conferma non è possibile."
 
-#: lib/vutuv_web/components/ui.ex:5436
+#: lib/vutuv_web/components/ui.ex:5437
 #, elixir-autogen, elixir-format
 msgid "bandwidth slow internet mobile data saving saver volume metered compression pictures images screenshots editor langsam daten sparen datensparmodus volumen schmalband komprimierung bilder"
 msgstr "banda lento internet mobile risparmio dati volume compressione immagini foto screenshot editor bandwidth slow data saving"
 
-#: lib/vutuv_web/components/ui.ex:5408
+#: lib/vutuv_web/components/ui.ex:5409
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr "Aspetto"
@@ -23995,7 +23995,7 @@ msgstr ""
 msgid "Accounts whose posts stay out of your feed, and accounts whose reposts do. This list is yours alone: it is never shared and nobody is told they are on it."
 msgstr "Account i cui post non compaiono nel Suo feed e account di cui ha nascosto le ripubblicazioni. Questo elenco è solo Suo: non viene mai condiviso e nessuno viene informato di farne parte."
 
-#: lib/vutuv_web/components/ui.ex:5357
+#: lib/vutuv_web/components/ui.ex:5358
 #, elixir-autogen, elixir-format
 msgid "Accounts you have silenced, and whose reposts you hide"
 msgstr "Account che ha silenziato e account di cui nasconde le ripubblicazioni"
@@ -24021,7 +24021,7 @@ msgstr "Cerca invece parole, frasi o tag?"
 msgid "Mute everything"
 msgstr "Silenzia tutto"
 
-#: lib/vutuv_web/components/ui.ex:5356
+#: lib/vutuv_web/components/ui.ex:5357
 #: lib/vutuv_web/controllers/settings_controller.ex:713
 #: lib/vutuv_web/templates/settings/mutes.html.heex:1
 #: lib/vutuv_web/templates/settings/mutes.html.heex:3
@@ -24065,7 +24065,7 @@ msgstr "Non ha ancora silenziato nessuno."
 msgid "You mute an account where you meet it: the ⋯ menu on any of its posts, or its own page. Muting works whether or not you follow them."
 msgstr "Può silenziare un account dove lo incontra: nel menu ⋯ di uno dei suoi post oppure sulla sua pagina. Funziona anche con gli account che non segue."
 
-#: lib/vutuv_web/components/ui.ex:5359
+#: lib/vutuv_web/components/ui.ex:5360
 #, elixir-autogen, elixir-format
 msgid "mute unmute hide account reposts boosts feed stumm stummschalten ausblenden konto"
 msgstr "silenzia silenziare nascondere account ripubblicazioni boost feed"
@@ -24165,7 +24165,7 @@ msgstr ""
 msgid "Feed settings saved."
 msgstr "Impostazioni del feed salvate."
 
-#: lib/vutuv_web/components/ui.ex:5427
+#: lib/vutuv_web/components/ui.ex:5428
 #, elixir-autogen, elixir-format
 msgid "How many load at once, and how many “Load more” adds"
 msgstr ""
@@ -24175,7 +24175,7 @@ msgstr ""
 msgid "How many posts your feed shows before the “Load more” button, and how many that button adds. More posts mean a longer wait for the page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5426
+#: lib/vutuv_web/components/ui.ex:5427
 #: lib/vutuv_web/controllers/settings_controller.ex:963
 #: lib/vutuv_web/templates/settings/feed.html.heex:12
 #, elixir-autogen, elixir-format
@@ -24198,7 +24198,7 @@ msgstr "Post per pagina"
 msgid "You can change this under the feed itself as well, right below the “Load more” button."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5429
+#: lib/vutuv_web/components/ui.ex:5430
 #, elixir-autogen, elixir-format
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr ""
@@ -24620,7 +24620,7 @@ msgstr "Nuove notifiche"
 msgid "Neither your profile picture nor your cover photo was replaced: a report about them is still open. Open the case to remove the picture or to say that it is yours."
 msgstr "Né la tua immagine del profilo né quella di copertina sono state sostituite: una segnalazione è ancora aperta. Apri il caso per rimuovere l'immagine o per dire che è tua."
 
-#: lib/vutuv_web/controllers/report_controller.ex:174
+#: lib/vutuv_web/controllers/report_controller.ex:190
 #, elixir-autogen, elixir-format
 msgid "Profile picture"
 msgstr "Immagine del profilo"
@@ -24706,7 +24706,7 @@ msgstr ""
 "offline subito; ogni altra segnalazione arriva ai nostri amministratori e "
 "l'immagine resta visibile."
 
-#: lib/vutuv_web/controllers/report_controller.ex:151
+#: lib/vutuv_web/controllers/report_controller.ex:155
 #, elixir-autogen, elixir-format
 msgid "Thank you for your report. Our moderators have been notified and will review this picture."
 msgstr ""
@@ -24744,8 +24744,8 @@ msgstr "Indirizzo della pagina"
 msgid "Confirm the report"
 msgstr "Confermare la segnalazione"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:91
-#: lib/vutuv_web/controllers/public_report_controller.ex:111
+#: lib/vutuv_web/controllers/public_report_controller.ex:98
+#: lib/vutuv_web/controllers/public_report_controller.ex:118
 #: lib/vutuv_web/templates/public_report/confirm.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Confirm your report"
@@ -24797,8 +24797,8 @@ msgstr "Il segnalante esterno ha confermato il proprio indirizzo"
 msgid "Please confirm your report"
 msgstr "Confermi la Sua segnalazione"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:88
-#: lib/vutuv_web/controllers/public_report_controller.ex:116
+#: lib/vutuv_web/controllers/public_report_controller.ex:95
+#: lib/vutuv_web/controllers/public_report_controller.ex:123
 #, elixir-autogen, elixir-format
 msgid "Report confirmed"
 msgstr "Segnalazione confermata"
@@ -24813,7 +24813,7 @@ msgstr "Segnalare un contenuto di questo sito"
 msgid "Report filed from outside"
 msgstr "Segnalazione ricevuta dall'esterno"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:171
+#: lib/vutuv_web/controllers/public_report_controller.ex:178
 #, elixir-autogen, elixir-format
 msgid "Report sent"
 msgstr "Segnalazione inviata"
@@ -24828,7 +24828,7 @@ msgstr "Segnalare contenuti di questo sito"
 msgid "Thank you - your report is with our admins"
 msgstr "Grazie, la Sua segnalazione è presso i nostri amministratori"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:133
+#: lib/vutuv_web/controllers/public_report_controller.ex:140
 #, elixir-autogen, elixir-format
 msgid "That address is not on this site. We can only act on content published here."
 msgstr "Questo indirizzo non appartiene a questo sito. Possiamo intervenire solo su contenuti pubblicati qui."
@@ -24843,7 +24843,7 @@ msgstr "Il post, l'immagine, il video, il profilo, la pagina o l'annuncio di lav
 msgid "The report by %{email} was a deliberate weapon (that address loses our trust)"
 msgstr "La segnalazione di %{email} era un'arma deliberata (quell'indirizzo perde la nostra fiducia)"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:232
+#: lib/vutuv_web/controllers/public_report_controller.ex:239
 #, elixir-autogen, elixir-format
 msgid "We could not find that page. Please check the address."
 msgstr "Non abbiamo trovato questa pagina. Controlli l'indirizzo."
@@ -24858,7 +24858,7 @@ msgstr "Abbiamo inviato un'e-mail a %{email}."
 msgid "What is wrong with it?"
 msgstr "Che cosa non va?"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:176
+#: lib/vutuv_web/controllers/public_report_controller.ex:183
 #, elixir-autogen, elixir-format
 msgid "You already sent us this report. Please use the confirmation link in the email we sent you."
 msgstr "Ci ha già inviato questa segnalazione. Utilizzi il link di conferma contenuto nell'e-mail che Le abbiamo inviato."
@@ -24873,7 +24873,7 @@ msgstr "Non Le serve un account. Ci dica quale pagina è il problema e che cosa 
 msgid "You do not need to do anything else."
 msgstr "Non deve fare altro."
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:72
+#: lib/vutuv_web/controllers/public_report_controller.ex:79
 #, elixir-autogen, elixir-format
 msgid "You have sent us a lot of reports just now. Please try again later."
 msgstr "Ci ha inviato molte segnalazioni in poco tempo. Riprovi più tardi."
@@ -24939,8 +24939,8 @@ msgstr "Segnalazione scartata: l'indirizzo non è mai stato confermato"
 msgid "Send the report again"
 msgstr "Invii di nuovo la segnalazione"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:99
-#: lib/vutuv_web/controllers/public_report_controller.ex:121
+#: lib/vutuv_web/controllers/public_report_controller.ex:106
+#: lib/vutuv_web/controllers/public_report_controller.ex:128
 #: lib/vutuv_web/templates/public_report/expired.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "This link has expired"
@@ -25136,7 +25136,7 @@ msgstr "Segnali in modo onesto. Chi segnala per danneggiare qualcuno viola le no
 msgid "Texts, photos and videos belong to whoever made them. Post your own work, or work you have permission to use. A rights holder can report content here without an account, through {form}; such a complaint is decided by one of our admins, and an edit does not settle it."
 msgstr "Testi, foto e video appartengono a chi li ha creati. Pubblica opere tue o per le quali hai il permesso. Il titolare dei diritti può segnalare un contenuto anche senza un account, tramite {form}; su una segnalazione del genere decide uno dei nostri amministratori, e una modifica non la risolve."
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:143
+#: lib/vutuv_web/controllers/public_report_controller.ex:150
 #, elixir-autogen, elixir-format
 msgid "That address is one of our own pages, not content somebody published here, so there is nothing on it we could act on. Please paste the address of the post, picture, video, profile or job posting itself."
 msgstr "Questo indirizzo è una nostra pagina, non un contenuto pubblicato qui da qualcuno: non c'è nulla su cui possiamo intervenire. Incolli l'indirizzo del post, dell'immagine, del video, del profilo o dell'annuncio di lavoro."
@@ -25162,7 +25162,7 @@ msgid "“%{note}”"
 msgstr "“%{note}”"
 
 #: lib/vutuv_web/components/post_components.ex:5236
-#: lib/vutuv_web/components/press_kit_components.ex:207
+#: lib/vutuv_web/components/press_kit_components.ex:209
 #, elixir-autogen, elixir-format
 msgid "Show these photos larger"
 msgstr "Ingrandisci le foto"
@@ -25232,7 +25232,7 @@ msgstr "Crediti"
 msgid "Dark"
 msgstr "Scuro"
 
-#: lib/vutuv_web/components/ui.ex:5278
+#: lib/vutuv_web/components/ui.ex:5279
 #, elixir-autogen, elixir-format
 msgid "Files a journalist may download and print"
 msgstr "File che una redazione può scaricare e stampare"
@@ -25257,6 +25257,7 @@ msgstr "Detengo i diritti su questo file e lo rilascio per uso editoriale, purch
 msgid "Light"
 msgstr "Chiaro"
 
+#: lib/vutuv_web/controllers/report_controller.ex:193
 #: lib/vutuv_web/live/press_kit_live.ex:1006
 #, elixir-autogen, elixir-format
 msgid "Logo variant"
@@ -25306,6 +25307,7 @@ msgstr "Immagine rimossa."
 msgid "Please confirm the rights first, then choose the file."
 msgstr "Confermi prima i diritti e scelga poi il file."
 
+#: lib/vutuv_web/controllers/report_controller.ex:193
 #: lib/vutuv_web/live/press_kit_live.ex:1006
 #, elixir-autogen, elixir-format
 msgid "Press photo"
@@ -25319,7 +25321,7 @@ msgstr "Foto per la stampa"
 msgid "Press photos"
 msgstr "Foto per la stampa"
 
-#: lib/vutuv_web/components/ui.ex:5277
+#: lib/vutuv_web/components/ui.ex:5278
 #: lib/vutuv_web/live/press_kit_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Press photos & logos"
@@ -25390,7 +25392,7 @@ msgstr "Non può aggiungere un'immagine a questo kit stampa."
 msgid "Your logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
 msgstr "Il Suo logo come file, un riquadro per variante. Una tipografia chiede un vettoriale (SVG); tutti gli altri possono aprire un PNG."
 
-#: lib/vutuv_web/components/ui.ex:5280
+#: lib/vutuv_web/components/ui.ex:5281
 #, elixir-autogen, elixir-format
 msgid "press kit media journalist photographer download original print logo svg credit copyright presse pressemappe fotos logo herunterladen bildnachweis"
 msgstr "kit stampa media redazione giornalista fotografo download originale stampa logo svg crediti copyright foto scaricare"
@@ -25400,24 +25402,24 @@ msgstr "kit stampa media redazione giornalista fotografo download originale stam
 msgid "Ready-made buttons and badges"
 msgstr "Pulsanti e badge già pronti"
 
-#: lib/vutuv_web/components/ui.ex:3619
+#: lib/vutuv_web/components/ui.ex:3620
 #, elixir-autogen, elixir-format
 msgid "%{count} byte"
 msgid_plural "%{count} bytes"
 msgstr[0] "%{count} byte"
 msgstr[1] "%{count} byte"
 
-#: lib/vutuv_web/components/press_kit_components.ex:99
+#: lib/vutuv_web/components/press_kit_components.ex:100
 #, elixir-autogen, elixir-format
 msgid "Add press photos"
 msgstr "Aggiungi foto stampa"
 
-#: lib/vutuv_web/components/press_kit_components.ex:117
+#: lib/vutuv_web/components/press_kit_components.ex:118
 #, elixir-autogen, elixir-format
 msgid "All press material"
 msgstr "Tutto il materiale stampa"
 
-#: lib/vutuv_web/components/press_kit_components.ex:173
+#: lib/vutuv_web/components/press_kit_components.ex:174
 #, elixir-autogen, elixir-format
 msgid "All press photos"
 msgstr "Tutte le foto stampa"
@@ -25428,18 +25430,18 @@ msgstr "Tutte le foto stampa"
 msgid "Credit: %{credit}"
 msgstr "Credito: %{credit}"
 
-#: lib/vutuv_web/components/press_kit_components.ex:320
 #: lib/vutuv_web/components/press_kit_components.ex:323
+#: lib/vutuv_web/components/press_kit_components.ex:326
 #, elixir-autogen, elixir-format
 msgid "Download %{format}"
 msgstr "Scarica %{format}"
 
-#: lib/vutuv_web/components/press_kit_components.ex:276
+#: lib/vutuv_web/components/press_kit_components.ex:279
 #, elixir-autogen, elixir-format
 msgid "Download photo"
 msgstr "Scarica la foto"
 
-#: lib/vutuv/press_kit.ex:496
+#: lib/vutuv/press_kit.ex:503
 #, elixir-autogen, elixir-format
 msgid "Free for editorial use with credit."
 msgstr "Libera per uso editoriale, citando il credito."
@@ -25454,7 +25456,7 @@ msgstr "Versione PNG"
 #: lib/vutuv_web/agent_docs/text.ex:57
 #: lib/vutuv_web/agent_docs/text.ex:257
 #: lib/vutuv_web/components/organization_components.ex:262
-#: lib/vutuv_web/components/press_kit_components.ex:97
+#: lib/vutuv_web/components/press_kit_components.ex:98
 #: lib/vutuv_web/live/organization_live/show.ex:168
 #: lib/vutuv_web/views/press_kit_html.ex:28
 #: lib/vutuv_web/views/press_kit_html.ex:46
@@ -25513,3 +25515,9 @@ msgstr "Usa il logo di questa pagina"
 #, elixir-autogen, elixir-format
 msgid "What a journalist writing about this page may download: photos in print quality and its logo as a file. Everything here is public and free for editorial use as long as the credit is shown."
 msgstr "Ciò che una redazione che scrive di questa pagina può scaricare: foto in qualità di stampa e il suo logo come file. Tutto qui è pubblico e libero per uso editoriale, purché vengano indicati i crediti."
+
+#: lib/vutuv_web/components/press_kit_components.ex:483
+#: lib/vutuv_web/components/ui.ex:3250
+#, elixir-autogen, elixir-format
+msgid "Report this picture"
+msgstr "Segnala questa immagine"

--- a/test/vutuv/press_kit_reporting_test.exs
+++ b/test/vutuv/press_kit_reporting_test.exs
@@ -1,0 +1,208 @@
+defmodule Vutuv.PressKitReportingTest do
+  @moduledoc """
+  Reporting a press photo or a logo variant, with or without an account
+  (issue #2089).
+
+  #2084 gave the kind a takedown, which opened the report gate for a **member's**
+  press picture and left three things broken behind it, each measured before it
+  was fixed:
+
+    * `Vutuv.Images.preview_url/1` and `bytes_path/1` raised `BadMapError` for
+      the kind — they index the profile-column map by kind and dereference the
+      `nil` that comes back — so the report form and the admin case page's
+      picture endpoint both 500ed, which is exactly the step an uphold needs;
+    * a **page's** press picture was takedown-ready and un-reportable, because
+      `Vutuv.Moderation`'s `owner_id/1` read `images.user_id` alone and that
+      column is NULL for a page's row;
+    * the outside notice form could not name a press picture at all: neither the
+      proxy addresses nor a page's section page resolved.
+
+  Not async: the freeze moves files on disk.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.ImageHelpers, only: [put_press_picture: 1, put_press_picture: 2]
+  import Vutuv.OrganizationsHelpers, only: [active_organization: 0]
+  import Vutuv.WebPushHelpers, only: [put_config: 2]
+
+  alias Vutuv.Images
+  alias Vutuv.Moderation
+  alias Vutuv.Moderation.ContentUrl
+  alias Vutuv.PressKit
+  alias Vutuv.Repo
+
+  @copyright %{"category" => "copyright", "note" => "Mein Foto.", "good_faith?" => "true"}
+  @house_rules %{"category" => "other", "note" => "Werbung."}
+
+  setup do
+    # A page is claimed through the DNS check, which the test env leaves off.
+    put_config(:verify_organization_domains, true)
+
+    reporter = insert(:activated_user)
+    {:ok, reporter: reporter}
+  end
+
+  describe "a member's press picture" do
+    test "is reportable and its preview URL is the picture, not a raise" do
+      member = insert(:activated_user)
+      image = put_press_picture(member, alt: "Am Schreibtisch")
+
+      assert Images.takedown_ready?(image)
+      assert Images.preview_url(image) =~ "/system/press_kit/#{image.token}/"
+    end
+
+    test "a copyright notice takes it off the page at once", %{reporter: reporter} do
+      member = insert(:activated_user)
+      insert(:email, user: member)
+      image = put_press_picture(member)
+
+      assert {:ok, case_record} = Moderation.report_content(reporter, image, @copyright)
+      assert case_record.owner_id == member.id
+
+      held = Repo.get!(Vutuv.Images.Image, image.id)
+      refute is_nil(held.frozen_at)
+      refute PressKit.visible_to?(held, member)
+    end
+
+    test "a house-rule report only flags it", %{reporter: reporter} do
+      member = insert(:activated_user)
+      image = put_press_picture(member)
+
+      assert {:ok, case_record} = Moderation.report_content(reporter, image, @house_rules)
+      assert case_record.status == "flagged"
+      assert Repo.get!(Vutuv.Images.Image, image.id).frozen_at == nil
+    end
+
+    test "its owner cannot report it", %{} do
+      member = insert(:activated_user)
+      image = put_press_picture(member)
+
+      assert {:error, :own_content} = Moderation.report_content(member, image, @house_rules)
+    end
+  end
+
+  describe "a page's press picture" do
+    setup do
+      {organization, owner} = active_organization()
+      {:ok, organization: organization, page_owner: owner}
+    end
+
+    test "is reportable, and the case is carried by the member who claimed the page", %{
+      reporter: reporter,
+      organization: organization,
+      page_owner: page_owner
+    } do
+      image = put_press_picture(organization)
+
+      assert Images.takedown_ready?(image)
+      assert Moderation.can_report?(reporter, image)
+
+      assert {:ok, case_record} = Moderation.report_content(reporter, image, @copyright)
+      assert case_record.owner_id == page_owner.id
+    end
+
+    test "the notice goes to the member who carries the case", %{
+      reporter: reporter,
+      organization: organization,
+      page_owner: page_owner
+    } do
+      insert(:email, user: page_owner)
+      image = put_press_picture(organization)
+      flush_emails()
+
+      assert {:ok, _case} = Moderation.report_content(reporter, image, @copyright)
+
+      address = Vutuv.Accounts.first_email_value(page_owner)
+      assert Enum.any?(flush_emails(), &match?([{_, ^address}], &1.to))
+    end
+
+    # The honest consequence of the clause above, and the same state a page's
+    # own posts have been in since #1334: with nobody to strike there is no
+    # case to open, so only an admin freeze can act.
+    test "is not reportable once the member who claimed the page is gone", %{
+      reporter: reporter,
+      organization: organization,
+      page_owner: page_owner
+    } do
+      image = put_press_picture(organization)
+      assert Moderation.can_report?(reporter, image)
+
+      {:ok, _} = Vutuv.Accounts.delete_user(page_owner)
+
+      refute Moderation.can_report?(reporter, image)
+      assert {:error, :not_allowed} = Moderation.report_content(reporter, image, @copyright)
+    end
+
+    test "a picture the AI gate is still holding is not reportable either", %{
+      reporter: reporter,
+      organization: organization
+    } do
+      image = put_press_picture(organization, moderation: "pending")
+
+      refute Moderation.can_report?(reporter, image)
+    end
+  end
+
+  describe "the outside notice form's URL" do
+    test "resolves a proxy address to the picture" do
+      member = insert(:activated_user)
+      image = put_press_picture(member)
+
+      for path <- [PressKit.url(image, "large"), PressKit.download_url(image)] do
+        assert {:ok, resolved} = ContentUrl.resolve(url(path))
+        assert resolved.id == image.id
+      end
+    end
+
+    test "resolves a member's and a page's section page to its owner" do
+      member = insert(:activated_user)
+      {organization, _owner} = active_organization()
+
+      assert {:ok, %Vutuv.Accounts.User{} = resolved} =
+               ContentUrl.resolve(url(PressKit.page_path(member)))
+
+      assert resolved.id == member.id
+
+      assert {:ok, %Vutuv.Organizations.Organization{} = page} =
+               ContentUrl.resolve(url(PressKit.page_path(organization)))
+
+      assert page.id == organization.id
+    end
+
+    test "does not resolve a picture the AI gate is still holding" do
+      member = insert(:activated_user)
+      image = put_press_picture(member, moderation: "pending")
+
+      assert {:error, :not_found} = ContentUrl.resolve(url(PressKit.url(image, "large")))
+    end
+  end
+
+  describe "the admin's look at the reported picture" do
+    test "answers with the bytes, held or not", %{reporter: reporter} do
+      member = insert(:activated_user)
+      insert(:email, user: member)
+
+      tmp =
+        Path.join(System.tmp_dir!(), "vutuv_press_report_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp)
+      put_config(:uploads_dir_prefix, tmp)
+      on_exit(fn -> File.rm_rf(tmp) end)
+
+      image = put_press_picture(member)
+      dir = Path.join([tmp, "press_kit", image.token])
+      File.mkdir_p!(dir)
+      File.write!(Path.join(dir, "large.avif"), "not-really-avif")
+
+      assert Images.bytes_path(image) |> File.exists?()
+
+      assert {:ok, _case} = Moderation.report_content(reporter, image, @copyright)
+      frozen = Repo.get!(Vutuv.Images.Image, image.id)
+
+      assert path = Images.bytes_path(frozen)
+      assert File.exists?(path)
+    end
+  end
+
+  defp url(path), do: VutuvWeb.Endpoint.url() <> path
+end

--- a/test/vutuv_web/press_kit_report_test.exs
+++ b/test/vutuv_web/press_kit_report_test.exs
@@ -1,0 +1,163 @@
+defmodule VutuvWeb.PressKitReportTest do
+  @moduledoc """
+  The Report control on the press surfaces (issue #2089), which is the one act a
+  press kit has to offer to somebody who has **no account here**: a picture
+  published for redistribution is the likeliest of all of them to draw a rights
+  holder's complaint.
+
+  What the tests below hold:
+
+    * the section page and the lightbox carry a quiet Report on every picture a
+      reader can actually see, and none on a held one — a stand-in is not a
+      picture anybody can recognise their work in;
+    * a signed-in member is sent to the in-app form and a signed-out reader to
+      the public notice form with the picture's own address already in it;
+    * the kit's own team is offered none — they remove a picture from the
+      editor rather than report it;
+    * the in-app form for a press picture renders (it raised `BadMapError`
+      until this issue: `Vutuv.Images.preview_url/1` indexed the profile-column
+      map by kind), names which picture it is, and offers `spam` — the one
+      picture that can itself be an advertisement;
+    * the German page says the German words, which is what a `.po` fuzzy-fill
+      would otherwise ship as confident nonsense.
+  """
+  use VutuvWeb.ConnCase, async: true
+
+  import Vutuv.ImageHelpers, only: [put_press_picture: 1, put_press_picture: 2]
+
+  alias Vutuv.PressKit
+
+  setup do
+    owner = insert_activated_user(username: "presse.person", first_name: "Ada", last_name: "King")
+    {:ok, owner: owner}
+  end
+
+  # The owner's own view of their kit, which is the one that must offer no
+  # Report at all.
+  defp as_owner(conn) do
+    {conn, owner} = create_and_login_user(conn)
+    {conn, owner}
+  end
+
+  defp de(conn), do: put_req_header(conn, "accept-language", "de-DE,de;q=0.9")
+
+  describe "the section page" do
+    test "offers a signed-out reader the public notice form, filled in", %{
+      conn: conn,
+      owner: owner
+    } do
+      image = put_press_picture(owner)
+
+      html = conn |> get(~p"/#{owner}/press") |> html_response(200)
+
+      assert html =~ "data-press-report"
+      assert html =~ "/system/report?url="
+      # The picture's own address, not the page's: a notice has to name the
+      # picture the freeze will take offline.
+      assert html =~ URI.encode_www_form(VutuvWeb.Endpoint.url() <> PressKit.url(image, "large"))
+    end
+
+    test "sends a signed-in member to the in-app form", %{conn: conn, owner: owner} do
+      image = put_press_picture(owner)
+      {conn, _reader} = create_and_login_user(conn)
+
+      html = conn |> get(~p"/#{owner}/press") |> html_response(200)
+
+      assert html =~ "/reports/new?"
+      assert html =~ "id=#{image.id}"
+      refute html =~ "/system/report?url="
+    end
+
+    test "offers the owner nothing to report", %{conn: conn} do
+      {conn, owner} = as_owner(conn)
+      put_press_picture(owner)
+
+      html = conn |> get(~p"/#{owner}/press") |> html_response(200)
+
+      refute html =~ "data-press-report"
+    end
+
+    test "offers nothing on a picture the AI gate is still holding", %{conn: conn, owner: owner} do
+      put_press_picture(owner, moderation: "pending")
+
+      html = conn |> get(~p"/#{owner}/press") |> html_response(200)
+
+      refute html =~ "data-press-report"
+    end
+
+    test "a logo variant carries it too", %{conn: conn, owner: owner} do
+      put_press_picture(owner, logo: true, alt: "Wortmarke, hell")
+
+      html = conn |> get(~p"/#{owner}/press") |> html_response(200)
+
+      assert html =~ "data-press-report"
+    end
+
+    test "the lightbox is told where to report the photo", %{conn: conn, owner: owner} do
+      put_press_picture(owner)
+
+      html = conn |> get(~p"/#{owner}/press") |> html_response(200)
+
+      assert html =~ "data-photo-report"
+      assert html =~ "data-label-report"
+    end
+
+    test "says it in German", %{conn: conn, owner: owner} do
+      put_press_picture(owner)
+
+      html = conn |> de() |> get(~p"/#{owner}/press") |> html_response(200)
+
+      assert html =~ "Dieses Bild melden"
+    end
+  end
+
+  describe "the in-app report form" do
+    test "renders for a press photo, with the picture and the spam category", %{
+      conn: conn,
+      owner: owner
+    } do
+      image = put_press_picture(owner, alt: "Am Schreibtisch")
+      {conn, _reader} = create_and_login_user(conn)
+
+      html =
+        conn
+        |> get(~p"/reports/new?#{[type: "image", id: image.id]}")
+        |> html_response(200)
+
+      assert html =~ "Press photo"
+      assert html =~ "Am Schreibtisch"
+      assert html =~ PressKit.url(image, "large")
+      # A press section is where a picture can itself be an advertisement; a
+      # profile picture deliberately offers no such category.
+      assert html =~ ~s(value="spam")
+      assert html =~ ~s(value="copyright")
+    end
+
+    test "names a logo variant as one, in German", %{conn: conn, owner: owner} do
+      image = put_press_picture(owner, logo: true, alt: "Wortmarke, dunkel")
+      {conn, _reader} = create_and_login_user(conn)
+
+      html =
+        conn
+        # The login already sent a response on this conn, and a header cannot be
+        # put on a sent one.
+        |> recycle()
+        |> de()
+        |> get(~p"/reports/new?#{[type: "image", id: image.id]}")
+        |> html_response(200)
+
+      assert html =~ "Logo-Variante"
+      assert html =~ "Wortmarke, dunkel"
+    end
+  end
+
+  describe "the public notice form" do
+    test "prefills the pasted address from the link", %{conn: conn} do
+      url = "https://vutuv.de/system/press_kit/abc/large.avif"
+
+      html = conn |> get(~p"/system/report?#{[url: url]}") |> html_response(200)
+
+      assert html =~ url
+    end
+  end
+end


### PR DESCRIPTION
A press photo is published for other people to take, so it is the likeliest picture on the site to draw a rights holder's complaint — and every way of making one led nowhere. `Vutuv.Images.preview_url/1` and `bytes_path/1` raised `BadMapError` for the kind, so the report form and the admin case page's picture endpoint both 500ed. A page's press picture was takedown-ready but un-reportable: accountability read `images.user_id`, which is NULL for a page's row. And the outside notice form at `/system/report` recognised neither a proxy address nor a page's press section.

Every visible picture now carries a quiet Report on `/:slug/press`, on `/organizations/:slug/press` and in the lightbox — a signed-in member goes to `/reports/new`, everybody else to the public form with the picture's address filled in. A copyright notice takes it offline at once, a house-rule one only flags it, and `spam` is offered here because a press picture can itself be the advert.

**To decide:** a page's notice reaches the member who claimed it, not every owner — a second recipient needs its own mail and a wider case page, which I left for an issue of its own.

Closes #2089

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01WPMGFtmCZNip8EJiRrx6ch
