### PR TITLE
The composer takes PDF, text and Markdown files, within a budget per member

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,8 @@ erl_crash.dump
 # pictures fetched from other networks (Vutuv.RemoteMedia): a followed
 # account's avatar and its posts' attachments
 /remote_media
+# the files a post or a message carries (Vutuv.AttachmentStore)
+/attachments
 # the AI-moderation limbo twin of the served trees (Vutuv.Uploads.quarantine_dir/1)
 /quarantine
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -765,6 +765,29 @@ config :vutuv, :organization_images, max_filesize: 4_000_000
 # Runtime overrides: MEDIA_KIT_MAX_MB, MEDIA_KIT_MAX_PHOTOS, MEDIA_KIT_MAX_LOGOS.
 config :vutuv, :press_kit, max_filesize: 30_000_000, max_photos: 10, max_logos: 5
 
+# Files on posts and messages (issue #2104, Vutuv.Attachments). `enabled` is
+# the product switch an installation that wants no files turns off
+# (ATTACHMENT_UPLOADS); `uploaders` is :admins while the milestone is being
+# built and :members once a post can actually carry a file, exactly as video
+# was introduced.
+#
+# 20 MB is a scanned twenty-page contract or a deck with pictures, and small
+# enough that five of them still fit one composer session over a phone
+# connection. The two budgets are per member and counted as **accepted
+# uploads** over a rolling window, so an upload-and-delete loop cannot reset
+# them; admins have none. `pdfinfo` comes from poppler-utils, the package
+# `pdftoppm` (qualification proofs) already asks for — without it PDFs are not
+# offered at all, and text and Markdown carry on.
+config :vutuv, :attachments,
+  enabled: true,
+  uploaders: :admins,
+  max_filesize: 20_000_000,
+  max_per_post: 5,
+  daily_budget: 100_000_000,
+  monthly_budget: 500_000_000,
+  pdfinfo: "pdfinfo",
+  pdfdetach: "pdfdetach"
+
 # Job postings (Vutuv.Jobs, milestone 11).
 #   * default_runtime_days — how long a published posting stays live before it
 #     auto-expires. Flat, no renewals: a still-open role gets a fresh posting.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -747,10 +747,22 @@ if config_env() == :prod do
   # how much of the machine it may take. Unset keeps the config.exs defaults.
   video_defaults = Application.get_env(:vutuv, :post_videos, [])
 
-  video_env_int = fn name ->
+  # Read an integer knob, or nil when it is unset. Shared with the attachment
+  # block below rather than written twice — the version that got its own
+  # closure was the one whose megabyte multiply then drifted.
+  env_int = fn name ->
     case System.get_env(name) do
       nil -> nil
       value -> String.to_integer(String.trim(value))
+    end
+  end
+
+  # …and the same as a megabyte count, since every size knob here is decimal
+  # (1 MB = 1,000,000 bytes), the unit the forms and the messages name.
+  env_mb = fn name ->
+    case env_int.(name) do
+      nil -> nil
+      megabytes -> megabytes * 1_000_000
     end
   end
 
@@ -761,15 +773,42 @@ if config_env() == :prod do
            uploaders:
              (System.get_env("VIDEO_UPLOADERS") == "members" && :members) ||
                video_defaults[:uploaders],
-           max_filesize:
-             (video_env_int.("VIDEO_MAX_MB") && video_env_int.("VIDEO_MAX_MB") * 1_000_000) ||
-               video_defaults[:max_filesize],
+           max_filesize: env_mb.("VIDEO_MAX_MB") || video_defaults[:max_filesize],
            max_duration_seconds:
-             video_env_int.("VIDEO_MAX_SECONDS") || video_defaults[:max_duration_seconds],
+             env_int.("VIDEO_MAX_SECONDS") || video_defaults[:max_duration_seconds],
            ffmpeg: System.get_env("FFMPEG_PATH") || video_defaults[:ffmpeg],
            ffprobe: System.get_env("FFPROBE_PATH") || video_defaults[:ffprobe],
-           threads: video_env_int.("VIDEO_THREADS") || video_defaults[:threads],
-           concurrency: video_env_int.("VIDEO_CONCURRENCY") || video_defaults[:concurrency]
+           threads: env_int.("VIDEO_THREADS") || video_defaults[:threads],
+           concurrency: env_int.("VIDEO_CONCURRENCY") || video_defaults[:concurrency]
+         )
+
+  # Files on posts and messages (issue #2104): the switch, who may upload, the
+  # per-file cap, how many go on one post, and the two per-member budgets.
+  # Unset keeps the config.exs defaults. The megabyte knobs are decimal (1 MB =
+  # 1,000,000 bytes), the same unit the composer's message names.
+  attachment_defaults = Application.get_env(:vutuv, :attachments, [])
+
+  config :vutuv,
+         :attachments,
+         Keyword.merge(attachment_defaults,
+           # Unset means "whatever config.exs says", not "on": an operator who
+           # turned files off in a source config must not get them back by
+           # leaving the env var alone.
+           enabled:
+             case System.get_env("ATTACHMENT_UPLOADS") do
+               nil -> attachment_defaults[:enabled]
+               value -> value != "false"
+             end,
+           uploaders:
+             (System.get_env("ATTACHMENT_UPLOADERS") == "members" && :members) ||
+               attachment_defaults[:uploaders],
+           max_filesize: env_mb.("ATTACHMENT_MAX_MB") || attachment_defaults[:max_filesize],
+           max_per_post: env_int.("ATTACHMENTS_PER_POST") || attachment_defaults[:max_per_post],
+           daily_budget: env_mb.("ATTACHMENT_DAILY_MB") || attachment_defaults[:daily_budget],
+           monthly_budget:
+             env_mb.("ATTACHMENT_MONTHLY_MB") || attachment_defaults[:monthly_budget],
+           pdfinfo: System.get_env("PDFINFO_PATH") || attachment_defaults[:pdfinfo],
+           pdfdetach: System.get_env("PDFDETACH_PATH") || attachment_defaults[:pdfdetach]
          )
 
   # Post images are auth-proxied: the app checks the post's audience, then

--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -37,7 +37,12 @@ Related documents: [README](../README.md) (overview) ·
   first page of PDF proof documents that members can attach to their
   certificates & licenses. Without `pdftoppm` on `$PATH`, PDF uploads are
   refused with a clear message ("please upload an image instead"); image
-  proofs keep working.
+  proofs keep working. The same package carries `pdfinfo` and `pdfdetach`,
+  which are what decide whether a PDF attached to a post is safe to publish
+  (encrypted, carrying a program, carrying another file). Without them **PDF
+  attachments are not offered at all** — the composer's picker does not accept
+  `.pdf` and the server refuses one — while text and Markdown files carry on.
+  A check that cannot run is never treated as a check that passed.
 - **ffmpeg** (optional, `apt-get install ffmpeg`) — video on posts: converts
   a member's clip into the files browsers play and pulls the stills the AI
   check looks at. Debian's build carries `libx264` and `libsvtav1`; without
@@ -122,6 +127,13 @@ Everything else has a default (the vutuv.de production value):
 | `VIDEO_THREADS` | `4` | The thread cap every ffmpeg run gets. Raise it on a big idle machine, lower it where the web server shares few cores |
 | `VIDEO_CONCURRENCY` | `2` | How many clips are converted at once. Everything past that queues; the author sees "waiting in line" |
 | `FFMPEG_PATH` / `FFPROBE_PATH` | `ffmpeg` / `ffprobe` | The two binaries, if not on `$PATH` under those names |
+| `ATTACHMENT_UPLOADS` | `true` | `false` turns files on posts off entirely: no picker in the composer, and the server refuses one. For an installation that wants text and pictures and nothing that can carry code |
+| `ATTACHMENT_UPLOADERS` | `admins` | Who may attach a file. `admins` while the feature is being built — a post cannot show or hand out its files yet — `members` opens it to everyone once it can |
+| `ATTACHMENT_MAX_MB` | `20` | The largest file a member may attach, in megabytes. 20 MB is a scanned twenty-page contract or a deck with pictures in it |
+| `ATTACHMENTS_PER_POST` | `5` | How many files one post may carry |
+| `ATTACHMENT_DAILY_MB` | `100` | How much a member may upload in **any 24 hours**, in megabytes. The window rolls rather than resetting at midnight, so there is no hour at which twice the allowance fits. Counted as *accepted uploads*: deleting a file does not give the megabytes back, which is what stops an upload-and-delete loop from filling your disk. Admins have no allowance |
+| `ATTACHMENT_MONTHLY_MB` | `500` | The same over any 30 days |
+| `PDFINFO_PATH` / `PDFDETACH_PATH` | `pdfinfo` / `pdfdetach` | The two poppler binaries the PDF check runs, if not on `$PATH` under those names. Missing either one means PDFs are not offered (see the dependency list above) |
 | `SCREENSHOT_BLOCKLIST` | – | Extra pages never to take a link-preview screenshot of, on top of the shipped `reddit.com` and `heise.de`. Comma-separated domains and/or URLs, copied into the blocklist table the first time you migrate; afterwards the live list is edited in the admin area (see "Screenshot blocklist" below) and this variable is inert. `SCREENSHOT_BLOCKED_HOSTS` is the older name and still works |
 | `SCREENSHOT_PAGE_CHECK` | `true` | Whether each link-preview capture is judged by the Ollama vision model on whether it shows the page or a consent / ad / login wall or a bot check, and the site blocklisted when it does not (see "The list mostly writes itself" below). `false` leaves the blocklist entirely hand-written — the setting for an installation without Ollama. Independent of `IMAGE_MODERATION_ENABLED`: that one is the safety gate, this one is a quality filter |
 | `SCREENSHOT_CHECK_VOTES` | `3` | How many opinions must agree before a site is blocklisted automatically. The first is deterministic, the rest are independent draws; a single dissent leaves the site alone. `1` acts on one opinion |
@@ -609,6 +621,12 @@ vutuv runs fine without internet access:
   AI check over the stills is the same local Ollama the photos use. Leave
   `ffmpeg` uninstalled (or set `VIDEO_UPLOADS=false`) if the installation
   should not take clips at all.
+- Files on posts need nothing from the internet either: the format is read
+  from the bytes and the PDF check is poppler, running locally. There is no
+  virus scanner behind it — the short format whitelist (PDF, plain text,
+  Markdown) and that check are the defence — so an installation that would
+  rather take no files at all sets `ATTACHMENT_UPLOADS=false`, and one that
+  wants text files but not PDFs simply leaves poppler-utils uninstalled.
 - Set `FETCH_BOOK_METADATA=false`: the cover fetch and the
   page-count/publisher lookup behind book-review posts call Open Library, and
   an audiobook's running time is read from a library catalogue (`DNB_SRU_URL`).

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -31,6 +31,7 @@ installing and operating vutuv in [Running your own vutuv](../ADMINS.md).
 | [email.md](email.md) | the Emailer chokepoint, multipart bodies, opt-outs, bounces & deliverability |
 | [images.md](images.md) | the AVIF pipeline, kept originals, fingerprinted filenames, the shared `images` table and its backfill, URL screenshots, AI image moderation (Ollama) |
 | [video.md](video.md) | video on posts: the ffmpeg pipeline and its resumable job, the AI check over the stills, the post that waits for its clip, the player and the range-answering proxy, what federates and what the Mastodon API says |
+| [attachments.md](attachments.md) | files on posts and messages: the upload chokepoint, the format read from the bytes, the PDF gate and why a raw-byte scan is not enough, the two on-disk copies, the per-member budget |
 | [admin.md](admin.md) | the admin panel: live dashboard, member browser, account deletion, newsletter & audiences, daily report |
 | [ads.md](ads.md) | the daily text ad: booking, review, serving |
 | [company-pages.md](company-pages.md) | the site footer, the English `/system/investors` and `/system/media-kit` pages, brand assets, and the daily head-count history behind the growth curve |

--- a/docs/architecture/attachments.md
+++ b/docs/architecture/attachments.md
@@ -1,0 +1,111 @@
+# Files on posts and messages
+
+A post can carry files as well as photos and a clip: PDF, plain text and
+Markdown to begin with (milestone #2102). This document covers the part that
+exists today — how a file gets in — and grows as the rest of the milestone
+lands: the preview pages (#2105), the post that waits for them (#2106), what
+a post shows and hands out (#2108), reports and copyright (#2109), messages
+(#2110).
+
+## One chokepoint
+
+`Vutuv.Attachments.create_pending/3` is the only way a file enters an
+installation. It is modelled on `Vutuv.Videos.create_pending_video/3`: the
+composer uploads eagerly, the row exists with **no parent** while the author
+is still writing, and a row nobody ever claimed is swept after a day
+(`sweep_pending/1`, run by `Vutuv.Posts.PendingImageSweeper` beside the
+pending photos and clips).
+
+Its refusals come cheapest-first and nothing is written to disk until every
+one has passed; the module's own doc lists them in order. Each is an atom the
+composer turns into a sentence (`attachment_error_message/1`), because "that
+file could not be processed" tells a member with a password-protected PDF
+nothing they can act on.
+
+## The format comes from the bytes
+
+`Vutuv.Attachments.Format` decides what a file is, and the extension only
+decides which names the installation offers at all and whether a text file is
+labelled Markdown or plain. The two have to **agree**, so a ZIP called
+`invoice.pdf` and a PDF called `notes.txt` are both refused: a lying name can
+never route a file past its own gate. The module's own doc has the rest.
+
+## The PDF gate
+
+`Vutuv.Uploads.PdfGate` blocks four effects — the file cannot be read
+(encrypted), it runs code when opened, it does something to the reader when
+opened, it carries another file inside it — and **fails closed**: poppler
+missing, poppler failing, or a scan that could not be finished is a refusal.
+Three of the four are poppler's answers (`pdfinfo` for encryption and
+JavaScript, `pdfdetach -list` for embedded files); `/OpenAction` no poppler
+tool reports, so it is read from the bytes.
+
+The one thing worth repeating outside that module: **a raw-byte scan alone is
+not enough, and this was measured.** One `qpdf --object-streams=generate` run
+moves every dictionary into a Flate-compressed object stream, after which
+`grep -ac` finds zero occurrences of `/JavaScript`, `/OpenAction` and
+`/EmbeddedFile` in a file that still does all three. So the scan also inflates
+every stream it can, bounded against a decompression bomb. `attachments_test.exs`
+tries every hostile PDF twice, as written and hidden that way; calibrated by
+removing the inflation pass, the `/OpenAction` file is then **accepted** while
+poppler still catches the other two.
+
+It lives under `Vutuv.Uploads` rather than beside the context that added it
+because two other doors already take a member's PDF and hand it back verbatim
+(`Vutuv.QualificationDocument`, `Vutuv.JobReferenceDocument`), whose only check
+is that page 1 renders. Neither calls it yet.
+
+## Two copies on disk
+
+`Vutuv.AttachmentStore` keeps the upload verbatim in the private
+`originals/attachments/<token>/` tree and a served copy under
+`attachments/<token>/`, both keyed by the row's URL token, never its id.
+They are byte-identical today; they are still two files, because the served
+copy is what #2107 rewrites when an author asks for the metadata to be
+removed, and the private tree's promise — this is exactly what the member sent
+— has to survive that. Neither tree gets a `Plug.Static` mount: every served
+byte will go through an authorizing proxy (#2108). Both are gitignored, and
+`test/vutuv/uploads_gitignore_test.exs` fails the build if that slips.
+
+## The budget
+
+Two rolling windows per member, 24 hours and 30 days, counted from
+`Vutuv.Attachments.Upload` — one ledger row per **accepted** upload, holding a
+member, a byte count and a moment, and nothing about the file.
+
+Two decisions sit in that sentence. **Accepted, not stored**: deleting a file,
+or letting the sweep take it, gives no megabytes back, so an
+upload-and-delete loop cannot run the disk down. **Rolling, not calendar**:
+there is no midnight at which twice the day's allowance fits.
+
+Admins have no budget. The composer shows what is left before the next file
+flows, as a formatted byte figure and a percentage.
+
+## Configuration
+
+Everything is per installation, read in `config/runtime.exs` with the
+`config/config.exs` values as defaults, and documented in the env-var table in
+[ADMINS.md](../ADMINS.md): `ATTACHMENT_UPLOADS`, `ATTACHMENT_UPLOADERS`,
+`ATTACHMENT_MAX_MB`, `ATTACHMENTS_PER_POST`, `ATTACHMENT_DAILY_MB`,
+`ATTACHMENT_MONTHLY_MB`, `PDFINFO_PATH`, `PDFDETACH_PATH`.
+
+`ATTACHMENT_UPLOADERS` is `admins` while the milestone is being built, the way
+video was introduced: a post cannot show or hand out its files until #2106 and
+#2108 land, so nobody else is offered a picker yet.
+
+## The nullable pair
+
+`attachments.post_id` and `attachments.message_id` are the shape CLAUDE.md
+warns about: at most one is set, and both are `nil` while the composer holds
+the file. `Vutuv.Attachments.pending?/1` is the one place that asks, so a
+later reader cannot write its own `is_nil/1` pair and get one of them wrong —
+an inner join to `posts` would silently drop every message's file, and a
+`NOT IN` over these ids without an `is_nil/1` branch is false for every row.
+
+## The media job
+
+The intake writes one `Vutuv.MediaJobs` row of kind `attachment_intake`, so
+`/admin/media` shows it beside the photo scans and video conversions. A
+refusal is a **finished** job with the reason in `detail` — the pipeline did
+its work and the answer was no; only a step that could not be run at all is
+`failed`.

--- a/lib/vutuv/attachments.ex
+++ b/lib/vutuv/attachments.ex
@@ -1,0 +1,328 @@
+defmodule Vutuv.Attachments do
+  @moduledoc """
+  Files on posts and messages (issue #2104): a PDF, a plain text file or a
+  Markdown file, up to the installation's cap, within a budget per member.
+
+  ## One chokepoint
+
+  `create_pending/3` is the only way a file enters this installation, and it
+  refuses in this order, cheapest first:
+
+    1. the installation, or this member, may not upload at all;
+    2. the file is over the per-file cap — answered from `File.stat!/1`,
+       before a byte is read;
+    3. the name's extension is not one this host offers;
+    4. the **bytes** are not the kind the name claims
+       (`Vutuv.Attachments.Format`);
+    5. the member has no budget left;
+    6. a PDF does not pass the gate (`Vutuv.Uploads.PdfGate`) — last, because
+       it is the only step that shells out and reads the whole file.
+
+  Only then is anything written to disk. A refusal leaves no file and costs no
+  budget.
+
+  ## The budget
+
+  Two rolling windows — 24 hours and 30 days — counted from
+  `Vutuv.Attachments.Upload`, a ledger row per **accepted** upload. Rolling
+  rather than calendar so there is no midnight at which twice the day's budget
+  fits, and a ledger rather than a sum over `attachments` so deleting a file
+  gives nothing back. Admins have no budget.
+
+  ## Off switch
+
+  `enabled?/0` is the product flag; `uploads_for?/1` adds the audience, which
+  is `:admins` until a post can actually carry a file (#2106, #2108) and
+  `:members` after — the way video was introduced. PDFs need poppler
+  (`pdfinfo`, `pdfdetach`): without it they are not offered and the gate
+  refuses them, because a check that cannot run is not a check that passed.
+  """
+
+  import Ecto.Query
+
+  alias Vutuv.Accounts.User
+  alias Vutuv.Attachments.Attachment
+  alias Vutuv.Attachments.Format
+  alias Vutuv.Attachments.Upload
+  alias Vutuv.AttachmentStore
+  alias Vutuv.MediaJobs
+  alias Vutuv.Repo
+  alias Vutuv.Uploads.PdfGate
+
+  @pending_max_age_hours 24
+  @day_hours 24
+  @month_hours 24 * 30
+
+  ## Configuration
+
+  @doc "Whether this installation offers files at all."
+  def enabled?, do: Keyword.get(config(), :enabled, true)
+
+  @doc """
+  Whether this member may attach a file: an admin always, anyone else once the
+  installation opens uploads (`ATTACHMENT_UPLOADERS=members`).
+  """
+  def uploads_for?(%User{admin?: true}), do: enabled?()
+  def uploads_for?(%User{}), do: enabled?() and uploaders() == :members
+  def uploads_for?(_anonymous), do: false
+
+  def max_filesize, do: Keyword.fetch!(config(), :max_filesize)
+  def max_per_post, do: Keyword.fetch!(config(), :max_per_post)
+  def daily_budget, do: Keyword.fetch!(config(), :daily_budget)
+  def monthly_budget, do: Keyword.fetch!(config(), :monthly_budget)
+
+  @doc "Whether PDFs can be checked here — without poppler they are not offered."
+  defdelegate pdf_supported?, to: PdfGate, as: :available?
+
+  @doc "Drops the cached poppler probe. For tests that move the binary."
+  defdelegate forget_capability, to: PdfGate
+
+  defdelegate extension_whitelist, to: Format
+
+  defp uploaders, do: Keyword.get(config(), :uploaders, :admins)
+  defp config, do: Application.fetch_env!(:vutuv, :attachments)
+
+  ## The upload
+
+  @doc """
+  Keeps the upload at `path` under `filename` and answers `{:ok, attachment}`,
+  or `{:error, reason}` — see the moduledoc for the order the refusals come
+  in. Nothing is stored until every check has passed.
+  """
+  def create_pending(%User{} = user, path, filename) do
+    if uploads_for?(user) do
+      job =
+        MediaJobs.start("attachment_intake",
+          user_id: user.id,
+          detail: Format.extension(filename)
+        )
+
+      user |> accept(path, filename) |> settle(job)
+    else
+      {:error, :disabled}
+    end
+  end
+
+  defp accept(user, path, filename) do
+    size = File.stat!(path).size
+
+    with :ok <- check_size(size),
+         {:ok, kind} <- check_format(path, filename),
+         :ok <- check_budget(user, size),
+         {:ok, pages} <- check_content(kind, path) do
+      store(user, path, filename, kind, size, pages)
+    end
+  end
+
+  defp check_size(size), do: if(size > max_filesize(), do: {:error, :too_large}, else: :ok)
+
+  defp check_format(path, filename) do
+    claimed = Format.claimed_kind(filename)
+
+    cond do
+      claimed == nil -> {:error, :invalid_file}
+      claimed == :pdf and not pdf_supported?() -> {:error, :pdf_unavailable}
+      Format.sniff(path) != claimed -> {:error, :invalid_file}
+      true -> {:ok, claimed}
+    end
+  end
+
+  defp check_content(:pdf, path), do: PdfGate.check(path)
+  defp check_content(:text, _path), do: {:ok, nil}
+
+  # Which of the two ran out decides what the member is told, so this asks them
+  # apart rather than comparing one combined number.
+  defp check_budget(user, size) do
+    case budget_for(user) do
+      %{unlimited?: true} -> :ok
+      %{daily: %{remaining: left}} when left < size -> {:error, :daily_budget}
+      %{monthly: %{remaining: left}} when left < size -> {:error, :monthly_budget}
+      _room -> :ok
+    end
+  end
+
+  defp store(user, path, filename, kind, size, pages) do
+    token = Attachment.gen_token()
+    :ok = AttachmentStore.store(token, path, Format.stored_extension(kind, filename))
+
+    insert =
+      %Attachment{user_id: user.id}
+      |> Attachment.changeset(%{
+        token: token,
+        # Cut rather than raise 22001 on a name the member did not choose to
+        # be long: a browser will happily hand over 400 characters.
+        file_name: String.slice(Path.basename(filename), 0, Attachment.name_max()),
+        content_type: Format.content_type(kind, filename),
+        size_bytes: size,
+        page_count: pages
+      })
+      |> Repo.insert()
+
+    case insert do
+      {:ok, attachment} ->
+        record_upload!(user, size)
+        {:ok, attachment}
+
+      {:error, _changeset} = error ->
+        AttachmentStore.delete(token)
+        error
+    end
+  end
+
+  # The intake is a media job like the photo scan and the video conversion
+  # (#2103). A refusal is a **finished** job — the pipeline did its work and
+  # the answer was no; only a step that could not be run is `failed`.
+  defp settle({:ok, attachment} = result, job) do
+    MediaJobs.finish(job, detail: "stored #{attachment.content_type}")
+    result
+  end
+
+  defp settle({:error, :unreadable} = result, job) do
+    MediaJobs.fail(job, :unreadable)
+    result
+  end
+
+  defp settle({:error, reason} = result, job) do
+    MediaJobs.finish(job, detail: "refused: #{reason}")
+    result
+  end
+
+  ## The budget
+
+  @doc """
+  What is left of this member's two budgets, in bytes:
+
+      %{unlimited?: false,
+        daily: %{used:, limit:, remaining:}, monthly: %{…}}
+
+  An admin gets `%{unlimited?: true, daily: nil, monthly: nil}` — the composer
+  says so in words rather than showing a number.
+  """
+  def budget_for(%User{admin?: true}) do
+    %{unlimited?: true, daily: nil, monthly: nil}
+  end
+
+  def budget_for(%User{} = user) do
+    {day, month} = used_since(user, @day_hours, @month_hours)
+
+    %{
+      unlimited?: false,
+      daily: window(day, daily_budget()),
+      monthly: window(month, monthly_budget())
+    }
+  end
+
+  defp window(used, limit), do: %{used: used, limit: limit, remaining: max(limit - used, 0)}
+
+  # Both windows in one round trip: the rows the month reads are a superset of
+  # the day's, so a second query would walk the same index range again.
+  # Postgres sums a bigint into a numeric, which arrives as a `Decimal` and
+  # cannot be subtracted from the limit — cast in SQL rather than unwrapping
+  # each one here.
+  defp used_since(%User{id: user_id}, day_hours, month_hours) do
+    day_cutoff = hours_ago(day_hours)
+    month_cutoff = hours_ago(month_hours)
+
+    from(u in Upload,
+      where: u.user_id == ^user_id and u.inserted_at > ^month_cutoff,
+      select: {
+        type(
+          coalesce(
+            fragment(
+              "sum(?) FILTER (WHERE ? > ?)",
+              u.size_bytes,
+              u.inserted_at,
+              type(^day_cutoff, :naive_datetime)
+            ),
+            0
+          ),
+          :integer
+        ),
+        type(coalesce(sum(u.size_bytes), 0), :integer)
+      }
+    )
+    |> Repo.one()
+  end
+
+  defp hours_ago(hours),
+    do: NaiveDateTime.add(NaiveDateTime.utc_now(), -hours * 3600, :second)
+
+  @doc """
+  Charges `size` bytes to `user`'s budget. `:hours_ago` backdates the entry,
+  which is how a test puts a member at their monthly budget without waiting a
+  month.
+  """
+  def record_upload!(%User{} = user, size, opts \\ []) do
+    at =
+      NaiveDateTime.utc_now(:second)
+      |> NaiveDateTime.add(-Keyword.get(opts, :hours_ago, 0) * 3600, :second)
+
+    Repo.insert!(%Upload{user_id: user.id, size_bytes: size, inserted_at: at})
+  end
+
+  ## Reading
+
+  @doc """
+  Whether this row still belongs to nobody. Both parents are nullable, so this
+  is the one place that asks — every other caller goes through here rather
+  than writing its own `is_nil/2` pair and getting one of them wrong.
+  """
+  def pending?(%Attachment{post_id: nil, message_id: nil}), do: true
+  def pending?(%Attachment{}), do: false
+
+  @doc """
+  The member's own still-unattached files, oldest first — what a re-mounted
+  composer re-adopts, and what `ids` narrows it to when the form named some.
+  """
+  def pending_for(%User{id: user_id}, ids) when is_list(ids) do
+    ids = Enum.filter(ids, &(Vutuv.UUIDv7.cast_or_nil(&1) != nil))
+
+    if ids == [] do
+      []
+    else
+      from(a in Attachment,
+        where: a.user_id == ^user_id and a.id in ^ids,
+        where: is_nil(a.post_id) and is_nil(a.message_id),
+        order_by: [asc: a.inserted_at]
+      )
+      |> Repo.all()
+    end
+  end
+
+  ## Deleting and sweeping
+
+  @doc """
+  Removes the member's own still-unattached file, bytes and all. A no-op for
+  one that already belongs to a post or a message — those go with their
+  parent. The budget keeps the bytes: they were accepted.
+  """
+  def delete_pending(%Attachment{} = attachment) do
+    if pending?(attachment) do
+      Repo.delete(attachment, allow_stale: true)
+      AttachmentStore.delete(attachment.token)
+    end
+
+    :ok
+  end
+
+  @doc """
+  Removes files older than `max_age_hours` that no post and no message ever
+  claimed. Returns how many went.
+
+  Prunes by age rather than picking work oldest-first, so the sweeper-clock
+  trap does not apply: a deleted row cannot come round again.
+  """
+  def sweep_pending(max_age_hours \\ @pending_max_age_hours) do
+    cutoff = hours_ago(max_age_hours)
+
+    rows =
+      from(a in Attachment,
+        where: is_nil(a.post_id) and is_nil(a.message_id),
+        where: a.inserted_at <= ^cutoff
+      )
+      |> Repo.all()
+
+    Enum.each(rows, &delete_pending/1)
+    length(rows)
+  end
+end

--- a/lib/vutuv/attachments/attachment.ex
+++ b/lib/vutuv/attachments/attachment.ex
@@ -1,0 +1,74 @@
+defmodule Vutuv.Attachments.Attachment do
+  @moduledoc """
+  A file a member uploaded in the composer (issue #2104) — a PDF, a plain
+  text file or a Markdown file.
+
+  Uploaded eagerly like a photo or a clip: the row exists the moment the file
+  is accepted, with **neither parent set**, and the post (#2106) or the
+  message (#2110) claims it later. A row that never gets a parent is swept
+  after a day (`Vutuv.Attachments.sweep_pending/1`).
+
+  ## The two parents
+
+  `post_id` and `message_id` are the nullable pair CLAUDE.md warns about: at
+  most one of them is set and both are `nil` while the composer holds the
+  file. Nothing here may be read with an inner join to `posts` (that drops
+  every message's file) or fed into a `NOT IN` without an `is_nil/1` branch
+  (one NULL in the list makes the predicate false for every row).
+  `Vutuv.Attachments.pending?/1` is the one place that asks.
+
+  ## What the row holds
+
+    * **what the member sent** — `file_name` as typed (for the download's
+      name), `size_bytes`, and `content_type` **derived from the bytes**, not
+      from the browser's claim.
+    * **`page_count`** — `pdfinfo`'s answer for a PDF, `nil` for text. What
+      #2105 renders its preview pages from.
+    * **`token`** — the URL key and the on-disk directory name, never the id.
+    * **`stage`** — where the pipeline is. Today `stored` the moment the file
+      lands, which is the column's default; #2105 puts the page rendering
+      between that and `ready`, and is what will first write it.
+  """
+
+  use VutuvWeb, :model
+
+  # `file_name` is the one column here a client writes — whatever the browser
+  # sent, and a browser will happily send 400 characters. Ecto does not enforce
+  # a varchar(255), so without this an oversized name raises Postgres 22001,
+  # which is a 500 on a plain upload. `content_type` is validated beside it
+  # because the two are set together and must not drift apart.
+  @name_max 255
+
+  schema "attachments" do
+    belongs_to(:post, Vutuv.Posts.Post)
+    belongs_to(:message, Vutuv.Chat.Message)
+    belongs_to(:user, Vutuv.Accounts.User)
+
+    field(:token, :string)
+    field(:file_name, :string)
+    field(:content_type, :string)
+    field(:size_bytes, :integer)
+    field(:page_count, :integer)
+
+    field(:stage, :string, default: "stored")
+
+    timestamps()
+  end
+
+  @doc "The insert the upload chokepoint writes; every value here is already checked."
+  def changeset(attachment, params) do
+    attachment
+    |> cast(params, [:token, :file_name, :content_type, :size_bytes, :page_count, :stage])
+    |> validate_required([:token, :file_name, :content_type, :size_bytes])
+    |> validate_length(:file_name, max: @name_max)
+    |> validate_length(:content_type, max: @name_max)
+    |> validate_number(:size_bytes, greater_than_or_equal_to: 0)
+    |> unique_constraint(:token)
+  end
+
+  @doc "The longest file name that fits the column — what the chokepoint cuts to."
+  def name_max, do: @name_max
+
+  @doc "A fresh unguessable URL token (~128 bits, URL-safe)."
+  defdelegate gen_token, to: Vutuv.Uploads
+end

--- a/lib/vutuv/attachments/format.ex
+++ b/lib/vutuv/attachments/format.ex
@@ -1,0 +1,92 @@
+defmodule Vutuv.Attachments.Format do
+  @moduledoc """
+  What kind of file this is (issue #2104) — read from the **bytes**, never
+  from the extension and never from the content type the browser sent.
+
+  Two answers today: `:pdf` and `:text`. A PDF is identified by its header at
+  offset 0; a text file by being text — valid UTF-8 from end to end with no
+  control characters beyond tab, newline, carriage return and form feed. Every
+  binary container fails that within a few bytes, which is why the sniff needs
+  no list of magic numbers to say no to.
+
+  The extension still has a job: it decides which names this installation
+  offers at all, and — once the bytes have said `:text` — whether the file is
+  labelled Markdown or plain text, which nothing in the bytes can tell. The two
+  have to **agree**: a ZIP called `invoice.pdf` and a PDF called `notes.txt`
+  are both refused, so a lying name can never route a file past its own gate.
+  """
+
+  alias Vutuv.Uploads.PdfGate
+
+  @pdf_magic "%PDF-"
+  @pdf_extensions ~w(.pdf)
+  @text_extensions ~w(.txt .md .markdown)
+  @markdown_extensions ~w(.md .markdown)
+
+  # Everything outside these is a control character a text file has no reason
+  # to carry, and every binary container has several in its first bytes.
+  @control_regex ~r/[\x00-\x08\x0b\x0e-\x1f\x7f]/
+
+  @doc """
+  The extensions the composer offers. `.pdf` drops out on an installation
+  without poppler, the way `.pdf` already drops out of the qualification
+  whitelist without `pdftoppm`.
+  """
+  def extension_whitelist do
+    if PdfGate.available?(), do: @pdf_extensions ++ @text_extensions, else: @text_extensions
+  end
+
+  @doc "The kind `file_name`'s extension claims (`:pdf`, `:text`) or `nil`."
+  def claimed_kind(file_name) do
+    case extension(file_name) do
+      ext when ext in @pdf_extensions -> :pdf
+      ext when ext in @text_extensions -> :text
+      _unknown -> nil
+    end
+  end
+
+  @doc """
+  The kind the bytes at `path` actually are (`:pdf`, `:text`) or `nil`.
+
+  The PDF answer costs five bytes; only the text question needs the whole
+  file, and only because being text is a claim about every byte in it. A PDF
+  therefore reaches `Vutuv.Uploads.PdfGate` without this having read it once
+  already.
+  """
+  def sniff(path) do
+    if header(path) == @pdf_magic do
+      :pdf
+    else
+      if text?(File.read!(path)), do: :text
+    end
+  end
+
+  defp header(path) do
+    File.open!(path, [:read, :binary], &IO.binread(&1, byte_size(@pdf_magic)))
+  end
+
+  @doc """
+  The content type stored on the row. The kind comes from the bytes; for text
+  the extension picks the flavour, because `# Title` and `# Title` are the
+  same bytes whether the member called the file Markdown or not.
+  """
+  def content_type(:pdf, _file_name), do: "application/pdf"
+
+  def content_type(:text, file_name) do
+    if extension(file_name) in @markdown_extensions, do: "text/markdown", else: "text/plain"
+  end
+
+  @doc """
+  The extension the stored copies get. For a PDF it is the sniffed kind's, so
+  a `.pdf` name that was not one never reaches the disk under it; for text the
+  claimed extension is already known to be one of ours, and it is the only
+  thing that tells `.md` from `.txt`.
+  """
+  def stored_extension(:pdf, _file_name), do: ".pdf"
+  def stored_extension(:text, file_name), do: extension(file_name)
+
+  @doc "The downcased extension of `file_name`, `\"\"` when it has none."
+  def extension(file_name), do: file_name |> Path.extname() |> String.downcase()
+
+  defp text?(bytes), do: String.valid?(bytes) and not Regex.match?(@control_regex, bytes)
+end

--- a/lib/vutuv/attachments/upload.ex
+++ b/lib/vutuv/attachments/upload.ex
@@ -1,0 +1,23 @@
+defmodule Vutuv.Attachments.Upload do
+  @moduledoc """
+  One accepted upload's entry in the budget ledger (issue #2104).
+
+  The daily and monthly budgets count **accepted uploads**, not stored bytes,
+  which is why this is its own table rather than a sum over `attachments`:
+  deleting a file — or having the abandoned-composer sweep take it — must not
+  hand the member their megabytes back and let an upload-and-delete loop run
+  the disk down.
+
+  The row says nothing about the file. A member, a byte count and a moment is
+  all the budget question needs, so that is all it keeps.
+  """
+
+  use VutuvWeb, :model
+
+  schema "attachment_uploads" do
+    belongs_to(:user, Vutuv.Accounts.User)
+    field(:size_bytes, :integer)
+
+    timestamps(updated_at: false)
+  end
+end

--- a/lib/vutuv/media_jobs.ex
+++ b/lib/vutuv/media_jobs.ex
@@ -52,7 +52,7 @@ defmodule Vutuv.MediaJobs do
   # What may open a row. A closed vocabulary rather than a free string, so a
   # typo at a call site shows up as a missing row here instead of as a second
   # kind nobody can filter by.
-  @kinds ~w(image_scan video_conversion screenshot)
+  @kinds ~w(image_scan video_conversion screenshot attachment_intake)
 
   # The columns the table can be sorted by — every column it shows.
   @sort_columns ~w(started member kind outcome duration)

--- a/lib/vutuv/posts/pending_image_sweeper.ex
+++ b/lib/vutuv/posts/pending_image_sweeper.ex
@@ -34,7 +34,8 @@ defmodule Vutuv.Posts.PendingImageSweeper do
   @sweeps [
     {"post image", &Vutuv.Posts.sweep_pending_images/0},
     {"job-posting image", &Vutuv.Jobs.sweep_pending_images/0},
-    {"post video", &Vutuv.Videos.sweep_pending_videos/0}
+    {"post video", &Vutuv.Videos.sweep_pending_videos/0},
+    {"attachment", &Vutuv.Attachments.sweep_pending/0}
   ]
 
   @impl true

--- a/lib/vutuv/uploaders/attachment_store.ex
+++ b/lib/vutuv/uploaders/attachment_store.ex
@@ -1,0 +1,77 @@
+defmodule Vutuv.AttachmentStore do
+  @moduledoc """
+  On-disk storage for the files a post or a message carries (issue #2104).
+
+  Like post images and clips there is **no public tree**: every served byte
+  will go through an authorizing proxy (#2108), so nothing here gets a
+  `Plug.Static` mount or an nginx alias. Two copies per file, keyed by the
+  attachment's URL token:
+
+      <uploads_dir_prefix>/attachments/<token>/file.<ext>            the served copy
+      <uploads_dir_prefix>/originals/attachments/<token>/original.<ext>   the upload, verbatim
+
+  They are byte-identical today. They are still two files, because the served
+  copy is the one #2107 rewrites when an author asks for the metadata to be
+  removed, and the promise the private tree makes — that what the member sent
+  is kept exactly as they sent it — has to survive that.
+
+  The served copy is written beside its target and renamed, so a process
+  killed mid-copy leaves no half file a proxy could hand out.
+  """
+
+  alias Vutuv.Uploads
+  alias Vutuv.Uploads.Originals
+
+  @served_name "file"
+  @root "attachments"
+
+  @doc """
+  Keeps `path` under `token`: the verbatim original in the private tree and
+  the served copy in `attachments/`. `ext` is the downcased extension the
+  **sniffed** format decides, never the one the client's file name claims.
+  """
+  def store(token, path, ext) when is_binary(ext) do
+    :ok = Originals.store(storage_dir(token), path, ext)
+    write_served(token, path, ext)
+    :ok
+  rescue
+    exception ->
+      # Half a stored file is worse than none: an original with no served copy
+      # and no row is invisible to the sweep, which only ever sees rows.
+      delete(token)
+      reraise(exception, __STACKTRACE__)
+  end
+
+  defp write_served(token, path, ext) do
+    dir = dir(token)
+    File.mkdir_p!(dir)
+    dest = Path.join(dir, @served_name <> ext)
+    temp = "#{dest}.#{System.unique_integer([:positive])}"
+    File.cp!(path, temp)
+    File.rename!(temp, dest)
+  end
+
+  @doc "The kept upload, or `nil` when it is gone."
+  def original_path(token), do: Originals.path(storage_dir(token))
+
+  @doc "The served copy, or `nil` when it is gone."
+  def served_path(token) do
+    token |> dir() |> Path.join(@served_name <> ".*") |> Path.wildcard() |> List.first()
+  end
+
+  @doc "Removes both copies of `token`. A no-op when nothing is stored."
+  def delete(token) when is_binary(token) do
+    File.rm_rf(dir(token))
+    Originals.delete(storage_dir(token))
+    :ok
+  end
+
+  defp storage_dir(token) do
+    # The token is Base64-URL by construction, but never trust a stored value
+    # enough to build paths with separators in it.
+    false = String.contains?(token, ["/", ".."])
+    Path.join(@root, token)
+  end
+
+  defp dir(token), do: Uploads.disk_dir(storage_dir(token))
+end

--- a/lib/vutuv/uploads/pdf_gate.ex
+++ b/lib/vutuv/uploads/pdf_gate.ex
@@ -1,0 +1,287 @@
+defmodule Vutuv.Uploads.PdfGate do
+  @moduledoc """
+  What a PDF has to be before this installation keeps it (issue #2104).
+
+  There is no virus scanner behind this; the format whitelist and this gate
+  are the defence, so it **fails closed**. Anything it cannot decide — poppler
+  missing, poppler failing, a scan it could not finish — is a refusal, never a
+  pass.
+
+  It lives under `Vutuv.Uploads` rather than under the context that added it
+  because two other doors already take a member's PDF and hand it back
+  verbatim — `Vutuv.QualificationDocument` and `Vutuv.JobReferenceDocument`,
+  whose only check is that page 1 renders. Neither calls this yet; putting it
+  here is what makes that a one-line change rather than a context dependency.
+
+  ## The four effects it blocks
+
+    * **The file cannot be read** (an encrypted PDF). `pdfinfo` exits non-zero
+      with *"Incorrect password"* for a user password and answers
+      `Encrypted: yes` for an owner-password-only file, which is readable but
+      restricted. Both are refused: nothing downstream — the page previews of
+      #2105, the metadata cleaning of #2107 — can work on a file it cannot open.
+    * **It runs code when it is opened** — `pdfinfo`'s own `JavaScript:` field.
+    * **It does something to the reader when it is opened** — an `/OpenAction`
+      that is an *action* rather than a destination.
+    * **It carries another file inside it** — `pdfdetach -list`, which counts
+      them.
+
+  ## Why a raw-byte scan is not enough, measured
+
+  The obvious implementation greps the file for `/JavaScript`, `/OpenAction`
+  and `/EmbeddedFile`. One `qpdf --object-streams=generate` run defeats all
+  three: every dictionary moves into a Flate-compressed object stream and the
+  three strings are simply not in the file any more (`grep -ac` says 0 for
+  each, checked on 2026-09-10), while the document goes on doing exactly what
+  it did.
+
+  So the two questions poppler can answer are asked of **poppler**, which
+  parses the structure and sees through object streams. The one it cannot —
+  `/OpenAction` — is asked of the raw bytes **and of every stream this can
+  inflate**, and since that pass is running anyway it looks for the other two
+  names as well; removing the inflation leaves only the `/OpenAction` case
+  red, which is how the test calibrates it. `#XX` escapes are tolerated,
+  because `/Open#41ction` is the same name to a reader.
+
+  ## Where the set is not closed
+
+  A stream whose filter is not zlib-compatible — LZW, RunLength, a filter
+  cascade, or a `/Crypt` filter — is skipped by the inflation pass, so an
+  `/OpenAction` inside such a stream would not be seen. No producer writes an
+  object stream that way (object streams exist to be Flate-compressed, and an
+  encrypted file is refused before this runs), but the possibility is real and
+  named here rather than pretended away. `/AA` (additional actions) and
+  `/Launch` are deliberately **not** blocked: `/AA` sits on the widgets of
+  every ordinary form, and the scripted half of both is what `pdfinfo`'s
+  JavaScript answer already covers.
+  """
+
+  require Logger
+
+  # The inflation pass's budget. An object stream holding a catalog is
+  # kilobytes; a stream that inflates past this is an image or a font, which
+  # cannot define an object, so it is skipped rather than refused. The total
+  # bounds a decompression bomb: past it the scan is incomplete, and an
+  # incomplete scan refuses.
+  @stream_limit 8_000_000
+  @total_limit 96_000_000
+
+  # The names, with `#XX` escapes allowed for every character — one pass that
+  # matches `/OpenAction` and `/Open#41ction` alike, so nothing has to decode a
+  # 20 MB buffer to find the second spelling. No `u` modifier anywhere in this
+  # module: these patterns run over slices of a PDF, which are not text.
+  @name_regexes (for name <- ~w(JavaScript EmbeddedFile OpenAction), into: %{} do
+                   pattern =
+                     "/" <>
+                       Enum.map_join(String.to_charlist(name), fn char ->
+                         hex = char |> Integer.to_string(16) |> String.pad_leading(2, "0")
+                         "(?:" <> <<char>> <> "|#(?i:" <> hex <> "))"
+                       end)
+
+                   {name, Regex.compile!(pattern)}
+                 end)
+
+  # `stream` … `endstream`, bytes rather than characters (no `u` modifier, so
+  # `.` matches any byte and a slice of a PDF cannot break the match).
+  @stream_regex ~r/stream\r?\n(.*?)endstream/s
+
+  # What may follow an `/OpenAction`: a destination array, or a dictionary
+  # whose action is `/GoTo` — a jump inside this same document. That is what
+  # hyperref's `pdfstartview` and Word write, and refusing it would refuse
+  # ordinary academic PDFs for nothing.
+  @destination_regex ~r/\A\s*\[/
+  @goto_regex ~r/\A\s*<<[^>]{0,400}?\/S\s*\/GoTo[\s\/>]/
+
+  @doc """
+  Reads the PDF at `path` and answers `{:ok, page_count}` or
+  `{:error, :encrypted | :javascript | :open_action | :embedded_files |
+  :unreadable}`.
+  """
+  def check(path) do
+    with {:ok, info} <- pdfinfo(path),
+         :ok <- refuse_if(info, ~r/^Encrypted:\s+yes/m, :encrypted),
+         :ok <- refuse_if(info, ~r/^JavaScript:\s+yes/m, :javascript),
+         :ok <- embedded_files(path),
+         :ok <- scan_bytes(path) do
+      {:ok, page_count(info)}
+    end
+  end
+
+  @doc """
+  Whether this installation can check PDFs at all: both poppler tools on
+  `$PATH`. Probed once per VM, like `Vutuv.Videos`' ffmpeg answer — without
+  them PDFs are simply not offered, and text and Markdown carry on.
+  """
+  def available? do
+    case :persistent_term.get({__MODULE__, :available}, :unknown) do
+      :unknown ->
+        verdict =
+          System.find_executable(tool(:pdfinfo)) != nil and
+            System.find_executable(tool(:pdfdetach)) != nil
+
+        :persistent_term.put({__MODULE__, :available}, verdict)
+        verdict
+
+      verdict ->
+        verdict
+    end
+  end
+
+  @doc "Drops the cached probe — the tests move the configured binary around."
+  def forget_capability, do: :persistent_term.erase({__MODULE__, :available})
+
+  ## poppler
+
+  defp pdfinfo(path) do
+    case run(:pdfinfo, [path]) do
+      {out, 0} ->
+        {:ok, out}
+
+      {out, _status} ->
+        # A user password stops poppler at the door: "Command Line Error:
+        # Incorrect password". Everything else is a file we could not read,
+        # which is equally a refusal — just a different sentence for the member.
+        if out =~ "password", do: {:error, :encrypted}, else: refused(:unreadable, out)
+    end
+  end
+
+  defp embedded_files(path) do
+    case run(:pdfdetach, ["-list", path]) do
+      {out, 0} ->
+        case Regex.run(~r/^\s*(\d+)\s+embedded files?/mi, out) do
+          [_all, "0"] -> :ok
+          [_all, _some] -> {:error, :embedded_files}
+          # It answered, but not in a shape we know. We cannot say there are
+          # none, so we do not.
+          nil -> refused(:unreadable, out)
+        end
+
+      {out, _status} ->
+        refused(:unreadable, out)
+    end
+  end
+
+  defp run(name, args) do
+    System.cmd(tool(name), args, stderr_to_stdout: true)
+  rescue
+    exception -> {Exception.message(exception), :crashed}
+  catch
+    :exit, reason -> {inspect(reason), :exit}
+  end
+
+  defp tool(name) do
+    :vutuv |> Application.get_env(:attachments, []) |> Keyword.get(name, to_string(name))
+  end
+
+  defp refuse_if(info, regex, reason), do: if(info =~ regex, do: {:error, reason}, else: :ok)
+
+  defp refused(reason, output) do
+    Logger.info("attachment pdf gate refused (#{reason}): #{String.slice(output, 0, 200)}")
+    {:error, reason}
+  end
+
+  defp page_count(info) do
+    case Regex.run(~r/^Pages:\s+(\d+)/m, info) do
+      [_all, count] -> String.to_integer(count)
+      nil -> nil
+    end
+  end
+
+  ## The byte scan
+
+  defp scan_bytes(path) do
+    bytes = File.read!(path)
+
+    with :ok <- scan_buffer(bytes) do
+      bytes |> streams() |> scan_streams(0)
+    end
+  end
+
+  defp scan_streams([], _spent), do: :ok
+
+  defp scan_streams(_streams, spent) when spent >= @total_limit do
+    # The scan could not be finished, so it did not pass.
+    {:error, :unreadable}
+  end
+
+  defp scan_streams([{bytes, start, length} | rest], spent) do
+    case inflate(binary_part(bytes, start, length)) do
+      # Too big to be an object stream: an image or a font, which defines
+      # nothing. Skipped, and its bytes are not charged to the budget.
+      :too_big -> scan_streams(rest, spent)
+      :error -> scan_streams(rest, spent)
+      {:ok, out} -> scan_inflated(out, rest, spent)
+    end
+  end
+
+  defp scan_inflated(out, rest, spent) do
+    case scan_buffer(out) do
+      :ok -> scan_streams(rest, spent + byte_size(out))
+      error -> error
+    end
+  end
+
+  defp scan_buffer(buffer) do
+    cond do
+      Regex.match?(@name_regexes["JavaScript"], buffer) -> {:error, :javascript}
+      Regex.match?(@name_regexes["EmbeddedFile"], buffer) -> {:error, :embedded_files}
+      open_action?(buffer) -> {:error, :open_action}
+      true -> :ok
+    end
+  end
+
+  defp open_action?(buffer) do
+    @name_regexes["OpenAction"]
+    |> Regex.scan(buffer, return: :index)
+    |> Enum.any?(fn [{start, length} | _] ->
+      after_name = start + length
+      rest = binary_part(buffer, after_name, min(512, byte_size(buffer) - after_name))
+      not destination?(rest)
+    end)
+  end
+
+  defp destination?(rest),
+    do: Regex.match?(@destination_regex, rest) or Regex.match?(@goto_regex, rest)
+
+  # Where each stream's payload sits, never a copy of it: `capture:
+  # :all_but_first` would allocate a fresh binary per stream, which on a PDF
+  # that is mostly stream data doubles the memory this holds while it scans.
+  # `binary_part/3` on the original hands back a sub-binary instead.
+  defp streams(bytes) do
+    @stream_regex
+    |> Regex.scan(bytes, return: :index, capture: :all_but_first)
+    |> Enum.map(fn [{start, length}] -> {bytes, start, length} end)
+  end
+
+  # Inflates one stream, stopping at `@stream_limit` rather than letting a
+  # deliberately tiny deflate stream expand into gigabytes.
+  defp inflate(payload) do
+    z = :zlib.open()
+
+    try do
+      :zlib.inflateInit(z)
+      collect(z, payload, [], 0)
+    rescue
+      _ -> :error
+    catch
+      _kind, _reason -> :error
+    after
+      :zlib.close(z)
+    end
+  end
+
+  defp collect(z, input, acc, size) do
+    case :zlib.safeInflate(z, input) do
+      {:continue, output} -> continue(z, output, acc, size)
+      {:finished, output} -> {:ok, IO.iodata_to_binary([acc, output])}
+    end
+  end
+
+  defp continue(z, output, acc, size) do
+    size = size + IO.iodata_length(output)
+
+    if size > @stream_limit,
+      do: :too_big,
+      else: collect(z, [], [acc, output], size)
+  end
+end

--- a/lib/vutuv/uploads/pdf_gate.ex
+++ b/lib/vutuv/uploads/pdf_gate.ex
@@ -22,7 +22,11 @@ defmodule Vutuv.Uploads.PdfGate do
       #2105, the metadata cleaning of #2107 — can work on a file it cannot open.
     * **It runs code when it is opened** — `pdfinfo`'s own `JavaScript:` field.
     * **It does something to the reader when it is opened** — an `/OpenAction`
-      that is an *action* rather than a destination.
+      that is an *action* rather than a destination, and an action that reaches
+      outside the document at all (`/Launch`, `/SubmitForm`, `/ImportData`)
+      wherever it stands. The second half is not decoration: the same effect
+      rides a page's `/AA` and an `/OpenAction`'s chained `/Next` under names
+      the `/OpenAction` rule never looks at.
     * **It carries another file inside it** — `pdfdetach -list`, which counts
       them.
 
@@ -50,10 +54,13 @@ defmodule Vutuv.Uploads.PdfGate do
   `/OpenAction` inside such a stream would not be seen. No producer writes an
   object stream that way (object streams exist to be Flate-compressed, and an
   encrypted file is refused before this runs), but the possibility is real and
-  named here rather than pretended away. `/AA` (additional actions) and
-  `/Launch` are deliberately **not** blocked: `/AA` sits on the widgets of
-  every ordinary form, and the scripted half of both is what `pdfinfo`'s
-  JavaScript answer already covers.
+  named here rather than pretended away.
+
+  `/AA` (additional actions) is deliberately **not** blocked as a name: it sits
+  on the widgets of every ordinary form, and it appeared in 2 of 1,051 real
+  PDFs measured on this machine on 2026-09-10. What is blocked is the *action*
+  inside it — see `@acting_names` — so a page whose `/AA` opens a calculator is
+  refused while a form's widgets are not.
   """
 
   require Logger
@@ -66,11 +73,25 @@ defmodule Vutuv.Uploads.PdfGate do
   @stream_limit 8_000_000
   @total_limit 96_000_000
 
+  # Actions that do something to the *machine* rather than move the reader
+  # inside the document, refused wherever they stand. Naming the effect rather
+  # than one spelling of it: leaving these out let two files through that the
+  # `/OpenAction` rule was meant to stop, because neither is an `/OpenAction`
+  # that is an action — an `/OpenAction << /S /GoTo … /Next << /S /Launch >> >>`,
+  # whose `/GoTo` prefix satisfies `destination?/1` and whose chained second
+  # half nothing looked at, and a page `/AA << /O << /S /Launch >> >>`, which
+  # fires on the same event under a different name. `pdfinfo` answers
+  # `JavaScript: no` for both. Measured over 1,051 real, local PDFs on
+  # 2026-09-10: `/Launch`, `/SubmitForm` and `/ImportData` appear in **none** of
+  # them, so naming them costs no ordinary document.
+  @acting_names ~w(Launch SubmitForm ImportData)
+
   # The names, with `#XX` escapes allowed for every character — one pass that
   # matches `/OpenAction` and `/Open#41ction` alike, so nothing has to decode a
   # 20 MB buffer to find the second spelling. No `u` modifier anywhere in this
   # module: these patterns run over slices of a PDF, which are not text.
-  @name_regexes (for name <- ~w(JavaScript EmbeddedFile OpenAction), into: %{} do
+  @name_regexes (for name <- ~w(JavaScript EmbeddedFile OpenAction) ++ @acting_names,
+                     into: %{} do
                    pattern =
                      "/" <>
                        Enum.map_join(String.to_charlist(name), fn char ->
@@ -225,10 +246,14 @@ defmodule Vutuv.Uploads.PdfGate do
     cond do
       Regex.match?(@name_regexes["JavaScript"], buffer) -> {:error, :javascript}
       Regex.match?(@name_regexes["EmbeddedFile"], buffer) -> {:error, :embedded_files}
+      acting?(buffer) -> {:error, :open_action}
       open_action?(buffer) -> {:error, :open_action}
       true -> :ok
     end
   end
+
+  defp acting?(buffer),
+    do: Enum.any?(@acting_names, &Regex.match?(@name_regexes[&1], buffer))
 
   defp open_action?(buffer) do
     @name_regexes["OpenAction"]

--- a/lib/vutuv/uploads/pdf_gate.ex
+++ b/lib/vutuv/uploads/pdf_gate.ex
@@ -65,11 +65,12 @@ defmodule Vutuv.Uploads.PdfGate do
 
   require Logger
 
-  # The inflation pass's budget. An object stream holding a catalog is
-  # kilobytes; a stream that inflates past this is an image or a font, which
-  # cannot define an object, so it is skipped rather than refused. The total
-  # bounds a decompression bomb: past it the scan is incomplete, and an
-  # incomplete scan refuses.
+  # The inflation pass's budget, per stream and in total. Past either one the
+  # scan is incomplete, and an incomplete scan refuses — a stream nobody could
+  # read is not a stream anybody proved harmless. Measured over 1,051 real,
+  # local PDFs on 2026-09-10: the largest single inflated stream is 3 MB and
+  # the largest whole-file total is under 96 MB, so both cuts sit well clear of
+  # an ordinary document while a bomb still stops at them.
   @stream_limit 8_000_000
   @total_limit 96_000_000
 
@@ -227,9 +228,20 @@ defmodule Vutuv.Uploads.PdfGate do
 
   defp scan_streams([{bytes, start, length} | rest], spent) do
     case inflate(binary_part(bytes, start, length)) do
-      # Too big to be an object stream: an image or a font, which defines
-      # nothing. Skipped, and its bytes are not charged to the budget.
-      :too_big -> scan_streams(rest, spent)
+      # A stream this could not finish inflating is a stream it did not scan,
+      # and an unfinished scan refuses — the same answer `@total_limit` gives.
+      # Skipping it instead was an exemption that cannot be proven: padding a
+      # catalog to 9 MB and running one `qpdf --object-streams=generate` puts
+      # `/OpenAction << /S /Launch >>` in a 9.5 KB file that inflates past the
+      # cut, and the scan walked straight past it. Measured over 1,051 real,
+      # local PDFs on 2026-09-10: the largest single inflated stream in the
+      # whole corpus is 3 MB and **none** reaches 4 MB, so the cut costs no
+      # ordinary document.
+      :too_big -> {:error, :unreadable}
+      # Not zlib at all — a JPEG, a font, an encrypted payload. There is
+      # nothing to inflate, so there is nothing this pass could have read; the
+      # filter that makes such a stream unreadable here is named in the
+      # moduledoc as the place the set is not closed.
       :error -> scan_streams(rest, spent)
       {:ok, out} -> scan_inflated(out, rest, spent)
     end
@@ -268,14 +280,26 @@ defmodule Vutuv.Uploads.PdfGate do
   defp destination?(rest),
     do: Regex.match?(@destination_regex, rest) or Regex.match?(@goto_regex, rest)
 
-  # Where each stream's payload sits, never a copy of it: `capture:
+  # Where each stream's payload *starts*, never a copy of it: `capture:
   # :all_but_first` would allocate a fresh binary per stream, which on a PDF
   # that is mostly stream data doubles the memory this holds while it scans.
   # `binary_part/3` on the original hands back a sub-binary instead.
+  #
+  # The slice runs from the `stream` marker to the **end of the file**, not to
+  # the next literal `endstream`: `endstream` is not a trustworthy terminator,
+  # because a stream's payload is arbitrary bytes an attacker chooses. A stored
+  # (uncompressed) deflate block can carry the nine bytes `endstream` ahead of
+  # a compressed `/OpenAction << /S /Launch >>`, and a scan that stopped the
+  # capture at that literal would inflate only the decoy prefix and never see
+  # the action. `:zlib` stops at the deflate stream's own end marker and
+  # ignores every trailing byte, so handing it the rest of the file reads the
+  # whole real stream and no more.
   defp streams(bytes) do
+    total = byte_size(bytes)
+
     @stream_regex
     |> Regex.scan(bytes, return: :index, capture: :all_but_first)
-    |> Enum.map(fn [{start, length}] -> {bytes, start, length} end)
+    |> Enum.map(fn [{start, _length}] -> {bytes, start, total - start} end)
   end
 
   # Inflates one stream, stopping at `@stream_limit` rather than letting a

--- a/lib/vutuv_web/live/admin/media_live.ex
+++ b/lib/vutuv_web/live/admin/media_live.ex
@@ -251,6 +251,7 @@ defmodule VutuvWeb.Admin.MediaLive do
   defp kind_label("image_scan"), do: gettext("Photo scan")
   defp kind_label("video_conversion"), do: gettext("Video conversion")
   defp kind_label("screenshot"), do: gettext("Link screenshot")
+  defp kind_label("attachment_intake"), do: gettext("File check")
   defp kind_label(other), do: other
 
   # What the step worked on: the subject's kind, and enough of its id to tell

--- a/lib/vutuv_web/live/post_live/composer.ex
+++ b/lib/vutuv_web/live/post_live/composer.ex
@@ -70,6 +70,7 @@ defmodule VutuvWeb.PostLive.Composer do
 
   use VutuvWeb, :live_component
 
+  alias Vutuv.Attachments
   alias Vutuv.Fediverse.Note
   alias Vutuv.Fediverse.RemotePost
   alias Vutuv.Languages
@@ -195,6 +196,12 @@ defmodule VutuvWeb.PostLive.Composer do
     # text; a new post's arrives through the upload below.
     |> assign(:video, post_video(post))
     |> assign(:video_uploads?, video_uploads?(post, socket.assigns.current_user))
+    # The files (issue #2104). Like photos they upload eagerly and hold no
+    # parent until the post claims them; unlike photos there is nothing to
+    # attach them to yet (#2106), so an edited post shows none.
+    |> assign(:attachments, [])
+    |> assign(:attachment_uploads?, attachment_uploads?(post, socket.assigns.current_user))
+    |> assign_attachment_budget()
     # The per-photo settings the composer is editing (issue #1104), keyed by
     # image id. Held in the socket rather than in form fields: the two switches
     # reveal follow-up controls, and an unchecked checkbox submits nothing — so
@@ -255,11 +262,40 @@ defmodule VutuvWeb.PostLive.Composer do
       auto_upload: true,
       progress: &handle_progress/3
     )
+    # The files (issue #2104). `accept` is what this host can actually check —
+    # without poppler `.pdf` is not offered at all — and the cap is the
+    # installation's, so LiveView refuses an oversized file in the browser
+    # before a byte crosses the socket. The budget is checked on the server,
+    # where the only trustworthy count of it lives.
+    |> allow_upload(:attachments,
+      accept: Attachments.extension_whitelist(),
+      max_entries: Attachments.max_per_post(),
+      max_file_size: Attachments.max_filesize(),
+      auto_upload: true,
+      progress: &handle_progress/3
+    )
     |> restore_draft()
   end
 
   defp post_video(%Post{video: %PostVideo{} = video}), do: video
   defp post_video(_post), do: nil
+
+  # Whether this composer offers the file picker: this member may upload
+  # (`Vutuv.Attachments.uploads_for?/1` — admins only until the installation
+  # opens it), and this is a new post.
+  defp attachment_uploads?(nil, user), do: Attachments.uploads_for?(user)
+  defp attachment_uploads?(_post, _user), do: false
+
+  # What is left of the member's budget, re-read after every accepted upload —
+  # the composer says it before the next file flows, so it has to be current
+  # rather than the number from mount.
+  defp assign_attachment_budget(socket) do
+    budget =
+      if socket.assigns.attachment_uploads?,
+        do: Attachments.budget_for(socket.assigns.current_user)
+
+    assign(socket, :attachment_budget, budget)
+  end
 
   # Whether this composer offers the picker at all: this member may upload
   # (`Vutuv.Videos.uploads_for?/1` — admins only until the installation opens
@@ -748,6 +784,7 @@ defmodule VutuvWeb.PostLive.Composer do
       # from here on this is simply what they are writing.
       |> assign(:restored_draft?, false)
       |> adopt_recovered_images(params["image_ids"])
+      |> adopt_recovered_attachments(params["attachment_ids"])
       |> merge_photo_texts(payload["photo"])
       |> update_video_alt(payload["video"])
       |> sweep_rejected_uploads()
@@ -985,6 +1022,20 @@ defmodule VutuvWeb.PostLive.Composer do
     {:noreply, cancel_upload(socket, :video, ref)}
   end
 
+  def handle_event("cancel-attachment-upload", %{"ref" => ref}, socket) do
+    {:noreply, cancel_upload(socket, :attachments, ref)}
+  end
+
+  # A file goes, bytes and all. The budget keeps its megabytes: they were
+  # accepted, and giving them back would make upload-and-delete a way round
+  # the allowance.
+  def handle_event("remove-attachment", %{"id" => id}, socket) do
+    {gone, kept} = Enum.split_with(socket.assigns.attachments, &(&1.id == id))
+    Enum.each(gone, &Attachments.delete_pending/1)
+
+    {:noreply, socket |> assign(:attachments, kept) |> assign(:error, nil)}
+  end
+
   # The clip goes, files and all — a new post's only; an edited post keeps
   # its clip, and the button is not offered there.
   def handle_event("remove-video", _params, socket) do
@@ -1206,7 +1257,7 @@ defmodule VutuvWeb.PostLive.Composer do
   defp drafting?(assigns),
     do:
       assigns.body != "" or assigns.tags_value != "" or assigns.images != [] or
-        assigns.video != nil
+        assigns.video != nil or assigns.attachments != []
 
   # Re-adopts photos LiveView form recovery hands back after a reconnect: the
   # composer's socket state died with the old socket, but the pending rows
@@ -1241,6 +1292,23 @@ defmodule VutuvWeb.PostLive.Composer do
   end
 
   defp adopt_recovered_images(socket, _none), do: socket
+
+  # The same for the files (issue #2104): the socket state died with the old
+  # socket, the rows did not, and the hidden `post[attachment_ids][]` inputs
+  # rode the recovered form. `Attachments.pending_for/2` answers only the
+  # author's own still-unattached rows, so a stale or hostile id list can
+  # neither steal a file nor bring a removed one back.
+  defp adopt_recovered_attachments(socket, ids) when is_list(ids) and ids != [] do
+    known = MapSet.new(socket.assigns.attachments, & &1.id)
+    missing = Enum.reject(ids, &MapSet.member?(known, &1))
+
+    case Attachments.pending_for(socket.assigns.current_user, missing) do
+      [] -> socket
+      adopted -> update(socket, :attachments, &(&1 ++ adopted))
+    end
+  end
+
+  defp adopt_recovered_attachments(socket, _none), do: socket
 
   # New posts publish public (there is no audience picker); the fallback to
   # the current preset keeps an edited restricted post from silently
@@ -1519,6 +1587,44 @@ defmodule VutuvWeb.PostLive.Composer do
   defp video_error_message(:disabled), do: gettext("Videos cannot be uploaded here.")
   defp video_error_message(_reason), do: gettext("That file could not be processed.")
 
+  # Every refusal the chokepoint can answer, in words that say what to do next.
+  # A member who cannot post their PDF deserves to know which of the four
+  # things it is, not one sentence covering all of them.
+  defp attachment_error_message(:too_large),
+    do:
+      gettext("Files may be up to %{size}.",
+        size: megabyte_label(Attachments.max_filesize())
+      )
+
+  defp attachment_error_message(:invalid_file),
+    do: gettext("Only PDF, plain text and Markdown files can be attached.")
+
+  defp attachment_error_message(:encrypted),
+    do: gettext("This PDF is password-protected, so it cannot be checked.")
+
+  defp attachment_error_message(:javascript),
+    do: gettext("This PDF contains a program, which cannot be published here.")
+
+  defp attachment_error_message(:open_action),
+    do: gettext("This PDF does something when it is opened, which cannot be published here.")
+
+  defp attachment_error_message(:embedded_files),
+    do: gettext("This PDF has another file inside it, which cannot be published here.")
+
+  defp attachment_error_message(:unreadable),
+    do: gettext("This PDF could not be read.")
+
+  defp attachment_error_message(:pdf_unavailable),
+    do: gettext("PDFs cannot be checked on this site. Text and Markdown files can.")
+
+  defp attachment_error_message(:daily_budget),
+    do: gettext("You have used up today's upload allowance. It frees up again over the day.")
+
+  defp attachment_error_message(:monthly_budget),
+    do: gettext("You have used up this month's upload allowance.")
+
+  defp attachment_error_message(_reason), do: gettext("That file could not be processed.")
+
   # The clip landed (issue #1907): keep it, probe it, and start the pipeline
   # while the author is still writing. The length is only known now, so a
   # clip over the cap is refused here, with the cap in the message.
@@ -1543,6 +1649,38 @@ defmodule VutuvWeb.PostLive.Composer do
         {:error, reason} ->
           {:noreply, assign(socket, :error, video_error_message(reason))}
       end
+    else
+      {:noreply, socket}
+    end
+  end
+
+  # Nothing offered this upload: cut a crafted client off at its first chunk
+  # rather than feed it through to the context's refusal after 20 MB.
+  defp handle_progress(:attachments, entry, %{assigns: %{attachment_uploads?: false}} = socket),
+    do: {:noreply, cancel_upload(socket, :attachments, entry.ref)}
+
+  # The file landed (issue #2104): the chokepoint reads it, decides, and either
+  # keeps it or says why in a sentence the composer shows. The budget is
+  # re-read either way — a refusal costs nothing, and saying so is the point.
+  defp handle_progress(:attachments, entry, socket) do
+    if entry.done? do
+      result =
+        consume_uploaded_entry(socket, entry, fn %{path: path} ->
+          {:ok, Attachments.create_pending(socket.assigns.current_user, path, entry.client_name)}
+        end)
+
+      socket =
+        case result do
+          {:ok, attachment} ->
+            socket
+            |> update(:attachments, &(&1 ++ [attachment]))
+            |> assign(:error, nil)
+
+          {:error, reason} ->
+            assign(socket, :error, attachment_error_message(reason))
+        end
+
+      {:noreply, assign_attachment_budget(socket)}
     else
       {:noreply, socket}
     end
@@ -2044,6 +2182,44 @@ defmodule VutuvWeb.PostLive.Composer do
             </p>
           </div>
 
+          <%!-- The files on their way up, and the ones that landed (issue
+          #2104). The budget line stands with them rather than beside the
+          picker: it is the sentence that explains a refusal about to happen,
+          and it is only worth the row's height once somebody is actually
+          attaching something. --%>
+          <div
+            :for={entry <- @uploads.attachments.entries}
+            id={"#{@id}-attachment-#{entry.ref}"}
+            class="mt-2 flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400"
+          >
+            <span class="truncate">📎 {entry.client_name}</span>
+            <progress value={entry.progress} max="100" class="h-2 flex-1">{entry.progress}%</progress>
+            <button
+              type="button"
+              phx-click="cancel-attachment-upload"
+              phx-value-ref={entry.ref}
+              phx-target={@myself}
+              aria-label={gettext("Cancel upload")}
+            >
+              ✕
+            </button>
+            <p :for={err <- upload_errors(@uploads.attachments, entry)} class="text-red-600">
+              {upload_error_message(err, :attachments)}
+            </p>
+          </div>
+
+          <.attachment_chips
+            :if={@attachments != []}
+            id={@id}
+            attachments={@attachments}
+            myself={@myself}
+          />
+
+          <.attachment_budget_line
+            :if={@attachment_budget}
+            budget={@attachment_budget}
+          />
+
           <.video_block :if={@video} id={@id} video={@video} editing?={@post != nil} myself={@myself} />
 
           <.gallery_sheet
@@ -2115,6 +2291,11 @@ defmodule VutuvWeb.PostLive.Composer do
               id={@id}
               upload={@uploads.video}
               uploading?={@uploads.video.entries != []}
+            />
+            <.add_files_picker
+              :if={@attachment_uploads? and length(@attachments) < Attachments.max_per_post()}
+              id={@id}
+              upload={@uploads.attachments}
             />
 
             <%!-- The author's declaration of what language this post is
@@ -2565,6 +2746,89 @@ defmodule VutuvWeb.PostLive.Composer do
   defp picker_label_class,
     do:
       "inline-flex h-10 mb-0 shrink-0 cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-lg bg-slate-100 px-3 text-sm font-semibold text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+
+  # The files' picker, beside the photos' and the clip's (issue #2104). It
+  # steps out of sight once the post is carrying as many files as it may.
+  attr(:id, :string, required: true)
+  attr(:upload, :any, required: true)
+
+  defp add_files_picker(assigns) do
+    ~H"""
+    <label id={"#{@id}-add-files"} class={picker_label_class()}>
+      📎 <span class="sm:hidden">{gettext("Files")}</span>
+      <span class="hidden sm:inline">{gettext("Add files")}</span>
+      <.live_file_input upload={@upload} class="sr-only" />
+    </label>
+    """
+  end
+
+  # The files this post is carrying: a chip each with its name and size, and
+  # the way to take one out again. The hidden inputs are what a reconnect
+  # brings back (`adopt_recovered_attachments/2`) — the same trick the photos
+  # ride, and the reason a half-written post does not lose its files to a
+  # network blip.
+  attr(:id, :string, required: true)
+  attr(:attachments, :list, required: true)
+  attr(:myself, :any, required: true)
+
+  defp attachment_chips(assigns) do
+    ~H"""
+    <div id={"#{@id}-attachments"} class="mt-2 flex flex-wrap gap-2">
+      <input
+        :for={attachment <- @attachments}
+        type="hidden"
+        name="post[attachment_ids][]"
+        value={attachment.id}
+      />
+      <span
+        :for={attachment <- @attachments}
+        class="inline-flex max-w-full items-center gap-2 rounded-lg border border-slate-200 py-1 pl-3 pr-1 text-sm text-slate-700 dark:border-slate-700 dark:text-slate-200"
+      >
+        <span class="truncate">📎 {attachment.file_name}</span>
+        <span class="shrink-0 text-xs text-slate-500 dark:text-slate-400">
+          {file_size(attachment.size_bytes)}
+        </span>
+        <button
+          type="button"
+          phx-click="remove-attachment"
+          phx-value-id={attachment.id}
+          phx-target={@myself}
+          class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+          aria-label={gettext("Remove %{name}", name: attachment.file_name)}
+        >
+          ✕
+        </button>
+      </span>
+    </div>
+    """
+  end
+
+  # What is left of the member's allowance, before the next file flows. Both
+  # numbers are formatted (`VutuvWeb.UI.file_size/1`, and a percent that is a
+  # count under a thousand): a run-together byte figure here would be the
+  # least readable number on the page.
+  attr(:budget, :map, required: true)
+
+  defp attachment_budget_line(assigns) do
+    ~H"""
+    <p class="mt-2 text-xs text-slate-600 dark:text-slate-400">
+      <%= if @budget.unlimited? do %>
+        {gettext("Your uploads are not limited.")}
+      <% else %>
+        {gettext("%{left} of today's %{limit} left (%{percent} %).",
+          left: file_size(@budget.daily.remaining),
+          limit: file_size(@budget.daily.limit),
+          percent: percent_left(@budget.daily)
+        )}
+      <% end %>
+    </p>
+    """
+  end
+
+  defp percent_left(%{remaining: remaining, limit: limit}) when limit > 0,
+    do: round(remaining * 100 / limit)
+
+  defp percent_left(_window), do: 0
 
   attr(:id, :string, required: true)
   attr(:upload, :any, required: true)
@@ -3245,6 +3509,20 @@ defmodule VutuvWeb.PostLive.Composer do
 
   defp upload_error_message(:too_large, :video) do
     gettext("File is larger than %{mb} MB.", mb: div(Videos.max_filesize(), 1_000_000))
+  end
+
+  defp upload_error_message(:too_large, :attachments) do
+    gettext("File is larger than %{size}.", size: megabyte_label(Attachments.max_filesize()))
+  end
+
+  defp upload_error_message(:not_accepted, :attachments) do
+    gettext("File type not supported (allowed: %{types}).",
+      types: Enum.join(Attachments.extension_whitelist(), ", ")
+    )
+  end
+
+  defp upload_error_message(:too_many_files, :attachments) do
+    gettext("No more than %{max} files per post.", max: Attachments.max_per_post())
   end
 
   defp upload_error_message(:too_large, _images) do

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -118,7 +118,7 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/live/job_posting_live/form.ex:857
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
-#: lib/vutuv_web/live/post_live/composer.ex:1917
+#: lib/vutuv_web/live/post_live/composer.ex:2055
 #: lib/vutuv_web/live/press_kit_live.ex:796
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
@@ -205,7 +205,7 @@ msgid "Disable"
 msgstr "Inaktivieren"
 
 #: lib/vutuv_web/live/cv_live.ex:446
-#: lib/vutuv_web/live/post_live/composer.ex:2962
+#: lib/vutuv_web/live/post_live/composer.ex:3226
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/views/qualification_html.ex:354
 #, elixir-autogen
@@ -607,7 +607,7 @@ msgstr "Profile von "
 msgid "Provider"
 msgstr "Provider"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2186
+#: lib/vutuv_web/live/post_live/composer.ex:2367
 #: lib/vutuv_web/live/section_reorder_live.ex:272
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -619,7 +619,7 @@ msgstr "Öffentlich"
 
 #: lib/vutuv_web/components/ui.ex:4848
 #: lib/vutuv_web/live/organization_live/edit.ex:376
-#: lib/vutuv_web/live/post_live/composer.ex:2201
+#: lib/vutuv_web/live/post_live/composer.ex:2382
 #: lib/vutuv_web/live/press_kit_live.ex:795
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
@@ -1634,11 +1634,11 @@ msgstr "Schauen Sie in Ihr Postfach"
 #: lib/vutuv_web/live/admin/job_live.ex:321
 #: lib/vutuv_web/live/admin/job_live.ex:477
 #: lib/vutuv_web/live/admin/organization_live.ex:296
-#: lib/vutuv_web/live/post_live/composer.ex:1773
-#: lib/vutuv_web/live/post_live/composer.ex:1875
-#: lib/vutuv_web/live/post_live/composer.ex:1876
-#: lib/vutuv_web/live/post_live/composer.ex:2839
-#: lib/vutuv_web/live/post_live/composer.ex:3105
+#: lib/vutuv_web/live/post_live/composer.ex:1911
+#: lib/vutuv_web/live/post_live/composer.ex:2013
+#: lib/vutuv_web/live/post_live/composer.ex:2014
+#: lib/vutuv_web/live/post_live/composer.ex:3103
+#: lib/vutuv_web/live/post_live/composer.ex:3369
 #: lib/vutuv_web/templates/layout/app.html.heex:200
 #: lib/vutuv_web/templates/layout/app.html.heex:206
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:28
@@ -2101,7 +2101,7 @@ msgstr "Markdown wird unterstützt: Fett, Kursiv, Links und Listen."
 msgid "Add images"
 msgstr "Bilder hinzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2315
+#: lib/vutuv_web/live/post_live/composer.ex:2496
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr "Sobald irgendetwas ausgeblendet ist, sehen auch abgemeldete Besucher und Suchmaschinen den Beitrag nicht mehr."
@@ -2112,8 +2112,9 @@ msgstr "Sobald irgendetwas ausgeblendet ist, sehen auch abgemeldete Besucher und
 msgid "Back to the post"
 msgstr "Zurück zum Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2015
-#: lib/vutuv_web/live/post_live/composer.ex:2038
+#: lib/vutuv_web/live/post_live/composer.ex:2153
+#: lib/vutuv_web/live/post_live/composer.ex:2176
+#: lib/vutuv_web/live/post_live/composer.ex:2202
 #: lib/vutuv_web/live/press_kit_live.ex:949
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
@@ -2159,12 +2160,12 @@ msgstr "Folgen Sie %{name}, um ihn zu lesen."
 msgid "Hidden from:"
 msgstr "Verborgen vor:"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2291
+#: lib/vutuv_web/live/post_live/composer.ex:2472
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr "Vor einer bestimmten Person verbergen…"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2219
+#: lib/vutuv_web/live/post_live/composer.ex:2400
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
@@ -2175,13 +2176,13 @@ msgstr "Diesen Beitrag verbergen vor…"
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2261
+#: lib/vutuv_web/live/post_live/composer.ex:2442
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr "Nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1459
-#: lib/vutuv_web/live/post_live/composer.ex:1562
+#: lib/vutuv_web/live/post_live/composer.ex:1527
+#: lib/vutuv_web/live/post_live/composer.ex:1700
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
@@ -2193,23 +2194,23 @@ msgstr ""
 "Hier ist noch nichts. Folgen Sie anderen, um Ihren Feed zu füllen, oder "
 "schreiben Sie Ihren ersten Beitrag."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1422
+#: lib/vutuv_web/live/post_live/composer.ex:1490
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr "Eines der Bilder konnte nicht angehängt werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2251
+#: lib/vutuv_web/live/post_live/composer.ex:2432
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr "Personen, denen ich nicht folge"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2241
+#: lib/vutuv_web/live/post_live/composer.ex:2422
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr "Personen, die mir nicht folgen"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:441
-#: lib/vutuv_web/live/post_live/composer.ex:2203
+#: lib/vutuv_web/live/post_live/composer.ex:2384
 #, elixir-autogen, elixir-format
 msgid "Post"
 msgstr "Posten"
@@ -2259,7 +2260,7 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/live/organization_live/domains.ex:265
 #: lib/vutuv_web/live/organization_live/edit.ex:404
 #: lib/vutuv_web/live/organization_live/roles.ex:257
-#: lib/vutuv_web/live/post_live/composer.ex:2277
+#: lib/vutuv_web/live/post_live/composer.ex:2458
 #: lib/vutuv_web/live/post_live/filter_band.ex:456
 #: lib/vutuv_web/live/post_live/saved.ex:666
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2278,7 +2279,7 @@ msgstr ""
 "Eingeschränkte Beiträge sind auch für nicht eingeloggte Besucher und "
 "Suchmaschinen unsichtbar."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2193
+#: lib/vutuv_web/live/post_live/composer.ex:2374
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr "Wird gespeichert…"
@@ -2295,14 +2296,15 @@ msgstr[1] "%{formatted} neue Beiträge anzeigen"
 msgid "Sorry, that page could not be found."
 msgstr "Diese Seite konnte leider nicht gefunden werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1520
 #: lib/vutuv_web/live/post_live/composer.ex:1588
+#: lib/vutuv_web/live/post_live/composer.ex:1626
+#: lib/vutuv_web/live/post_live/composer.ex:1726
 #: lib/vutuv_web/live/press_kit_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr "Diese Datei konnte nicht verarbeitet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1404
+#: lib/vutuv_web/live/post_live/composer.ex:1472
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr "Die Sichtbarkeitsauswahl ist ungültig."
@@ -2312,12 +2314,12 @@ msgstr "Die Sichtbarkeitsauswahl ist ungültig."
 msgid "This post is for followers of %{name}"
 msgstr "Dieser Beitrag ist für Follower von %{name}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3266
+#: lib/vutuv_web/live/post_live/composer.ex:3544
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3267
+#: lib/vutuv_web/live/post_live/composer.ex:3545
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
@@ -2331,12 +2333,12 @@ msgstr "Upload fehlgeschlagen."
 msgid "View profile"
 msgstr "Profil ansehen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2409
+#: lib/vutuv_web/live/post_live/composer.ex:2590
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr "Was gibt's Neues?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2410
+#: lib/vutuv_web/live/post_live/composer.ex:2591
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
@@ -2373,20 +2375,21 @@ msgstr "Personen, denen Sie nicht folgen"
 msgid "unknown"
 msgstr "unbekannt"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2076
+#: lib/vutuv_web/live/post_live/composer.ex:2252
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr "Tags, durch Komma getrennt (max. %{max})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1517
-#: lib/vutuv_web/live/post_live/composer.ex:3247
-#: lib/vutuv_web/live/post_live/composer.ex:3251
+#: lib/vutuv_web/live/post_live/composer.ex:1585
+#: lib/vutuv_web/live/post_live/composer.ex:3511
+#: lib/vutuv_web/live/post_live/composer.ex:3529
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr "Die Datei ist größer als %{mb} MB."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3255
-#: lib/vutuv_web/live/post_live/composer.ex:3261
+#: lib/vutuv_web/live/post_live/composer.ex:3519
+#: lib/vutuv_web/live/post_live/composer.ex:3533
+#: lib/vutuv_web/live/post_live/composer.ex:3539
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr "Dateityp wird nicht unterstützt (erlaubt: %{types})."
@@ -2543,13 +2546,13 @@ msgstr "Antworten"
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1407
-#: lib/vutuv_web/live/post_live/composer.ex:2181
+#: lib/vutuv_web/live/post_live/composer.ex:1475
+#: lib/vutuv_web/live/post_live/composer.ex:2362
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr "Solange es geteilte Beiträge oder Antworten gibt, lässt sich der Empfängerkreis nicht einschränken."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2322
+#: lib/vutuv_web/live/post_live/composer.ex:2503
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beiträge oder Antworten gibt, bleibt er öffentlich; löschen können Sie ihn weiterhin."
@@ -2852,7 +2855,7 @@ msgstr "Noch keine Vernetzungen."
 msgid "Other formats"
 msgstr "Andere Formate"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2231
+#: lib/vutuv_web/live/post_live/composer.ex:2412
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr "Personen, mit denen ich nicht vernetzt bin"
@@ -5455,7 +5458,7 @@ msgstr ""
 "dauerhaft. Wir senden Ihnen zur Bestätigung eine PIN per E-Mail. Es kann "
 "nicht rückgängig gemacht werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1428
+#: lib/vutuv_web/live/post_live/composer.ex:1496
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
@@ -5670,7 +5673,7 @@ msgstr "Personen, die nicht mit Ihnen interagieren können."
 msgid "Personal tokens for the vutuv API."
 msgstr "Persönliche Tokens für die vutuv-API."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2575
+#: lib/vutuv_web/live/post_live/composer.ex:2839
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
@@ -6297,7 +6300,7 @@ msgstr "Foto positionieren"
 msgid "Use photo"
 msgstr "Foto verwenden"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1919
+#: lib/vutuv_web/live/post_live/composer.ex:2057
 #: lib/vutuv_web/templates/user/edit.html.heex:66
 #: lib/vutuv_web/templates/user/edit.html.heex:151
 #, elixir-autogen, elixir-format
@@ -7518,7 +7521,7 @@ msgid "Removed:"
 msgstr "Entfernt:"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:974
-#: lib/vutuv_web/live/post_live/composer.ex:1767
+#: lib/vutuv_web/live/post_live/composer.ex:1905
 #: lib/vutuv_web/live/post_live/filter_band.ex:533
 #, elixir-autogen, elixir-format
 msgid "Undo"
@@ -7676,7 +7679,7 @@ msgstr ""
 "der Versand läuft weiter."
 
 #: lib/vutuv_web/components/welcome_components.ex:362
-#: lib/vutuv_web/live/admin/media_live.ex:268
+#: lib/vutuv_web/live/admin/media_live.ex:269
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
 #: lib/vutuv_web/live/post_live/feed.ex:3888
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
@@ -9826,7 +9829,7 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Beschäftigungsstatus"
 
-#: lib/vutuv/accounts/user.ex:1292
+#: lib/vutuv/accounts/user.ex:1295
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9837,7 +9840,7 @@ msgstr "Auf Jobsuche"
 msgid "Not open to work"
 msgstr "Nicht offen für Angebote"
 
-#: lib/vutuv/accounts/user.ex:1289
+#: lib/vutuv/accounts/user.ex:1292
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -11161,15 +11164,15 @@ msgstr ""
 "Jeder aufgenommene Link-Screenshot, neueste zuerst. Jeder verlinkt auf die "
 "Seite und den zugehörigen Beitrag."
 
-#: lib/vutuv_web/live/admin/media_live.ex:269
+#: lib/vutuv_web/live/admin/media_live.ex:270
 #: lib/vutuv_web/live/admin/screenshot_live.ex:551
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr "Fehlgeschlagen"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:198
-#: lib/vutuv_web/live/post_live/composer.ex:1998
-#: lib/vutuv_web/live/post_live/composer.ex:2833
+#: lib/vutuv_web/live/post_live/composer.ex:2136
+#: lib/vutuv_web/live/post_live/composer.ex:3097
 #, elixir-autogen, elixir-format
 msgid "Gallery"
 msgstr "Galerie"
@@ -11275,19 +11278,19 @@ msgstr ""
 " Konto anlegen kann. Wählen Sie „Niemand“, um den Status zu speichern, ohne "
 "ihn anzuzeigen."
 
-#: lib/vutuv/accounts/user.ex:1330
+#: lib/vutuv/accounts/user.ex:1333
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Alle, auch nicht angemeldete Besucher"
 
-#: lib/vutuv/accounts/user.ex:1335
+#: lib/vutuv/accounts/user.ex:1338
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Niemand"
 
-#: lib/vutuv/accounts/user.ex:1333
+#: lib/vutuv/accounts/user.ex:1336
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:823
 #, elixir-autogen, elixir-format
@@ -12635,7 +12638,7 @@ msgstr "Hervorgehobene Tags passen zu Ihrem Profil."
 msgid "How to apply"
 msgstr "So bewerben Sie sich"
 
-#: lib/vutuv/accounts/user.ex:1304
+#: lib/vutuv/accounts/user.ex:1307
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12754,7 +12757,7 @@ msgstr "Hier ist noch nichts. Jobs, die Ihnen gefallen, erscheinen hier."
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) für KI-Agenten anbieten."
 
-#: lib/vutuv/accounts/user.ex:1303
+#: lib/vutuv/accounts/user.ex:1306
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12836,7 +12839,7 @@ msgstr "Anzeige nicht gefunden."
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: lib/vutuv/accounts/user.ex:1305
+#: lib/vutuv/accounts/user.ex:1308
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:590
 #: lib/vutuv_web/agent_docs/markdown.ex:563
@@ -13861,7 +13864,7 @@ msgstr "Screenshot entfernt."
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr "Dieser Screenshot wurde automatisch aus dem Link in Ihrem Beitrag erstellt. Falls er unbrauchbar ist (zum Beispiel weil ein Cookie-Banner die Seite verdeckt), können Sie ihn entfernen."
 
-#: lib/vutuv/accounts/user.ex:1348
+#: lib/vutuv/accounts/user.ex:1351
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13872,19 +13875,19 @@ msgstr "Nur das Alter, ohne das Datum"
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr "Wählen Sie, wie viel von Ihrem Geburtstag Ihr Profil zeigt. „Nur das Alter“ verbirgt das genaue Datum, „Tag und Monat“ verbirgt das Jahr (und Ihr Alter), und „Nicht anzeigen“ speichert ihn weiterhin, hält ihn aber von Ihrem Profil fern."
 
-#: lib/vutuv/accounts/user.ex:1351
+#: lib/vutuv/accounts/user.ex:1354
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Tag und Monat, ohne das Jahr"
 
-#: lib/vutuv/accounts/user.ex:1354
+#: lib/vutuv/accounts/user.ex:1357
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Geburtstag nicht anzeigen"
 
-#: lib/vutuv/accounts/user.ex:1345
+#: lib/vutuv/accounts/user.ex:1348
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13949,7 +13952,7 @@ msgstr "Volle Breite"
 msgid "Insert image"
 msgstr "Bild einfügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3224
+#: lib/vutuv_web/live/post_live/composer.ex:3488
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr "In den Text einfügen"
@@ -14601,13 +14604,13 @@ msgstr "Erwähnung"
 msgid "mentioned you in a post."
 msgstr "hat Sie in einem Beitrag erwähnt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1412
+#: lib/vutuv_web/live/post_live/composer.ex:1480
 #: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr "Dieser Beitrag lässt sich nicht mehr bearbeiten: jemand hat ihn geliked, geteilt oder beantwortet."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1415
+#: lib/vutuv_web/live/post_live/composer.ex:1483
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -16752,7 +16755,7 @@ msgstr ""
 "in eckigen Klammern, wie eine Lautschrift geschrieben wird; die Klammern "
 "ergänzen wir für Sie. Bleibt das Feld leer, wird nichts angezeigt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3237
+#: lib/vutuv_web/live/post_live/composer.ex:3501
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr "Diese Einstellungen für alle Fotos übernehmen"
@@ -16784,12 +16787,12 @@ msgstr "CC0 1.0 (keine Rechte vorbehalten)"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1449
 #: lib/vutuv_web/agent_docs/text.ex:920
-#: lib/vutuv_web/live/post_live/composer.ex:2661
+#: lib/vutuv_web/live/post_live/composer.ex:2925
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr "Titelbild"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3075
+#: lib/vutuv_web/live/post_live/composer.ex:3339
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
@@ -16801,22 +16804,22 @@ msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 msgid "Download the original"
 msgstr "Original herunterladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3174
+#: lib/vutuv_web/live/post_live/composer.ex:3438
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr "Alle Metadaten bleiben erhalten, auch alles, was Ihre Kamera hineingeschrieben hat."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3130
+#: lib/vutuv_web/live/post_live/composer.ex:3394
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr "Alle dürfen dieses Foto herunterladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3132
+#: lib/vutuv_web/live/post_live/composer.ex:3396
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr "Volle Auflösung, direkt aus dem Beitrag."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3151
+#: lib/vutuv_web/live/post_live/composer.ex:3415
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr "Nur das Bild"
@@ -16826,7 +16829,7 @@ msgstr "Nur das Bild"
 msgid "Next photo"
 msgstr "Nächstes Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2680
+#: lib/vutuv_web/live/post_live/composer.ex:2944
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
@@ -16848,8 +16851,8 @@ msgstr "Foto %{n} von %{total}"
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2633
-#: lib/vutuv_web/live/post_live/composer.ex:2634
+#: lib/vutuv_web/live/post_live/composer.ex:2897
+#: lib/vutuv_web/live/post_live/composer.ex:2898
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr "Foto-Einstellungen"
@@ -16866,18 +16869,18 @@ msgstr "Fotos:"
 msgid "Previous photo"
 msgstr "Vorheriges Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2693
-#: lib/vutuv_web/live/post_live/composer.ex:2694
+#: lib/vutuv_web/live/post_live/composer.ex:2957
+#: lib/vutuv_web/live/post_live/composer.ex:2958
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr "Foto entfernen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3153
+#: lib/vutuv_web/live/post_live/composer.ex:3417
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qualität unverändert."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3094
+#: lib/vutuv_web/live/post_live/composer.ex:3358
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
@@ -16887,17 +16890,17 @@ msgstr "Kameradaten anzeigen"
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3172
+#: lib/vutuv_web/live/post_live/composer.ex:3436
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr "Die Datei genau so, wie ich sie hochgeladen habe"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3208
+#: lib/vutuv_web/live/post_live/composer.ex:3472
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen Sie das Foto, wenn Sie das nicht möchten."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3200
+#: lib/vutuv_web/live/post_live/composer.ex:3464
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
@@ -16922,12 +16925,12 @@ msgstr "Diese Seite nimmt nicht am Fediverse teil."
 msgid "Turn on Fediverse participation to answer"
 msgstr "Fediverse-Teilnahme einschalten, um zu antworten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2951
+#: lib/vutuv_web/live/post_live/composer.ex:3215
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr "Wer diese Fotos weiterverwenden darf"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1442
+#: lib/vutuv_web/live/post_live/composer.ex:1510
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
@@ -16937,7 +16940,7 @@ msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke gesc
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshalb werden von hier aus keine Antworten mehr gesendet."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1456
+#: lib/vutuv_web/live/post_live/composer.ex:1524
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
@@ -16952,64 +16955,64 @@ msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fedive
 msgid "© All rights reserved"
 msgstr "© Alle Rechte vorbehalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2576
+#: lib/vutuv_web/live/post_live/composer.ex:2840
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr "Fotos hinzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2946
+#: lib/vutuv_web/live/post_live/composer.ex:3210
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr "Lizenz"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3065
+#: lib/vutuv_web/live/post_live/composer.ex:3329
 #, elixir-autogen, elixir-format
 msgid "Caption (optional)"
 msgstr "Bildunterschrift (optional)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1742
-#: lib/vutuv_web/live/post_live/composer.ex:1805
-#: lib/vutuv_web/live/post_live/composer.ex:1863
+#: lib/vutuv_web/live/post_live/composer.ex:1880
+#: lib/vutuv_web/live/post_live/composer.ex:1943
+#: lib/vutuv_web/live/post_live/composer.ex:2001
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr "Entwurf verwerfen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1735
+#: lib/vutuv_web/live/post_live/composer.ex:1873
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr "Weiter, wo Sie aufgehört haben."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2999
+#: lib/vutuv_web/live/post_live/composer.ex:3263
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr "Eine Datei, deren Format sich nicht säubern lässt, wird exakt so weitergegeben, wie sie hochgeladen wurde."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2388
+#: lib/vutuv_web/live/post_live/composer.ex:2569
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr "Pro Foto verschieden"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2387
+#: lib/vutuv_web/live/post_live/composer.ex:2568
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr "Original, exakt wie hochgeladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2386
+#: lib/vutuv_web/live/post_live/composer.ex:2567
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr "Original, ohne Metadaten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2391
+#: lib/vutuv_web/live/post_live/composer.ex:2572
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr "Nur Web-Versionen (%{format})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2969
+#: lib/vutuv_web/live/post_live/composer.ex:3233
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr "Was Besucher speichern können"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2988
+#: lib/vutuv_web/live/post_live/composer.ex:3252
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -17129,8 +17132,8 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr "Rücknahme"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1999
-#: lib/vutuv_web/live/post_live/composer.ex:2833
+#: lib/vutuv_web/live/post_live/composer.ex:2137
+#: lib/vutuv_web/live/post_live/composer.ex:3097
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr "Fotodetails"
@@ -17881,104 +17884,104 @@ msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, desh
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr "Einen nachgeschlagenen Beitrag bewahrt vutuv genauso sechs Monate lang auf wie jeden anderen Beitrag aus einem anderen Netzwerk. Der Server der verfassenden Person wird sonst nichts gefragt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1916
+#: lib/vutuv_web/live/post_live/composer.ex:2054
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr "Zuschnitt übernehmen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2739
+#: lib/vutuv_web/live/post_live/composer.ex:3003
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr "Großes Foto links"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2740
+#: lib/vutuv_web/live/post_live/composer.ex:3004
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr "Großes Foto rechts"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2745
+#: lib/vutuv_web/live/post_live/composer.ex:3009
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr "Spalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2742
+#: lib/vutuv_web/live/post_live/composer.ex:3006
 #, elixir-autogen, elixir-format
 msgid "Cover left"
 msgstr "Titelbild links"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2743
+#: lib/vutuv_web/live/post_live/composer.ex:3007
 #, elixir-autogen, elixir-format
 msgid "Cover on top"
 msgstr "Titelbild oben"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2744
+#: lib/vutuv_web/live/post_live/composer.ex:3008
 #, elixir-autogen, elixir-format
 msgid "Cover right"
 msgstr "Titelbild rechts"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1912
-#: lib/vutuv_web/live/post_live/composer.ex:2710
-#: lib/vutuv_web/live/post_live/composer.ex:2711
+#: lib/vutuv_web/live/post_live/composer.ex:2050
+#: lib/vutuv_web/live/post_live/composer.ex:2974
+#: lib/vutuv_web/live/post_live/composer.ex:2975
 #, elixir-autogen, elixir-format
 msgid "Crop photo"
 msgstr "Foto zuschneiden"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2669
+#: lib/vutuv_web/live/post_live/composer.ex:2933
 #, elixir-autogen, elixir-format
 msgid "Cropped"
 msgstr "Zugeschnitten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1834
+#: lib/vutuv_web/live/post_live/composer.ex:1972
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr "Fotos hier ablegen, um sie hinzuzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2746
+#: lib/vutuv_web/live/post_live/composer.ex:3010
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr "Raster"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2747
+#: lib/vutuv_web/live/post_live/composer.ex:3011
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr "Mosaik"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1914
+#: lib/vutuv_web/live/post_live/composer.ex:2052
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr "Wählen Sie ein Format, dann verschieben und zoomen Sie. Der gerahmte Ausschnitt ist das, was der Beitrag zeigt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2738
+#: lib/vutuv_web/live/post_live/composer.ex:3002
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr "Nebeneinander"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2741
+#: lib/vutuv_web/live/post_live/composer.ex:3005
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr "Übereinander"
 
-#: lib/vutuv_web/live/post_live/composer.ex:572
+#: lib/vutuv_web/live/post_live/composer.ex:608
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr "Das Foto konnte nicht zugeschnitten werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3187
+#: lib/vutuv_web/live/post_live/composer.ex:3451
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr "Dieses Foto ist zugeschnitten: Downloads geben das zugeschnittene Bild heraus, die unveränderte Originaldatei bleibt privat."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1918
+#: lib/vutuv_web/live/post_live/composer.ex:2056
 #, elixir-autogen, elixir-format
 msgid "Whole photo"
 msgstr "Ganzes Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2936
+#: lib/vutuv_web/live/post_live/composer.ex:3200
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr "Kacheln füllen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2920
+#: lib/vutuv_web/live/post_live/composer.ex:3184
 #, elixir-autogen, elixir-format
 msgid "Whole photos"
 msgstr "Ganze Fotos"
@@ -19225,17 +19228,17 @@ msgstr ""
 "Kommt keine PIN an? Ist die E-Mail-Adresse {email} korrekt? Haben Sie einmal "
 "in Ihren Spam-Ordner geschaut?"
 
-#: lib/vutuv/accounts/user.ex:1451
+#: lib/vutuv/accounts/user.ex:1454
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/vutuv/accounts/user.ex:1449
+#: lib/vutuv/accounts/user.ex:1452
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr "Weiblich"
 
-#: lib/vutuv/accounts/user.ex:1450
+#: lib/vutuv/accounts/user.ex:1453
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Männlich"
@@ -19984,17 +19987,17 @@ msgstr "Der Besitzer vergibt die Rollen der anderen Mitglieder auf der Seite und
 msgid "Nothing published yet."
 msgstr "Noch nichts veröffentlicht."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2202
+#: lib/vutuv_web/live/post_live/composer.ex:2383
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
 msgstr "Als %{name} veröffentlichen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1435
+#: lib/vutuv_web/live/post_live/composer.ex:1503
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr "Sie dürfen nicht mehr im Namen dieser Organisation schreiben."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2179
+#: lib/vutuv_web/live/post_live/composer.ex:2360
 #, elixir-autogen, elixir-format
 msgid "A post in an organization's name is always public."
 msgstr "Ein Beitrag im Namen einer Organisation ist immer öffentlich."
@@ -20794,19 +20797,19 @@ msgstr "Sie haben %{used} von %{max} Tags."
 msgid "{n} of {max} free slots selected."
 msgstr "{n} von {max} freien Plätzen ausgewählt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2161
+#: lib/vutuv_web/live/post_live/composer.ex:2342
 #, elixir-autogen, elixir-format
 msgid "More languages"
 msgstr "Weitere Sprachen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2152
+#: lib/vutuv_web/live/post_live/composer.ex:2333
 #, elixir-autogen, elixir-format
 msgctxt "post composer"
 msgid "Language"
 msgstr "Sprache"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2148
-#: lib/vutuv_web/live/post_live/composer.ex:2149
+#: lib/vutuv_web/live/post_live/composer.ex:2329
+#: lib/vutuv_web/live/post_live/composer.ex:2330
 #, elixir-autogen, elixir-format
 msgid "The language this post is written in"
 msgstr "Die Sprache, in der dieser Beitrag geschrieben ist"
@@ -22583,18 +22586,18 @@ msgid "Nothing matches."
 msgstr "Nichts gefunden."
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:336
-#: lib/vutuv_web/live/post_live/composer.ex:1998
-#: lib/vutuv_web/live/post_live/composer.ex:2866
+#: lib/vutuv_web/live/post_live/composer.ex:2136
+#: lib/vutuv_web/live/post_live/composer.ex:3130
 #, elixir-autogen, elixir-format
 msgid "Automatic"
 msgstr "Automatisch"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2003
+#: lib/vutuv_web/live/post_live/composer.ex:2141
 #, elixir-autogen, elixir-format
 msgid "Drag one photo onto another to swap them."
 msgstr "Ein Foto auf ein anderes ziehen, um sie zu tauschen."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1950
+#: lib/vutuv_web/live/post_live/composer.ex:2088
 #, elixir-autogen, elixir-format
 msgid "Not shown in the gallery — drag one into it to swap."
 msgstr "Nicht in der Galerie zu sehen — eines hineinziehen, um zu tauschen."
@@ -22651,17 +22654,17 @@ msgstr "Anfrage wirklich zurückziehen?"
 msgid "Unmute %{host}"
 msgstr "%{host} wieder einschalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1758
+#: lib/vutuv_web/live/post_live/composer.ex:1896
 #, elixir-autogen, elixir-format
 msgid "Draft discarded."
 msgstr "Entwurf gelöscht."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1797
+#: lib/vutuv_web/live/post_live/composer.ex:1935
 #, elixir-autogen, elixir-format
 msgid "Keep it"
 msgstr "Behalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1788
+#: lib/vutuv_web/live/post_live/composer.ex:1926
 #, elixir-autogen, elixir-format
 msgid "Keep this draft for later?"
 msgstr "Diesen Entwurf für später behalten?"
@@ -22868,7 +22871,7 @@ msgstr[1] "%{count} Videos in Arbeit"
 msgid "About %{minutes} min of video"
 msgstr "Etwa %{minutes} Min. Video"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2459
+#: lib/vutuv_web/live/post_live/composer.ex:2640
 #, elixir-autogen, elixir-format
 msgid "Add video"
 msgstr "Video hinzufügen"
@@ -22910,32 +22913,32 @@ msgstr "Ohne das Video veröffentlichen"
 msgid "Reading the frames"
 msgstr "Standbilder werden gelesen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2495
+#: lib/vutuv_web/live/post_live/composer.ex:2676
 #, elixir-autogen, elixir-format
 msgid "Remove it to post the text without it, or pick another file."
 msgstr "Entfernen Sie es, um den Text ohne Video zu veröffentlichen, oder wählen Sie eine andere Datei."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1145
+#: lib/vutuv_web/live/post_live/composer.ex:1196
 #, elixir-autogen, elixir-format
 msgid "Remove the refused video to post the text without it."
 msgstr "Entfernen Sie das abgelehnte Video, um den Text ohne Video zu veröffentlichen."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2524
+#: lib/vutuv_web/live/post_live/composer.ex:2705
 #, elixir-autogen, elixir-format
 msgid "Remove video"
 msgstr "Video entfernen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2534
+#: lib/vutuv_web/live/post_live/composer.ex:2715
 #, elixir-autogen, elixir-format
 msgid "Tap a frame to make it the cover."
 msgstr "Tippen Sie auf ein Bild, um es zum Titelbild zu machen."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1008
+#: lib/vutuv_web/live/post_live/composer.ex:1059
 #, elixir-autogen, elixir-format
 msgid "That frame could not be used."
 msgstr "Dieses Bild konnte nicht verwendet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1425
+#: lib/vutuv_web/live/post_live/composer.ex:1493
 #, elixir-autogen, elixir-format
 msgid "The video could not be attached."
 msgstr "Das Video konnte nicht angehängt werden."
@@ -22945,7 +22948,7 @@ msgstr "Das Video konnte nicht angehängt werden."
 msgid "The video is gone."
 msgstr "Das Video ist nicht mehr da."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1512
+#: lib/vutuv_web/live/post_live/composer.ex:1580
 #, elixir-autogen, elixir-format
 msgid "The video is longer than %{seconds} seconds."
 msgstr "Das Video ist länger als %{seconds} Sekunden."
@@ -22966,17 +22969,17 @@ msgstr "Dieses Video konnte nicht umgewandelt werden."
 #: lib/vutuv_web/agent_docs/text.ex:918
 #: lib/vutuv_web/components/post_components.ex:2980
 #: lib/vutuv_web/components/video_components.ex:127
-#: lib/vutuv_web/live/post_live/composer.ex:2458
+#: lib/vutuv_web/live/post_live/composer.ex:2639
 #, elixir-autogen, elixir-format
 msgid "Video"
 msgstr "Video"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2502
+#: lib/vutuv_web/live/post_live/composer.ex:2683
 #, elixir-autogen, elixir-format
 msgid "Video description"
 msgstr "Videobeschreibung"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1519
+#: lib/vutuv_web/live/post_live/composer.ex:1587
 #, elixir-autogen, elixir-format
 msgid "Videos cannot be uploaded here."
 msgstr "Hier können keine Videos hochgeladen werden."
@@ -22986,12 +22989,12 @@ msgstr "Hier können keine Videos hochgeladen werden."
 msgid "Waiting in line"
 msgstr "Wartet in der Warteschlange"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2509
+#: lib/vutuv_web/live/post_live/composer.ex:2690
 #, elixir-autogen, elixir-format
 msgid "What is in the video, for people who cannot watch it"
 msgstr "Was im Video zu sehen ist, für Menschen, die es nicht ansehen können"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2498
+#: lib/vutuv_web/live/post_live/composer.ex:2679
 #, elixir-autogen, elixir-format
 msgid "You can post now — the post appears as soon as the video is ready."
 msgstr "Sie können jetzt veröffentlichen: Der Beitrag erscheint, sobald das Video fertig ist."
@@ -24864,7 +24867,7 @@ msgstr "Ergebnis"
 msgid "Photo scan"
 msgstr "Fotoprüfung"
 
-#: lib/vutuv_web/live/admin/media_live.ex:270
+#: lib/vutuv_web/live/admin/media_live.ex:271
 #, elixir-autogen, elixir-format
 msgid "Running"
 msgstr "Läuft"
@@ -24956,3 +24959,93 @@ msgstr "Link zum Beitrag kopieren"
 #, elixir-autogen, elixir-format
 msgid "Link copied"
 msgstr "Link kopiert"
+
+#: lib/vutuv_web/live/post_live/composer.ex:2818
+#, elixir-autogen, elixir-format
+msgid "%{left} of today's %{limit} left (%{percent} %)."
+msgstr "Noch %{left} von %{limit} für heute frei (%{percent} %)."
+
+#: lib/vutuv_web/live/post_live/composer.ex:2759
+#, elixir-autogen, elixir-format
+msgid "Add files"
+msgstr "Dateien hinzufügen"
+
+#: lib/vutuv_web/live/admin/media_live.ex:254
+#, elixir-autogen, elixir-format
+msgid "File check"
+msgstr "Dateiprüfung"
+
+#: lib/vutuv_web/live/post_live/composer.ex:3515
+#, elixir-autogen, elixir-format
+msgid "File is larger than %{size}."
+msgstr "Die Datei ist größer als %{size}."
+
+#: lib/vutuv_web/live/post_live/composer.ex:2758
+#, elixir-autogen, elixir-format
+msgid "Files"
+msgstr "Dateien"
+
+#: lib/vutuv_web/live/post_live/composer.ex:1595
+#, elixir-autogen, elixir-format
+msgid "Files may be up to %{size}."
+msgstr "Dateien dürfen bis zu %{size} groß sein."
+
+#: lib/vutuv_web/live/post_live/composer.ex:3525
+#, elixir-autogen, elixir-format
+msgid "No more than %{max} files per post."
+msgstr "Höchstens %{max} Dateien pro Beitrag."
+
+#: lib/vutuv_web/live/post_live/composer.ex:1600
+#, elixir-autogen, elixir-format
+msgid "Only PDF, plain text and Markdown files can be attached."
+msgstr "Anhängen lassen sich nur PDF-, Text- und Markdown-Dateien."
+
+#: lib/vutuv_web/live/post_live/composer.ex:1618
+#, elixir-autogen, elixir-format
+msgid "PDFs cannot be checked on this site. Text and Markdown files can."
+msgstr "PDFs können auf dieser Website nicht geprüft werden, Text- und Markdown-Dateien schon."
+
+#: lib/vutuv_web/live/post_live/composer.ex:2797
+#, elixir-autogen, elixir-format
+msgid "Remove %{name}"
+msgstr "%{name} entfernen"
+
+#: lib/vutuv_web/live/post_live/composer.ex:1606
+#, elixir-autogen, elixir-format
+msgid "This PDF contains a program, which cannot be published here."
+msgstr "Dieses PDF enthält ein Programm und kann hier nicht veröffentlicht werden."
+
+#: lib/vutuv_web/live/post_live/composer.ex:1615
+#, elixir-autogen, elixir-format
+msgid "This PDF could not be read."
+msgstr "Dieses PDF konnte nicht gelesen werden."
+
+#: lib/vutuv_web/live/post_live/composer.ex:1609
+#, elixir-autogen, elixir-format
+msgid "This PDF does something when it is opened, which cannot be published here."
+msgstr "Dieses PDF führt beim Öffnen etwas aus und kann hier nicht veröffentlicht werden."
+
+#: lib/vutuv_web/live/post_live/composer.ex:1612
+#, elixir-autogen, elixir-format
+msgid "This PDF has another file inside it, which cannot be published here."
+msgstr "In diesem PDF steckt eine weitere Datei, deshalb kann es hier nicht veröffentlicht werden."
+
+#: lib/vutuv_web/live/post_live/composer.ex:1603
+#, elixir-autogen, elixir-format
+msgid "This PDF is password-protected, so it cannot be checked."
+msgstr "Dieses PDF ist mit einem Kennwort geschützt und lässt sich deshalb nicht prüfen."
+
+#: lib/vutuv_web/live/post_live/composer.ex:1624
+#, elixir-autogen, elixir-format
+msgid "You have used up this month's upload allowance."
+msgstr "Ihr Upload-Kontingent für diesen Monat ist aufgebraucht."
+
+#: lib/vutuv_web/live/post_live/composer.ex:1621
+#, elixir-autogen, elixir-format
+msgid "You have used up today's upload allowance. It frees up again over the day."
+msgstr "Ihr Upload-Kontingent für heute ist aufgebraucht. Es wird im Lauf des Tages wieder frei."
+
+#: lib/vutuv_web/live/post_live/composer.ex:2816
+#, elixir-autogen, elixir-format
+msgid "Your uploads are not limited."
+msgstr "Ihre Uploads sind nicht begrenzt."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -120,7 +120,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_posting_live/form.ex:857
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
-#: lib/vutuv_web/live/post_live/composer.ex:1917
+#: lib/vutuv_web/live/post_live/composer.ex:2055
 #: lib/vutuv_web/live/press_kit_live.ex:796
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
@@ -205,7 +205,7 @@ msgid "Disable"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:446
-#: lib/vutuv_web/live/post_live/composer.ex:2962
+#: lib/vutuv_web/live/post_live/composer.ex:3226
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/views/qualification_html.ex:354
 #, elixir-autogen
@@ -607,7 +607,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2186
+#: lib/vutuv_web/live/post_live/composer.ex:2367
 #: lib/vutuv_web/live/section_reorder_live.ex:272
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -619,7 +619,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4848
 #: lib/vutuv_web/live/organization_live/edit.ex:376
-#: lib/vutuv_web/live/post_live/composer.ex:2201
+#: lib/vutuv_web/live/post_live/composer.ex:2382
 #: lib/vutuv_web/live/press_kit_live.ex:795
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
@@ -1607,11 +1607,11 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:321
 #: lib/vutuv_web/live/admin/job_live.ex:477
 #: lib/vutuv_web/live/admin/organization_live.ex:296
-#: lib/vutuv_web/live/post_live/composer.ex:1773
-#: lib/vutuv_web/live/post_live/composer.ex:1875
-#: lib/vutuv_web/live/post_live/composer.ex:1876
-#: lib/vutuv_web/live/post_live/composer.ex:2839
-#: lib/vutuv_web/live/post_live/composer.ex:3105
+#: lib/vutuv_web/live/post_live/composer.ex:1911
+#: lib/vutuv_web/live/post_live/composer.ex:2013
+#: lib/vutuv_web/live/post_live/composer.ex:2014
+#: lib/vutuv_web/live/post_live/composer.ex:3103
+#: lib/vutuv_web/live/post_live/composer.ex:3369
 #: lib/vutuv_web/templates/layout/app.html.heex:200
 #: lib/vutuv_web/templates/layout/app.html.heex:206
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:28
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Add images"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2315
+#: lib/vutuv_web/live/post_live/composer.ex:2496
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2074,8 +2074,9 @@ msgstr ""
 msgid "Back to the post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2015
-#: lib/vutuv_web/live/post_live/composer.ex:2038
+#: lib/vutuv_web/live/post_live/composer.ex:2153
+#: lib/vutuv_web/live/post_live/composer.ex:2176
+#: lib/vutuv_web/live/post_live/composer.ex:2202
 #: lib/vutuv_web/live/press_kit_live.ex:949
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
@@ -2121,12 +2122,12 @@ msgstr ""
 msgid "Hidden from:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2291
+#: lib/vutuv_web/live/post_live/composer.ex:2472
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2219
+#: lib/vutuv_web/live/post_live/composer.ex:2400
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr ""
@@ -2137,13 +2138,13 @@ msgstr ""
 msgid "Limited audience"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2261
+#: lib/vutuv_web/live/post_live/composer.ex:2442
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1459
-#: lib/vutuv_web/live/post_live/composer.ex:1562
+#: lib/vutuv_web/live/post_live/composer.ex:1527
+#: lib/vutuv_web/live/post_live/composer.ex:1700
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr ""
@@ -2153,23 +2154,23 @@ msgstr ""
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1422
+#: lib/vutuv_web/live/post_live/composer.ex:1490
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2251
+#: lib/vutuv_web/live/post_live/composer.ex:2432
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2241
+#: lib/vutuv_web/live/post_live/composer.ex:2422
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:441
-#: lib/vutuv_web/live/post_live/composer.ex:2203
+#: lib/vutuv_web/live/post_live/composer.ex:2384
 #, elixir-autogen, elixir-format
 msgid "Post"
 msgstr ""
@@ -2219,7 +2220,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:265
 #: lib/vutuv_web/live/organization_live/edit.ex:404
 #: lib/vutuv_web/live/organization_live/roles.ex:257
-#: lib/vutuv_web/live/post_live/composer.ex:2277
+#: lib/vutuv_web/live/post_live/composer.ex:2458
 #: lib/vutuv_web/live/post_live/filter_band.ex:456
 #: lib/vutuv_web/live/post_live/saved.ex:666
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2236,7 +2237,7 @@ msgstr ""
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2193
+#: lib/vutuv_web/live/post_live/composer.ex:2374
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr ""
@@ -2253,14 +2254,15 @@ msgstr[1] ""
 msgid "Sorry, that page could not be found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1520
 #: lib/vutuv_web/live/post_live/composer.ex:1588
+#: lib/vutuv_web/live/post_live/composer.ex:1626
+#: lib/vutuv_web/live/post_live/composer.ex:1726
 #: lib/vutuv_web/live/press_kit_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1404
+#: lib/vutuv_web/live/post_live/composer.ex:1472
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr ""
@@ -2270,12 +2272,12 @@ msgstr ""
 msgid "This post is for followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3266
+#: lib/vutuv_web/live/post_live/composer.ex:3544
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3267
+#: lib/vutuv_web/live/post_live/composer.ex:3545
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
@@ -2289,12 +2291,12 @@ msgstr ""
 msgid "View profile"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2409
+#: lib/vutuv_web/live/post_live/composer.ex:2590
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2410
+#: lib/vutuv_web/live/post_live/composer.ex:2591
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr ""
@@ -2331,20 +2333,21 @@ msgstr ""
 msgid "unknown"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2076
+#: lib/vutuv_web/live/post_live/composer.ex:2252
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1517
-#: lib/vutuv_web/live/post_live/composer.ex:3247
-#: lib/vutuv_web/live/post_live/composer.ex:3251
+#: lib/vutuv_web/live/post_live/composer.ex:1585
+#: lib/vutuv_web/live/post_live/composer.ex:3511
+#: lib/vutuv_web/live/post_live/composer.ex:3529
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3255
-#: lib/vutuv_web/live/post_live/composer.ex:3261
+#: lib/vutuv_web/live/post_live/composer.ex:3519
+#: lib/vutuv_web/live/post_live/composer.ex:3533
+#: lib/vutuv_web/live/post_live/composer.ex:3539
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr ""
@@ -2501,13 +2504,13 @@ msgstr ""
 msgid "Reply to a deleted post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1407
-#: lib/vutuv_web/live/post_live/composer.ex:2181
+#: lib/vutuv_web/live/post_live/composer.ex:1475
+#: lib/vutuv_web/live/post_live/composer.ex:2362
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2322
+#: lib/vutuv_web/live/post_live/composer.ex:2503
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2808,7 +2811,7 @@ msgstr ""
 msgid "Other formats"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2231
+#: lib/vutuv_web/live/post_live/composer.ex:2412
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr ""
@@ -5243,7 +5246,7 @@ msgstr ""
 msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1428
+#: lib/vutuv_web/live/post_live/composer.ex:1496
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr ""
@@ -5457,7 +5460,7 @@ msgstr ""
 msgid "Personal tokens for the vutuv API."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2575
+#: lib/vutuv_web/live/post_live/composer.ex:2839
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
@@ -6064,7 +6067,7 @@ msgstr ""
 msgid "Use photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1919
+#: lib/vutuv_web/live/post_live/composer.ex:2057
 #: lib/vutuv_web/templates/user/edit.html.heex:66
 #: lib/vutuv_web/templates/user/edit.html.heex:151
 #, elixir-autogen, elixir-format
@@ -7227,7 +7230,7 @@ msgid "Removed:"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:974
-#: lib/vutuv_web/live/post_live/composer.ex:1767
+#: lib/vutuv_web/live/post_live/composer.ex:1905
 #: lib/vutuv_web/live/post_live/filter_band.ex:533
 #, elixir-autogen, elixir-format
 msgid "Undo"
@@ -7377,7 +7380,7 @@ msgid "This updates on its own. You can leave this page; the send keeps running.
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:362
-#: lib/vutuv_web/live/admin/media_live.ex:268
+#: lib/vutuv_web/live/admin/media_live.ex:269
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
 #: lib/vutuv_web/live/post_live/feed.ex:3888
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
@@ -9382,7 +9385,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1292
+#: lib/vutuv/accounts/user.ex:1295
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9393,7 +9396,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1289
+#: lib/vutuv/accounts/user.ex:1292
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10604,15 +10607,15 @@ msgstr ""
 msgid "Every captured link screenshot, newest first. Each links to the page and its post."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/media_live.ex:269
+#: lib/vutuv_web/live/admin/media_live.ex:270
 #: lib/vutuv_web/live/admin/screenshot_live.ex:551
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:198
-#: lib/vutuv_web/live/post_live/composer.ex:1998
-#: lib/vutuv_web/live/post_live/composer.ex:2833
+#: lib/vutuv_web/live/post_live/composer.ex:2136
+#: lib/vutuv_web/live/post_live/composer.ex:3097
 #, elixir-autogen, elixir-format
 msgid "Gallery"
 msgstr ""
@@ -10711,19 +10714,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1330
+#: lib/vutuv/accounts/user.ex:1333
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1335
+#: lib/vutuv/accounts/user.ex:1338
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1333
+#: lib/vutuv/accounts/user.ex:1336
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:823
 #, elixir-autogen, elixir-format
@@ -12003,7 +12006,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1304
+#: lib/vutuv/accounts/user.ex:1307
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12122,7 +12125,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1303
+#: lib/vutuv/accounts/user.ex:1306
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12204,7 +12207,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1305
+#: lib/vutuv/accounts/user.ex:1308
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:590
 #: lib/vutuv_web/agent_docs/markdown.ex:563
@@ -13215,7 +13218,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1348
+#: lib/vutuv/accounts/user.ex:1351
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13226,19 +13229,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1351
+#: lib/vutuv/accounts/user.ex:1354
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1354
+#: lib/vutuv/accounts/user.ex:1357
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1345
+#: lib/vutuv/accounts/user.ex:1348
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13303,7 +13306,7 @@ msgstr ""
 msgid "Insert image"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3224
+#: lib/vutuv_web/live/post_live/composer.ex:3488
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr ""
@@ -13939,13 +13942,13 @@ msgstr ""
 msgid "mentioned you in a post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1412
+#: lib/vutuv_web/live/post_live/composer.ex:1480
 #: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1415
+#: lib/vutuv_web/live/post_live/composer.ex:1483
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -16057,7 +16060,7 @@ msgstr ""
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3237
+#: lib/vutuv_web/live/post_live/composer.ex:3501
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr ""
@@ -16089,12 +16092,12 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1449
 #: lib/vutuv_web/agent_docs/text.ex:920
-#: lib/vutuv_web/live/post_live/composer.ex:2661
+#: lib/vutuv_web/live/post_live/composer.ex:2925
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3075
+#: lib/vutuv_web/live/post_live/composer.ex:3339
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr ""
@@ -16106,22 +16109,22 @@ msgstr ""
 msgid "Download the original"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3174
+#: lib/vutuv_web/live/post_live/composer.ex:3438
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3130
+#: lib/vutuv_web/live/post_live/composer.ex:3394
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3132
+#: lib/vutuv_web/live/post_live/composer.ex:3396
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3151
+#: lib/vutuv_web/live/post_live/composer.ex:3415
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr ""
@@ -16131,7 +16134,7 @@ msgstr ""
 msgid "Next photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2680
+#: lib/vutuv_web/live/post_live/composer.ex:2944
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr ""
@@ -16153,8 +16156,8 @@ msgstr ""
 msgid "Photo is being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2633
-#: lib/vutuv_web/live/post_live/composer.ex:2634
+#: lib/vutuv_web/live/post_live/composer.ex:2897
+#: lib/vutuv_web/live/post_live/composer.ex:2898
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr ""
@@ -16171,18 +16174,18 @@ msgstr ""
 msgid "Previous photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2693
-#: lib/vutuv_web/live/post_live/composer.ex:2694
+#: lib/vutuv_web/live/post_live/composer.ex:2957
+#: lib/vutuv_web/live/post_live/composer.ex:2958
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3153
+#: lib/vutuv_web/live/post_live/composer.ex:3417
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3094
+#: lib/vutuv_web/live/post_live/composer.ex:3358
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr ""
@@ -16192,17 +16195,17 @@ msgstr ""
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3172
+#: lib/vutuv_web/live/post_live/composer.ex:3436
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3208
+#: lib/vutuv_web/live/post_live/composer.ex:3472
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3200
+#: lib/vutuv_web/live/post_live/composer.ex:3464
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
@@ -16227,12 +16230,12 @@ msgstr ""
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2951
+#: lib/vutuv_web/live/post_live/composer.ex:3215
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1442
+#: lib/vutuv_web/live/post_live/composer.ex:1510
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
@@ -16242,7 +16245,7 @@ msgstr ""
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1456
+#: lib/vutuv_web/live/post_live/composer.ex:1524
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
@@ -16257,64 +16260,64 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2576
+#: lib/vutuv_web/live/post_live/composer.ex:2840
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2946
+#: lib/vutuv_web/live/post_live/composer.ex:3210
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3065
+#: lib/vutuv_web/live/post_live/composer.ex:3329
 #, elixir-autogen, elixir-format
 msgid "Caption (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1742
-#: lib/vutuv_web/live/post_live/composer.ex:1805
-#: lib/vutuv_web/live/post_live/composer.ex:1863
+#: lib/vutuv_web/live/post_live/composer.ex:1880
+#: lib/vutuv_web/live/post_live/composer.ex:1943
+#: lib/vutuv_web/live/post_live/composer.ex:2001
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1735
+#: lib/vutuv_web/live/post_live/composer.ex:1873
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2999
+#: lib/vutuv_web/live/post_live/composer.ex:3263
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2388
+#: lib/vutuv_web/live/post_live/composer.ex:2569
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2387
+#: lib/vutuv_web/live/post_live/composer.ex:2568
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2386
+#: lib/vutuv_web/live/post_live/composer.ex:2567
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2391
+#: lib/vutuv_web/live/post_live/composer.ex:2572
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2969
+#: lib/vutuv_web/live/post_live/composer.ex:3233
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2988
+#: lib/vutuv_web/live/post_live/composer.ex:3252
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -16425,8 +16428,8 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1999
-#: lib/vutuv_web/live/post_live/composer.ex:2833
+#: lib/vutuv_web/live/post_live/composer.ex:2137
+#: lib/vutuv_web/live/post_live/composer.ex:3097
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr ""
@@ -17164,104 +17167,104 @@ msgstr ""
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1916
+#: lib/vutuv_web/live/post_live/composer.ex:2054
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2739
+#: lib/vutuv_web/live/post_live/composer.ex:3003
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2740
+#: lib/vutuv_web/live/post_live/composer.ex:3004
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2745
+#: lib/vutuv_web/live/post_live/composer.ex:3009
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2742
+#: lib/vutuv_web/live/post_live/composer.ex:3006
 #, elixir-autogen, elixir-format
 msgid "Cover left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2743
+#: lib/vutuv_web/live/post_live/composer.ex:3007
 #, elixir-autogen, elixir-format
 msgid "Cover on top"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2744
+#: lib/vutuv_web/live/post_live/composer.ex:3008
 #, elixir-autogen, elixir-format
 msgid "Cover right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1912
-#: lib/vutuv_web/live/post_live/composer.ex:2710
-#: lib/vutuv_web/live/post_live/composer.ex:2711
+#: lib/vutuv_web/live/post_live/composer.ex:2050
+#: lib/vutuv_web/live/post_live/composer.ex:2974
+#: lib/vutuv_web/live/post_live/composer.ex:2975
 #, elixir-autogen, elixir-format
 msgid "Crop photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2669
+#: lib/vutuv_web/live/post_live/composer.ex:2933
 #, elixir-autogen, elixir-format
 msgid "Cropped"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1834
+#: lib/vutuv_web/live/post_live/composer.ex:1972
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2746
+#: lib/vutuv_web/live/post_live/composer.ex:3010
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2747
+#: lib/vutuv_web/live/post_live/composer.ex:3011
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1914
+#: lib/vutuv_web/live/post_live/composer.ex:2052
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2738
+#: lib/vutuv_web/live/post_live/composer.ex:3002
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2741
+#: lib/vutuv_web/live/post_live/composer.ex:3005
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:572
+#: lib/vutuv_web/live/post_live/composer.ex:608
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3187
+#: lib/vutuv_web/live/post_live/composer.ex:3451
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1918
+#: lib/vutuv_web/live/post_live/composer.ex:2056
 #, elixir-autogen, elixir-format
 msgid "Whole photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2936
+#: lib/vutuv_web/live/post_live/composer.ex:3200
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2920
+#: lib/vutuv_web/live/post_live/composer.ex:3184
 #, elixir-autogen, elixir-format
 msgid "Whole photos"
 msgstr ""
@@ -18491,17 +18494,17 @@ msgstr ""
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1451
+#: lib/vutuv/accounts/user.ex:1454
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1449
+#: lib/vutuv/accounts/user.ex:1452
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1450
+#: lib/vutuv/accounts/user.ex:1453
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -19248,17 +19251,17 @@ msgstr ""
 msgid "Nothing published yet."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2202
+#: lib/vutuv_web/live/post_live/composer.ex:2383
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1435
+#: lib/vutuv_web/live/post_live/composer.ex:1503
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2179
+#: lib/vutuv_web/live/post_live/composer.ex:2360
 #, elixir-autogen, elixir-format
 msgid "A post in an organization's name is always public."
 msgstr ""
@@ -20039,19 +20042,19 @@ msgstr ""
 msgid "{n} of {max} free slots selected."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2161
+#: lib/vutuv_web/live/post_live/composer.ex:2342
 #, elixir-autogen, elixir-format
 msgid "More languages"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2152
+#: lib/vutuv_web/live/post_live/composer.ex:2333
 #, elixir-autogen, elixir-format
 msgctxt "post composer"
 msgid "Language"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2148
-#: lib/vutuv_web/live/post_live/composer.ex:2149
+#: lib/vutuv_web/live/post_live/composer.ex:2329
+#: lib/vutuv_web/live/post_live/composer.ex:2330
 #, elixir-autogen, elixir-format
 msgid "The language this post is written in"
 msgstr ""
@@ -21798,18 +21801,18 @@ msgid "Nothing matches."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:336
-#: lib/vutuv_web/live/post_live/composer.ex:1998
-#: lib/vutuv_web/live/post_live/composer.ex:2866
+#: lib/vutuv_web/live/post_live/composer.ex:2136
+#: lib/vutuv_web/live/post_live/composer.ex:3130
 #, elixir-autogen, elixir-format
 msgid "Automatic"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2003
+#: lib/vutuv_web/live/post_live/composer.ex:2141
 #, elixir-autogen, elixir-format
 msgid "Drag one photo onto another to swap them."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1950
+#: lib/vutuv_web/live/post_live/composer.ex:2088
 #, elixir-autogen, elixir-format
 msgid "Not shown in the gallery — drag one into it to swap."
 msgstr ""
@@ -21866,17 +21869,17 @@ msgstr ""
 msgid "Unmute %{host}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1758
+#: lib/vutuv_web/live/post_live/composer.ex:1896
 #, elixir-autogen, elixir-format
 msgid "Draft discarded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1797
+#: lib/vutuv_web/live/post_live/composer.ex:1935
 #, elixir-autogen, elixir-format
 msgid "Keep it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1788
+#: lib/vutuv_web/live/post_live/composer.ex:1926
 #, elixir-autogen, elixir-format
 msgid "Keep this draft for later?"
 msgstr ""
@@ -22083,7 +22086,7 @@ msgstr[1] ""
 msgid "About %{minutes} min of video"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2459
+#: lib/vutuv_web/live/post_live/composer.ex:2640
 #, elixir-autogen, elixir-format
 msgid "Add video"
 msgstr ""
@@ -22125,32 +22128,32 @@ msgstr ""
 msgid "Reading the frames"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2495
+#: lib/vutuv_web/live/post_live/composer.ex:2676
 #, elixir-autogen, elixir-format
 msgid "Remove it to post the text without it, or pick another file."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1145
+#: lib/vutuv_web/live/post_live/composer.ex:1196
 #, elixir-autogen, elixir-format
 msgid "Remove the refused video to post the text without it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2524
+#: lib/vutuv_web/live/post_live/composer.ex:2705
 #, elixir-autogen, elixir-format
 msgid "Remove video"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2534
+#: lib/vutuv_web/live/post_live/composer.ex:2715
 #, elixir-autogen, elixir-format
 msgid "Tap a frame to make it the cover."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1008
+#: lib/vutuv_web/live/post_live/composer.ex:1059
 #, elixir-autogen, elixir-format
 msgid "That frame could not be used."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1425
+#: lib/vutuv_web/live/post_live/composer.ex:1493
 #, elixir-autogen, elixir-format
 msgid "The video could not be attached."
 msgstr ""
@@ -22160,7 +22163,7 @@ msgstr ""
 msgid "The video is gone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1512
+#: lib/vutuv_web/live/post_live/composer.ex:1580
 #, elixir-autogen, elixir-format
 msgid "The video is longer than %{seconds} seconds."
 msgstr ""
@@ -22181,17 +22184,17 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:918
 #: lib/vutuv_web/components/post_components.ex:2980
 #: lib/vutuv_web/components/video_components.ex:127
-#: lib/vutuv_web/live/post_live/composer.ex:2458
+#: lib/vutuv_web/live/post_live/composer.ex:2639
 #, elixir-autogen, elixir-format
 msgid "Video"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2502
+#: lib/vutuv_web/live/post_live/composer.ex:2683
 #, elixir-autogen, elixir-format
 msgid "Video description"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1519
+#: lib/vutuv_web/live/post_live/composer.ex:1587
 #, elixir-autogen, elixir-format
 msgid "Videos cannot be uploaded here."
 msgstr ""
@@ -22201,12 +22204,12 @@ msgstr ""
 msgid "Waiting in line"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2509
+#: lib/vutuv_web/live/post_live/composer.ex:2690
 #, elixir-autogen, elixir-format
 msgid "What is in the video, for people who cannot watch it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2498
+#: lib/vutuv_web/live/post_live/composer.ex:2679
 #, elixir-autogen, elixir-format
 msgid "You can post now — the post appears as soon as the video is ready."
 msgstr ""
@@ -24031,7 +24034,7 @@ msgstr ""
 msgid "Photo scan"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/media_live.ex:270
+#: lib/vutuv_web/live/admin/media_live.ex:271
 #, elixir-autogen, elixir-format
 msgid "Running"
 msgstr ""
@@ -24122,4 +24125,94 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:2051
 #, elixir-autogen, elixir-format
 msgid "Link copied"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:2818
+#, elixir-autogen, elixir-format
+msgid "%{left} of today's %{limit} left (%{percent} %)."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:2759
+#, elixir-autogen, elixir-format
+msgid "Add files"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/media_live.ex:254
+#, elixir-autogen, elixir-format
+msgid "File check"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:3515
+#, elixir-autogen, elixir-format
+msgid "File is larger than %{size}."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:2758
+#, elixir-autogen, elixir-format
+msgid "Files"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1595
+#, elixir-autogen, elixir-format
+msgid "Files may be up to %{size}."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:3525
+#, elixir-autogen, elixir-format
+msgid "No more than %{max} files per post."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1600
+#, elixir-autogen, elixir-format
+msgid "Only PDF, plain text and Markdown files can be attached."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1618
+#, elixir-autogen, elixir-format
+msgid "PDFs cannot be checked on this site. Text and Markdown files can."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:2797
+#, elixir-autogen, elixir-format
+msgid "Remove %{name}"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1606
+#, elixir-autogen, elixir-format
+msgid "This PDF contains a program, which cannot be published here."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1615
+#, elixir-autogen, elixir-format
+msgid "This PDF could not be read."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1609
+#, elixir-autogen, elixir-format
+msgid "This PDF does something when it is opened, which cannot be published here."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1612
+#, elixir-autogen, elixir-format
+msgid "This PDF has another file inside it, which cannot be published here."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1603
+#, elixir-autogen, elixir-format
+msgid "This PDF is password-protected, so it cannot be checked."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1624
+#, elixir-autogen, elixir-format
+msgid "You have used up this month's upload allowance."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1621
+#, elixir-autogen, elixir-format
+msgid "You have used up today's upload allowance. It frees up again over the day."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:2816
+#, elixir-autogen, elixir-format
+msgid "Your uploads are not limited."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -118,7 +118,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_posting_live/form.ex:857
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
-#: lib/vutuv_web/live/post_live/composer.ex:1917
+#: lib/vutuv_web/live/post_live/composer.ex:2055
 #: lib/vutuv_web/live/press_kit_live.ex:796
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
@@ -203,7 +203,7 @@ msgid "Disable"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:446
-#: lib/vutuv_web/live/post_live/composer.ex:2962
+#: lib/vutuv_web/live/post_live/composer.ex:3226
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/views/qualification_html.ex:354
 #, elixir-autogen
@@ -605,7 +605,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2186
+#: lib/vutuv_web/live/post_live/composer.ex:2367
 #: lib/vutuv_web/live/section_reorder_live.ex:272
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -617,7 +617,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4848
 #: lib/vutuv_web/live/organization_live/edit.ex:376
-#: lib/vutuv_web/live/post_live/composer.ex:2201
+#: lib/vutuv_web/live/post_live/composer.ex:2382
 #: lib/vutuv_web/live/press_kit_live.ex:795
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
@@ -1605,11 +1605,11 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:321
 #: lib/vutuv_web/live/admin/job_live.ex:477
 #: lib/vutuv_web/live/admin/organization_live.ex:296
-#: lib/vutuv_web/live/post_live/composer.ex:1773
-#: lib/vutuv_web/live/post_live/composer.ex:1875
-#: lib/vutuv_web/live/post_live/composer.ex:1876
-#: lib/vutuv_web/live/post_live/composer.ex:2839
-#: lib/vutuv_web/live/post_live/composer.ex:3105
+#: lib/vutuv_web/live/post_live/composer.ex:1911
+#: lib/vutuv_web/live/post_live/composer.ex:2013
+#: lib/vutuv_web/live/post_live/composer.ex:2014
+#: lib/vutuv_web/live/post_live/composer.ex:3103
+#: lib/vutuv_web/live/post_live/composer.ex:3369
 #: lib/vutuv_web/templates/layout/app.html.heex:200
 #: lib/vutuv_web/templates/layout/app.html.heex:206
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:28
@@ -2061,7 +2061,7 @@ msgstr ""
 msgid "Add images"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2315
+#: lib/vutuv_web/live/post_live/composer.ex:2496
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2072,8 +2072,9 @@ msgstr ""
 msgid "Back to the post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2015
-#: lib/vutuv_web/live/post_live/composer.ex:2038
+#: lib/vutuv_web/live/post_live/composer.ex:2153
+#: lib/vutuv_web/live/post_live/composer.ex:2176
+#: lib/vutuv_web/live/post_live/composer.ex:2202
 #: lib/vutuv_web/live/press_kit_live.ex:949
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
@@ -2119,12 +2120,12 @@ msgstr ""
 msgid "Hidden from:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2291
+#: lib/vutuv_web/live/post_live/composer.ex:2472
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2219
+#: lib/vutuv_web/live/post_live/composer.ex:2400
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr ""
@@ -2135,13 +2136,13 @@ msgstr ""
 msgid "Limited audience"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2261
+#: lib/vutuv_web/live/post_live/composer.ex:2442
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1459
-#: lib/vutuv_web/live/post_live/composer.ex:1562
+#: lib/vutuv_web/live/post_live/composer.ex:1527
+#: lib/vutuv_web/live/post_live/composer.ex:1700
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr ""
@@ -2151,23 +2152,23 @@ msgstr ""
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1422
+#: lib/vutuv_web/live/post_live/composer.ex:1490
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2251
+#: lib/vutuv_web/live/post_live/composer.ex:2432
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2241
+#: lib/vutuv_web/live/post_live/composer.ex:2422
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:441
-#: lib/vutuv_web/live/post_live/composer.ex:2203
+#: lib/vutuv_web/live/post_live/composer.ex:2384
 #, elixir-autogen, elixir-format
 msgid "Post"
 msgstr ""
@@ -2217,7 +2218,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:265
 #: lib/vutuv_web/live/organization_live/edit.ex:404
 #: lib/vutuv_web/live/organization_live/roles.ex:257
-#: lib/vutuv_web/live/post_live/composer.ex:2277
+#: lib/vutuv_web/live/post_live/composer.ex:2458
 #: lib/vutuv_web/live/post_live/filter_band.ex:456
 #: lib/vutuv_web/live/post_live/saved.ex:666
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2234,7 +2235,7 @@ msgstr ""
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2193
+#: lib/vutuv_web/live/post_live/composer.ex:2374
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr ""
@@ -2251,14 +2252,15 @@ msgstr[1] ""
 msgid "Sorry, that page could not be found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1520
 #: lib/vutuv_web/live/post_live/composer.ex:1588
+#: lib/vutuv_web/live/post_live/composer.ex:1626
+#: lib/vutuv_web/live/post_live/composer.ex:1726
 #: lib/vutuv_web/live/press_kit_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1404
+#: lib/vutuv_web/live/post_live/composer.ex:1472
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr ""
@@ -2268,12 +2270,12 @@ msgstr ""
 msgid "This post is for followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3266
+#: lib/vutuv_web/live/post_live/composer.ex:3544
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3267
+#: lib/vutuv_web/live/post_live/composer.ex:3545
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
@@ -2287,12 +2289,12 @@ msgstr ""
 msgid "View profile"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2409
+#: lib/vutuv_web/live/post_live/composer.ex:2590
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2410
+#: lib/vutuv_web/live/post_live/composer.ex:2591
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr ""
@@ -2329,20 +2331,21 @@ msgstr ""
 msgid "unknown"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2076
+#: lib/vutuv_web/live/post_live/composer.ex:2252
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1517
-#: lib/vutuv_web/live/post_live/composer.ex:3247
-#: lib/vutuv_web/live/post_live/composer.ex:3251
+#: lib/vutuv_web/live/post_live/composer.ex:1585
+#: lib/vutuv_web/live/post_live/composer.ex:3511
+#: lib/vutuv_web/live/post_live/composer.ex:3529
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3255
-#: lib/vutuv_web/live/post_live/composer.ex:3261
+#: lib/vutuv_web/live/post_live/composer.ex:3519
+#: lib/vutuv_web/live/post_live/composer.ex:3533
+#: lib/vutuv_web/live/post_live/composer.ex:3539
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr ""
@@ -2499,13 +2502,13 @@ msgstr ""
 msgid "Reply to a deleted post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1407
-#: lib/vutuv_web/live/post_live/composer.ex:2181
+#: lib/vutuv_web/live/post_live/composer.ex:1475
+#: lib/vutuv_web/live/post_live/composer.ex:2362
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2322
+#: lib/vutuv_web/live/post_live/composer.ex:2503
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2806,7 +2809,7 @@ msgstr ""
 msgid "Other formats"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2231
+#: lib/vutuv_web/live/post_live/composer.ex:2412
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr ""
@@ -5241,7 +5244,7 @@ msgstr ""
 msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1428
+#: lib/vutuv_web/live/post_live/composer.ex:1496
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr ""
@@ -5455,7 +5458,7 @@ msgstr ""
 msgid "Personal tokens for the vutuv API."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2575
+#: lib/vutuv_web/live/post_live/composer.ex:2839
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
@@ -6062,7 +6065,7 @@ msgstr ""
 msgid "Use photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1919
+#: lib/vutuv_web/live/post_live/composer.ex:2057
 #: lib/vutuv_web/templates/user/edit.html.heex:66
 #: lib/vutuv_web/templates/user/edit.html.heex:151
 #, elixir-autogen, elixir-format
@@ -7225,7 +7228,7 @@ msgid "Removed:"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:974
-#: lib/vutuv_web/live/post_live/composer.ex:1767
+#: lib/vutuv_web/live/post_live/composer.ex:1905
 #: lib/vutuv_web/live/post_live/filter_band.ex:533
 #, elixir-autogen, elixir-format
 msgid "Undo"
@@ -7375,7 +7378,7 @@ msgid "This updates on its own. You can leave this page; the send keeps running.
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:362
-#: lib/vutuv_web/live/admin/media_live.ex:268
+#: lib/vutuv_web/live/admin/media_live.ex:269
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
 #: lib/vutuv_web/live/post_live/feed.ex:3888
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
@@ -9380,7 +9383,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1292
+#: lib/vutuv/accounts/user.ex:1295
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9391,7 +9394,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1289
+#: lib/vutuv/accounts/user.ex:1292
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10602,15 +10605,15 @@ msgstr ""
 msgid "Every captured link screenshot, newest first. Each links to the page and its post."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/media_live.ex:269
+#: lib/vutuv_web/live/admin/media_live.ex:270
 #: lib/vutuv_web/live/admin/screenshot_live.ex:551
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:198
-#: lib/vutuv_web/live/post_live/composer.ex:1998
-#: lib/vutuv_web/live/post_live/composer.ex:2833
+#: lib/vutuv_web/live/post_live/composer.ex:2136
+#: lib/vutuv_web/live/post_live/composer.ex:3097
 #, elixir-autogen, elixir-format
 msgid "Gallery"
 msgstr ""
@@ -10709,19 +10712,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1330
+#: lib/vutuv/accounts/user.ex:1333
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1335
+#: lib/vutuv/accounts/user.ex:1338
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1333
+#: lib/vutuv/accounts/user.ex:1336
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:823
 #, elixir-autogen, elixir-format
@@ -12001,7 +12004,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1304
+#: lib/vutuv/accounts/user.ex:1307
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12120,7 +12123,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1303
+#: lib/vutuv/accounts/user.ex:1306
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12202,7 +12205,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1305
+#: lib/vutuv/accounts/user.ex:1308
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:590
 #: lib/vutuv_web/agent_docs/markdown.ex:563
@@ -13213,7 +13216,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1348
+#: lib/vutuv/accounts/user.ex:1351
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13224,19 +13227,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1351
+#: lib/vutuv/accounts/user.ex:1354
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1354
+#: lib/vutuv/accounts/user.ex:1357
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1345
+#: lib/vutuv/accounts/user.ex:1348
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13301,7 +13304,7 @@ msgstr ""
 msgid "Insert image"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3224
+#: lib/vutuv_web/live/post_live/composer.ex:3488
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr ""
@@ -13937,13 +13940,13 @@ msgstr ""
 msgid "mentioned you in a post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1412
+#: lib/vutuv_web/live/post_live/composer.ex:1480
 #: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1415
+#: lib/vutuv_web/live/post_live/composer.ex:1483
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -16055,7 +16058,7 @@ msgstr ""
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3237
+#: lib/vutuv_web/live/post_live/composer.ex:3501
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr ""
@@ -16087,12 +16090,12 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1449
 #: lib/vutuv_web/agent_docs/text.ex:920
-#: lib/vutuv_web/live/post_live/composer.ex:2661
+#: lib/vutuv_web/live/post_live/composer.ex:2925
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3075
+#: lib/vutuv_web/live/post_live/composer.ex:3339
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr ""
@@ -16104,22 +16107,22 @@ msgstr ""
 msgid "Download the original"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3174
+#: lib/vutuv_web/live/post_live/composer.ex:3438
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3130
+#: lib/vutuv_web/live/post_live/composer.ex:3394
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3132
+#: lib/vutuv_web/live/post_live/composer.ex:3396
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3151
+#: lib/vutuv_web/live/post_live/composer.ex:3415
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr ""
@@ -16129,7 +16132,7 @@ msgstr ""
 msgid "Next photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2680
+#: lib/vutuv_web/live/post_live/composer.ex:2944
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr ""
@@ -16151,8 +16154,8 @@ msgstr ""
 msgid "Photo is being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2633
-#: lib/vutuv_web/live/post_live/composer.ex:2634
+#: lib/vutuv_web/live/post_live/composer.ex:2897
+#: lib/vutuv_web/live/post_live/composer.ex:2898
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr ""
@@ -16169,18 +16172,18 @@ msgstr ""
 msgid "Previous photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2693
-#: lib/vutuv_web/live/post_live/composer.ex:2694
+#: lib/vutuv_web/live/post_live/composer.ex:2957
+#: lib/vutuv_web/live/post_live/composer.ex:2958
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3153
+#: lib/vutuv_web/live/post_live/composer.ex:3417
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3094
+#: lib/vutuv_web/live/post_live/composer.ex:3358
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Show camera settings"
 msgstr ""
@@ -16190,17 +16193,17 @@ msgstr ""
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3172
+#: lib/vutuv_web/live/post_live/composer.ex:3436
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3208
+#: lib/vutuv_web/live/post_live/composer.ex:3472
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3200
+#: lib/vutuv_web/live/post_live/composer.ex:3464
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
@@ -16225,12 +16228,12 @@ msgstr ""
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2951
+#: lib/vutuv_web/live/post_live/composer.ex:3215
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1442
+#: lib/vutuv_web/live/post_live/composer.ex:1510
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
@@ -16240,7 +16243,7 @@ msgstr ""
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1456
+#: lib/vutuv_web/live/post_live/composer.ex:1524
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
@@ -16255,64 +16258,64 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2576
+#: lib/vutuv_web/live/post_live/composer.ex:2840
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2946
+#: lib/vutuv_web/live/post_live/composer.ex:3210
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3065
+#: lib/vutuv_web/live/post_live/composer.ex:3329
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Caption (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1742
-#: lib/vutuv_web/live/post_live/composer.ex:1805
-#: lib/vutuv_web/live/post_live/composer.ex:1863
+#: lib/vutuv_web/live/post_live/composer.ex:1880
+#: lib/vutuv_web/live/post_live/composer.ex:1943
+#: lib/vutuv_web/live/post_live/composer.ex:2001
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1735
+#: lib/vutuv_web/live/post_live/composer.ex:1873
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2999
+#: lib/vutuv_web/live/post_live/composer.ex:3263
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2388
+#: lib/vutuv_web/live/post_live/composer.ex:2569
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2387
+#: lib/vutuv_web/live/post_live/composer.ex:2568
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2386
+#: lib/vutuv_web/live/post_live/composer.ex:2567
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2391
+#: lib/vutuv_web/live/post_live/composer.ex:2572
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2969
+#: lib/vutuv_web/live/post_live/composer.ex:3233
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2988
+#: lib/vutuv_web/live/post_live/composer.ex:3252
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -16423,8 +16426,8 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1999
-#: lib/vutuv_web/live/post_live/composer.ex:2833
+#: lib/vutuv_web/live/post_live/composer.ex:2137
+#: lib/vutuv_web/live/post_live/composer.ex:3097
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr ""
@@ -17162,104 +17165,104 @@ msgstr ""
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1916
+#: lib/vutuv_web/live/post_live/composer.ex:2054
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2739
+#: lib/vutuv_web/live/post_live/composer.ex:3003
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2740
+#: lib/vutuv_web/live/post_live/composer.ex:3004
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2745
+#: lib/vutuv_web/live/post_live/composer.ex:3009
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2742
+#: lib/vutuv_web/live/post_live/composer.ex:3006
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2743
+#: lib/vutuv_web/live/post_live/composer.ex:3007
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover on top"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2744
+#: lib/vutuv_web/live/post_live/composer.ex:3008
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1912
-#: lib/vutuv_web/live/post_live/composer.ex:2710
-#: lib/vutuv_web/live/post_live/composer.ex:2711
+#: lib/vutuv_web/live/post_live/composer.ex:2050
+#: lib/vutuv_web/live/post_live/composer.ex:2974
+#: lib/vutuv_web/live/post_live/composer.ex:2975
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Crop photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2669
+#: lib/vutuv_web/live/post_live/composer.ex:2933
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cropped"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1834
+#: lib/vutuv_web/live/post_live/composer.ex:1972
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2746
+#: lib/vutuv_web/live/post_live/composer.ex:3010
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2747
+#: lib/vutuv_web/live/post_live/composer.ex:3011
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1914
+#: lib/vutuv_web/live/post_live/composer.ex:2052
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2738
+#: lib/vutuv_web/live/post_live/composer.ex:3002
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2741
+#: lib/vutuv_web/live/post_live/composer.ex:3005
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:572
+#: lib/vutuv_web/live/post_live/composer.ex:608
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3187
+#: lib/vutuv_web/live/post_live/composer.ex:3451
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1918
+#: lib/vutuv_web/live/post_live/composer.ex:2056
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Whole photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2936
+#: lib/vutuv_web/live/post_live/composer.ex:3200
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2920
+#: lib/vutuv_web/live/post_live/composer.ex:3184
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Whole photos"
 msgstr ""
@@ -18489,17 +18492,17 @@ msgstr ""
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1451
+#: lib/vutuv/accounts/user.ex:1454
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1449
+#: lib/vutuv/accounts/user.ex:1452
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1450
+#: lib/vutuv/accounts/user.ex:1453
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -19246,17 +19249,17 @@ msgstr ""
 msgid "Nothing published yet."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2202
+#: lib/vutuv_web/live/post_live/composer.ex:2383
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1435
+#: lib/vutuv_web/live/post_live/composer.ex:1503
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2179
+#: lib/vutuv_web/live/post_live/composer.ex:2360
 #, elixir-autogen, elixir-format
 msgid "A post in an organization's name is always public."
 msgstr ""
@@ -20037,19 +20040,19 @@ msgstr ""
 msgid "{n} of {max} free slots selected."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2161
+#: lib/vutuv_web/live/post_live/composer.ex:2342
 #, elixir-autogen, elixir-format
 msgid "More languages"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2152
+#: lib/vutuv_web/live/post_live/composer.ex:2333
 #, elixir-autogen, elixir-format
 msgctxt "post composer"
 msgid "Language"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2148
-#: lib/vutuv_web/live/post_live/composer.ex:2149
+#: lib/vutuv_web/live/post_live/composer.ex:2329
+#: lib/vutuv_web/live/post_live/composer.ex:2330
 #, elixir-autogen, elixir-format
 msgid "The language this post is written in"
 msgstr ""
@@ -21796,18 +21799,18 @@ msgid "Nothing matches."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:336
-#: lib/vutuv_web/live/post_live/composer.ex:1998
-#: lib/vutuv_web/live/post_live/composer.ex:2866
+#: lib/vutuv_web/live/post_live/composer.ex:2136
+#: lib/vutuv_web/live/post_live/composer.ex:3130
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Automatic"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2003
+#: lib/vutuv_web/live/post_live/composer.ex:2141
 #, elixir-autogen, elixir-format
 msgid "Drag one photo onto another to swap them."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1950
+#: lib/vutuv_web/live/post_live/composer.ex:2088
 #, elixir-autogen, elixir-format
 msgid "Not shown in the gallery — drag one into it to swap."
 msgstr ""
@@ -21864,17 +21867,17 @@ msgstr ""
 msgid "Unmute %{host}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1758
+#: lib/vutuv_web/live/post_live/composer.ex:1896
 #, elixir-autogen, elixir-format
 msgid "Draft discarded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1797
+#: lib/vutuv_web/live/post_live/composer.ex:1935
 #, elixir-autogen, elixir-format
 msgid "Keep it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1788
+#: lib/vutuv_web/live/post_live/composer.ex:1926
 #, elixir-autogen, elixir-format
 msgid "Keep this draft for later?"
 msgstr ""
@@ -22081,7 +22084,7 @@ msgstr[1] ""
 msgid "About %{minutes} min of video"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2459
+#: lib/vutuv_web/live/post_live/composer.ex:2640
 #, elixir-autogen, elixir-format
 msgid "Add video"
 msgstr ""
@@ -22123,32 +22126,32 @@ msgstr ""
 msgid "Reading the frames"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2495
+#: lib/vutuv_web/live/post_live/composer.ex:2676
 #, elixir-autogen, elixir-format
 msgid "Remove it to post the text without it, or pick another file."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1145
+#: lib/vutuv_web/live/post_live/composer.ex:1196
 #, elixir-autogen, elixir-format
 msgid "Remove the refused video to post the text without it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2524
+#: lib/vutuv_web/live/post_live/composer.ex:2705
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove video"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2534
+#: lib/vutuv_web/live/post_live/composer.ex:2715
 #, elixir-autogen, elixir-format
 msgid "Tap a frame to make it the cover."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1008
+#: lib/vutuv_web/live/post_live/composer.ex:1059
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That frame could not be used."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1425
+#: lib/vutuv_web/live/post_live/composer.ex:1493
 #, elixir-autogen, elixir-format, fuzzy
 msgid "The video could not be attached."
 msgstr ""
@@ -22158,7 +22161,7 @@ msgstr ""
 msgid "The video is gone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1512
+#: lib/vutuv_web/live/post_live/composer.ex:1580
 #, elixir-autogen, elixir-format
 msgid "The video is longer than %{seconds} seconds."
 msgstr ""
@@ -22179,17 +22182,17 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:918
 #: lib/vutuv_web/components/post_components.ex:2980
 #: lib/vutuv_web/components/video_components.ex:127
-#: lib/vutuv_web/live/post_live/composer.ex:2458
+#: lib/vutuv_web/live/post_live/composer.ex:2639
 #, elixir-autogen, elixir-format
 msgid "Video"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2502
+#: lib/vutuv_web/live/post_live/composer.ex:2683
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Video description"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1519
+#: lib/vutuv_web/live/post_live/composer.ex:1587
 #, elixir-autogen, elixir-format
 msgid "Videos cannot be uploaded here."
 msgstr ""
@@ -22199,12 +22202,12 @@ msgstr ""
 msgid "Waiting in line"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2509
+#: lib/vutuv_web/live/post_live/composer.ex:2690
 #, elixir-autogen, elixir-format
 msgid "What is in the video, for people who cannot watch it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2498
+#: lib/vutuv_web/live/post_live/composer.ex:2679
 #, elixir-autogen, elixir-format
 msgid "You can post now — the post appears as soon as the video is ready."
 msgstr ""
@@ -24029,7 +24032,7 @@ msgstr ""
 msgid "Photo scan"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/media_live.ex:270
+#: lib/vutuv_web/live/admin/media_live.ex:271
 #, elixir-autogen, elixir-format
 msgid "Running"
 msgstr ""
@@ -24120,4 +24123,94 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:2051
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Link copied"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:2818
+#, elixir-autogen, elixir-format
+msgid "%{left} of today's %{limit} left (%{percent} %)."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:2759
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Add files"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/media_live.ex:254
+#, elixir-autogen, elixir-format
+msgid "File check"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:3515
+#, elixir-autogen, elixir-format, fuzzy
+msgid "File is larger than %{size}."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:2758
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Files"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1595
+#, elixir-autogen, elixir-format
+msgid "Files may be up to %{size}."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:3525
+#, elixir-autogen, elixir-format, fuzzy
+msgid "No more than %{max} files per post."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1600
+#, elixir-autogen, elixir-format
+msgid "Only PDF, plain text and Markdown files can be attached."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1618
+#, elixir-autogen, elixir-format
+msgid "PDFs cannot be checked on this site. Text and Markdown files can."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:2797
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Remove %{name}"
+msgstr "Remove %{name}"
+
+#: lib/vutuv_web/live/post_live/composer.ex:1606
+#, elixir-autogen, elixir-format
+msgid "This PDF contains a program, which cannot be published here."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1615
+#, elixir-autogen, elixir-format
+msgid "This PDF could not be read."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1609
+#, elixir-autogen, elixir-format
+msgid "This PDF does something when it is opened, which cannot be published here."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1612
+#, elixir-autogen, elixir-format
+msgid "This PDF has another file inside it, which cannot be published here."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1603
+#, elixir-autogen, elixir-format
+msgid "This PDF is password-protected, so it cannot be checked."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1624
+#, elixir-autogen, elixir-format
+msgid "You have used up this month's upload allowance."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1621
+#, elixir-autogen, elixir-format
+msgid "You have used up today's upload allowance. It frees up again over the day."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:2816
+#, elixir-autogen, elixir-format
+msgid "Your uploads are not limited."
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -120,7 +120,7 @@ msgstr "Compleanno"
 #: lib/vutuv_web/live/job_posting_live/form.ex:857
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
-#: lib/vutuv_web/live/post_live/composer.ex:1917
+#: lib/vutuv_web/live/post_live/composer.ex:2055
 #: lib/vutuv_web/live/press_kit_live.ex:796
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
@@ -205,7 +205,7 @@ msgid "Disable"
 msgstr "Disattiva"
 
 #: lib/vutuv_web/live/cv_live.ex:446
-#: lib/vutuv_web/live/post_live/composer.ex:2962
+#: lib/vutuv_web/live/post_live/composer.ex:3226
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/views/qualification_html.ex:354
 #, elixir-autogen
@@ -609,7 +609,7 @@ msgstr "Profili di "
 msgid "Provider"
 msgstr "Piattaforma"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2186
+#: lib/vutuv_web/live/post_live/composer.ex:2367
 #: lib/vutuv_web/live/section_reorder_live.ex:272
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -621,7 +621,7 @@ msgstr "Pubblico"
 
 #: lib/vutuv_web/components/ui.ex:4848
 #: lib/vutuv_web/live/organization_live/edit.ex:376
-#: lib/vutuv_web/live/post_live/composer.ex:2201
+#: lib/vutuv_web/live/post_live/composer.ex:2382
 #: lib/vutuv_web/live/press_kit_live.ex:795
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
@@ -1635,11 +1635,11 @@ msgstr "Controlli la Sua casella di posta"
 #: lib/vutuv_web/live/admin/job_live.ex:321
 #: lib/vutuv_web/live/admin/job_live.ex:477
 #: lib/vutuv_web/live/admin/organization_live.ex:296
-#: lib/vutuv_web/live/post_live/composer.ex:1773
-#: lib/vutuv_web/live/post_live/composer.ex:1875
-#: lib/vutuv_web/live/post_live/composer.ex:1876
-#: lib/vutuv_web/live/post_live/composer.ex:2839
-#: lib/vutuv_web/live/post_live/composer.ex:3105
+#: lib/vutuv_web/live/post_live/composer.ex:1911
+#: lib/vutuv_web/live/post_live/composer.ex:2013
+#: lib/vutuv_web/live/post_live/composer.ex:2014
+#: lib/vutuv_web/live/post_live/composer.ex:3103
+#: lib/vutuv_web/live/post_live/composer.ex:3369
 #: lib/vutuv_web/templates/layout/app.html.heex:200
 #: lib/vutuv_web/templates/layout/app.html.heex:206
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:28
@@ -2101,7 +2101,7 @@ msgstr "Markdown è supportato: grassetto, corsivo, link ed elenchi."
 msgid "Add images"
 msgstr "Aggiungi immagini"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2315
+#: lib/vutuv_web/live/post_live/composer.ex:2496
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2114,8 +2114,9 @@ msgstr ""
 msgid "Back to the post"
 msgstr "Torna al post"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2015
-#: lib/vutuv_web/live/post_live/composer.ex:2038
+#: lib/vutuv_web/live/post_live/composer.ex:2153
+#: lib/vutuv_web/live/post_live/composer.ex:2176
+#: lib/vutuv_web/live/post_live/composer.ex:2202
 #: lib/vutuv_web/live/press_kit_live.ex:949
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
@@ -2161,12 +2162,12 @@ msgstr "Segua %{name} per leggerlo."
 msgid "Hidden from:"
 msgstr "Nascosto a:"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2291
+#: lib/vutuv_web/live/post_live/composer.ex:2472
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr "Nascondi a una persona specifica…"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2219
+#: lib/vutuv_web/live/post_live/composer.ex:2400
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr "Nascondi questo post a…"
@@ -2177,13 +2178,13 @@ msgstr "Nascondi questo post a…"
 msgid "Limited audience"
 msgstr "Pubblico limitato"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2261
+#: lib/vutuv_web/live/post_live/composer.ex:2442
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr "Visitatori non connessi"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1459
-#: lib/vutuv_web/live/post_live/composer.ex:1562
+#: lib/vutuv_web/live/post_live/composer.ex:1527
+#: lib/vutuv_web/live/post_live/composer.ex:1700
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr "Non più di %{max} immagini per post."
@@ -2195,23 +2196,23 @@ msgstr ""
 "Qui non c'è ancora nulla. Segua altre persone per riempire il Suo feed, "
 "oppure scriva il Suo primo post."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1422
+#: lib/vutuv_web/live/post_live/composer.ex:1490
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr "Non è stato possibile allegare una delle immagini."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2251
+#: lib/vutuv_web/live/post_live/composer.ex:2432
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr "Persone che non seguo"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2241
+#: lib/vutuv_web/live/post_live/composer.ex:2422
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr "Persone che non mi seguono"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:441
-#: lib/vutuv_web/live/post_live/composer.ex:2203
+#: lib/vutuv_web/live/post_live/composer.ex:2384
 #, elixir-autogen, elixir-format
 msgid "Post"
 msgstr "Pubblica"
@@ -2261,7 +2262,7 @@ msgstr "Mostra meno"
 #: lib/vutuv_web/live/organization_live/domains.ex:265
 #: lib/vutuv_web/live/organization_live/edit.ex:404
 #: lib/vutuv_web/live/organization_live/roles.ex:257
-#: lib/vutuv_web/live/post_live/composer.ex:2277
+#: lib/vutuv_web/live/post_live/composer.ex:2458
 #: lib/vutuv_web/live/post_live/filter_band.ex:456
 #: lib/vutuv_web/live/post_live/saved.ex:666
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2280,7 +2281,7 @@ msgstr ""
 "I post con pubblico limitato sono nascosti anche ai visitatori non connessi "
 "e ai motori di ricerca."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2193
+#: lib/vutuv_web/live/post_live/composer.ex:2374
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr "Salvataggio…"
@@ -2297,14 +2298,15 @@ msgstr[1] "Mostra %{formatted} nuovi post"
 msgid "Sorry, that page could not be found."
 msgstr "Spiacenti, la pagina non è stata trovata."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1520
 #: lib/vutuv_web/live/post_live/composer.ex:1588
+#: lib/vutuv_web/live/post_live/composer.ex:1626
+#: lib/vutuv_web/live/post_live/composer.ex:1726
 #: lib/vutuv_web/live/press_kit_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr "Non è stato possibile elaborare il file."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1404
+#: lib/vutuv_web/live/post_live/composer.ex:1472
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr "La selezione del pubblico non è valida."
@@ -2314,12 +2316,12 @@ msgstr "La selezione del pubblico non è valida."
 msgid "This post is for followers of %{name}"
 msgstr "Questo post è per i follower di %{name}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3266
+#: lib/vutuv_web/live/post_live/composer.ex:3544
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Troppi file."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3267
+#: lib/vutuv_web/live/post_live/composer.ex:3545
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr "Caricamento non riuscito."
@@ -2333,12 +2335,12 @@ msgstr "Caricamento non riuscito."
 msgid "View profile"
 msgstr "Vedi il profilo"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2409
+#: lib/vutuv_web/live/post_live/composer.ex:2590
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr "Che c'è di nuovo?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2410
+#: lib/vutuv_web/live/post_live/composer.ex:2591
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr "Che c'è di nuovo? Markdown è supportato."
@@ -2375,20 +2377,21 @@ msgstr "persone che non segue"
 msgid "unknown"
 msgstr "sconosciuto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2076
+#: lib/vutuv_web/live/post_live/composer.ex:2252
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr "Tag separati da virgole (max. %{max})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1517
-#: lib/vutuv_web/live/post_live/composer.ex:3247
-#: lib/vutuv_web/live/post_live/composer.ex:3251
+#: lib/vutuv_web/live/post_live/composer.ex:1585
+#: lib/vutuv_web/live/post_live/composer.ex:3511
+#: lib/vutuv_web/live/post_live/composer.ex:3529
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr "Il file supera %{mb} MB."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3255
-#: lib/vutuv_web/live/post_live/composer.ex:3261
+#: lib/vutuv_web/live/post_live/composer.ex:3519
+#: lib/vutuv_web/live/post_live/composer.ex:3533
+#: lib/vutuv_web/live/post_live/composer.ex:3539
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr "Tipo di file non supportato (ammessi: %{types})."
@@ -2545,15 +2548,15 @@ msgstr "Rispondi"
 msgid "Reply to a deleted post"
 msgstr "Risposta a un post eliminato"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1407
-#: lib/vutuv_web/live/post_live/composer.ex:2181
+#: lib/vutuv_web/live/post_live/composer.ex:1475
+#: lib/vutuv_web/live/post_live/composer.ex:2362
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 "Il pubblico non può essere limitato finché esistono ripubblicazioni o "
 "risposte."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2322
+#: lib/vutuv_web/live/post_live/composer.ex:2503
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2859,7 +2862,7 @@ msgstr "Ancora nessun collegamento."
 msgid "Other formats"
 msgstr "Altri formati"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2231
+#: lib/vutuv_web/live/post_live/composer.ex:2412
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr "Persone che non sono miei collegamenti"
@@ -5449,7 +5452,7 @@ msgstr ""
 "Questo elimina definitivamente il Suo profilo, i post, i messaggi e tutto il"
 " resto. Le inviamo un PIN per e-mail per confermare. Non si può annullare."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1428
+#: lib/vutuv_web/live/post_live/composer.ex:1496
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr "Non può più rispondere a questo post."
@@ -5663,7 +5666,7 @@ msgstr "Persone che non possono interagire con Lei."
 msgid "Personal tokens for the vutuv API."
 msgstr "Token personali per l'API di vutuv."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2575
+#: lib/vutuv_web/live/post_live/composer.ex:2839
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
@@ -6284,7 +6287,7 @@ msgstr "Posizioni la Sua foto"
 msgid "Use photo"
 msgstr "Usa questa foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1919
+#: lib/vutuv_web/live/post_live/composer.ex:2057
 #: lib/vutuv_web/templates/user/edit.html.heex:66
 #: lib/vutuv_web/templates/user/edit.html.heex:151
 #, elixir-autogen, elixir-format
@@ -7506,7 +7509,7 @@ msgid "Removed:"
 msgstr "Rimossi:"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:974
-#: lib/vutuv_web/live/post_live/composer.ex:1767
+#: lib/vutuv_web/live/post_live/composer.ex:1905
 #: lib/vutuv_web/live/post_live/filter_band.ex:533
 #, elixir-autogen, elixir-format
 msgid "Undo"
@@ -7661,7 +7664,7 @@ msgid "This updates on its own. You can leave this page; the send keeps running.
 msgstr "Si aggiorna da sola. Può lasciare questa pagina: l'invio prosegue."
 
 #: lib/vutuv_web/components/welcome_components.ex:362
-#: lib/vutuv_web/live/admin/media_live.ex:268
+#: lib/vutuv_web/live/admin/media_live.ex:269
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
 #: lib/vutuv_web/live/post_live/feed.ex:3888
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
@@ -9794,7 +9797,7 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Situazione lavorativa"
 
-#: lib/vutuv/accounts/user.ex:1292
+#: lib/vutuv/accounts/user.ex:1295
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9805,7 +9808,7 @@ msgstr "In cerca di lavoro"
 msgid "Not open to work"
 msgstr "Non in cerca di lavoro"
 
-#: lib/vutuv/accounts/user.ex:1289
+#: lib/vutuv/accounts/user.ex:1292
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -11127,15 +11130,15 @@ msgstr ""
 "Ogni screenshot di link acquisito, dal più recente. Ciascuno rimanda alla "
 "pagina e al relativo post."
 
-#: lib/vutuv_web/live/admin/media_live.ex:269
+#: lib/vutuv_web/live/admin/media_live.ex:270
 #: lib/vutuv_web/live/admin/screenshot_live.ex:551
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr "Non riuscito"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:198
-#: lib/vutuv_web/live/post_live/composer.ex:1998
-#: lib/vutuv_web/live/post_live/composer.ex:2833
+#: lib/vutuv_web/live/post_live/composer.ex:2136
+#: lib/vutuv_web/live/post_live/composer.ex:3097
 #, elixir-autogen, elixir-format
 msgid "Gallery"
 msgstr "Galleria"
@@ -11240,19 +11243,19 @@ msgstr ""
 "Sua disponibilità ma non può garantirla, perché chiunque può creare un "
 "account. Scelga \"Nessuno\" per conservare lo stato senza mostrarlo."
 
-#: lib/vutuv/accounts/user.ex:1330
+#: lib/vutuv/accounts/user.ex:1333
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Tutti, compresi i visitatori non connessi"
 
-#: lib/vutuv/accounts/user.ex:1335
+#: lib/vutuv/accounts/user.ex:1338
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Nessuno"
 
-#: lib/vutuv/accounts/user.ex:1333
+#: lib/vutuv/accounts/user.ex:1336
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:823
 #, elixir-autogen, elixir-format
@@ -12619,7 +12622,7 @@ msgstr "I tag evidenziati corrispondono al Suo profilo."
 msgid "How to apply"
 msgstr "Come candidarsi"
 
-#: lib/vutuv/accounts/user.ex:1304
+#: lib/vutuv/accounts/user.ex:1307
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12741,7 +12744,7 @@ msgstr ""
 "Offri i formati leggibili dalle macchine (.md/.txt/.json/.xml) agli agenti "
 "IA."
 
-#: lib/vutuv/accounts/user.ex:1303
+#: lib/vutuv/accounts/user.ex:1306
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12825,7 +12828,7 @@ msgstr "Annuncio non trovato."
 msgid "Publish"
 msgstr "Pubblica"
 
-#: lib/vutuv/accounts/user.ex:1305
+#: lib/vutuv/accounts/user.ex:1308
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:590
 #: lib/vutuv_web/agent_docs/markdown.ex:563
@@ -13921,7 +13924,7 @@ msgstr ""
 "Se è venuto male (ad esempio con un avviso sui cookie che copre la pagina), "
 "può rimuoverlo."
 
-#: lib/vutuv/accounts/user.ex:1348
+#: lib/vutuv/accounts/user.ex:1351
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13935,19 +13938,19 @@ msgstr ""
 "la data esatta, \"Giorno e mese\" nasconde l'anno (e la Sua età) e \"Non "
 "mostrare\" lo conserva ma lo tiene fuori dal profilo."
 
-#: lib/vutuv/accounts/user.ex:1351
+#: lib/vutuv/accounts/user.ex:1354
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Giorno e mese, senza l'anno"
 
-#: lib/vutuv/accounts/user.ex:1354
+#: lib/vutuv/accounts/user.ex:1357
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Non mostrare il mio compleanno"
 
-#: lib/vutuv/accounts/user.ex:1345
+#: lib/vutuv/accounts/user.ex:1348
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -14023,7 +14026,7 @@ msgstr "A tutta larghezza"
 msgid "Insert image"
 msgstr "Inserisci un'immagine"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3224
+#: lib/vutuv_web/live/post_live/composer.ex:3488
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr "Inserisci nel testo"
@@ -14688,7 +14691,7 @@ msgstr "Menzione"
 msgid "mentioned you in a post."
 msgstr "L'ha menzionata in un post."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1412
+#: lib/vutuv_web/live/post_live/composer.ex:1480
 #: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
@@ -14696,7 +14699,7 @@ msgstr ""
 "Questo post non può più essere modificato: qualcuno gli ha messo Mi piace, "
 "lo ha ripubblicato o gli ha risposto."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1415
+#: lib/vutuv_web/live/post_live/composer.ex:1483
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -16992,7 +16995,7 @@ msgstr ""
 "profilo, come si scrive una trascrizione, e le parentesi le aggiungiamo noi."
 " Se lo lascia vuoto non viene mostrato nulla."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3237
+#: lib/vutuv_web/live/post_live/composer.ex:3501
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr "Applica queste impostazioni a tutte le foto"
@@ -17024,12 +17027,12 @@ msgstr "CC0 1.0 (nessun diritto riservato)"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1449
 #: lib/vutuv_web/agent_docs/text.ex:920
-#: lib/vutuv_web/live/post_live/composer.ex:2661
+#: lib/vutuv_web/live/post_live/composer.ex:2925
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr "Copertina"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3075
+#: lib/vutuv_web/live/post_live/composer.ex:3339
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr "Descriva la foto per chi non può vederla"
@@ -17041,24 +17044,24 @@ msgstr "Descriva la foto per chi non può vederla"
 msgid "Download the original"
 msgstr "Scarica l'originale"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3174
+#: lib/vutuv_web/live/post_live/composer.ex:3438
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 "Tutti i campi di metadati conservati, compreso ciò che ha scritto la Sua "
 "fotocamera."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3130
+#: lib/vutuv_web/live/post_live/composer.ex:3394
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr "Chiunque può scaricare questa foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3132
+#: lib/vutuv_web/live/post_live/composer.ex:3396
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr "Risoluzione piena, direttamente dal post."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3151
+#: lib/vutuv_web/live/post_live/composer.ex:3415
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr "Solo l'immagine"
@@ -17068,7 +17071,7 @@ msgstr "Solo l'immagine"
 msgid "Next photo"
 msgstr "Foto successiva"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2680
+#: lib/vutuv_web/live/post_live/composer.ex:2944
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr "Ancora nessuna descrizione dell'immagine"
@@ -17090,8 +17093,8 @@ msgstr "Foto %{n} di %{total}"
 msgid "Photo is being checked"
 msgstr "La foto è in fase di controllo"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2633
-#: lib/vutuv_web/live/post_live/composer.ex:2634
+#: lib/vutuv_web/live/post_live/composer.ex:2897
+#: lib/vutuv_web/live/post_live/composer.ex:2898
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr "Opzioni della foto"
@@ -17108,20 +17111,20 @@ msgstr "Foto:"
 msgid "Previous photo"
 msgstr "Foto precedente"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2693
-#: lib/vutuv_web/live/post_live/composer.ex:2694
+#: lib/vutuv_web/live/post_live/composer.ex:2957
+#: lib/vutuv_web/live/post_live/composer.ex:2958
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr "Rimuovi la foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3153
+#: lib/vutuv_web/live/post_live/composer.ex:3417
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 "Gli stessi pixel e nient'altro: posizione e numeri di serie rimossi, qualità"
 " intatta."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3094
+#: lib/vutuv_web/live/post_live/composer.ex:3358
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr "Mostra le impostazioni della fotocamera"
@@ -17133,19 +17136,19 @@ msgstr ""
 "Quel server è bloccato su questo sito, quindi non gli si può inviare alcuna "
 "risposta."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3172
+#: lib/vutuv_web/live/post_live/composer.ex:3436
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr "Il file esattamente come l'ho caricato"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3208
+#: lib/vutuv_web/live/post_live/composer.ex:3472
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 "Questo formato di file può essere consegnato solo così com'è. Rimuova la "
 "foto se non è ciò che desidera."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3200
+#: lib/vutuv_web/live/post_live/composer.ex:3464
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
@@ -17177,12 +17180,12 @@ msgstr "Questo sito non partecipa al Fediverso."
 msgid "Turn on Fediverse participation to answer"
 msgstr "Attivi la partecipazione al Fediverso per rispondere"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2951
+#: lib/vutuv_web/live/post_live/composer.ex:3215
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr "Chi può riutilizzare queste foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1442
+#: lib/vutuv_web/live/post_live/composer.ex:1510
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
@@ -17195,7 +17198,7 @@ msgstr ""
 "Ha spostato il Suo account del Fediverso su un altro server, quindi da qui "
 "non vengono più inviate risposte."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1456
+#: lib/vutuv_web/live/post_live/composer.ex:1524
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
@@ -17214,66 +17217,66 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr "© Tutti i diritti riservati"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2576
+#: lib/vutuv_web/live/post_live/composer.ex:2840
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr "Aggiungi foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2946
+#: lib/vutuv_web/live/post_live/composer.ex:3210
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr "Licenza"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3065
+#: lib/vutuv_web/live/post_live/composer.ex:3329
 #, elixir-autogen, elixir-format
 msgid "Caption (optional)"
 msgstr "Didascalia (facoltativa)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1742
-#: lib/vutuv_web/live/post_live/composer.ex:1805
-#: lib/vutuv_web/live/post_live/composer.ex:1863
+#: lib/vutuv_web/live/post_live/composer.ex:1880
+#: lib/vutuv_web/live/post_live/composer.ex:1943
+#: lib/vutuv_web/live/post_live/composer.ex:2001
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr "Scarta la bozza"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1735
+#: lib/vutuv_web/live/post_live/composer.ex:1873
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr "Ripreso da dove aveva lasciato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2999
+#: lib/vutuv_web/live/post_live/composer.ex:3263
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 "Un file il cui formato non può essere ripulito viene consegnato esattamente "
 "come caricato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2388
+#: lib/vutuv_web/live/post_live/composer.ex:2569
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr "Diverso per ogni foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2387
+#: lib/vutuv_web/live/post_live/composer.ex:2568
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr "Originale, esattamente come caricato"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2386
+#: lib/vutuv_web/live/post_live/composer.ex:2567
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr "Originale, senza metadati"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2391
+#: lib/vutuv_web/live/post_live/composer.ex:2572
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr "Solo versioni per il web (%{format})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2969
+#: lib/vutuv_web/live/post_live/composer.ex:3233
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr "Cosa può salvare un visitatore"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2988
+#: lib/vutuv_web/live/post_live/composer.ex:3252
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -17397,8 +17400,8 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr "Richiesta di ritiro"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1999
-#: lib/vutuv_web/live/post_live/composer.ex:2833
+#: lib/vutuv_web/live/post_live/composer.ex:2137
+#: lib/vutuv_web/live/post_live/composer.ex:3097
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr "Dettagli della foto"
@@ -18237,108 +18240,108 @@ msgstr ""
 "previsti per ogni altro post da un'altra rete, e al server del suo autore "
 "non viene chiesto nient'altro."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1916
+#: lib/vutuv_web/live/post_live/composer.ex:2054
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr "Applica il ritaglio"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2739
+#: lib/vutuv_web/live/post_live/composer.ex:3003
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr "Foto grande a sinistra"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2740
+#: lib/vutuv_web/live/post_live/composer.ex:3004
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr "Foto grande a destra"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2745
+#: lib/vutuv_web/live/post_live/composer.ex:3009
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr "Colonne"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2742
+#: lib/vutuv_web/live/post_live/composer.ex:3006
 #, elixir-autogen, elixir-format
 msgid "Cover left"
 msgstr "Copertina a sinistra"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2743
+#: lib/vutuv_web/live/post_live/composer.ex:3007
 #, elixir-autogen, elixir-format
 msgid "Cover on top"
 msgstr "Copertina in alto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2744
+#: lib/vutuv_web/live/post_live/composer.ex:3008
 #, elixir-autogen, elixir-format
 msgid "Cover right"
 msgstr "Copertina a destra"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1912
-#: lib/vutuv_web/live/post_live/composer.ex:2710
-#: lib/vutuv_web/live/post_live/composer.ex:2711
+#: lib/vutuv_web/live/post_live/composer.ex:2050
+#: lib/vutuv_web/live/post_live/composer.ex:2974
+#: lib/vutuv_web/live/post_live/composer.ex:2975
 #, elixir-autogen, elixir-format
 msgid "Crop photo"
 msgstr "Ritaglia la foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2669
+#: lib/vutuv_web/live/post_live/composer.ex:2933
 #, elixir-autogen, elixir-format
 msgid "Cropped"
 msgstr "Ritagliata"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1834
+#: lib/vutuv_web/live/post_live/composer.ex:1972
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr "Trascini qui le foto per aggiungerle"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2746
+#: lib/vutuv_web/live/post_live/composer.ex:3010
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr "Griglia"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2747
+#: lib/vutuv_web/live/post_live/composer.ex:3011
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr "Mosaico"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1914
+#: lib/vutuv_web/live/post_live/composer.ex:2052
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr ""
 "Scelga una forma, poi trascini e ingrandisca. La parte nel riquadro è quella"
 " che il post mostra."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2738
+#: lib/vutuv_web/live/post_live/composer.ex:3002
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr "Affiancate"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2741
+#: lib/vutuv_web/live/post_live/composer.ex:3005
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr "Impilate"
 
-#: lib/vutuv_web/live/post_live/composer.ex:572
+#: lib/vutuv_web/live/post_live/composer.ex:608
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr "Non è stato possibile ritagliare la foto."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3187
+#: lib/vutuv_web/live/post_live/composer.ex:3451
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr ""
 "Questa foto è ritagliata: i download consegnano l'immagine ritagliata, e il "
 "caricamento intatto resta privato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1918
+#: lib/vutuv_web/live/post_live/composer.ex:2056
 #, elixir-autogen, elixir-format
 msgid "Whole photo"
 msgstr "Foto intera"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2936
+#: lib/vutuv_web/live/post_live/composer.ex:3200
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr "Riempi le caselle"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2920
+#: lib/vutuv_web/live/post_live/composer.ex:3184
 #, elixir-autogen, elixir-format
 msgid "Whole photos"
 msgstr "Foto intere"
@@ -19673,17 +19676,17 @@ msgstr ""
 "Il PIN non arriva? L'indirizzo e-mail {email} è corretto? Ha controllato la "
 "cartella dello spam?"
 
-#: lib/vutuv/accounts/user.ex:1451
+#: lib/vutuv/accounts/user.ex:1454
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Non binario"
 
-#: lib/vutuv/accounts/user.ex:1449
+#: lib/vutuv/accounts/user.ex:1452
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr "Femminile"
 
-#: lib/vutuv/accounts/user.ex:1450
+#: lib/vutuv/accounts/user.ex:1453
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Maschile"
@@ -20513,17 +20516,17 @@ msgstr ""
 msgid "Nothing published yet."
 msgstr "Ancora nulla di pubblicato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2202
+#: lib/vutuv_web/live/post_live/composer.ex:2383
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
 msgstr "Pubblica come %{name}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1435
+#: lib/vutuv_web/live/post_live/composer.ex:1503
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr "Non può più scrivere a nome di questa organizzazione."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2179
+#: lib/vutuv_web/live/post_live/composer.ex:2360
 #, elixir-autogen, elixir-format
 msgid "A post in an organization's name is always public."
 msgstr "Un post a nome di un'organizzazione è sempre pubblico."
@@ -21389,19 +21392,19 @@ msgstr "Ha %{used} tag su %{max}."
 msgid "{n} of {max} free slots selected."
 msgstr "Selezionati {n} posti liberi su {max}."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2161
+#: lib/vutuv_web/live/post_live/composer.ex:2342
 #, elixir-autogen, elixir-format
 msgid "More languages"
 msgstr "Altre lingue"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2152
+#: lib/vutuv_web/live/post_live/composer.ex:2333
 #, elixir-autogen, elixir-format
 msgctxt "post composer"
 msgid "Language"
 msgstr "Lingua"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2148
-#: lib/vutuv_web/live/post_live/composer.ex:2149
+#: lib/vutuv_web/live/post_live/composer.ex:2329
+#: lib/vutuv_web/live/post_live/composer.ex:2330
 #, elixir-autogen, elixir-format
 msgid "The language this post is written in"
 msgstr "La lingua in cui è scritto questo post"
@@ -23262,18 +23265,18 @@ msgid "Nothing matches."
 msgstr "Nessun risultato."
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:336
-#: lib/vutuv_web/live/post_live/composer.ex:1998
-#: lib/vutuv_web/live/post_live/composer.ex:2866
+#: lib/vutuv_web/live/post_live/composer.ex:2136
+#: lib/vutuv_web/live/post_live/composer.ex:3130
 #, elixir-autogen, elixir-format
 msgid "Automatic"
 msgstr "Automatico"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2003
+#: lib/vutuv_web/live/post_live/composer.ex:2141
 #, elixir-autogen, elixir-format
 msgid "Drag one photo onto another to swap them."
 msgstr "Trascina una foto su un'altra per scambiarle."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1950
+#: lib/vutuv_web/live/post_live/composer.ex:2088
 #, elixir-autogen, elixir-format
 msgid "Not shown in the gallery — drag one into it to swap."
 msgstr "Non nella galleria — trascinane una dentro per scambiarla."
@@ -23330,17 +23333,17 @@ msgstr "Ritirare davvero la richiesta?"
 msgid "Unmute %{host}"
 msgstr "Riattiva %{host}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1758
+#: lib/vutuv_web/live/post_live/composer.ex:1896
 #, elixir-autogen, elixir-format
 msgid "Draft discarded."
 msgstr "Bozza eliminata."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1797
+#: lib/vutuv_web/live/post_live/composer.ex:1935
 #, elixir-autogen, elixir-format
 msgid "Keep it"
 msgstr "Conserva"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1788
+#: lib/vutuv_web/live/post_live/composer.ex:1926
 #, elixir-autogen, elixir-format
 msgid "Keep this draft for later?"
 msgstr "Conservare questa bozza per dopo?"
@@ -23547,7 +23550,7 @@ msgstr[1] "%{count} video in lavorazione"
 msgid "About %{minutes} min of video"
 msgstr "Circa %{minutes} min di video"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2459
+#: lib/vutuv_web/live/post_live/composer.ex:2640
 #, elixir-autogen, elixir-format
 msgid "Add video"
 msgstr "Aggiungi video"
@@ -23589,32 +23592,32 @@ msgstr "Pubblica senza il video"
 msgid "Reading the frames"
 msgstr "Lettura dei fotogrammi"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2495
+#: lib/vutuv_web/live/post_live/composer.ex:2676
 #, elixir-autogen, elixir-format
 msgid "Remove it to post the text without it, or pick another file."
 msgstr "Lo rimuova per pubblicare il testo senza video, oppure scelga un altro file."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1145
+#: lib/vutuv_web/live/post_live/composer.ex:1196
 #, elixir-autogen, elixir-format
 msgid "Remove the refused video to post the text without it."
 msgstr "Rimuova il video rifiutato per pubblicare il testo senza di esso."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2524
+#: lib/vutuv_web/live/post_live/composer.ex:2705
 #, elixir-autogen, elixir-format
 msgid "Remove video"
 msgstr "Rimuovi video"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2534
+#: lib/vutuv_web/live/post_live/composer.ex:2715
 #, elixir-autogen, elixir-format
 msgid "Tap a frame to make it the cover."
 msgstr "Tocchi un fotogramma per usarlo come copertina."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1008
+#: lib/vutuv_web/live/post_live/composer.ex:1059
 #, elixir-autogen, elixir-format
 msgid "That frame could not be used."
 msgstr "Questo fotogramma non può essere usato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1425
+#: lib/vutuv_web/live/post_live/composer.ex:1493
 #, elixir-autogen, elixir-format
 msgid "The video could not be attached."
 msgstr "Il video non può essere allegato."
@@ -23624,7 +23627,7 @@ msgstr "Il video non può essere allegato."
 msgid "The video is gone."
 msgstr "Il video non c'è più."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1512
+#: lib/vutuv_web/live/post_live/composer.ex:1580
 #, elixir-autogen, elixir-format
 msgid "The video is longer than %{seconds} seconds."
 msgstr "Il video dura più di %{seconds} secondi."
@@ -23645,17 +23648,17 @@ msgstr "Questo video non può essere convertito."
 #: lib/vutuv_web/agent_docs/text.ex:918
 #: lib/vutuv_web/components/post_components.ex:2980
 #: lib/vutuv_web/components/video_components.ex:127
-#: lib/vutuv_web/live/post_live/composer.ex:2458
+#: lib/vutuv_web/live/post_live/composer.ex:2639
 #, elixir-autogen, elixir-format
 msgid "Video"
 msgstr "Video"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2502
+#: lib/vutuv_web/live/post_live/composer.ex:2683
 #, elixir-autogen, elixir-format
 msgid "Video description"
 msgstr "Descrizione del video"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1519
+#: lib/vutuv_web/live/post_live/composer.ex:1587
 #, elixir-autogen, elixir-format
 msgid "Videos cannot be uploaded here."
 msgstr "Qui non è possibile caricare video."
@@ -23665,12 +23668,12 @@ msgstr "Qui non è possibile caricare video."
 msgid "Waiting in line"
 msgstr "In attesa in coda"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2509
+#: lib/vutuv_web/live/post_live/composer.ex:2690
 #, elixir-autogen, elixir-format
 msgid "What is in the video, for people who cannot watch it"
 msgstr "Cosa mostra il video, per chi non può guardarlo"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2498
+#: lib/vutuv_web/live/post_live/composer.ex:2679
 #, elixir-autogen, elixir-format
 msgid "You can post now — the post appears as soon as the video is ready."
 msgstr "Può pubblicare subito: il post apparirà appena il video sarà pronto."
@@ -25542,7 +25545,7 @@ msgstr "Esito"
 msgid "Photo scan"
 msgstr "Controllo delle foto"
 
-#: lib/vutuv_web/live/admin/media_live.ex:270
+#: lib/vutuv_web/live/admin/media_live.ex:271
 #, elixir-autogen, elixir-format
 msgid "Running"
 msgstr "In corso"
@@ -25634,3 +25637,93 @@ msgstr "Copia il link al post"
 #, elixir-autogen, elixir-format
 msgid "Link copied"
 msgstr "Link copiato"
+
+#: lib/vutuv_web/live/post_live/composer.ex:2818
+#, elixir-autogen, elixir-format
+msgid "%{left} of today's %{limit} left (%{percent} %)."
+msgstr "Restano %{left} di %{limit} per oggi (%{percent} %)."
+
+#: lib/vutuv_web/live/post_live/composer.ex:2759
+#, elixir-autogen, elixir-format
+msgid "Add files"
+msgstr "Aggiungi file"
+
+#: lib/vutuv_web/live/admin/media_live.ex:254
+#, elixir-autogen, elixir-format
+msgid "File check"
+msgstr "Controllo file"
+
+#: lib/vutuv_web/live/post_live/composer.ex:3515
+#, elixir-autogen, elixir-format
+msgid "File is larger than %{size}."
+msgstr "Il file è più grande di %{size}."
+
+#: lib/vutuv_web/live/post_live/composer.ex:2758
+#, elixir-autogen, elixir-format
+msgid "Files"
+msgstr "File"
+
+#: lib/vutuv_web/live/post_live/composer.ex:1595
+#, elixir-autogen, elixir-format
+msgid "Files may be up to %{size}."
+msgstr "I file possono arrivare a %{size}."
+
+#: lib/vutuv_web/live/post_live/composer.ex:3525
+#, elixir-autogen, elixir-format
+msgid "No more than %{max} files per post."
+msgstr "Non più di %{max} file per post."
+
+#: lib/vutuv_web/live/post_live/composer.ex:1600
+#, elixir-autogen, elixir-format
+msgid "Only PDF, plain text and Markdown files can be attached."
+msgstr "Si possono allegare solo file PDF, di testo e Markdown."
+
+#: lib/vutuv_web/live/post_live/composer.ex:1618
+#, elixir-autogen, elixir-format
+msgid "PDFs cannot be checked on this site. Text and Markdown files can."
+msgstr "Su questo sito i PDF non possono essere controllati, i file di testo e Markdown sì."
+
+#: lib/vutuv_web/live/post_live/composer.ex:2797
+#, elixir-autogen, elixir-format
+msgid "Remove %{name}"
+msgstr "Rimuovi %{name}"
+
+#: lib/vutuv_web/live/post_live/composer.ex:1606
+#, elixir-autogen, elixir-format
+msgid "This PDF contains a program, which cannot be published here."
+msgstr "Questo PDF contiene un programma e qui non può essere pubblicato."
+
+#: lib/vutuv_web/live/post_live/composer.ex:1615
+#, elixir-autogen, elixir-format
+msgid "This PDF could not be read."
+msgstr "Non è stato possibile leggere questo PDF."
+
+#: lib/vutuv_web/live/post_live/composer.ex:1609
+#, elixir-autogen, elixir-format
+msgid "This PDF does something when it is opened, which cannot be published here."
+msgstr "Questo PDF fa qualcosa quando viene aperto e qui non può essere pubblicato."
+
+#: lib/vutuv_web/live/post_live/composer.ex:1612
+#, elixir-autogen, elixir-format
+msgid "This PDF has another file inside it, which cannot be published here."
+msgstr "Questo PDF contiene un altro file e qui non può essere pubblicato."
+
+#: lib/vutuv_web/live/post_live/composer.ex:1603
+#, elixir-autogen, elixir-format
+msgid "This PDF is password-protected, so it cannot be checked."
+msgstr "Questo PDF è protetto da password, quindi non può essere controllato."
+
+#: lib/vutuv_web/live/post_live/composer.ex:1624
+#, elixir-autogen, elixir-format
+msgid "You have used up this month's upload allowance."
+msgstr "Ha esaurito il Suo limite di caricamento per questo mese."
+
+#: lib/vutuv_web/live/post_live/composer.ex:1621
+#, elixir-autogen, elixir-format
+msgid "You have used up today's upload allowance. It frees up again over the day."
+msgstr "Ha esaurito il Suo limite di caricamento per oggi. Si libera di nuovo nel corso della giornata."
+
+#: lib/vutuv_web/live/post_live/composer.ex:2816
+#, elixir-autogen, elixir-format
+msgid "Your uploads are not limited."
+msgstr "I Suoi caricamenti non hanno limiti."

--- a/priv/repo/migrations/20260910100831_create_attachments.exs
+++ b/priv/repo/migrations/20260910100831_create_attachments.exs
@@ -1,0 +1,70 @@
+defmodule Vutuv.Repo.Migrations.CreateAttachments do
+  use Ecto.Migration
+
+  # Files on posts and messages (issue #2104): the row the composer's upload
+  # writes, and the ledger the per-member budget is counted from.
+  #
+  # Two new tables and nothing else — purely additive, so the release still
+  # serving traffic during the blue/green window neither reads nor writes
+  # either of them (N-1).
+  def change do
+    create table(:attachments) do
+      # The parent, one nullable column each: a file hangs under a post
+      # (#2106) or under a private message (#2110), and under neither while
+      # the composer still holds it. Every query over these has to carry an
+      # `is_nil/1` branch of its own — a NULL in a `NOT IN` list makes the
+      # whole predicate false, and an inner join to `posts` would silently
+      # drop every message's file (the trap in CLAUDE.md).
+      add(:post_id, references(:posts, type: :binary_id, on_delete: :delete_all))
+      add(:message_id, references(:messages, type: :binary_id, on_delete: :delete_all))
+      add(:user_id, references(:users, type: :binary_id, on_delete: :delete_all), null: false)
+
+      # The lookup key and the on-disk directory name, never the row id.
+      add(:token, :string, null: false)
+
+      # What the member sent, kept for display and for the download's name.
+      # The sniffed format decides `content_type`, never the browser's claim.
+      add(:file_name, :string, null: false)
+      add(:content_type, :string, null: false)
+      add(:size_bytes, :bigint, null: false)
+
+      # How many pages the PDF has (`pdfinfo`), nil for a text file. What
+      # #2105 renders previews from.
+      add(:page_count, :integer)
+
+      # Where the pipeline is: stored -> ready, or failed. #2105 adds the
+      # rendering steps between them; today an accepted file is `stored`, so
+      # nothing writes this yet and the default is the whole answer.
+      add(:stage, :string, null: false, default: "stored")
+
+      timestamps()
+    end
+
+    create(unique_index(:attachments, [:token]))
+    create(index(:attachments, [:post_id]))
+    create(index(:attachments, [:message_id]))
+    # The abandoned-composer sweep, like the pending-image and pending-clip
+    # ones: a row with neither parent and old enough.
+    create(
+      index(:attachments, [:inserted_at],
+        where: "post_id IS NULL AND message_id IS NULL",
+        name: :attachments_pending_inserted_at_index
+      )
+    )
+
+    # The budget ledger. Deliberately its own table rather than a sum over
+    # `attachments`: the budget counts **accepted uploads**, so deleting a
+    # file (or having the sweep take it) must not give the member their
+    # megabytes back. Nothing here identifies the file, only that a member
+    # was granted so many bytes at so much o'clock.
+    create table(:attachment_uploads) do
+      add(:user_id, references(:users, type: :binary_id, on_delete: :delete_all), null: false)
+      add(:size_bytes, :bigint, null: false)
+
+      timestamps(updated_at: false)
+    end
+
+    # The only query there is: this member's accepted bytes since a cutoff.
+    create(index(:attachment_uploads, [:user_id, :inserted_at]))
+  end
+end

--- a/test/support/attachment_fixtures.ex
+++ b/test/support/attachment_fixtures.ex
@@ -1,0 +1,187 @@
+defmodule Vutuv.AttachmentFixtures do
+  @moduledoc """
+  Files for the attachment tests (issue #2104), **built at run time** rather
+  than checked in — the same reasoning as `Vutuv.VideoFixtures`, and stronger
+  here: half of these are PDFs carrying JavaScript, an OpenAction or an
+  embedded payload, and a repository this public should not hold one even as a
+  fixture.
+
+  Each builder writes a minimal but structurally real PDF (one page, one
+  font), so `pdfinfo` reads it as a document rather than rejecting it as
+  broken. `hidden/2` runs a file through `qpdf --object-streams=generate`,
+  which moves every dictionary into a Flate-compressed object stream — the one
+  transformation that makes a raw-byte scan for `/JavaScript` come back empty
+  while the document still does the same thing.
+  """
+
+  @doc "A PDF with nothing in it but a page."
+  def plain_pdf(dir), do: write(dir, "plain.pdf", pdf(:plain))
+
+  @doc "A PDF whose catalog carries a document-level JavaScript action."
+  def javascript_pdf(dir), do: write(dir, "javascript.pdf", pdf(:javascript))
+
+  @doc "A PDF that performs a URI action when it is opened."
+  def open_action_pdf(dir), do: write(dir, "open_action.pdf", pdf(:open_action))
+
+  @doc "A PDF whose OpenAction is a plain destination — what LaTeX and Word write."
+  def destination_pdf(dir), do: write(dir, "destination.pdf", pdf(:destination))
+
+  @doc "A PDF carrying another file inside it."
+  def embedded_file_pdf(dir), do: write(dir, "embedded.pdf", pdf(:embedded))
+
+  @doc "A PDF encrypted with a user password — `pdfinfo` cannot even open it."
+  def encrypted_pdf(dir) do
+    encrypt(dir, "encrypted.pdf", ["--user-password=secret", "--owner-password=owner"])
+  end
+
+  @doc """
+  A PDF with an owner password only: readable by anybody, but restricted, and
+  the shape `pdfinfo` answers `Encrypted: yes` for rather than refusing.
+  """
+  def owner_encrypted_pdf(dir) do
+    encrypt(dir, "owner-encrypted.pdf", ["--user-password=", "--owner-password=owner"])
+  end
+
+  @doc """
+  The same file with every dictionary moved into a compressed object stream.
+  Needs `qpdf`; returns `nil` when it is not installed, so a machine without it
+  skips the "and the same trick hidden" half rather than failing the suite.
+  """
+  def hidden(dir, source) do
+    dest = Path.join(dir, "hidden-" <> Path.basename(source))
+
+    with qpdf when is_binary(qpdf) <- System.find_executable("qpdf"),
+         {_out, 0} <-
+           System.cmd(qpdf, ["--object-streams=generate", source, dest], stderr_to_stdout: true) do
+      dest
+    else
+      _no_qpdf -> nil
+    end
+  end
+
+  @doc "A ZIP file under a `.pdf` name: the extension lies, the bytes do not."
+  def zip_named_pdf(dir) do
+    # A real (empty) ZIP: the end-of-central-directory record on its own.
+    write(dir, "invoice.pdf", "PK\x05\x06" <> :binary.copy(<<0>>, 18))
+  end
+
+  @doc "A plain text file."
+  def text_file(dir, body \\ "Just some notes.\nOn two lines.\n"),
+    do: write(dir, "notes.txt", body)
+
+  @doc "A Markdown file."
+  def markdown_file(dir), do: write(dir, "readme.md", "# Title\n\nA paragraph.\n")
+
+  @doc "A file of `bytes` zero bytes under a `.txt` name."
+  def sized_file(dir, bytes, name \\ "big.txt"),
+    do: write(dir, name, :binary.copy("a", bytes))
+
+  @doc """
+  Sets keys of `:attachments` for the rest of the test module (restored on
+  exit), the twin of `Vutuv.VideoFixtures.put_video_config/2`. The keys are read
+  by the chokepoint, the composer and the sweeper alike, so the module must be
+  `async: false`.
+  """
+  def put_config(overrides) when is_list(overrides) do
+    Vutuv.WebPushHelpers.put_config(
+      :attachments,
+      Keyword.merge(Application.fetch_env!(:vutuv, :attachments), overrides)
+    )
+  end
+
+  defp encrypt(dir, name, args) do
+    source = plain_pdf(dir)
+    dest = Path.join(dir, name)
+
+    qpdf =
+      System.find_executable("qpdf") ||
+        raise "qpdf is not installed; the encrypted-PDF tests need it to build their fixture"
+
+    {out, status} =
+      System.cmd(qpdf, ["--encrypt"] ++ args ++ ["--bits=256", "--", source, dest],
+        stderr_to_stdout: true
+      )
+
+    if status != 0, do: raise("qpdf could not encrypt the fixture (#{status}): #{out}")
+    dest
+  end
+
+  defp write(dir, name, bytes) do
+    File.mkdir_p!(dir)
+    path = Path.join(dir, name)
+    File.write!(path, bytes)
+    path
+  end
+
+  ## The PDFs themselves
+
+  @content "BT /F1 24 Tf 72 700 Td (hello) Tj ET"
+
+  defp pdf(kind) do
+    {root, extra} = catalog(kind)
+
+    build([
+      {1, root},
+      {2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>"},
+      {3,
+       "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R " <>
+         "/Resources << /Font << /F1 5 0 R >> >> >>"},
+      {4, "<< /Length #{byte_size(@content)} >>\nstream\n#{@content}\nendstream"},
+      {5, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>"}
+      | extra
+    ])
+  end
+
+  defp catalog(:plain), do: {"<< /Type /Catalog /Pages 2 0 R >>", []}
+
+  defp catalog(:javascript) do
+    {"<< /Type /Catalog /Pages 2 0 R /Names << /JavaScript << /Names [(a) 6 0 R] >> >> >>",
+     [{6, "<< /S /JavaScript /JS (app.alert\\(1\\);) >>"}]}
+  end
+
+  defp catalog(:open_action) do
+    {"<< /Type /Catalog /Pages 2 0 R /OpenAction << /S /URI /URI (https://example.com) >> >>", []}
+  end
+
+  defp catalog(:destination) do
+    {"<< /Type /Catalog /Pages 2 0 R /OpenAction [3 0 R /FitH 800] >>", []}
+  end
+
+  defp catalog(:embedded) do
+    payload = "payload bytes"
+
+    {"<< /Type /Catalog /Pages 2 0 R /Names << /EmbeddedFiles << /Names [(f.txt) 6 0 R] >> >> >>",
+     [
+       {6, "<< /Type /Filespec /F (f.txt) /EF << /F 7 0 R >> >>"},
+       {7, "<< /Length #{byte_size(payload)} >>\nstream\n#{payload}\nendstream"}
+     ]}
+  end
+
+  # Serialises numbered objects with a cross-reference table. Nothing clever:
+  # the offsets have to be right or poppler will not read the file, which is
+  # what makes these fixtures worth having.
+  defp build(objects) do
+    objects = Enum.sort_by(objects, &elem(&1, 0))
+
+    {body, offsets} =
+      Enum.reduce(objects, {"%PDF-1.7\n", %{}}, fn {number, content}, {acc, offsets} ->
+        {acc <> "#{number} 0 obj\n#{content}\nendobj\n", Map.put(offsets, number, byte_size(acc))}
+      end)
+
+    size = (offsets |> Map.keys() |> Enum.max()) + 1
+
+    entries =
+      Enum.map_join(1..(size - 1), fn number ->
+        offsets
+        |> Map.fetch!(number)
+        |> Integer.to_string()
+        |> String.pad_leading(10, "0")
+        |> Kernel.<>(" 00000 n \n")
+      end)
+
+    body <>
+      "xref\n0 #{size}\n0000000000 65535 f \n" <>
+      entries <>
+      "trailer\n<< /Size #{size} /Root 1 0 R >>\nstartxref\n#{byte_size(body)}\n%%EOF\n"
+  end
+end

--- a/test/support/attachment_fixtures.ex
+++ b/test/support/attachment_fixtures.ex
@@ -26,6 +26,19 @@ defmodule Vutuv.AttachmentFixtures do
   @doc "A PDF whose OpenAction is a plain destination — what LaTeX and Word write."
   def destination_pdf(dir), do: write(dir, "destination.pdf", pdf(:destination))
 
+  @doc """
+  A PDF whose OpenAction *looks* like a destination — `/S /GoTo` — and chains a
+  second action behind `/Next` that launches an application. `pdfinfo` answers
+  `JavaScript: no`; only naming `/Launch` catches it.
+  """
+  def chained_launch_pdf(dir), do: write(dir, "chained.pdf", pdf(:chained_launch))
+
+  @doc """
+  A PDF with no OpenAction at all: the launch hangs off the page's `/AA /O`,
+  which fires on the same event under a different name.
+  """
+  def page_action_launch_pdf(dir), do: write(dir, "page-action.pdf", pdf(:page_action))
+
   @doc "A PDF carrying another file inside it."
   def embedded_file_pdf(dir), do: write(dir, "embedded.pdf", pdf(:embedded))
 
@@ -123,13 +136,24 @@ defmodule Vutuv.AttachmentFixtures do
     build([
       {1, root},
       {2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>"},
-      {3,
-       "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R " <>
-         "/Resources << /Font << /F1 5 0 R >> >> >>"},
+      {3, page(kind)},
       {4, "<< /Length #{byte_size(@content)} >>\nstream\n#{@content}\nendstream"},
       {5, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>"}
       | extra
     ])
+  end
+
+  # The page dictionary. `:page_action` hangs an additional action off it, which
+  # is where a launch goes when there is no `/OpenAction` to put it in.
+  defp page(:page_action) do
+    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R " <>
+      "/AA << /O << /S /Launch /F (calc.exe) >> >> " <>
+      "/Resources << /Font << /F1 5 0 R >> >> >>"
+  end
+
+  defp page(_kind) do
+    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R " <>
+      "/Resources << /Font << /F1 5 0 R >> >> >>"
   end
 
   defp catalog(:plain), do: {"<< /Type /Catalog /Pages 2 0 R >>", []}
@@ -146,6 +170,13 @@ defmodule Vutuv.AttachmentFixtures do
   defp catalog(:destination) do
     {"<< /Type /Catalog /Pages 2 0 R /OpenAction [3 0 R /FitH 800] >>", []}
   end
+
+  defp catalog(:chained_launch) do
+    {"<< /Type /Catalog /Pages 2 0 R /OpenAction << /S /GoTo /D [3 0 R /Fit] " <>
+       "/Next << /S /Launch /F (calc.exe) >> >> >>", []}
+  end
+
+  defp catalog(:page_action), do: {"<< /Type /Catalog /Pages 2 0 R >>", []}
 
   defp catalog(:embedded) do
     payload = "payload bytes"

--- a/test/support/attachment_fixtures.ex
+++ b/test/support/attachment_fixtures.ex
@@ -42,14 +42,20 @@ defmodule Vutuv.AttachmentFixtures do
   @doc "A PDF carrying another file inside it."
   def embedded_file_pdf(dir), do: write(dir, "embedded.pdf", pdf(:embedded))
 
-  @doc "A PDF encrypted with a user password — `pdfinfo` cannot even open it."
+  @doc """
+  A PDF encrypted with a user password — `pdfinfo` cannot even open it. Needs
+  `qpdf`; returns `nil` when it is not installed (CI carries poppler for the
+  gate itself but not qpdf), so a machine without it skips the encryption tests
+  rather than failing the suite, the same way `hidden/2` does.
+  """
   def encrypted_pdf(dir) do
     encrypt(dir, "encrypted.pdf", ["--user-password=secret", "--owner-password=owner"])
   end
 
   @doc """
   A PDF with an owner password only: readable by anybody, but restricted, and
-  the shape `pdfinfo` answers `Encrypted: yes` for rather than refusing.
+  the shape `pdfinfo` answers `Encrypted: yes` for rather than refusing. Needs
+  `qpdf`; `nil` without it, as `encrypted_pdf/1`.
   """
   def owner_encrypted_pdf(dir) do
     encrypt(dir, "owner-encrypted.pdf", ["--user-password=", "--owner-password=owner"])
@@ -70,6 +76,69 @@ defmodule Vutuv.AttachmentFixtures do
     else
       _no_qpdf -> nil
     end
+  end
+
+  @doc """
+  An `/OpenAction` that launches something, hidden in an object stream padded
+  past `PdfGate`'s per-stream inflation cut. One `qpdf --object-streams=generate`
+  over a catalog carrying 9 MB of filler yields a ~10 KB file whose only object
+  stream inflates past the cut — so a pass that *skipped* what it could not
+  finish reading walked straight past the action. Returns `nil` without qpdf.
+  """
+  def oversized_object_stream_pdf(dir) do
+    padded =
+      write(
+        dir,
+        "padded-source.pdf",
+        pdf(:launch_padded)
+      )
+
+    dest = Path.join(dir, "padded.pdf")
+
+    with qpdf when is_binary(qpdf) <- System.find_executable("qpdf"),
+         {_out, 0} <-
+           System.cmd(qpdf, ["--object-streams=generate", "--compress-streams=y", padded, dest],
+             stderr_to_stdout: true
+           ) do
+      File.rm(padded)
+      dest
+    else
+      _no_qpdf -> nil
+    end
+  end
+
+  @doc """
+  A launch action genuinely compressed inside a FlateDecode stream whose
+  payload carries the literal bytes `endstream` ahead of it, planted in an
+  uncompressed deflate block. `/Launch` is not in the raw file, and a scan that
+  ended the stream at the first literal `endstream` would inflate only the
+  decoy. Needs no external tool — the deflate stream is assembled here.
+  """
+  def endstream_decoy_pdf(dir) do
+    decoy = "clean content endstream more padding so the scan would stop here"
+    real = "/OpenAction << /S /Launch /F (calc.exe) >> plus real bytes to compress"
+
+    # A zlib stream is a 2-byte header, deflate blocks, then a 4-byte adler32.
+    # The decoy is a stored (uncompressed) block, so its `endstream` bytes stay
+    # literal; the real payload is `:zlib.zip/1`'s raw deflate, whose last block
+    # is final. The adler32 of the whole output is lifted off a normal
+    # `:zlib.compress/1` so the stream verifies and inflates to decoy <> real.
+    full = decoy <> real
+    zwrapped = :zlib.compress(full)
+    adler = binary_part(zwrapped, byte_size(zwrapped) - 4, 4)
+
+    body = <<0x78, 0x9C>> <> stored_block(decoy) <> :zlib.zip(real) <> adler
+    ^full = :zlib.uncompress(body)
+
+    stream = "<< /Length #{byte_size(body)} /Filter /FlateDecode >>\nstream\n#{body}\nendstream"
+    write(dir, "endstream-decoy.pdf", pdf(:plain, [{6, stream}]))
+  end
+
+  # One uncompressed deflate block (BTYPE 00), never the final one, so a real
+  # compressed block can follow it. LEN then its ones-complement, little-endian.
+  defp stored_block(payload) do
+    len = byte_size(payload)
+    <<0, len::little-16, Bitwise.bxor(len, 0xFFFF)::little-16>> <> payload
   end
 
   @doc "A ZIP file under a `.pdf` name: the extension lies, the bytes do not."
@@ -103,20 +172,22 @@ defmodule Vutuv.AttachmentFixtures do
   end
 
   defp encrypt(dir, name, args) do
-    source = plain_pdf(dir)
-    dest = Path.join(dir, name)
+    case System.find_executable("qpdf") do
+      nil ->
+        nil
 
-    qpdf =
-      System.find_executable("qpdf") ||
-        raise "qpdf is not installed; the encrypted-PDF tests need it to build their fixture"
+      qpdf ->
+        source = plain_pdf(dir)
+        dest = Path.join(dir, name)
 
-    {out, status} =
-      System.cmd(qpdf, ["--encrypt"] ++ args ++ ["--bits=256", "--", source, dest],
-        stderr_to_stdout: true
-      )
+        {out, status} =
+          System.cmd(qpdf, ["--encrypt"] ++ args ++ ["--bits=256", "--", source, dest],
+            stderr_to_stdout: true
+          )
 
-    if status != 0, do: raise("qpdf could not encrypt the fixture (#{status}): #{out}")
-    dest
+        if status != 0, do: raise("qpdf could not encrypt the fixture (#{status}): #{out}")
+        dest
+    end
   end
 
   defp write(dir, name, bytes) do
@@ -130,17 +201,19 @@ defmodule Vutuv.AttachmentFixtures do
 
   @content "BT /F1 24 Tf 72 700 Td (hello) Tj ET"
 
-  defp pdf(kind) do
+  defp pdf(kind, more \\ []) do
     {root, extra} = catalog(kind)
 
-    build([
-      {1, root},
-      {2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>"},
-      {3, page(kind)},
-      {4, "<< /Length #{byte_size(@content)} >>\nstream\n#{@content}\nendstream"},
-      {5, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>"}
-      | extra
-    ])
+    build(
+      [
+        {1, root},
+        {2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>"},
+        {3, page(kind)},
+        {4, "<< /Length #{byte_size(@content)} >>\nstream\n#{@content}\nendstream"},
+        {5, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>"}
+        | extra
+      ] ++ more
+    )
   end
 
   # The page dictionary. `:page_action` hangs an additional action off it, which
@@ -177,6 +250,14 @@ defmodule Vutuv.AttachmentFixtures do
   end
 
   defp catalog(:page_action), do: {"<< /Type /Catalog /Pages 2 0 R >>", []}
+
+  # 9 MB of filler in the catalog, so the object stream qpdf builds from it
+  # inflates past `PdfGate`'s per-stream cut. The padding compresses to nothing,
+  # which is what makes the finished file ~10 KB.
+  defp catalog(:launch_padded) do
+    {"<< /Type /Catalog /Pages 2 0 R /OpenAction << /S /Launch /F (calc.exe) >> " <>
+       "/Pad (" <> String.duplicate("A", 9_000_000) <> ") >>", []}
+  end
 
   defp catalog(:embedded) do
     payload = "payload bytes"

--- a/test/vutuv/attachments_test.exs
+++ b/test/vutuv/attachments_test.exs
@@ -169,6 +169,24 @@ defmodule Vutuv.AttachmentsTest do
       assert {:error, :embedded_files} = upload(user, Fixtures.embedded_file_pdf(files))
     end
 
+    # The `/OpenAction` rule reads what follows the name and lets a destination
+    # through, so an action that is not spelled `/OpenAction <<action>>` walked
+    # past it: `pdfinfo` answers `JavaScript: no` for both of these and the gate
+    # accepted them until the acting names were added. Calibration: take
+    # `@acting_names` back out of `Vutuv.Uploads.PdfGate` and both go red with
+    # `{:ok, _}`. Cost measured over 1,051 real local PDFs: `/Launch`,
+    # `/SubmitForm` and `/ImportData` in none of them.
+    test "an OpenAction that chains a launch behind /Next is refused", %{
+      user: user,
+      files: files
+    } do
+      assert {:error, :open_action} = upload(user, Fixtures.chained_launch_pdf(files))
+    end
+
+    test "a page whose /AA launches something is refused", %{user: user, files: files} do
+      assert {:error, :open_action} = upload(user, Fixtures.page_action_launch_pdf(files))
+    end
+
     test "hiding the trick in an object stream does not get it past", %{user: user, files: files} do
       # `qpdf --object-streams=generate` compresses every dictionary away, so
       # a raw-byte grep for these three names comes back empty. Each is

--- a/test/vutuv/attachments_test.exs
+++ b/test/vutuv/attachments_test.exs
@@ -1,0 +1,292 @@
+defmodule Vutuv.AttachmentsTest do
+  @moduledoc """
+  The upload chokepoint for files on posts (issue #2104): who may upload, what
+  the caps refuse, what the PDF gate refuses, and the budget that counts
+  accepted uploads rather than stored bytes.
+
+  The PDFs are real and built at run time (`Vutuv.AttachmentFixtures`), and
+  `pdfinfo` really runs, so what is asserted here is what a member gets. Each
+  hostile PDF is tried twice: as written, and with every dictionary moved into
+  a compressed object stream — the transformation that empties a raw-byte scan
+  while the document goes on doing the same thing.
+  """
+
+  use Vutuv.DataCase
+
+  import Vutuv.WebPushHelpers, only: [put_config: 2]
+
+  alias Vutuv.AttachmentFixtures, as: Fixtures
+  alias Vutuv.Attachments
+  alias Vutuv.Attachments.Attachment
+  alias Vutuv.AttachmentStore
+  alias Vutuv.MediaJobs.MediaJob
+  alias Vutuv.Repo
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "vutuv_attachments_#{System.unique_integer([:positive])}")
+    files = Path.join(tmp, "files")
+    File.mkdir_p!(files)
+    put_config(:uploads_dir_prefix, tmp)
+    on_exit(fn -> File.rm_rf(tmp) end)
+
+    # Uploads are for admins until an installation opens them, exactly like
+    # video; the budget block below opens them and uses plain members, since
+    # an admin has no budget to hit.
+    %{user: insert_activated_user(admin?: true), tmp: tmp, files: files}
+  end
+
+  defp upload(user, path), do: Attachments.create_pending(user, path, Path.basename(path))
+
+  describe "who may upload" do
+    test "a plain member is refused while uploads are for admins", %{files: files} do
+      member = insert_activated_user()
+      assert {:error, :disabled} = upload(member, Fixtures.plain_pdf(files))
+    end
+
+    test "with the installation switched off nobody may", %{user: user, files: files} do
+      Fixtures.put_config(enabled: false)
+
+      assert {:error, :disabled} = upload(user, Fixtures.plain_pdf(files))
+    end
+  end
+
+  describe "what is accepted" do
+    test "a PDF is stored with its page count", %{user: user, files: files} do
+      assert {:ok, %Attachment{} = attachment} = upload(user, Fixtures.plain_pdf(files))
+      assert attachment.content_type == "application/pdf"
+      assert attachment.page_count == 1
+      assert attachment.post_id == nil and attachment.message_id == nil
+      assert attachment.size_bytes > 0
+    end
+
+    test "a text file and a Markdown file keep their own content types", %{
+      user: user,
+      files: files
+    } do
+      assert {:ok, text} = upload(user, Fixtures.text_file(files))
+      assert text.content_type == "text/plain"
+      assert text.page_count == nil
+
+      assert {:ok, markdown} = upload(user, Fixtures.markdown_file(files))
+      assert markdown.content_type == "text/markdown"
+    end
+
+    test "the original is kept verbatim and the served copy is written", %{
+      user: user,
+      files: files
+    } do
+      source = Fixtures.plain_pdf(files)
+      assert {:ok, attachment} = upload(user, source)
+
+      original = AttachmentStore.original_path(attachment.token)
+      assert File.read!(original) == File.read!(source)
+      assert File.exists?(AttachmentStore.served_path(attachment.token))
+    end
+
+    test "an OpenAction that is only a destination is fine", %{user: user, files: files} do
+      assert {:ok, _attachment} = upload(user, Fixtures.destination_pdf(files))
+    end
+
+    test "the intake writes a media job", %{user: user, files: files} do
+      assert {:ok, _attachment} = upload(user, Fixtures.plain_pdf(files))
+
+      assert [%MediaJob{kind: "attachment_intake", status: "done"}] =
+               Repo.all(MediaJob)
+    end
+
+    test "a refusal is a finished media job, not a failed one", %{user: user, files: files} do
+      assert {:error, :javascript} = upload(user, Fixtures.javascript_pdf(files))
+
+      assert [%MediaJob{kind: "attachment_intake", status: "done", detail: detail}] =
+               Repo.all(MediaJob)
+
+      assert detail =~ "javascript"
+    end
+  end
+
+  describe "the size cap" do
+    test "one byte over is refused", %{user: user, files: files} do
+      Fixtures.put_config(max_filesize: 1_000)
+
+      assert {:error, :too_large} = upload(user, Fixtures.sized_file(files, 1_001))
+      assert {:ok, _} = upload(user, Fixtures.sized_file(files, 1_000, "exact.txt"))
+    end
+
+    test "an over-cap file is never stored", %{user: user, files: files, tmp: tmp} do
+      Fixtures.put_config(max_filesize: 1_000)
+
+      assert {:error, :too_large} = upload(user, Fixtures.sized_file(files, 5_000))
+      assert Path.wildcard(Path.join(tmp, "attachments/**/*")) == []
+    end
+  end
+
+  describe "the format is read from the bytes" do
+    test "a ZIP under a .pdf name is refused", %{user: user, files: files} do
+      assert {:error, :invalid_file} = upload(user, Fixtures.zip_named_pdf(files))
+    end
+
+    test "a PDF under a .txt name is refused", %{user: user, files: files} do
+      pdf = Fixtures.plain_pdf(files)
+      renamed = Path.join(files, "notes.txt")
+      File.cp!(pdf, renamed)
+
+      assert {:error, :invalid_file} = upload(user, renamed)
+    end
+
+    test "an extension nobody offered is refused", %{user: user, files: files} do
+      path = Path.join(files, "script.sh")
+      File.write!(path, "echo hi\n")
+
+      assert {:error, :invalid_file} = upload(user, path)
+    end
+
+    test "a text file with NUL bytes in it is not text", %{user: user, files: files} do
+      path = Path.join(files, "binary.txt")
+      File.write!(path, "hello" <> <<0, 1, 2>> <> "world")
+
+      assert {:error, :invalid_file} = upload(user, path)
+    end
+  end
+
+  describe "the PDF gate" do
+    test "an encrypted PDF is refused", %{user: user, files: files} do
+      assert {:error, :encrypted} = upload(user, Fixtures.encrypted_pdf(files))
+    end
+
+    test "a PDF with an owner password is refused too", %{user: user, files: files} do
+      assert {:error, :encrypted} = upload(user, Fixtures.owner_encrypted_pdf(files))
+    end
+
+    test "a PDF with JavaScript is refused", %{user: user, files: files} do
+      assert {:error, :javascript} = upload(user, Fixtures.javascript_pdf(files))
+    end
+
+    test "a PDF that acts when it is opened is refused", %{user: user, files: files} do
+      assert {:error, :open_action} = upload(user, Fixtures.open_action_pdf(files))
+    end
+
+    test "a PDF carrying another file is refused", %{user: user, files: files} do
+      assert {:error, :embedded_files} = upload(user, Fixtures.embedded_file_pdf(files))
+    end
+
+    test "hiding the trick in an object stream does not get it past", %{user: user, files: files} do
+      # `qpdf --object-streams=generate` compresses every dictionary away, so
+      # a raw-byte grep for these three names comes back empty. Each is
+      # asserted by name: without the inflation pass in `PdfGate` the
+      # `/OpenAction` line is the one that goes red, because poppler answers
+      # the other two for itself.
+      got =
+        for {source, reason} <- [
+              {Fixtures.javascript_pdf(files), :javascript},
+              {Fixtures.open_action_pdf(files), :open_action},
+              {Fixtures.embedded_file_pdf(files), :embedded_files}
+            ],
+            hidden = Fixtures.hidden(files, source),
+            hidden != nil do
+          case upload(user, hidden) do
+            {:error, seen} -> {reason, seen}
+            {:ok, _accepted} -> {reason, :accepted}
+          end
+        end
+
+      assert Enum.all?(got, fn {reason, seen} -> reason == seen end),
+             "hidden in an object stream, the gate answered: #{inspect(got)}"
+    end
+
+    test "a refused PDF leaves nothing on disk", %{user: user, files: files, tmp: tmp} do
+      assert {:error, :javascript} = upload(user, Fixtures.javascript_pdf(files))
+      assert Path.wildcard(Path.join(tmp, "attachments/**/*")) == []
+      assert Path.wildcard(Path.join(tmp, "originals/attachments/**/*")) == []
+    end
+
+    test "without poppler a PDF is refused and text still works", %{user: user, files: files} do
+      Fixtures.put_config(pdfinfo: "vutuv-no-such-binary")
+
+      Attachments.forget_capability()
+      on_exit(&Attachments.forget_capability/0)
+
+      refute Attachments.pdf_supported?()
+      assert {:error, :pdf_unavailable} = upload(user, Fixtures.plain_pdf(files))
+      assert {:ok, _text} = upload(user, Fixtures.text_file(files))
+    end
+  end
+
+  describe "the budget" do
+    setup do
+      Fixtures.put_config(uploaders: :members, daily_budget: 3_000, monthly_budget: 5_000)
+
+      %{member: insert_activated_user()}
+    end
+
+    test "a member at their daily budget is refused", %{member: member, files: files} do
+      assert {:ok, _} = upload(member, Fixtures.sized_file(files, 2_000, "a.txt"))
+      assert {:error, :daily_budget} = upload(member, Fixtures.sized_file(files, 1_500, "b.txt"))
+    end
+
+    test "a member at their monthly budget is refused", %{member: member, files: files} do
+      # Yesterday's uploads are outside the daily window but inside the monthly one.
+      Attachments.record_upload!(member, 4_500, hours_ago: 30)
+
+      assert {:error, :monthly_budget} =
+               upload(member, Fixtures.sized_file(files, 1_000, "c.txt"))
+    end
+
+    test "deleting the file does not give the bytes back", %{member: member, files: files} do
+      assert {:ok, attachment} = upload(member, Fixtures.sized_file(files, 2_000, "d.txt"))
+      before = Attachments.budget_for(member)
+
+      :ok = Attachments.delete_pending(attachment)
+
+      assert Attachments.budget_for(member).daily.used == before.daily.used
+      assert {:error, :daily_budget} = upload(member, Fixtures.sized_file(files, 1_500, "e.txt"))
+    end
+
+    test "a refused upload costs nothing", %{member: member, files: files} do
+      assert {:error, :javascript} = upload(member, Fixtures.javascript_pdf(files))
+      assert Attachments.budget_for(member).daily.used == 0
+    end
+
+    test "an admin has no budget", %{user: user, files: files} do
+      budget = Attachments.budget_for(user)
+      assert budget.unlimited?
+      assert budget.daily == nil and budget.monthly == nil
+
+      assert {:ok, _} = upload(user, Fixtures.sized_file(files, 4_000, "f.txt"))
+      assert {:ok, _} = upload(user, Fixtures.sized_file(files, 4_000, "g.txt"))
+    end
+  end
+
+  describe "the abandoned-composer sweep" do
+    test "a file nobody attached is taken with its bytes", %{user: user, files: files} do
+      assert {:ok, attachment} = upload(user, Fixtures.plain_pdf(files))
+      dir = Path.dirname(AttachmentStore.served_path(attachment.token))
+
+      assert Attachments.sweep_pending(0) == 1
+      refute Repo.get(Attachment, attachment.id)
+      refute File.exists?(dir)
+      refute File.exists?(AttachmentStore.original_path(attachment.token) || "/nonexistent")
+    end
+
+    test "a file that belongs to a post stays", %{user: user, files: files} do
+      assert {:ok, attachment} = upload(user, Fixtures.plain_pdf(files))
+      {:ok, post} = Vutuv.Posts.create_post(user, %{body: "text"})
+
+      attachment |> Ecto.Changeset.change(post_id: post.id) |> Repo.update!()
+
+      assert Attachments.sweep_pending(0) == 0
+      assert Repo.get(Attachment, attachment.id)
+    end
+
+    test "a file that belongs to a message stays", %{user: user, files: files} do
+      assert {:ok, attachment} = upload(user, Fixtures.plain_pdf(files))
+      other = insert_activated_user()
+      {:ok, conversation} = Vutuv.Chat.find_or_create_conversation(user, other)
+      message = Vutuv.ChatHelpers.send!(user, conversation)
+
+      attachment |> Ecto.Changeset.change(message_id: message.id) |> Repo.update!()
+
+      assert Attachments.sweep_pending(0) == 0
+      assert Repo.get(Attachment, attachment.id)
+    end
+  end
+end

--- a/test/vutuv/attachments_test.exs
+++ b/test/vutuv/attachments_test.exs
@@ -149,12 +149,22 @@ defmodule Vutuv.AttachmentsTest do
   end
 
   describe "the PDF gate" do
+    # The encrypted fixtures are built with qpdf, which the gate itself does not
+    # use (poppler answers encryption) — CI carries poppler but not qpdf, so
+    # `nil` means "cannot build the fixture here" and the check is left to a dev
+    # machine with qpdf, the same skip `hidden/2` already takes.
     test "an encrypted PDF is refused", %{user: user, files: files} do
-      assert {:error, :encrypted} = upload(user, Fixtures.encrypted_pdf(files))
+      case Fixtures.encrypted_pdf(files) do
+        nil -> :ok
+        path -> assert {:error, :encrypted} = upload(user, path)
+      end
     end
 
     test "a PDF with an owner password is refused too", %{user: user, files: files} do
-      assert {:error, :encrypted} = upload(user, Fixtures.owner_encrypted_pdf(files))
+      case Fixtures.owner_encrypted_pdf(files) do
+        nil -> :ok
+        path -> assert {:error, :encrypted} = upload(user, path)
+      end
     end
 
     test "a PDF with JavaScript is refused", %{user: user, files: files} do
@@ -209,6 +219,32 @@ defmodule Vutuv.AttachmentsTest do
 
       assert Enum.all?(got, fn {reason, seen} -> reason == seen end),
              "hidden in an object stream, the gate answered: #{inspect(got)}"
+    end
+
+    test "a launch hidden in a stream padded past the inflation cut is refused", %{
+      user: user,
+      files: files
+    } do
+      # One `qpdf --object-streams=generate` over a catalog padded to 9 MB puts
+      # `/OpenAction << /S /Launch >>` in a ~10 KB file whose only object stream
+      # inflates past `@stream_limit`. Skipping that stream (the shape before
+      # the fix) accepted it; refusing an unfinished inflate catches it.
+      # Calibration: make `scan_streams/2`'s `:too_big` branch skip again and
+      # this goes red with `{:ok, _}`. Returns nil without qpdf → skipped.
+      case Fixtures.oversized_object_stream_pdf(files) do
+        nil -> :ok
+        path -> assert {:error, :unreadable} = upload(user, path)
+      end
+    end
+
+    test "a launch compressed behind a literal endstream is refused", %{user: user, files: files} do
+      # A stored deflate block carries the nine bytes `endstream` ahead of a
+      # genuinely compressed `/OpenAction << /S /Launch >>`, so `/Launch` is not
+      # in the raw bytes and a scan that ended each stream at the first literal
+      # `endstream` would inflate only the decoy. Inflating to the deflate
+      # stream's own end marker reads the whole thing. Calibration: end
+      # `streams/1` at `endstream` again and this goes red with `{:ok, _}`.
+      assert {:error, :open_action} = upload(user, Fixtures.endstream_decoy_pdf(files))
     end
 
     test "a refused PDF leaves nothing on disk", %{user: user, files: files, tmp: tmp} do

--- a/test/vutuv/uploads_gitignore_test.exs
+++ b/test/vutuv/uploads_gitignore_test.exs
@@ -37,6 +37,7 @@ defmodule Vutuv.UploadsGitignoreTest do
     job_posting_images
     press_kit
     remote_media
+    attachments
   )
 
   test "no member upload artifact is tracked in git" do

--- a/test/vutuv_web/live/attachment_composer_test.exs
+++ b/test/vutuv_web/live/attachment_composer_test.exs
@@ -79,6 +79,12 @@ defmodule VutuvWeb.AttachmentComposerTest do
     # as a bare integer.
     attachment = newest_attachment(user)
     assert html =~ VutuvWeb.UI.file_size(attachment.size_bytes)
+
+    # The remove button's label names the file. Asserted because the English
+    # catalogue shipped this msgid with `%{pattern}` in place of `%{name}` —
+    # a fuzzy fill nothing flags, which renders the placeholder itself and
+    # logs a missing-bindings error on every render.
+    assert has_element?(live, ~s|button[aria-label="Remove #{attachment.file_name}"]|)
   end
 
   test "the composer says what is left of the budget before the file flows", %{conn: conn} do
@@ -88,7 +94,7 @@ defmodule VutuvWeb.AttachmentComposerTest do
     assert render(live) =~ "Your uploads are not limited."
   end
 
-  test "a plain member reads a formatted allowance", %{conn: conn} do
+  test "a plain member reads a formatted allowance", %{conn: _conn} do
     Fixtures.put_config(uploaders: :members, daily_budget: 100_000_000)
 
     {conn, _member} =

--- a/test/vutuv_web/live/attachment_composer_test.exs
+++ b/test/vutuv_web/live/attachment_composer_test.exs
@@ -1,0 +1,147 @@
+defmodule VutuvWeb.AttachmentComposerTest do
+  @moduledoc """
+  The composer's file handling (issue #2104): the picker, the real upload path,
+  the chip the accepted file leaves, the sentence a refusal leaves, and the
+  remaining budget the member reads before the next file flows.
+
+  `async: false` because it flips `:attachments` and `:uploads_dir_prefix`,
+  both global — `Vutuv.Attachments`, the composer and the sweeper all read the
+  first, and every uploader reads the second.
+  """
+
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  import Vutuv.WebPushHelpers, only: [put_config: 2]
+
+  alias Vutuv.AttachmentFixtures, as: Fixtures
+  alias Vutuv.Attachments
+
+  setup %{conn: conn} do
+    tmp =
+      Path.join(System.tmp_dir!(), "vutuv_attachment_ui_#{System.unique_integer([:positive])}")
+
+    files = Path.join(tmp, "files")
+    File.mkdir_p!(files)
+    put_config(:uploads_dir_prefix, tmp)
+    on_exit(fn -> File.rm_rf(tmp) end)
+
+    # Uploads are for admins until an installation opens them
+    # (ATTACHMENT_UPLOADERS), so the composer is opened as one.
+    {conn, user} = create_and_login_admin(conn)
+    %{conn: conn, user: user, files: files}
+  end
+
+  defp open_composer(conn) do
+    {:ok, live, _html} = live(conn, ~p"/feed")
+    live |> element("#open-composer") |> render_click()
+    live
+  end
+
+  defp upload!(live, path, type \\ "application/pdf") do
+    content = File.read!(path)
+    name = "#{System.unique_integer([:positive])}-#{Path.basename(path)}"
+
+    input =
+      file_input(live, "#composer-form", :attachments, [
+        %{name: name, content: content, type: type, size: byte_size(content)}
+      ])
+
+    render_upload(input, name)
+  end
+
+  test "a member who is not an admin is offered no files at all" do
+    {conn, _member} =
+      build_conn() |> Plug.Test.init_test_session(%{}) |> create_and_login_user()
+
+    live = open_composer(conn)
+
+    refute has_element?(live, "#composer-add-files")
+    refute has_element?(live, "input[type=file][name=attachments]")
+  end
+
+  test "the picker is there and an accepted file leaves a chip with its size", %{
+    conn: conn,
+    user: user,
+    files: files
+  } do
+    live = open_composer(conn)
+    assert has_element?(live, "#composer-add-files")
+
+    html = upload!(live, Fixtures.plain_pdf(files))
+
+    assert html =~ "plain.pdf"
+    assert has_element?(live, "#composer-attachments")
+    assert has_element?(live, "button[phx-click=remove-attachment]")
+
+    # The size goes through the shared formatter rather than being interpolated
+    # as a bare integer.
+    attachment = newest_attachment(user)
+    assert html =~ VutuvWeb.UI.file_size(attachment.size_bytes)
+  end
+
+  test "the composer says what is left of the budget before the file flows", %{conn: conn} do
+    live = open_composer(conn)
+
+    # An admin has no allowance, and the line says so rather than a number.
+    assert render(live) =~ "Your uploads are not limited."
+  end
+
+  test "a plain member reads a formatted allowance", %{conn: conn} do
+    Fixtures.put_config(uploaders: :members, daily_budget: 100_000_000)
+
+    {conn, _member} =
+      build_conn() |> Plug.Test.init_test_session(%{}) |> create_and_login_user()
+
+    html = conn |> open_composer() |> render()
+
+    assert html =~ "100 MB"
+    assert html =~ "(100 %)"
+  end
+
+  test "a refused PDF says which of the four things it is", %{conn: conn, files: files} do
+    live = open_composer(conn)
+
+    html = upload!(live, Fixtures.javascript_pdf(files))
+
+    assert html =~ "contains a program"
+    refute has_element?(live, "#composer-attachments")
+  end
+
+  test "the remove button takes the file and its bytes", %{conn: conn, user: user, files: files} do
+    live = open_composer(conn)
+    upload!(live, Fixtures.plain_pdf(files))
+
+    attachment = newest_attachment(user)
+
+    live |> element(~s|button[phx-value-id="#{attachment.id}"]|) |> render_click()
+
+    refute has_element?(live, "#composer-attachments")
+    assert Attachments.pending_for(user, [attachment.id]) == []
+  end
+
+  test "the German composer names the control and the allowance in German", %{conn: conn} do
+    html =
+      conn
+      |> Phoenix.ConnTest.recycle()
+      |> Plug.Conn.put_req_header("accept-language", "de-DE,de")
+      |> open_composer()
+      |> render()
+
+    assert html =~ "Dateien hinzufügen"
+    assert html =~ "Ihre Uploads sind nicht begrenzt."
+  end
+
+  defp newest_attachment(user) do
+    import Ecto.Query
+
+    Vutuv.Repo.one!(
+      from(a in Vutuv.Attachments.Attachment,
+        where: a.user_id == ^user.id,
+        order_by: [desc: a.id],
+        limit: 1
+      )
+    )
+  end
+end


### PR DESCRIPTION
A post could carry photos and one clip; anything else had to be linked somewhere else.

`Vutuv.Attachments.create_pending/3` is now the one door for PDF, plain text and Markdown: it reads the format from the **bytes** (a ZIP called `invoice.pdf` is refused), runs the PDF through `Vutuv.Uploads.PdfGate`, and only then writes anything. The composer's picker sits beside Add photos / Add video and shows what is left of the member's allowance.

**A raw-byte scan is not enough, measured.** One `qpdf --object-streams=generate` run hides `/JavaScript`, `/OpenAction` and `/EmbeddedFile` where `grep` finds nothing. So poppler answers three of the four questions itself, and the scan also inflates every stream it can. Calibrated: remove the inflation pass and the `/OpenAction` file is accepted.

**To decide:** `ATTACHMENT_UPLOADERS` defaults to `admins`, as video did — a post cannot yet show or hand out its files (#2106, #2108), so the budget is inert until that flips.

Where: `lib/vutuv/attachments.ex`, `lib/vutuv/uploads/pdf_gate.ex`, `/feed` composer, `docs/architecture/attachments.md`.

Closes #2104

https://claude.ai/code/session_013VnEsuePUe2CB2QvDcshcp
