### PR TITLE
A profile picture may be a WebP, and up to 8 MB

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -25,7 +25,6 @@ config :vutuv, VutuvWeb.Endpoint,
   # from secret_key_base and from the Plug.Session signing_salt.
   live_view: [signing_salt: "PHEbY7u44Jfd3Ei0"],
   locales: ~w(en de it),
-  max_image_filesize: 2_000_000,
   max_page_items: 250
 
 config :logger, :console,
@@ -715,6 +714,14 @@ config :vutuv, :audible_domain, "www.audible.de"
 # Derived versions are AVIF; originals stay private on disk, and leave only
 # through the per-photo download an author switches on (Vutuv.PostImageStore).
 config :vutuv, :post_images, max_filesize: 50_000_000, max_per_post: 10
+
+# Profile pictures (avatar, cover). 8 MB, where it was 2: the form recommends a
+# 2100 × 2100 avatar, which a PNG at that size regularly overruns and a photo
+# straight off a phone always does, so the first upload a new member makes was
+# the one most likely to be refused. Its own key rather than a corner of the
+# endpoint's config, like every other upload budget beside it — which is also
+# what lets an installation override it in runtime.exs.
+config :vutuv, :profile_images, max_filesize: 8_000_000
 
 # Video on posts (issue #1906, Vutuv.Videos). `enabled` is the product switch
 # (an installation without ffmpeg runs with it off — VIDEO_UPLOADS in

--- a/docs/architecture/images.md
+++ b/docs/architecture/images.md
@@ -96,6 +96,18 @@ Pending gallery uploads (a composer that was never submitted) are swept after a
 day by `Vutuv.Posts.PendingImageSweeper`, which cleans **both** the post and the
 job-posting galleries (rows and files).
 
+### What a profile picture may be
+
+`Vutuv.Uploads.extension_whitelist/0` delegates to the post photo's list, and
+`max_filesize/0` reads `:profile_images` from the config. Both feed the `accept`
+attribute, the hint under the field and the two refusals in
+`Vutuv.Accounts.User`, so nothing states a rule the server does not enforce.
+
+Until then it was the narrowest whitelist on the site — JPEG and PNG at 2 MB
+against a post photo's WebP and HEIC at 50 MB — so the first upload a new member
+ever makes was the one most likely to be refused, and the refusal named neither
+the formats nor the cap.
+
 ### SVG (organization logos, press logos)
 
 An **organization logo** or a **press-kit logo variant** (#2083) may also be

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -9,7 +9,9 @@ defmodule Vutuv.Accounts.User do
   alias Vutuv.Mentions
   alias Vutuv.Prefs
   alias Vutuv.Tags.Tag
+  alias Vutuv.Uploads
   alias Vutuv.WebAddress
+  alias VutuvWeb.UI
   @derive {Phoenix.Param, key: :username}
 
   # How a job-seeking member wants to work. Deliberately the same three values
@@ -776,8 +778,6 @@ defmodule Vutuv.Accounts.User do
     do:
       ~w(notification_emails? email_on_endorsement? email_on_follower? email_on_reference_check? newsletter_emails? saved_search_emails?)a
 
-  @max_image_filesize Application.compile_env!(:vutuv, [VutuvWeb.Endpoint, :max_image_filesize])
-
   # Deliberately does NOT cast :emails: an address is an identity that must be
   # PIN-verified before it is attached (EmailController.create/confirm, issue
   # #759). Only registration_changeset/2 accepts the initial address, which the
@@ -1219,7 +1219,7 @@ defmodule Vutuv.Accounts.User do
     do: validate_avatar(changeset, %{"avatar" => avatar})
 
   defp validate_avatar(changeset, %{"avatar" => %Plug.Upload{} = upload}),
-    do: validate_image_upload(changeset, :avatar, upload, "Avatar")
+    do: validate_image_upload(changeset, :avatar, upload)
 
   defp validate_avatar(changeset, _params), do: changeset
 
@@ -1227,21 +1227,38 @@ defmodule Vutuv.Accounts.User do
     do: validate_cover_photo(changeset, %{"cover_photo" => cover_photo})
 
   defp validate_cover_photo(changeset, %{"cover_photo" => %Plug.Upload{} = upload}),
-    do: validate_image_upload(changeset, :cover_photo, upload, "Cover photo")
+    do: validate_image_upload(changeset, :cover_photo, upload)
 
   defp validate_cover_photo(changeset, _params), do: changeset
 
-  defp validate_image_upload(changeset, field, %Plug.Upload{} = upload, label) do
+  # Both refusals say what to do next, and both are translated (the anchors in
+  # VutuvWeb.ErrorHelpers put the msgids into errors.pot). The pair they
+  # replace — "Avatar filesize is greater than 2MB" and a bare "is not a valid
+  # image" — reached a German member in English, named neither the formats nor
+  # the real cap, and sat directly above the gravatar.com button, which is why
+  # the dead end read as "you need a Gravatar account to have a picture here".
+  # The size sentence is the one `VutuvWeb.UI.upload_problem_message/2` already
+  # gives a LiveView upload, word for word, so the site refuses an oversized
+  # file the same way wherever it is dropped.
+  defp validate_image_upload(changeset, field, %Plug.Upload{} = upload) do
+    cap = Uploads.max_filesize()
+
     cond do
-      File.stat!(upload.path).size > @max_image_filesize ->
+      File.stat!(upload.path).size > cap ->
         add_error(
           changeset,
           field,
-          "#{label} filesize is greater than 2MB. Please upload a smaller image."
+          "That file is larger than %{limit}. Please upload a smaller one.",
+          limit: UI.megabyte_label(cap)
         )
 
-      not Vutuv.Uploads.valid_upload?(upload) ->
-        add_error(changeset, field, "is not a valid image")
+      not Uploads.valid_upload?(upload) ->
+        add_error(
+          changeset,
+          field,
+          "We cannot read this file. Please upload one of these formats: %{formats}.",
+          formats: UI.format_list(Uploads.extension_whitelist())
+        )
 
       true ->
         changeset

--- a/lib/vutuv/uploads.ex
+++ b/lib/vutuv/uploads.ex
@@ -30,8 +30,6 @@ defmodule Vutuv.Uploads do
   alias Vutuv.Uploads.Spec
   alias Vutuv.UUIDv7
 
-  @extension_whitelist ~w(.jpg .jpeg .png)
-
   # The takedown hold's root, under `uploads_dir_prefix/0` (see `hold_dir/1`).
   @hold_root "frozen"
 
@@ -452,6 +450,25 @@ defmodule Vutuv.Uploads do
   end
 
   @doc """
+  The formats a profile picture (avatar, cover) may arrive in: whatever a post
+  photo may be, HEIC capability-detection included.
+
+  Deliberately the same list rather than one of its own. A member's picture
+  comes off a phone or out of a design tool, and this was the narrowest
+  whitelist on the site — JPEG and PNG alone — while a WebP logo or a HEIC
+  snapshot passed everywhere else, so refusing it here was a dead end nobody
+  could debug. SVG stays out with it: a profile picture is a photograph, and a
+  vector one would be the only member-uploaded markup the AI gate has to reason
+  about.
+  """
+  defdelegate extension_whitelist, to: Vutuv.PostImageStore
+
+  @doc "The largest profile picture a member may upload, in bytes."
+  def max_filesize, do: Keyword.fetch!(config(), :max_filesize)
+
+  defp config, do: Application.fetch_env!(:vutuv, :profile_images)
+
+  @doc """
   Whether `upload` is a storable image — a whitelisted extension whose bytes
   decode as an image — **without writing anything to disk**. The pre-commit
   half of `store/2`: a changeset validates here, and only after the row
@@ -847,7 +864,7 @@ defmodule Vutuv.Uploads do
     extension in whitelist
   end
 
-  defp valid_extension?(file_name), do: valid_extension?(file_name, @extension_whitelist)
+  defp valid_extension?(file_name), do: valid_extension?(file_name, extension_whitelist())
 
   @doc """
   A fresh unguessable URL token (~128 bits, URL-safe Base64) for the

--- a/lib/vutuv_web/templates/email/image_rejected_de.text.eex
+++ b/lib/vutuv_web/templates/email/image_rejected_de.text.eex
@@ -5,7 +5,7 @@ unsere automatische Bildprüfung hat
 <%= if @category == "unverifiable" do %>
 Der Grund ist diesmal technisch: Unsere Prüfung konnte die Bilddatei
 nicht öffnen und deshalb auch nicht beurteilen. Über den Inhalt sagt
-das nichts. Mit einer JPEG- oder PNG-Datei klappt es meistens.
+das nichts. Mit einer JPEG-, PNG- oder WebP-Datei klappt es meistens.
 <% else %>
 Über Ihr Bild hat kein Mensch entschieden. Das macht bei uns eine KI:
 Sie sieht sich jedes hochgeladene Bild an und entscheidet allein, ob es

--- a/lib/vutuv_web/templates/email/image_rejected_en.text.eex
+++ b/lib/vutuv_web/templates/email/image_rejected_en.text.eex
@@ -5,7 +5,7 @@ our automated image review removed
 <%= if @category == "unverifiable" do %>
 This one is a technical problem: our review could not open the image
 file and therefore could not judge it. That says nothing about what was
-on it. A JPEG or PNG file usually works.
+on it. A JPEG, PNG or WebP file usually works.
 <% else %>
 No human decided this. An AI does it here: it looks at every uploaded
 image and decides on its own whether it is family-friendly and suitable

--- a/lib/vutuv_web/templates/email/image_rejected_it.text.eex
+++ b/lib/vutuv_web/templates/email/image_rejected_it.text.eex
@@ -5,7 +5,7 @@ il nostro esame automatico delle immagini ha rimosso
 <%= if @category == "unverifiable" do %>
 Si tratta di un problema tecnico: il nostro esame non è riuscito ad aprire il
 file dell'immagine e quindi non ha potuto giudicarla. Questo non dice nulla su
-cosa vi fosse raffigurato. Di solito un file JPEG o PNG funziona.
+cosa vi fosse raffigurato. Di solito un file JPEG, PNG o WebP funziona.
 <% else %>
 Non ha deciso nessuna persona. Qui lo fa un'IA: guarda ogni immagine caricata e
 decide da sé se è adatta a tutti e a un ambiente di lavoro. Funziona allo

--- a/lib/vutuv_web/templates/email_body/image_rejected_de.html.heex
+++ b/lib/vutuv_web/templates/email_body/image_rejected_de.html.heex
@@ -8,8 +8,8 @@
   </.email_p>
   <.email_p :if={@category == "unverifiable"}>
     Der Grund ist diesmal technisch: Unsere Prüfung konnte die Bilddatei nicht öffnen und deshalb
-    auch nicht beurteilen. Über den Inhalt sagt das nichts. Mit einer JPEG- oder PNG-Datei klappt
-    es meistens.
+    auch nicht beurteilen. Über den Inhalt sagt das nichts. Mit einer JPEG-, PNG- oder WebP-Datei
+    klappt es meistens.
   </.email_p>
   <.email_p :if={@category != "unverifiable"}>
     Über Ihr Bild hat kein Mensch entschieden. Das macht bei uns eine KI: Sie sieht sich jedes

--- a/lib/vutuv_web/templates/email_body/image_rejected_en.html.heex
+++ b/lib/vutuv_web/templates/email_body/image_rejected_en.html.heex
@@ -8,7 +8,7 @@
   </.email_p>
   <.email_p :if={@category == "unverifiable"}>
     This one is a technical problem: our review could not open the image file and therefore could
-    not judge it. That says nothing about what was on it. A JPEG or PNG file usually works.
+    not judge it. That says nothing about what was on it. A JPEG, PNG or WebP file usually works.
   </.email_p>
   <.email_p :if={@category != "unverifiable"}>
     No human decided this. An AI does it here: it looks at every uploaded image and decides on its

--- a/lib/vutuv_web/templates/email_body/image_rejected_it.html.heex
+++ b/lib/vutuv_web/templates/email_body/image_rejected_it.html.heex
@@ -9,7 +9,7 @@
   <.email_p :if={@category == "unverifiable"}>
     Si tratta di un problema tecnico: il nostro esame non è riuscito ad aprire il file
     dell'immagine e quindi non ha potuto giudicarla. Questo non dice nulla su cosa vi fosse
-    raffigurato. Di solito un file JPEG o PNG funziona.
+    raffigurato. Di solito un file JPEG, PNG o WebP funziona.
   </.email_p>
   <.email_p :if={@category != "unverifiable"}>
     Non ha deciso nessuna persona. Qui lo fa un'IA: guarda ogni immagine caricata e decide da sé

--- a/lib/vutuv_web/templates/user/edit.html.heex
+++ b/lib/vutuv_web/templates/user/edit.html.heex
@@ -11,6 +11,18 @@ lands here). --%>
 
     <.card>
       <.section_title>{gettext("Photos")}</.section_title>
+      <%!-- What the box takes, said once for both pictures. The accept list is
+      the whitelist itself and not "image/*": with the wide one the picker
+      happily offered a HEIC or a TIFF the server then refused after the upload,
+      which on a phone is a minute of somebody's uplink spent on a dead end.
+      Both halves are derived — an installation whose libvips decodes HEIC
+      accepts more, and the cap is a config value. --%>
+      <% picture_accept = Enum.join(Vutuv.Uploads.extension_whitelist(), ",") %>
+      <% picture_limits =
+        gettext("%{formats}, up to %{limit}",
+          formats: format_list(Vutuv.Uploads.extension_whitelist()),
+          limit: megabyte_label(Vutuv.Uploads.max_filesize())
+        ) %>
       <div class="mt-4 grid gap-5 sm:grid-cols-2">
         <%!-- Avatar: preview the current avatar (the real photo, or the initials
         tile visitors currently see) above the upload, so the owner sees what
@@ -42,7 +54,7 @@ lands here). --%>
             </span>
           </div>
           <%= file_input f, :avatar,
-            accept: "image/*",
+            accept: picture_accept,
             class: "mt-3 block w-full text-sm text-slate-600 file:mr-3 file:rounded-lg file:border-0 file:bg-brand-50 file:px-3 file:py-2 file:text-sm file:font-semibold file:text-brand-700 hover:file:bg-brand-100 dark:text-slate-300 dark:file:bg-brand-800/60 dark:file:text-brand-100",
             data: [
               crop_target: "user_avatar_crop",
@@ -59,6 +71,7 @@ lands here). --%>
             id: "user_avatar_crop",
             value: Vutuv.Images.crop(@user, "avatar") %>
           <% {avatar_w, avatar_h} = recommended_avatar_size() %>
+          <p class="mt-1 text-xs text-slate-600 dark:text-slate-400">{picture_limits}</p>
           <p class="mt-1 text-xs text-slate-600 dark:text-slate-400">
             {gettext("Recommended: square, at least %{width} × %{height} pixels.",
               width: delimited_count(avatar_w),
@@ -126,7 +139,7 @@ lands here). --%>
             </figcaption>
           </figure>
           <%= file_input f, :cover_photo,
-            accept: "image/*",
+            accept: picture_accept,
             class: "mt-3 block w-full text-sm text-slate-600 file:mr-3 file:rounded-lg file:border-0 file:bg-brand-50 file:px-3 file:py-2 file:text-sm file:font-semibold file:text-brand-700 hover:file:bg-brand-100 dark:text-slate-300 dark:file:bg-brand-800/60 dark:file:text-brand-100",
             data: [
               crop_target: "user_cover_crop",
@@ -141,6 +154,7 @@ lands here). --%>
             id: "user_cover_crop",
             value: Vutuv.Images.crop(@user, "cover") %>
           <% {cover_w, cover_h} = recommended_cover_size() %>
+          <p class="mt-1 text-xs text-slate-600 dark:text-slate-400">{picture_limits}</p>
           <p class="mt-1 text-xs text-slate-600 dark:text-slate-400">
             {gettext("Recommended: %{width} × %{height} pixels (%{ratio}).",
               width: delimited_count(cover_w),

--- a/lib/vutuv_web/views/error_helpers.ex
+++ b/lib/vutuv_web/views/error_helpers.ex
@@ -115,6 +115,15 @@ defmodule VutuvWeb.ErrorHelpers do
         "PDF uploads are not available on this installation. Please upload an image instead."
       ),
       dgettext_noop("errors", "could not be read. Please upload a PDF, JPG, PNG or WebP file."),
+      # Vutuv.Accounts.User, the avatar and cover uploads on /settings/profile.
+      # The first is `VutuvWeb.UI.upload_problem_message/2`'s sentence for the
+      # same refusal, repeated here only because a changeset error reads the
+      # "errors" domain rather than the default one.
+      dgettext_noop("errors", "That file is larger than %{limit}. Please upload a smaller one."),
+      dgettext_noop(
+        "errors",
+        "We cannot read this file. Please upload one of these formats: %{formats}."
+      ),
       # Vutuv.Accounts.User, sign-up: only the address the PIN goes to.
       dgettext_noop("errors", "Only one email address can be given at sign-up."),
       # Vutuv.Tags.Tag / Vutuv.Accounts.User, the "this field is not a

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -90,12 +90,12 @@ msgstr "Schon ein Mitglied? Einloggen."
 msgid "Are you sure?"
 msgstr "Sind Sie sicher?"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:22
+#: lib/vutuv_web/templates/user/edit.html.heex:34
 #, elixir-autogen
 msgid "Avatar"
 msgstr "Avatar"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:416
+#: lib/vutuv_web/templates/user/edit.html.heex:430
 #, elixir-autogen
 msgid "Birthdate"
 msgstr "Geburtstag"
@@ -129,10 +129,10 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:255
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:23
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
-#: lib/vutuv_web/templates/user/edit.html.heex:53
-#: lib/vutuv_web/templates/user/edit.html.heex:137
-#: lib/vutuv_web/templates/user/edit.html.heex:472
-#: lib/vutuv_web/templates/user/edit.html.heex:517
+#: lib/vutuv_web/templates/user/edit.html.heex:65
+#: lib/vutuv_web/templates/user/edit.html.heex:150
+#: lib/vutuv_web/templates/user/edit.html.heex:486
+#: lib/vutuv_web/templates/user/edit.html.heex:531
 #: lib/vutuv_web/templates/username/confirm.html.heex:220
 #, elixir-autogen
 msgid "Cancel"
@@ -309,7 +309,7 @@ msgid "Fax"
 msgstr "Fax"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:693
-#: lib/vutuv_web/templates/user/edit.html.heex:170
+#: lib/vutuv_web/templates/user/edit.html.heex:184
 #, elixir-autogen
 msgid "First Name"
 msgstr "Vorname"
@@ -343,7 +343,7 @@ msgstr "Folge ich"
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:310
 #: lib/vutuv_web/templates/page/index.html.heex:121
-#: lib/vutuv_web/templates/user/edit.html.heex:207
+#: lib/vutuv_web/templates/user/edit.html.heex:221
 #: lib/vutuv_web/views/account_event_text.ex:219
 #, elixir-autogen
 msgid "Gender"
@@ -386,7 +386,7 @@ msgid "Language"
 msgstr "Sprache"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:695
-#: lib/vutuv_web/templates/user/edit.html.heex:175
+#: lib/vutuv_web/templates/user/edit.html.heex:189
 #, elixir-autogen
 msgid "Last Name"
 msgstr "Nachname"
@@ -453,7 +453,7 @@ msgid "Log in"
 msgstr "Einloggen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:694
-#: lib/vutuv_web/templates/user/edit.html.heex:180
+#: lib/vutuv_web/templates/user/edit.html.heex:194
 #, elixir-autogen
 msgid "Middle Name"
 msgstr "Zweiter Vorname"
@@ -490,7 +490,7 @@ msgid "New"
 msgstr "Neu"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:697
-#: lib/vutuv_web/templates/user/edit.html.heex:185
+#: lib/vutuv_web/templates/user/edit.html.heex:199
 #, elixir-autogen
 msgid "Nickname"
 msgstr "Spitzname"
@@ -571,7 +571,7 @@ msgid "Phone number updated successfully."
 msgstr "Telefonnummer wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:692
-#: lib/vutuv_web/templates/user/edit.html.heex:190
+#: lib/vutuv_web/templates/user/edit.html.heex:204
 #, elixir-autogen
 msgid "Prefix"
 msgstr "Titel"
@@ -634,7 +634,7 @@ msgstr "Öffentlich"
 #: lib/vutuv_web/templates/settings/preferences.html.heex:362
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:61
-#: lib/vutuv_web/templates/user/edit.html.heex:467
+#: lib/vutuv_web/templates/user/edit.html.heex:481
 #: lib/vutuv_web/views/settings_html.ex:253
 #, elixir-autogen
 msgid "Save"
@@ -752,7 +752,7 @@ msgid "Submit a bugreport or a feature request."
 msgstr "Fehler auf der Seite melden."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:696
-#: lib/vutuv_web/templates/user/edit.html.heex:195
+#: lib/vutuv_web/templates/user/edit.html.heex:209
 #, elixir-autogen
 msgid "Suffix"
 msgstr "Namenszusatz"
@@ -2019,7 +2019,7 @@ msgid "Change cover photo"
 msgstr "Titelbild ändern"
 
 #: lib/vutuv_web/controllers/report_controller.ex:177
-#: lib/vutuv_web/templates/user/edit.html.heex:100
+#: lib/vutuv_web/templates/user/edit.html.heex:113
 #, elixir-autogen, elixir-format
 msgid "Cover photo"
 msgstr "Titelbild"
@@ -2090,7 +2090,7 @@ msgid "September"
 msgstr "September"
 
 #: lib/vutuv_web/templates/education/form_content.html.heex:32
-#: lib/vutuv_web/templates/user/edit.html.heex:263
+#: lib/vutuv_web/templates/user/edit.html.heex:277
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Markdown is supported: bold, italics, links and lists."
@@ -5614,7 +5614,7 @@ msgstr "Art der E-Mail"
 msgid "Type of email address"
 msgstr "Art der E-Mail-Adresse"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:242
+#: lib/vutuv_web/templates/user/edit.html.heex:256
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr "Über Sie"
@@ -5698,7 +5698,7 @@ msgid "View"
 msgstr "Ansehen"
 
 #: lib/vutuv_web/templates/public_report/new.html.heex:92
-#: lib/vutuv_web/templates/user/edit.html.heex:167
+#: lib/vutuv_web/templates/user/edit.html.heex:181
 #, elixir-autogen, elixir-format
 msgid "Your name"
 msgstr "Ihr Name"
@@ -5752,24 +5752,24 @@ msgstr ""
 "Dies stellt die Sprache der gesamten vutuv-Oberfläche ein, nicht die Ihres "
 "öffentlichen Profils."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:30
-#: lib/vutuv_web/templates/user/edit.html.heex:34
+#: lib/vutuv_web/templates/user/edit.html.heex:42
+#: lib/vutuv_web/templates/user/edit.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "Current avatar"
 msgstr "Aktueller Avatar"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:111
-#: lib/vutuv_web/templates/user/edit.html.heex:118
+#: lib/vutuv_web/templates/user/edit.html.heex:124
+#: lib/vutuv_web/templates/user/edit.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Current cover photo"
 msgstr "Aktuelles Titelbild"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:191
+#: lib/vutuv_web/templates/user/edit.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "e.g. Dr. or Prof."
 msgstr "z. B. Dr. oder Prof."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:196
+#: lib/vutuv_web/templates/user/edit.html.heex:210
 #, elixir-autogen, elixir-format
 msgid "e.g. Jr. or PhD"
 msgstr "z. B. jun. oder B.Sc."
@@ -6228,7 +6228,7 @@ msgid "Add a tagline"
 msgstr "Kurzbeschreibung hinzufügen"
 
 #: lib/vutuv_web/live/cv_live.ex:166
-#: lib/vutuv_web/templates/user/edit.html.heex:259
+#: lib/vutuv_web/templates/user/edit.html.heex:273
 #: lib/vutuv_web/views/account_event_text.ex:212
 #, elixir-autogen, elixir-format
 msgid "Tagline"
@@ -6252,8 +6252,8 @@ msgid_plural "Posts"
 msgstr[0] "Beitrag"
 msgstr[1] "Beiträge"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:67
-#: lib/vutuv_web/templates/user/edit.html.heex:150
+#: lib/vutuv_web/templates/user/edit.html.heex:80
+#: lib/vutuv_web/templates/user/edit.html.heex:164
 #, elixir-autogen, elixir-format
 msgid "After choosing a file you can reposition and zoom it."
 msgstr "Nach der Auswahl einer Datei können Sie sie verschieben und zoomen."
@@ -6263,43 +6263,43 @@ msgstr "Nach der Auswahl einer Datei können Sie sie verschieben und zoomen."
 msgid "Also on"
 msgstr "Auch auf"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:51
-#: lib/vutuv_web/templates/user/edit.html.heex:135
+#: lib/vutuv_web/templates/user/edit.html.heex:63
+#: lib/vutuv_web/templates/user/edit.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "Drag to move, use the slider to zoom. The framed area is what others see."
 msgstr ""
 "Zum Verschieben ziehen, zum Zoomen den Regler nutzen. Der umrahmte Bereich "
 "ist für andere sichtbar."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:72
+#: lib/vutuv_web/templates/user/edit.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "New avatar preview"
 msgstr "Vorschau des neuen Avatars"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:155
+#: lib/vutuv_web/templates/user/edit.html.heex:169
 #, elixir-autogen, elixir-format
 msgid "New cover photo preview"
 msgstr "Vorschau des neuen Titelbilds"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:134
+#: lib/vutuv_web/templates/user/edit.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "Position your cover photo"
 msgstr "Titelbild positionieren"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:50
+#: lib/vutuv_web/templates/user/edit.html.heex:62
 #, elixir-autogen, elixir-format
 msgid "Position your photo"
 msgstr "Foto positionieren"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:52
-#: lib/vutuv_web/templates/user/edit.html.heex:136
+#: lib/vutuv_web/templates/user/edit.html.heex:64
+#: lib/vutuv_web/templates/user/edit.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "Use photo"
 msgstr "Foto verwenden"
 
 #: lib/vutuv_web/live/post_live/composer.ex:1919
-#: lib/vutuv_web/templates/user/edit.html.heex:54
-#: lib/vutuv_web/templates/user/edit.html.heex:138
+#: lib/vutuv_web/templates/user/edit.html.heex:66
+#: lib/vutuv_web/templates/user/edit.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Zoom"
 msgstr "Zoom"
@@ -8723,7 +8723,7 @@ msgstr "Basisdaten & Fotos"
 msgid "Language & display"
 msgstr "Sprache & Anzeige"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:532
+#: lib/vutuv_web/templates/user/edit.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "More profile sections"
 msgstr "Weitere Profil-Bereiche"
@@ -9257,7 +9257,7 @@ msgstr ""
 "LaTeX ist der Quelltext zum Setzen, und JSON Resume ist das offene Format "
 "von %{link}."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:272
+#: lib/vutuv_web/templates/user/edit.html.heex:286
 #, elixir-autogen, elixir-format
 msgid "characters"
 msgstr "Zeichen"
@@ -9826,7 +9826,7 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Beschäftigungsstatus"
 
-#: lib/vutuv/accounts/user.ex:1278
+#: lib/vutuv/accounts/user.ex:1292
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9837,13 +9837,13 @@ msgstr "Auf Jobsuche"
 msgid "Not open to work"
 msgstr "Nicht offen für Angebote"
 
-#: lib/vutuv/accounts/user.ex:1275
+#: lib/vutuv/accounts/user.ex:1289
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
 msgstr "Offen für Angebote"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:296
+#: lib/vutuv_web/templates/user/edit.html.heex:310
 #, elixir-autogen, elixir-format
 msgid "Shown as a badge next to your tagline so people can see whether you are open to opportunities."
 msgstr ""
@@ -10118,18 +10118,18 @@ msgstr "+%{code} ist die Ländervorwahl von %{region}"
 msgid "Date of birth"
 msgstr "Geburtsdatum"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:445
-#: lib/vutuv_web/templates/user/edit.html.heex:520
+#: lib/vutuv_web/templates/user/edit.html.heex:459
+#: lib/vutuv_web/templates/user/edit.html.heex:534
 #, elixir-autogen, elixir-format
 msgid "Remove date of birth"
 msgstr "Geburtsdatum entfernen"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:508
+#: lib/vutuv_web/templates/user/edit.html.heex:522
 #, elixir-autogen, elixir-format
 msgid "Remove your date of birth?"
 msgstr "Geburtsdatum entfernen?"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:511
+#: lib/vutuv_web/templates/user/edit.html.heex:525
 #, elixir-autogen, elixir-format
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
@@ -11266,7 +11266,7 @@ msgstr "Versuche"
 msgid "Views"
 msgstr "Ansichten"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:305
+#: lib/vutuv_web/templates/user/edit.html.heex:319
 #, elixir-autogen, elixir-format
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
@@ -11275,19 +11275,19 @@ msgstr ""
 " Konto anlegen kann. Wählen Sie „Niemand“, um den Status zu speichern, ohne "
 "ihn anzuzeigen."
 
-#: lib/vutuv/accounts/user.ex:1316
+#: lib/vutuv/accounts/user.ex:1330
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Alle, auch nicht angemeldete Besucher"
 
-#: lib/vutuv/accounts/user.ex:1321
+#: lib/vutuv/accounts/user.ex:1335
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Niemand"
 
-#: lib/vutuv/accounts/user.ex:1319
+#: lib/vutuv/accounts/user.ex:1333
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:823
 #, elixir-autogen, elixir-format
@@ -11295,25 +11295,25 @@ msgid "Signed-in members only"
 msgstr "Nur angemeldete Mitglieder"
 
 #: lib/vutuv_web/components/welcome_components.ex:259
-#: lib/vutuv_web/templates/user/edit.html.heex:302
+#: lib/vutuv_web/templates/user/edit.html.heex:316
 #, elixir-autogen, elixir-format
 msgid "Who can see your availability?"
 msgstr "Wer kann Ihre Verfügbarkeit sehen?"
 
 #: lib/vutuv_web/components/welcome_components.ex:270
-#: lib/vutuv_web/templates/user/edit.html.heex:327
+#: lib/vutuv_web/templates/user/edit.html.heex:341
 #, elixir-autogen, elixir-format
 msgid "Amount"
 msgstr "Betrag"
 
 #: lib/vutuv_web/components/welcome_components.ex:278
 #: lib/vutuv_web/live/job_posting_live/form.ex:693
-#: lib/vutuv_web/templates/user/edit.html.heex:335
+#: lib/vutuv_web/templates/user/edit.html.heex:349
 #, elixir-autogen, elixir-format
 msgid "Currency"
 msgstr "Währung"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:345
+#: lib/vutuv_web/templates/user/edit.html.heex:359
 #, elixir-autogen, elixir-format
 msgid "Hidden by default, and it still does its job while hidden. \"Signed-in members only\" adds a quiet line to your profile for members; \"Everyone\" also shows it to logged-out visitors."
 msgstr ""
@@ -11322,12 +11322,12 @@ msgstr ""
 "Mitglieder; „Alle“ zeigt sie auch nicht angemeldeten Besuchern."
 
 #: lib/vutuv_web/components/welcome_components.ex:266
-#: lib/vutuv_web/templates/user/edit.html.heex:318
+#: lib/vutuv_web/templates/user/edit.html.heex:332
 #, elixir-autogen, elixir-format
 msgid "Minimum salary expectation"
 msgstr "Mindest-Gehaltsvorstellung"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:321
+#: lib/vutuv_web/templates/user/edit.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "Optional. Even when hidden, it sharpens your own job search and alerts by filtering out postings below it. Leave the amount empty to remove it."
 msgstr ""
@@ -11337,7 +11337,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:274
 #: lib/vutuv_web/live/job_posting_live/form.ex:700
-#: lib/vutuv_web/templates/user/edit.html.heex:331
+#: lib/vutuv_web/templates/user/edit.html.heex:345
 #, elixir-autogen, elixir-format
 msgid "Per"
 msgstr "Pro"
@@ -11347,7 +11347,7 @@ msgstr "Pro"
 msgid "Salary expectation from %{amount} %{currency} per %{period}"
 msgstr "Gehaltsvorstellung ab %{amount} %{currency} pro %{period}"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:342
+#: lib/vutuv_web/templates/user/edit.html.heex:356
 #, elixir-autogen, elixir-format
 msgid "Who can see your salary expectation?"
 msgstr "Wer kann Ihre Gehaltsvorstellung sehen?"
@@ -11416,7 +11416,7 @@ msgstr "Ein Mitglied ausschließen"
 msgid "Exclude an email domain"
 msgstr "Eine E-Mail-Domain ausschließen"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:393
+#: lib/vutuv_web/templates/user/edit.html.heex:407
 #, elixir-autogen, elixir-format
 msgid "Hide from specific people"
 msgstr "Vor bestimmten Personen verbergen"
@@ -11427,7 +11427,7 @@ msgstr "Vor bestimmten Personen verbergen"
 msgid "Job-search exclusion list"
 msgstr "Ausschlussliste für die Jobsuche"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:396
+#: lib/vutuv_web/templates/user/edit.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "Keep your availability broadly visible while making sure your own employer never sees it. Exclude specific members or email domains, and they never see your availability or salary expectation, even at \"Everyone\"."
 msgstr ""
@@ -11436,7 +11436,7 @@ msgstr ""
 "Mitglieder oder E-Mail-Domains aus; sie sehen Ihre Verfügbarkeit und Ihre "
 "Gehaltsvorstellung dann nie, auch nicht bei „Alle“."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:404
+#: lib/vutuv_web/templates/user/edit.html.heex:418
 #, elixir-autogen, elixir-format
 msgid "Manage exclusion list (1 entry)"
 msgid_plural "Manage exclusion list (%{formatted} entries)"
@@ -12635,7 +12635,7 @@ msgstr "Hervorgehobene Tags passen zu Ihrem Profil."
 msgid "How to apply"
 msgstr "So bewerben Sie sich"
 
-#: lib/vutuv/accounts/user.ex:1290
+#: lib/vutuv/accounts/user.ex:1304
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12754,7 +12754,7 @@ msgstr "Hier ist noch nichts. Jobs, die Ihnen gefallen, erscheinen hier."
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) für KI-Agenten anbieten."
 
-#: lib/vutuv/accounts/user.ex:1289
+#: lib/vutuv/accounts/user.ex:1303
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12836,7 +12836,7 @@ msgstr "Anzeige nicht gefunden."
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: lib/vutuv/accounts/user.ex:1291
+#: lib/vutuv/accounts/user.ex:1305
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:590
 #: lib/vutuv_web/agent_docs/markdown.ex:563
@@ -13813,8 +13813,8 @@ msgstr "Dieses Mitglied existiert nicht mehr."
 msgid "%{pending} image(s) in the scan queue; %{rejected} rejected in the last 7 days. A growing queue usually means Ollama is unreachable."
 msgstr "%{pending} Bild(er) in der Warteschlange; %{rejected} in den letzten 7 Tagen abgelehnt. Eine wachsende Warteschlange bedeutet meist, dass Ollama nicht erreichbar ist."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:41
-#: lib/vutuv_web/templates/user/edit.html.heex:125
+#: lib/vutuv_web/templates/user/edit.html.heex:53
+#: lib/vutuv_web/templates/user/edit.html.heex:138
 #: lib/vutuv_web/templates/user/show.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Image awaiting review, visible only to you"
@@ -13861,36 +13861,36 @@ msgstr "Screenshot entfernt."
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr "Dieser Screenshot wurde automatisch aus dem Link in Ihrem Beitrag erstellt. Falls er unbrauchbar ist (zum Beispiel weil ein Cookie-Banner die Seite verdeckt), können Sie ihn entfernen."
 
-#: lib/vutuv/accounts/user.ex:1334
+#: lib/vutuv/accounts/user.ex:1348
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
 msgstr "Nur das Alter, ohne das Datum"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:456
+#: lib/vutuv_web/templates/user/edit.html.heex:470
 #, elixir-autogen, elixir-format
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr "Wählen Sie, wie viel von Ihrem Geburtstag Ihr Profil zeigt. „Nur das Alter“ verbirgt das genaue Datum, „Tag und Monat“ verbirgt das Jahr (und Ihr Alter), und „Nicht anzeigen“ speichert ihn weiterhin, hält ihn aber von Ihrem Profil fern."
 
-#: lib/vutuv/accounts/user.ex:1337
+#: lib/vutuv/accounts/user.ex:1351
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Tag und Monat, ohne das Jahr"
 
-#: lib/vutuv/accounts/user.ex:1340
+#: lib/vutuv/accounts/user.ex:1354
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Geburtstag nicht anzeigen"
 
-#: lib/vutuv/accounts/user.ex:1331
+#: lib/vutuv/accounts/user.ex:1345
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
 msgstr "Vollständiges Datum und Alter"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:453
+#: lib/vutuv_web/templates/user/edit.html.heex:467
 #, elixir-autogen, elixir-format
 msgid "Show my birthday as"
 msgstr "Geburtstag anzeigen als"
@@ -14528,7 +14528,7 @@ msgid "Are you looking for a job?"
 msgstr "Suchen Sie eine Stelle?"
 
 #: lib/vutuv_web/components/welcome_components.ex:290
-#: lib/vutuv_web/templates/user/edit.html.heex:365
+#: lib/vutuv_web/templates/user/edit.html.heex:379
 #, elixir-autogen, elixir-format
 msgid "How do you want to work?"
 msgstr "Wie möchten Sie arbeiten?"
@@ -14545,7 +14545,7 @@ msgid "Preferred workplace"
 msgstr "Bevorzugte Arbeitsform"
 
 #: lib/vutuv_web/components/welcome_components.ex:249
-#: lib/vutuv_web/templates/user/edit.html.heex:293
+#: lib/vutuv_web/templates/user/edit.html.heex:307
 #, elixir-autogen, elixir-format
 msgid "Availability"
 msgstr "Verfügbarkeit"
@@ -16731,19 +16731,19 @@ msgstr "angehefteter Beitrag"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:657
 #: lib/vutuv_web/agent_docs/text.ex:629
-#: lib/vutuv_web/templates/user/edit.html.heex:225
+#: lib/vutuv_web/templates/user/edit.html.heex:239
 #: lib/vutuv_web/templates/user/show.html.heex:291
 #: lib/vutuv_web/views/account_event_text.ex:213
 #, elixir-autogen, elixir-format
 msgid "Name pronunciation"
 msgstr "Aussprache des Namens"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:229
+#: lib/vutuv_web/templates/user/edit.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "e.g. [SHTEH-fahn VIN-ter-my-er]"
 msgstr "z. B. [SCHTEH-fan WIN-ter-mei-er]"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:232
+#: lib/vutuv_web/templates/user/edit.html.heex:246
 #, elixir-autogen, elixir-format
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
@@ -19225,17 +19225,17 @@ msgstr ""
 "Kommt keine PIN an? Ist die E-Mail-Adresse {email} korrekt? Haben Sie einmal "
 "in Ihren Spam-Ordner geschaut?"
 
-#: lib/vutuv/accounts/user.ex:1437
+#: lib/vutuv/accounts/user.ex:1451
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/vutuv/accounts/user.ex:1435
+#: lib/vutuv/accounts/user.ex:1449
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr "Weiblich"
 
-#: lib/vutuv/accounts/user.ex:1436
+#: lib/vutuv/accounts/user.ex:1450
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Männlich"
@@ -20466,7 +20466,7 @@ msgstr "eine Adresse in einem anderen Netzwerk: vutuv bietet Ihnen an, ihr zu fo
 msgid "the address of a post out there: vutuv fetches it so you can answer it here"
 msgstr "die Adresse eines Beitrags dort draußen: vutuv holt ihn, damit Sie hier darauf antworten können"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:85
+#: lib/vutuv_web/templates/user/edit.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Fetch my picture from gravatar.com"
 msgstr "Mein Bild von gravatar.com holen"
@@ -20491,7 +20491,7 @@ msgstr "gravatar.com war nicht erreichbar. Bitte versuchen Sie es später noch e
 msgid "gravatar.com has no picture for your email address."
 msgstr "gravatar.com hat kein Bild zu Ihrer E-Mail-Adresse."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:88
+#: lib/vutuv_web/templates/user/edit.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Only when you press this: we ask gravatar.com whether there is a picture for your email address, sending a hash of the address rather than the address itself. Nothing leaves this server otherwise."
 msgstr "Nur wenn Sie hier klicken: Wir fragen bei gravatar.com nach, ob es zu Ihrer E-Mail-Adresse ein Bild gibt, und übermitteln dafür einen Hashwert der Adresse, nicht die Adresse selbst. Sonst verlässt nichts diesen Server."
@@ -20990,12 +20990,12 @@ msgid_plural "Our AI is looking at them. They appear here by themselves once the
 msgstr[0] "Unsere KI sieht es sich an. Es erscheint hier von selbst, sobald sie durch ist."
 msgstr[1] "Unsere KI sieht sie sich an. Sie erscheinen hier von selbst, sobald sie durch ist."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:145
+#: lib/vutuv_web/templates/user/edit.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "Recommended: %{width} × %{height} pixels (%{ratio})."
 msgstr "Empfohlen: %{width} × %{height} Pixel (%{ratio})."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:63
+#: lib/vutuv_web/templates/user/edit.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Empfohlen: quadratisch, mindestens %{width} × %{height} Pixel."
@@ -22305,6 +22305,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:290
 #: lib/vutuv_web/live/press_kit_live.ex:882
+#: lib/vutuv_web/templates/user/edit.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "%{formats}, up to %{limit}"
 msgstr "%{formats}, bis %{limit}"

--- a/priv/gettext/de/LC_MESSAGES/errors.po
+++ b/priv/gettext/de/LC_MESSAGES/errors.po
@@ -207,176 +207,188 @@ msgstr "konnte nicht gelesen werden. Bitte laden Sie eine PDF-, JPG-, PNG- oder 
 msgid "is larger than 10 MB. Please upload a smaller file."
 msgstr "ist größer als 10 MB. Bitte laden Sie eine kleinere Datei hoch."
 
-#: lib/vutuv_web/views/error_helpers.ex:122
+#: lib/vutuv_web/views/error_helpers.ex:131
 #, elixir-autogen, elixir-format
 msgid "must not be a web or email address"
 msgstr "darf keine Web- oder E-Mail-Adresse sein"
 
-#: lib/vutuv_web/views/error_helpers.ex:123
+#: lib/vutuv_web/views/error_helpers.ex:132
 #, elixir-autogen, elixir-format
 msgid "can't be only a link. Please describe yourself in a few words."
 msgstr "darf nicht nur ein Link sein. Bitte beschreiben Sie sich in ein paar Worten."
 
-#: lib/vutuv_web/views/error_helpers.ex:127
+#: lib/vutuv_web/views/error_helpers.ex:136
 #, elixir-autogen, elixir-format
 msgid "\"%{tag}\" is a web address, not a tag. Please describe yourself with words."
 msgstr "„%{tag}“ ist eine Web-Adresse, kein Tag. Bitte beschreiben Sie sich mit Worten."
 
-#: lib/vutuv_web/views/error_helpers.ex:134
+#: lib/vutuv_web/views/error_helpers.ex:143
 #, elixir-autogen, elixir-format
 msgid "must not be only punctuation"
 msgstr "darf nicht nur aus Satzzeichen bestehen"
 
-#: lib/vutuv_web/views/error_helpers.ex:135
+#: lib/vutuv_web/views/error_helpers.ex:144
 #, elixir-autogen, elixir-format
 msgid "\"%{tag}\" is only punctuation, not a tag."
 msgstr "„%{tag}“ besteht nur aus Satzzeichen und ist kein Tag."
 
-#: lib/vutuv_web/views/error_helpers.ex:164
+#: lib/vutuv_web/views/error_helpers.ex:173
 #, elixir-autogen, elixir-format
 msgid "\"%{uri}\" is not a valid https account address."
 msgstr "„%{uri}“ ist keine gültige https-Kontoadresse."
 
-#: lib/vutuv_web/views/error_helpers.ex:163
+#: lib/vutuv_web/views/error_helpers.ex:172
 #, elixir-autogen, elixir-format
 msgid "Please list at most %{max} accounts."
 msgstr "Bitte geben Sie höchstens %{max} Konten an."
 
-#: lib/vutuv_web/views/error_helpers.ex:132
+#: lib/vutuv_web/views/error_helpers.ex:141
 #, elixir-autogen, elixir-format
 msgid "must spell out how the name sounds"
 msgstr "muss beschreiben, wie der Name klingt"
 
-#: lib/vutuv_web/views/error_helpers.ex:156
+#: lib/vutuv_web/views/error_helpers.ex:165
 #, elixir-autogen, elixir-format
 msgid "Please use at most %{max} tags."
 msgstr "Bitte verwenden Sie höchstens %{max} Tags."
 
-#: lib/vutuv_web/views/error_helpers.ex:166
+#: lib/vutuv_web/views/error_helpers.ex:175
 #, elixir-autogen, elixir-format
 msgid "Enter your Signal link, it starts with https://signal.me/#"
 msgstr "Bitte geben Sie Ihren Signal-Link ein, er beginnt mit https://signal.me/#"
 
-#: lib/vutuv_web/views/error_helpers.ex:158
+#: lib/vutuv_web/views/error_helpers.ex:167
 #, elixir-autogen, elixir-format
 msgid "We allow at most %{max} accounts per post. Please remove some mentions."
 msgstr ""
 "Wir erlauben höchstens %{max} Konten pro Beitrag. Bitte entfernen Sie einige "
 "Erwähnungen."
 
-#: lib/vutuv_web/views/error_helpers.ex:169
+#: lib/vutuv_web/views/error_helpers.ex:178
 #, elixir-autogen, elixir-format
 msgid "Enter your Bluesky handle, e.g. name.bsky.social"
 msgstr "Geben Sie Ihr Bluesky-Handle an, z. B. name.bsky.social"
 
-#: lib/vutuv_web/views/error_helpers.ex:182
+#: lib/vutuv_web/views/error_helpers.ex:191
 #, elixir-autogen, elixir-format
 msgid "Enter your Codeberg username, not a full URL with extra path segments"
 msgstr "Geben Sie Ihren Codeberg-Benutzernamen an, keine vollständige URL mit weiteren Pfadangaben"
 
-#: lib/vutuv_web/views/error_helpers.ex:178
+#: lib/vutuv_web/views/error_helpers.ex:187
 #, elixir-autogen, elixir-format
 msgid "Enter your GitHub username, not a full URL with extra path segments"
 msgstr "Geben Sie Ihren GitHub-Benutzernamen an, keine vollständige URL mit weiteren Pfadangaben"
 
-#: lib/vutuv_web/views/error_helpers.ex:174
+#: lib/vutuv_web/views/error_helpers.ex:183
 #, elixir-autogen, elixir-format
 msgid "Enter your GitLab username, e.g. gitlab.com/username (not a /-/u/ ID link)"
 msgstr "Geben Sie Ihren GitLab-Benutzernamen an, z. B. gitlab.com/benutzername (keinen ID-Link mit /-/u/)"
 
-#: lib/vutuv_web/views/error_helpers.ex:168
+#: lib/vutuv_web/views/error_helpers.ex:177
 #, elixir-autogen, elixir-format
 msgid "Enter your full Mastodon handle, e.g. @user@instance.social"
 msgstr "Geben Sie Ihr vollständiges Mastodon-Handle an, z. B. @name@instanz.social"
 
-#: lib/vutuv_web/views/error_helpers.ex:170
+#: lib/vutuv_web/views/error_helpers.ex:179
 #, elixir-autogen, elixir-format
 msgid "Enter your username and your instance, e.g. name@git.example.com"
 msgstr "Geben Sie Ihren Benutzernamen und Ihre Instanz an, z. B. name@git.example.com"
 
-#: lib/vutuv_web/views/error_helpers.ex:186
+#: lib/vutuv_web/views/error_helpers.ex:195
 #, elixir-autogen, elixir-format
 msgid "Invalid account name"
 msgstr "Ungültiger Kontoname"
 
-#: lib/vutuv_web/views/error_helpers.ex:187
+#: lib/vutuv_web/views/error_helpers.ex:196
 #, elixir-autogen, elixir-format
 msgid "Someone has already claimed this account"
 msgstr "Dieses Konto hat bereits jemand für sich beansprucht"
 
-#: lib/vutuv_web/views/error_helpers.ex:194
+#: lib/vutuv_web/views/error_helpers.ex:203
 #, elixir-autogen, elixir-format
 msgid "That instance did not answer. Please try again in a moment."
 msgstr "Diese Instanz hat nicht geantwortet. Bitte versuchen Sie es gleich noch einmal."
 
-#: lib/vutuv_web/views/error_helpers.ex:195
+#: lib/vutuv_web/views/error_helpers.ex:204
 #, elixir-autogen, elixir-format
 msgid "Too many checks for now. Please try again later."
 msgstr "Vorerst zu viele Prüfungen. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/views/error_helpers.ex:190
+#: lib/vutuv_web/views/error_helpers.ex:199
 #, elixir-autogen, elixir-format
 msgid "We could not find this account on that instance. Please check the address."
 msgstr "Wir konnten dieses Konto auf dieser Instanz nicht finden. Bitte prüfen Sie die Adresse."
 
-#: lib/vutuv_web/views/error_helpers.ex:119
+#: lib/vutuv_web/views/error_helpers.ex:128
 #, elixir-autogen, elixir-format
 msgid "Only one email address can be given at sign-up."
 msgstr "Bei der Anmeldung kann nur eine E-Mail-Adresse angegeben werden."
 
-#: lib/vutuv_web/views/error_helpers.ex:143
+#: lib/vutuv_web/views/error_helpers.ex:152
 #, elixir-autogen, elixir-format
 msgid "Please confirm that you are making this claim in good faith."
 msgstr "Bitte bestätigen Sie, dass Sie diese Meldung nach bestem Wissen machen."
 
-#: lib/vutuv_web/views/error_helpers.ex:137
+#: lib/vutuv_web/views/error_helpers.ex:146
 #, elixir-autogen, elixir-format
 msgid "Please pick a category."
 msgstr "Bitte wählen Sie eine Kategorie."
 
-#: lib/vutuv_web/views/error_helpers.ex:139
+#: lib/vutuv_web/views/error_helpers.ex:148
 #, elixir-autogen, elixir-format
 msgid "Please tell us which work it is and where the original can be seen."
 msgstr "Bitte sagen Sie uns, um welches Werk es geht und wo das Original zu sehen ist."
 
-#: lib/vutuv_web/views/error_helpers.ex:138
+#: lib/vutuv_web/views/error_helpers.ex:147
 #, elixir-autogen, elixir-format
 msgid "Your note is too long."
 msgstr "Ihre Notiz ist zu lang."
 
-#: lib/vutuv_web/views/error_helpers.ex:146
+#: lib/vutuv_web/views/error_helpers.ex:155
 #, elixir-autogen, elixir-format
 msgid "Please give us an email address."
 msgstr "Bitte geben Sie eine E-Mail-Adresse an."
 
-#: lib/vutuv_web/views/error_helpers.ex:150
+#: lib/vutuv_web/views/error_helpers.ex:159
 #, elixir-autogen, elixir-format
 msgid "Please tell us what is wrong with this content, in your own words."
 msgstr "Bitte sagen Sie uns mit Ihren eigenen Worten, was an diesem Inhalt nicht stimmt."
 
-#: lib/vutuv_web/views/error_helpers.ex:145
+#: lib/vutuv_web/views/error_helpers.ex:154
 #, elixir-autogen, elixir-format
 msgid "Please tell us your name."
 msgstr "Bitte nennen Sie uns Ihren Namen."
 
-#: lib/vutuv_web/views/error_helpers.ex:148
+#: lib/vutuv_web/views/error_helpers.ex:157
 #, elixir-autogen, elixir-format
 msgid "That address is too long."
 msgstr "Diese Adresse ist zu lang."
 
-#: lib/vutuv_web/views/error_helpers.ex:147
+#: lib/vutuv_web/views/error_helpers.ex:156
 #, elixir-autogen, elixir-format
 msgid "That does not look like an email address."
 msgstr "Das sieht nicht nach einer E-Mail-Adresse aus."
 
 ## Custom message from the duplicate-tag unique constraint
 ## (Vutuv.Tags.UserTag.changeset/2).
-#: lib/vutuv_web/views/error_helpers.ex:154
+#: lib/vutuv_web/views/error_helpers.ex:163
 #, elixir-autogen, elixir-format
 msgid "You already reported this."
 msgstr "Das haben Sie bereits gemeldet."
 
-#: lib/vutuv_web/views/error_helpers.ex:149
+#: lib/vutuv_web/views/error_helpers.ex:158
 #, elixir-autogen, elixir-format
 msgid "Your name is too long."
 msgstr "Ihr Name ist zu lang."
+
+#: lib/vutuv_web/views/error_helpers.ex:123
+#, elixir-autogen, elixir-format
+msgid "We cannot read this file. Please upload one of these formats: %{formats}."
+msgstr ""
+"Diese Datei können wir nicht lesen. Bitte laden Sie eines dieser Formate "
+"hoch: %{formats}."
+
+#: lib/vutuv_web/views/error_helpers.ex:122
+#, elixir-autogen, elixir-format
+msgid "That file is larger than %{limit}. Please upload a smaller one."
+msgstr "Diese Datei ist größer als %{limit}. Bitte laden Sie eine kleinere hoch."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -92,12 +92,12 @@ msgstr ""
 msgid "Are you sure?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:22
+#: lib/vutuv_web/templates/user/edit.html.heex:34
 #, elixir-autogen
 msgid "Avatar"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:416
+#: lib/vutuv_web/templates/user/edit.html.heex:430
 #, elixir-autogen
 msgid "Birthdate"
 msgstr ""
@@ -131,10 +131,10 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:255
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:23
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
-#: lib/vutuv_web/templates/user/edit.html.heex:53
-#: lib/vutuv_web/templates/user/edit.html.heex:137
-#: lib/vutuv_web/templates/user/edit.html.heex:472
-#: lib/vutuv_web/templates/user/edit.html.heex:517
+#: lib/vutuv_web/templates/user/edit.html.heex:65
+#: lib/vutuv_web/templates/user/edit.html.heex:150
+#: lib/vutuv_web/templates/user/edit.html.heex:486
+#: lib/vutuv_web/templates/user/edit.html.heex:531
 #: lib/vutuv_web/templates/username/confirm.html.heex:220
 #, elixir-autogen
 msgid "Cancel"
@@ -309,7 +309,7 @@ msgid "Fax"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:693
-#: lib/vutuv_web/templates/user/edit.html.heex:170
+#: lib/vutuv_web/templates/user/edit.html.heex:184
 #, elixir-autogen
 msgid "First Name"
 msgstr ""
@@ -343,7 +343,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:310
 #: lib/vutuv_web/templates/page/index.html.heex:121
-#: lib/vutuv_web/templates/user/edit.html.heex:207
+#: lib/vutuv_web/templates/user/edit.html.heex:221
 #: lib/vutuv_web/views/account_event_text.ex:219
 #, elixir-autogen
 msgid "Gender"
@@ -386,7 +386,7 @@ msgid "Language"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:695
-#: lib/vutuv_web/templates/user/edit.html.heex:175
+#: lib/vutuv_web/templates/user/edit.html.heex:189
 #, elixir-autogen
 msgid "Last Name"
 msgstr ""
@@ -453,7 +453,7 @@ msgid "Log in"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:694
-#: lib/vutuv_web/templates/user/edit.html.heex:180
+#: lib/vutuv_web/templates/user/edit.html.heex:194
 #, elixir-autogen
 msgid "Middle Name"
 msgstr ""
@@ -490,7 +490,7 @@ msgid "New"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:697
-#: lib/vutuv_web/templates/user/edit.html.heex:185
+#: lib/vutuv_web/templates/user/edit.html.heex:199
 #, elixir-autogen
 msgid "Nickname"
 msgstr ""
@@ -571,7 +571,7 @@ msgid "Phone number updated successfully."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:692
-#: lib/vutuv_web/templates/user/edit.html.heex:190
+#: lib/vutuv_web/templates/user/edit.html.heex:204
 #, elixir-autogen
 msgid "Prefix"
 msgstr ""
@@ -634,7 +634,7 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/preferences.html.heex:362
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:61
-#: lib/vutuv_web/templates/user/edit.html.heex:467
+#: lib/vutuv_web/templates/user/edit.html.heex:481
 #: lib/vutuv_web/views/settings_html.ex:253
 #, elixir-autogen
 msgid "Save"
@@ -752,7 +752,7 @@ msgid "Submit a bugreport or a feature request."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:696
-#: lib/vutuv_web/templates/user/edit.html.heex:195
+#: lib/vutuv_web/templates/user/edit.html.heex:209
 #, elixir-autogen
 msgid "Suffix"
 msgstr ""
@@ -1981,7 +1981,7 @@ msgid "Change cover photo"
 msgstr ""
 
 #: lib/vutuv_web/controllers/report_controller.ex:177
-#: lib/vutuv_web/templates/user/edit.html.heex:100
+#: lib/vutuv_web/templates/user/edit.html.heex:113
 #, elixir-autogen, elixir-format
 msgid "Cover photo"
 msgstr ""
@@ -2052,7 +2052,7 @@ msgid "September"
 msgstr ""
 
 #: lib/vutuv_web/templates/education/form_content.html.heex:32
-#: lib/vutuv_web/templates/user/edit.html.heex:263
+#: lib/vutuv_web/templates/user/edit.html.heex:277
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Markdown is supported: bold, italics, links and lists."
@@ -5402,7 +5402,7 @@ msgstr ""
 msgid "Type of email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:242
+#: lib/vutuv_web/templates/user/edit.html.heex:256
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr ""
@@ -5485,7 +5485,7 @@ msgid "View"
 msgstr ""
 
 #: lib/vutuv_web/templates/public_report/new.html.heex:92
-#: lib/vutuv_web/templates/user/edit.html.heex:167
+#: lib/vutuv_web/templates/user/edit.html.heex:181
 #, elixir-autogen, elixir-format
 msgid "Your name"
 msgstr ""
@@ -5537,24 +5537,24 @@ msgstr ""
 msgid "This sets the language of the whole vutuv interface, not your public profile."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:30
-#: lib/vutuv_web/templates/user/edit.html.heex:34
+#: lib/vutuv_web/templates/user/edit.html.heex:42
+#: lib/vutuv_web/templates/user/edit.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "Current avatar"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:111
-#: lib/vutuv_web/templates/user/edit.html.heex:118
+#: lib/vutuv_web/templates/user/edit.html.heex:124
+#: lib/vutuv_web/templates/user/edit.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Current cover photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:191
+#: lib/vutuv_web/templates/user/edit.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "e.g. Dr. or Prof."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:196
+#: lib/vutuv_web/templates/user/edit.html.heex:210
 #, elixir-autogen, elixir-format
 msgid "e.g. Jr. or PhD"
 msgstr ""
@@ -5997,7 +5997,7 @@ msgid "Add a tagline"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:166
-#: lib/vutuv_web/templates/user/edit.html.heex:259
+#: lib/vutuv_web/templates/user/edit.html.heex:273
 #: lib/vutuv_web/views/account_event_text.ex:212
 #, elixir-autogen, elixir-format
 msgid "Tagline"
@@ -6021,8 +6021,8 @@ msgid_plural "Posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:67
-#: lib/vutuv_web/templates/user/edit.html.heex:150
+#: lib/vutuv_web/templates/user/edit.html.heex:80
+#: lib/vutuv_web/templates/user/edit.html.heex:164
 #, elixir-autogen, elixir-format
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
@@ -6032,41 +6032,41 @@ msgstr ""
 msgid "Also on"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:51
-#: lib/vutuv_web/templates/user/edit.html.heex:135
+#: lib/vutuv_web/templates/user/edit.html.heex:63
+#: lib/vutuv_web/templates/user/edit.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "Drag to move, use the slider to zoom. The framed area is what others see."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:72
+#: lib/vutuv_web/templates/user/edit.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "New avatar preview"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:155
+#: lib/vutuv_web/templates/user/edit.html.heex:169
 #, elixir-autogen, elixir-format
 msgid "New cover photo preview"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:134
+#: lib/vutuv_web/templates/user/edit.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "Position your cover photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:50
+#: lib/vutuv_web/templates/user/edit.html.heex:62
 #, elixir-autogen, elixir-format
 msgid "Position your photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:52
-#: lib/vutuv_web/templates/user/edit.html.heex:136
+#: lib/vutuv_web/templates/user/edit.html.heex:64
+#: lib/vutuv_web/templates/user/edit.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "Use photo"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/composer.ex:1919
-#: lib/vutuv_web/templates/user/edit.html.heex:54
-#: lib/vutuv_web/templates/user/edit.html.heex:138
+#: lib/vutuv_web/templates/user/edit.html.heex:66
+#: lib/vutuv_web/templates/user/edit.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Zoom"
 msgstr ""
@@ -8343,7 +8343,7 @@ msgstr ""
 msgid "Language & display"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:532
+#: lib/vutuv_web/templates/user/edit.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "More profile sections"
 msgstr ""
@@ -8821,7 +8821,7 @@ msgstr ""
 msgid "For a PDF, open the print view and choose \"Save as PDF\" in your browser's print dialog. Word and OpenDocument are editable; LaTeX is the typesetting source; JSON Resume is the open %{link} format."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:272
+#: lib/vutuv_web/templates/user/edit.html.heex:286
 #, elixir-autogen, elixir-format
 msgid "characters"
 msgstr ""
@@ -9382,7 +9382,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1278
+#: lib/vutuv/accounts/user.ex:1292
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9393,13 +9393,13 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1275
+#: lib/vutuv/accounts/user.ex:1289
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:296
+#: lib/vutuv_web/templates/user/edit.html.heex:310
 #, elixir-autogen, elixir-format
 msgid "Shown as a badge next to your tagline so people can see whether you are open to opportunities."
 msgstr ""
@@ -9658,18 +9658,18 @@ msgstr ""
 msgid "Date of birth"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:445
-#: lib/vutuv_web/templates/user/edit.html.heex:520
+#: lib/vutuv_web/templates/user/edit.html.heex:459
+#: lib/vutuv_web/templates/user/edit.html.heex:534
 #, elixir-autogen, elixir-format
 msgid "Remove date of birth"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:508
+#: lib/vutuv_web/templates/user/edit.html.heex:522
 #, elixir-autogen, elixir-format
 msgid "Remove your date of birth?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:511
+#: lib/vutuv_web/templates/user/edit.html.heex:525
 #, elixir-autogen, elixir-format
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
@@ -10706,24 +10706,24 @@ msgstr ""
 msgid "Views"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:305
+#: lib/vutuv_web/templates/user/edit.html.heex:319
 #, elixir-autogen, elixir-format
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1316
+#: lib/vutuv/accounts/user.ex:1330
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1321
+#: lib/vutuv/accounts/user.ex:1335
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1319
+#: lib/vutuv/accounts/user.ex:1333
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:823
 #, elixir-autogen, elixir-format
@@ -10731,43 +10731,43 @@ msgid "Signed-in members only"
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:259
-#: lib/vutuv_web/templates/user/edit.html.heex:302
+#: lib/vutuv_web/templates/user/edit.html.heex:316
 #, elixir-autogen, elixir-format
 msgid "Who can see your availability?"
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:270
-#: lib/vutuv_web/templates/user/edit.html.heex:327
+#: lib/vutuv_web/templates/user/edit.html.heex:341
 #, elixir-autogen, elixir-format
 msgid "Amount"
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:278
 #: lib/vutuv_web/live/job_posting_live/form.ex:693
-#: lib/vutuv_web/templates/user/edit.html.heex:335
+#: lib/vutuv_web/templates/user/edit.html.heex:349
 #, elixir-autogen, elixir-format
 msgid "Currency"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:345
+#: lib/vutuv_web/templates/user/edit.html.heex:359
 #, elixir-autogen, elixir-format
 msgid "Hidden by default, and it still does its job while hidden. \"Signed-in members only\" adds a quiet line to your profile for members; \"Everyone\" also shows it to logged-out visitors."
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:266
-#: lib/vutuv_web/templates/user/edit.html.heex:318
+#: lib/vutuv_web/templates/user/edit.html.heex:332
 #, elixir-autogen, elixir-format
 msgid "Minimum salary expectation"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:321
+#: lib/vutuv_web/templates/user/edit.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "Optional. Even when hidden, it sharpens your own job search and alerts by filtering out postings below it. Leave the amount empty to remove it."
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:274
 #: lib/vutuv_web/live/job_posting_live/form.ex:700
-#: lib/vutuv_web/templates/user/edit.html.heex:331
+#: lib/vutuv_web/templates/user/edit.html.heex:345
 #, elixir-autogen, elixir-format
 msgid "Per"
 msgstr ""
@@ -10777,7 +10777,7 @@ msgstr ""
 msgid "Salary expectation from %{amount} %{currency} per %{period}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:342
+#: lib/vutuv_web/templates/user/edit.html.heex:356
 #, elixir-autogen, elixir-format
 msgid "Who can see your salary expectation?"
 msgstr ""
@@ -10846,7 +10846,7 @@ msgstr ""
 msgid "Exclude an email domain"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:393
+#: lib/vutuv_web/templates/user/edit.html.heex:407
 #, elixir-autogen, elixir-format
 msgid "Hide from specific people"
 msgstr ""
@@ -10857,12 +10857,12 @@ msgstr ""
 msgid "Job-search exclusion list"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:396
+#: lib/vutuv_web/templates/user/edit.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "Keep your availability broadly visible while making sure your own employer never sees it. Exclude specific members or email domains, and they never see your availability or salary expectation, even at \"Everyone\"."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:404
+#: lib/vutuv_web/templates/user/edit.html.heex:418
 #, elixir-autogen, elixir-format
 msgid "Manage exclusion list (1 entry)"
 msgid_plural "Manage exclusion list (%{formatted} entries)"
@@ -12003,7 +12003,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1290
+#: lib/vutuv/accounts/user.ex:1304
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12122,7 +12122,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1289
+#: lib/vutuv/accounts/user.ex:1303
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12204,7 +12204,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1291
+#: lib/vutuv/accounts/user.ex:1305
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:590
 #: lib/vutuv_web/agent_docs/markdown.ex:563
@@ -13167,8 +13167,8 @@ msgstr ""
 msgid "%{pending} image(s) in the scan queue; %{rejected} rejected in the last 7 days. A growing queue usually means Ollama is unreachable."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:41
-#: lib/vutuv_web/templates/user/edit.html.heex:125
+#: lib/vutuv_web/templates/user/edit.html.heex:53
+#: lib/vutuv_web/templates/user/edit.html.heex:138
 #: lib/vutuv_web/templates/user/show.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Image awaiting review, visible only to you"
@@ -13215,36 +13215,36 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1334
+#: lib/vutuv/accounts/user.ex:1348
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:456
+#: lib/vutuv_web/templates/user/edit.html.heex:470
 #, elixir-autogen, elixir-format
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1337
+#: lib/vutuv/accounts/user.ex:1351
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1340
+#: lib/vutuv/accounts/user.ex:1354
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1331
+#: lib/vutuv/accounts/user.ex:1345
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:453
+#: lib/vutuv_web/templates/user/edit.html.heex:467
 #, elixir-autogen, elixir-format
 msgid "Show my birthday as"
 msgstr ""
@@ -13869,7 +13869,7 @@ msgid "Are you looking for a job?"
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:290
-#: lib/vutuv_web/templates/user/edit.html.heex:365
+#: lib/vutuv_web/templates/user/edit.html.heex:379
 #, elixir-autogen, elixir-format
 msgid "How do you want to work?"
 msgstr ""
@@ -13886,7 +13886,7 @@ msgid "Preferred workplace"
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:249
-#: lib/vutuv_web/templates/user/edit.html.heex:293
+#: lib/vutuv_web/templates/user/edit.html.heex:307
 #, elixir-autogen, elixir-format
 msgid "Availability"
 msgstr ""
@@ -16040,19 +16040,19 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:657
 #: lib/vutuv_web/agent_docs/text.ex:629
-#: lib/vutuv_web/templates/user/edit.html.heex:225
+#: lib/vutuv_web/templates/user/edit.html.heex:239
 #: lib/vutuv_web/templates/user/show.html.heex:291
 #: lib/vutuv_web/views/account_event_text.ex:213
 #, elixir-autogen, elixir-format
 msgid "Name pronunciation"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:229
+#: lib/vutuv_web/templates/user/edit.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "e.g. [SHTEH-fahn VIN-ter-my-er]"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:232
+#: lib/vutuv_web/templates/user/edit.html.heex:246
 #, elixir-autogen, elixir-format
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
@@ -18491,17 +18491,17 @@ msgstr ""
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1437
+#: lib/vutuv/accounts/user.ex:1451
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1435
+#: lib/vutuv/accounts/user.ex:1449
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1436
+#: lib/vutuv/accounts/user.ex:1450
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -19728,7 +19728,7 @@ msgstr ""
 msgid "the address of a post out there: vutuv fetches it so you can answer it here"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:85
+#: lib/vutuv_web/templates/user/edit.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Fetch my picture from gravatar.com"
 msgstr ""
@@ -19753,7 +19753,7 @@ msgstr ""
 msgid "gravatar.com has no picture for your email address."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:88
+#: lib/vutuv_web/templates/user/edit.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Only when you press this: we ask gravatar.com whether there is a picture for your email address, sending a hash of the address rather than the address itself. Nothing leaves this server otherwise."
 msgstr ""
@@ -20235,12 +20235,12 @@ msgid_plural "Our AI is looking at them. They appear here by themselves once the
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:145
+#: lib/vutuv_web/templates/user/edit.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "Recommended: %{width} × %{height} pixels (%{ratio})."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:63
+#: lib/vutuv_web/templates/user/edit.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
@@ -21522,6 +21522,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:290
 #: lib/vutuv_web/live/press_kit_live.ex:882
+#: lib/vutuv_web/templates/user/edit.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "%{formats}, up to %{limit}"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -90,12 +90,12 @@ msgstr ""
 msgid "Are you sure?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:22
+#: lib/vutuv_web/templates/user/edit.html.heex:34
 #, elixir-autogen
 msgid "Avatar"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:416
+#: lib/vutuv_web/templates/user/edit.html.heex:430
 #, elixir-autogen
 msgid "Birthdate"
 msgstr ""
@@ -129,10 +129,10 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:255
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:23
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
-#: lib/vutuv_web/templates/user/edit.html.heex:53
-#: lib/vutuv_web/templates/user/edit.html.heex:137
-#: lib/vutuv_web/templates/user/edit.html.heex:472
-#: lib/vutuv_web/templates/user/edit.html.heex:517
+#: lib/vutuv_web/templates/user/edit.html.heex:65
+#: lib/vutuv_web/templates/user/edit.html.heex:150
+#: lib/vutuv_web/templates/user/edit.html.heex:486
+#: lib/vutuv_web/templates/user/edit.html.heex:531
 #: lib/vutuv_web/templates/username/confirm.html.heex:220
 #, elixir-autogen
 msgid "Cancel"
@@ -307,7 +307,7 @@ msgid "Fax"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:693
-#: lib/vutuv_web/templates/user/edit.html.heex:170
+#: lib/vutuv_web/templates/user/edit.html.heex:184
 #, elixir-autogen
 msgid "First Name"
 msgstr ""
@@ -341,7 +341,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:310
 #: lib/vutuv_web/templates/page/index.html.heex:121
-#: lib/vutuv_web/templates/user/edit.html.heex:207
+#: lib/vutuv_web/templates/user/edit.html.heex:221
 #: lib/vutuv_web/views/account_event_text.ex:219
 #, elixir-autogen
 msgid "Gender"
@@ -384,7 +384,7 @@ msgid "Language"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:695
-#: lib/vutuv_web/templates/user/edit.html.heex:175
+#: lib/vutuv_web/templates/user/edit.html.heex:189
 #, elixir-autogen
 msgid "Last Name"
 msgstr ""
@@ -451,7 +451,7 @@ msgid "Log in"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:694
-#: lib/vutuv_web/templates/user/edit.html.heex:180
+#: lib/vutuv_web/templates/user/edit.html.heex:194
 #, elixir-autogen
 msgid "Middle Name"
 msgstr ""
@@ -488,7 +488,7 @@ msgid "New"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:697
-#: lib/vutuv_web/templates/user/edit.html.heex:185
+#: lib/vutuv_web/templates/user/edit.html.heex:199
 #, elixir-autogen
 msgid "Nickname"
 msgstr ""
@@ -569,7 +569,7 @@ msgid "Phone number updated successfully."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:692
-#: lib/vutuv_web/templates/user/edit.html.heex:190
+#: lib/vutuv_web/templates/user/edit.html.heex:204
 #, elixir-autogen
 msgid "Prefix"
 msgstr ""
@@ -632,7 +632,7 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/preferences.html.heex:362
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:61
-#: lib/vutuv_web/templates/user/edit.html.heex:467
+#: lib/vutuv_web/templates/user/edit.html.heex:481
 #: lib/vutuv_web/views/settings_html.ex:253
 #, elixir-autogen
 msgid "Save"
@@ -750,7 +750,7 @@ msgid "Submit a bugreport or a feature request."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:696
-#: lib/vutuv_web/templates/user/edit.html.heex:195
+#: lib/vutuv_web/templates/user/edit.html.heex:209
 #, elixir-autogen
 msgid "Suffix"
 msgstr ""
@@ -1979,7 +1979,7 @@ msgid "Change cover photo"
 msgstr ""
 
 #: lib/vutuv_web/controllers/report_controller.ex:177
-#: lib/vutuv_web/templates/user/edit.html.heex:100
+#: lib/vutuv_web/templates/user/edit.html.heex:113
 #, elixir-autogen, elixir-format
 msgid "Cover photo"
 msgstr ""
@@ -2050,7 +2050,7 @@ msgid "September"
 msgstr ""
 
 #: lib/vutuv_web/templates/education/form_content.html.heex:32
-#: lib/vutuv_web/templates/user/edit.html.heex:263
+#: lib/vutuv_web/templates/user/edit.html.heex:277
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Markdown is supported: bold, italics, links and lists."
@@ -5400,7 +5400,7 @@ msgstr ""
 msgid "Type of email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:242
+#: lib/vutuv_web/templates/user/edit.html.heex:256
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr ""
@@ -5483,7 +5483,7 @@ msgid "View"
 msgstr ""
 
 #: lib/vutuv_web/templates/public_report/new.html.heex:92
-#: lib/vutuv_web/templates/user/edit.html.heex:167
+#: lib/vutuv_web/templates/user/edit.html.heex:181
 #, elixir-autogen, elixir-format
 msgid "Your name"
 msgstr ""
@@ -5535,24 +5535,24 @@ msgstr ""
 msgid "This sets the language of the whole vutuv interface, not your public profile."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:30
-#: lib/vutuv_web/templates/user/edit.html.heex:34
+#: lib/vutuv_web/templates/user/edit.html.heex:42
+#: lib/vutuv_web/templates/user/edit.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "Current avatar"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:111
-#: lib/vutuv_web/templates/user/edit.html.heex:118
+#: lib/vutuv_web/templates/user/edit.html.heex:124
+#: lib/vutuv_web/templates/user/edit.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Current cover photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:191
+#: lib/vutuv_web/templates/user/edit.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "e.g. Dr. or Prof."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:196
+#: lib/vutuv_web/templates/user/edit.html.heex:210
 #, elixir-autogen, elixir-format
 msgid "e.g. Jr. or PhD"
 msgstr ""
@@ -5995,7 +5995,7 @@ msgid "Add a tagline"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:166
-#: lib/vutuv_web/templates/user/edit.html.heex:259
+#: lib/vutuv_web/templates/user/edit.html.heex:273
 #: lib/vutuv_web/views/account_event_text.ex:212
 #, elixir-autogen, elixir-format
 msgid "Tagline"
@@ -6019,8 +6019,8 @@ msgid_plural "Posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:67
-#: lib/vutuv_web/templates/user/edit.html.heex:150
+#: lib/vutuv_web/templates/user/edit.html.heex:80
+#: lib/vutuv_web/templates/user/edit.html.heex:164
 #, elixir-autogen, elixir-format
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
@@ -6030,41 +6030,41 @@ msgstr ""
 msgid "Also on"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:51
-#: lib/vutuv_web/templates/user/edit.html.heex:135
+#: lib/vutuv_web/templates/user/edit.html.heex:63
+#: lib/vutuv_web/templates/user/edit.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "Drag to move, use the slider to zoom. The framed area is what others see."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:72
+#: lib/vutuv_web/templates/user/edit.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "New avatar preview"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:155
+#: lib/vutuv_web/templates/user/edit.html.heex:169
 #, elixir-autogen, elixir-format
 msgid "New cover photo preview"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:134
+#: lib/vutuv_web/templates/user/edit.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "Position your cover photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:50
+#: lib/vutuv_web/templates/user/edit.html.heex:62
 #, elixir-autogen, elixir-format
 msgid "Position your photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:52
-#: lib/vutuv_web/templates/user/edit.html.heex:136
+#: lib/vutuv_web/templates/user/edit.html.heex:64
+#: lib/vutuv_web/templates/user/edit.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "Use photo"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/composer.ex:1919
-#: lib/vutuv_web/templates/user/edit.html.heex:54
-#: lib/vutuv_web/templates/user/edit.html.heex:138
+#: lib/vutuv_web/templates/user/edit.html.heex:66
+#: lib/vutuv_web/templates/user/edit.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Zoom"
 msgstr ""
@@ -8341,7 +8341,7 @@ msgstr ""
 msgid "Language & display"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:532
+#: lib/vutuv_web/templates/user/edit.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "More profile sections"
 msgstr ""
@@ -8819,7 +8819,7 @@ msgstr ""
 msgid "For a PDF, open the print view and choose \"Save as PDF\" in your browser's print dialog. Word and OpenDocument are editable; LaTeX is the typesetting source; JSON Resume is the open %{link} format."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:272
+#: lib/vutuv_web/templates/user/edit.html.heex:286
 #, elixir-autogen, elixir-format
 msgid "characters"
 msgstr ""
@@ -9380,7 +9380,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1278
+#: lib/vutuv/accounts/user.ex:1292
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9391,13 +9391,13 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1275
+#: lib/vutuv/accounts/user.ex:1289
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:296
+#: lib/vutuv_web/templates/user/edit.html.heex:310
 #, elixir-autogen, elixir-format
 msgid "Shown as a badge next to your tagline so people can see whether you are open to opportunities."
 msgstr ""
@@ -9656,18 +9656,18 @@ msgstr ""
 msgid "Date of birth"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:445
-#: lib/vutuv_web/templates/user/edit.html.heex:520
+#: lib/vutuv_web/templates/user/edit.html.heex:459
+#: lib/vutuv_web/templates/user/edit.html.heex:534
 #, elixir-autogen, elixir-format
 msgid "Remove date of birth"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:508
+#: lib/vutuv_web/templates/user/edit.html.heex:522
 #, elixir-autogen, elixir-format
 msgid "Remove your date of birth?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:511
+#: lib/vutuv_web/templates/user/edit.html.heex:525
 #, elixir-autogen, elixir-format
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
@@ -10704,24 +10704,24 @@ msgstr ""
 msgid "Views"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:305
+#: lib/vutuv_web/templates/user/edit.html.heex:319
 #, elixir-autogen, elixir-format
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1316
+#: lib/vutuv/accounts/user.ex:1330
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1321
+#: lib/vutuv/accounts/user.ex:1335
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1319
+#: lib/vutuv/accounts/user.ex:1333
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:823
 #, elixir-autogen, elixir-format
@@ -10729,43 +10729,43 @@ msgid "Signed-in members only"
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:259
-#: lib/vutuv_web/templates/user/edit.html.heex:302
+#: lib/vutuv_web/templates/user/edit.html.heex:316
 #, elixir-autogen, elixir-format
 msgid "Who can see your availability?"
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:270
-#: lib/vutuv_web/templates/user/edit.html.heex:327
+#: lib/vutuv_web/templates/user/edit.html.heex:341
 #, elixir-autogen, elixir-format
 msgid "Amount"
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:278
 #: lib/vutuv_web/live/job_posting_live/form.ex:693
-#: lib/vutuv_web/templates/user/edit.html.heex:335
+#: lib/vutuv_web/templates/user/edit.html.heex:349
 #, elixir-autogen, elixir-format
 msgid "Currency"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:345
+#: lib/vutuv_web/templates/user/edit.html.heex:359
 #, elixir-autogen, elixir-format
 msgid "Hidden by default, and it still does its job while hidden. \"Signed-in members only\" adds a quiet line to your profile for members; \"Everyone\" also shows it to logged-out visitors."
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:266
-#: lib/vutuv_web/templates/user/edit.html.heex:318
+#: lib/vutuv_web/templates/user/edit.html.heex:332
 #, elixir-autogen, elixir-format
 msgid "Minimum salary expectation"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:321
+#: lib/vutuv_web/templates/user/edit.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "Optional. Even when hidden, it sharpens your own job search and alerts by filtering out postings below it. Leave the amount empty to remove it."
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:274
 #: lib/vutuv_web/live/job_posting_live/form.ex:700
-#: lib/vutuv_web/templates/user/edit.html.heex:331
+#: lib/vutuv_web/templates/user/edit.html.heex:345
 #, elixir-autogen, elixir-format
 msgid "Per"
 msgstr ""
@@ -10775,7 +10775,7 @@ msgstr ""
 msgid "Salary expectation from %{amount} %{currency} per %{period}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:342
+#: lib/vutuv_web/templates/user/edit.html.heex:356
 #, elixir-autogen, elixir-format
 msgid "Who can see your salary expectation?"
 msgstr ""
@@ -10844,7 +10844,7 @@ msgstr ""
 msgid "Exclude an email domain"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:393
+#: lib/vutuv_web/templates/user/edit.html.heex:407
 #, elixir-autogen, elixir-format
 msgid "Hide from specific people"
 msgstr ""
@@ -10855,12 +10855,12 @@ msgstr ""
 msgid "Job-search exclusion list"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:396
+#: lib/vutuv_web/templates/user/edit.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "Keep your availability broadly visible while making sure your own employer never sees it. Exclude specific members or email domains, and they never see your availability or salary expectation, even at \"Everyone\"."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:404
+#: lib/vutuv_web/templates/user/edit.html.heex:418
 #, elixir-autogen, elixir-format
 msgid "Manage exclusion list (1 entry)"
 msgid_plural "Manage exclusion list (%{formatted} entries)"
@@ -12001,7 +12001,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1290
+#: lib/vutuv/accounts/user.ex:1304
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12120,7 +12120,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1289
+#: lib/vutuv/accounts/user.ex:1303
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12202,7 +12202,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1291
+#: lib/vutuv/accounts/user.ex:1305
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:590
 #: lib/vutuv_web/agent_docs/markdown.ex:563
@@ -13165,8 +13165,8 @@ msgstr ""
 msgid "%{pending} image(s) in the scan queue; %{rejected} rejected in the last 7 days. A growing queue usually means Ollama is unreachable."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:41
-#: lib/vutuv_web/templates/user/edit.html.heex:125
+#: lib/vutuv_web/templates/user/edit.html.heex:53
+#: lib/vutuv_web/templates/user/edit.html.heex:138
 #: lib/vutuv_web/templates/user/show.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Image awaiting review, visible only to you"
@@ -13213,36 +13213,36 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1334
+#: lib/vutuv/accounts/user.ex:1348
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:456
+#: lib/vutuv_web/templates/user/edit.html.heex:470
 #, elixir-autogen, elixir-format
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1337
+#: lib/vutuv/accounts/user.ex:1351
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1340
+#: lib/vutuv/accounts/user.ex:1354
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1331
+#: lib/vutuv/accounts/user.ex:1345
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:453
+#: lib/vutuv_web/templates/user/edit.html.heex:467
 #, elixir-autogen, elixir-format
 msgid "Show my birthday as"
 msgstr ""
@@ -13867,7 +13867,7 @@ msgid "Are you looking for a job?"
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:290
-#: lib/vutuv_web/templates/user/edit.html.heex:365
+#: lib/vutuv_web/templates/user/edit.html.heex:379
 #, elixir-autogen, elixir-format
 msgid "How do you want to work?"
 msgstr ""
@@ -13884,7 +13884,7 @@ msgid "Preferred workplace"
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:249
-#: lib/vutuv_web/templates/user/edit.html.heex:293
+#: lib/vutuv_web/templates/user/edit.html.heex:307
 #, elixir-autogen, elixir-format
 msgid "Availability"
 msgstr ""
@@ -16038,19 +16038,19 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:657
 #: lib/vutuv_web/agent_docs/text.ex:629
-#: lib/vutuv_web/templates/user/edit.html.heex:225
+#: lib/vutuv_web/templates/user/edit.html.heex:239
 #: lib/vutuv_web/templates/user/show.html.heex:291
 #: lib/vutuv_web/views/account_event_text.ex:213
 #, elixir-autogen, elixir-format
 msgid "Name pronunciation"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:229
+#: lib/vutuv_web/templates/user/edit.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "e.g. [SHTEH-fahn VIN-ter-my-er]"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:232
+#: lib/vutuv_web/templates/user/edit.html.heex:246
 #, elixir-autogen, elixir-format
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
@@ -18489,17 +18489,17 @@ msgstr ""
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1437
+#: lib/vutuv/accounts/user.ex:1451
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1435
+#: lib/vutuv/accounts/user.ex:1449
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1436
+#: lib/vutuv/accounts/user.ex:1450
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -19726,7 +19726,7 @@ msgstr ""
 msgid "the address of a post out there: vutuv fetches it so you can answer it here"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:85
+#: lib/vutuv_web/templates/user/edit.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Fetch my picture from gravatar.com"
 msgstr ""
@@ -19751,7 +19751,7 @@ msgstr ""
 msgid "gravatar.com has no picture for your email address."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:88
+#: lib/vutuv_web/templates/user/edit.html.heex:101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Only when you press this: we ask gravatar.com whether there is a picture for your email address, sending a hash of the address rather than the address itself. Nothing leaves this server otherwise."
 msgstr ""
@@ -20233,12 +20233,12 @@ msgid_plural "Our AI is looking at them. They appear here by themselves once the
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:145
+#: lib/vutuv_web/templates/user/edit.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "Recommended: %{width} × %{height} pixels (%{ratio})."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:63
+#: lib/vutuv_web/templates/user/edit.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
@@ -21520,6 +21520,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:290
 #: lib/vutuv_web/live/press_kit_live.ex:882
+#: lib/vutuv_web/templates/user/edit.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "%{formats}, up to %{limit}"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -205,174 +205,184 @@ msgstr ""
 msgid "is larger than 10 MB. Please upload a smaller file."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:122
+#: lib/vutuv_web/views/error_helpers.ex:131
 #, elixir-autogen, elixir-format
 msgid "must not be a web or email address"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:123
+#: lib/vutuv_web/views/error_helpers.ex:132
 #, elixir-autogen, elixir-format
 msgid "can't be only a link. Please describe yourself in a few words."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:127
+#: lib/vutuv_web/views/error_helpers.ex:136
 #, elixir-autogen, elixir-format
 msgid "\"%{tag}\" is a web address, not a tag. Please describe yourself with words."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:134
+#: lib/vutuv_web/views/error_helpers.ex:143
 #, elixir-autogen, elixir-format
 msgid "must not be only punctuation"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:135
+#: lib/vutuv_web/views/error_helpers.ex:144
 #, elixir-autogen, elixir-format
 msgid "\"%{tag}\" is only punctuation, not a tag."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:164
+#: lib/vutuv_web/views/error_helpers.ex:173
 #, elixir-autogen, elixir-format
 msgid "\"%{uri}\" is not a valid https account address."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:163
+#: lib/vutuv_web/views/error_helpers.ex:172
 #, elixir-autogen, elixir-format
 msgid "Please list at most %{max} accounts."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:132
+#: lib/vutuv_web/views/error_helpers.ex:141
 #, elixir-autogen, elixir-format
 msgid "must spell out how the name sounds"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:156
+#: lib/vutuv_web/views/error_helpers.ex:165
 #, elixir-autogen, elixir-format
 msgid "Please use at most %{max} tags."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:166
+#: lib/vutuv_web/views/error_helpers.ex:175
 #, elixir-autogen, elixir-format
 msgid "Enter your Signal link, it starts with https://signal.me/#"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:158
+#: lib/vutuv_web/views/error_helpers.ex:167
 #, elixir-autogen, elixir-format
 msgid "We allow at most %{max} accounts per post. Please remove some mentions."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:169
+#: lib/vutuv_web/views/error_helpers.ex:178
 #, elixir-autogen, elixir-format
 msgid "Enter your Bluesky handle, e.g. name.bsky.social"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:182
+#: lib/vutuv_web/views/error_helpers.ex:191
 #, elixir-autogen, elixir-format
 msgid "Enter your Codeberg username, not a full URL with extra path segments"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:178
+#: lib/vutuv_web/views/error_helpers.ex:187
 #, elixir-autogen, elixir-format
 msgid "Enter your GitHub username, not a full URL with extra path segments"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:174
+#: lib/vutuv_web/views/error_helpers.ex:183
 #, elixir-autogen, elixir-format
 msgid "Enter your GitLab username, e.g. gitlab.com/username (not a /-/u/ ID link)"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:168
+#: lib/vutuv_web/views/error_helpers.ex:177
 #, elixir-autogen, elixir-format
 msgid "Enter your full Mastodon handle, e.g. @user@instance.social"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:170
+#: lib/vutuv_web/views/error_helpers.ex:179
 #, elixir-autogen, elixir-format
 msgid "Enter your username and your instance, e.g. name@git.example.com"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:186
+#: lib/vutuv_web/views/error_helpers.ex:195
 #, elixir-autogen, elixir-format
 msgid "Invalid account name"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:187
+#: lib/vutuv_web/views/error_helpers.ex:196
 #, elixir-autogen, elixir-format
 msgid "Someone has already claimed this account"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:194
+#: lib/vutuv_web/views/error_helpers.ex:203
 #, elixir-autogen, elixir-format
 msgid "That instance did not answer. Please try again in a moment."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:195
+#: lib/vutuv_web/views/error_helpers.ex:204
 #, elixir-autogen, elixir-format
 msgid "Too many checks for now. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:190
+#: lib/vutuv_web/views/error_helpers.ex:199
 #, elixir-autogen, elixir-format
 msgid "We could not find this account on that instance. Please check the address."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:119
+#: lib/vutuv_web/views/error_helpers.ex:128
 #, elixir-autogen, elixir-format
 msgid "Only one email address can be given at sign-up."
 msgstr "Only one email address can be given at sign-up."
 
-#: lib/vutuv_web/views/error_helpers.ex:143
+#: lib/vutuv_web/views/error_helpers.ex:152
 #, elixir-autogen, elixir-format
 msgid "Please confirm that you are making this claim in good faith."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:137
+#: lib/vutuv_web/views/error_helpers.ex:146
 #, elixir-autogen, elixir-format
 msgid "Please pick a category."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:139
+#: lib/vutuv_web/views/error_helpers.ex:148
 #, elixir-autogen, elixir-format
 msgid "Please tell us which work it is and where the original can be seen."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:138
+#: lib/vutuv_web/views/error_helpers.ex:147
 #, elixir-autogen, elixir-format
 msgid "Your note is too long."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:146
+#: lib/vutuv_web/views/error_helpers.ex:155
 #, elixir-autogen, elixir-format
 msgid "Please give us an email address."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:150
+#: lib/vutuv_web/views/error_helpers.ex:159
 #, elixir-autogen, elixir-format
 msgid "Please tell us what is wrong with this content, in your own words."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:145
+#: lib/vutuv_web/views/error_helpers.ex:154
 #, elixir-autogen, elixir-format
 msgid "Please tell us your name."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:148
+#: lib/vutuv_web/views/error_helpers.ex:157
 #, elixir-autogen, elixir-format
 msgid "That address is too long."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:147
+#: lib/vutuv_web/views/error_helpers.ex:156
 #, elixir-autogen, elixir-format
 msgid "That does not look like an email address."
 msgstr ""
 
 ## Custom message from the duplicate-tag unique constraint
 ## (Vutuv.Tags.UserTag.changeset/2).
-#: lib/vutuv_web/views/error_helpers.ex:154
+#: lib/vutuv_web/views/error_helpers.ex:163
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You already reported this."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:149
+#: lib/vutuv_web/views/error_helpers.ex:158
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Your name is too long."
+msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:123
+#, elixir-autogen, elixir-format
+msgid "We cannot read this file. Please upload one of these formats: %{formats}."
+msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:122
+#, elixir-autogen, elixir-format
+msgid "That file is larger than %{limit}. Please upload a smaller one."
 msgstr ""

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -208,172 +208,182 @@ msgstr ""
 msgid "is larger than 10 MB. Please upload a smaller file."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:122
+#: lib/vutuv_web/views/error_helpers.ex:131
 #, elixir-autogen, elixir-format
 msgid "must not be a web or email address"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:123
+#: lib/vutuv_web/views/error_helpers.ex:132
 #, elixir-autogen, elixir-format
 msgid "can't be only a link. Please describe yourself in a few words."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:127
+#: lib/vutuv_web/views/error_helpers.ex:136
 #, elixir-autogen, elixir-format
 msgid "\"%{tag}\" is a web address, not a tag. Please describe yourself with words."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:134
+#: lib/vutuv_web/views/error_helpers.ex:143
 #, elixir-autogen, elixir-format
 msgid "must not be only punctuation"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:135
+#: lib/vutuv_web/views/error_helpers.ex:144
 #, elixir-autogen, elixir-format
 msgid "\"%{tag}\" is only punctuation, not a tag."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:164
+#: lib/vutuv_web/views/error_helpers.ex:173
 #, elixir-autogen, elixir-format
 msgid "\"%{uri}\" is not a valid https account address."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:163
+#: lib/vutuv_web/views/error_helpers.ex:172
 #, elixir-autogen, elixir-format
 msgid "Please list at most %{max} accounts."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:132
+#: lib/vutuv_web/views/error_helpers.ex:141
 #, elixir-autogen, elixir-format
 msgid "must spell out how the name sounds"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:156
+#: lib/vutuv_web/views/error_helpers.ex:165
 #, elixir-autogen, elixir-format
 msgid "Please use at most %{max} tags."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:166
+#: lib/vutuv_web/views/error_helpers.ex:175
 #, elixir-autogen, elixir-format
 msgid "Enter your Signal link, it starts with https://signal.me/#"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:158
+#: lib/vutuv_web/views/error_helpers.ex:167
 #, elixir-autogen, elixir-format
 msgid "We allow at most %{max} accounts per post. Please remove some mentions."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:169
+#: lib/vutuv_web/views/error_helpers.ex:178
 #, elixir-autogen, elixir-format
 msgid "Enter your Bluesky handle, e.g. name.bsky.social"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:182
+#: lib/vutuv_web/views/error_helpers.ex:191
 #, elixir-autogen, elixir-format
 msgid "Enter your Codeberg username, not a full URL with extra path segments"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:178
+#: lib/vutuv_web/views/error_helpers.ex:187
 #, elixir-autogen, elixir-format
 msgid "Enter your GitHub username, not a full URL with extra path segments"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:174
+#: lib/vutuv_web/views/error_helpers.ex:183
 #, elixir-autogen, elixir-format
 msgid "Enter your GitLab username, e.g. gitlab.com/username (not a /-/u/ ID link)"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:168
+#: lib/vutuv_web/views/error_helpers.ex:177
 #, elixir-autogen, elixir-format
 msgid "Enter your full Mastodon handle, e.g. @user@instance.social"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:170
+#: lib/vutuv_web/views/error_helpers.ex:179
 #, elixir-autogen, elixir-format
 msgid "Enter your username and your instance, e.g. name@git.example.com"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:186
+#: lib/vutuv_web/views/error_helpers.ex:195
 #, elixir-autogen, elixir-format
 msgid "Invalid account name"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:187
+#: lib/vutuv_web/views/error_helpers.ex:196
 #, elixir-autogen, elixir-format
 msgid "Someone has already claimed this account"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:194
+#: lib/vutuv_web/views/error_helpers.ex:203
 #, elixir-autogen, elixir-format
 msgid "That instance did not answer. Please try again in a moment."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:195
+#: lib/vutuv_web/views/error_helpers.ex:204
 #, elixir-autogen, elixir-format
 msgid "Too many checks for now. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:190
+#: lib/vutuv_web/views/error_helpers.ex:199
 #, elixir-autogen, elixir-format
 msgid "We could not find this account on that instance. Please check the address."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:119
+#: lib/vutuv_web/views/error_helpers.ex:128
 #, elixir-autogen, elixir-format
 msgid "Only one email address can be given at sign-up."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:143
+#: lib/vutuv_web/views/error_helpers.ex:152
 #, elixir-autogen, elixir-format
 msgid "Please confirm that you are making this claim in good faith."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:137
+#: lib/vutuv_web/views/error_helpers.ex:146
 #, elixir-autogen, elixir-format
 msgid "Please pick a category."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:139
+#: lib/vutuv_web/views/error_helpers.ex:148
 #, elixir-autogen, elixir-format
 msgid "Please tell us which work it is and where the original can be seen."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:138
+#: lib/vutuv_web/views/error_helpers.ex:147
 #, elixir-autogen, elixir-format
 msgid "Your note is too long."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:146
+#: lib/vutuv_web/views/error_helpers.ex:155
 #, elixir-autogen, elixir-format
 msgid "Please give us an email address."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:150
+#: lib/vutuv_web/views/error_helpers.ex:159
 #, elixir-autogen, elixir-format
 msgid "Please tell us what is wrong with this content, in your own words."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:145
+#: lib/vutuv_web/views/error_helpers.ex:154
 #, elixir-autogen, elixir-format
 msgid "Please tell us your name."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:148
+#: lib/vutuv_web/views/error_helpers.ex:157
 #, elixir-autogen, elixir-format
 msgid "That address is too long."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:147
+#: lib/vutuv_web/views/error_helpers.ex:156
 #, elixir-autogen, elixir-format
 msgid "That does not look like an email address."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:154
+#: lib/vutuv_web/views/error_helpers.ex:163
 #, elixir-autogen, elixir-format
 msgid "You already reported this."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:149
+#: lib/vutuv_web/views/error_helpers.ex:158
 #, elixir-autogen, elixir-format
 msgid "Your name is too long."
+msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:123
+#, elixir-autogen, elixir-format
+msgid "We cannot read this file. Please upload one of these formats: %{formats}."
+msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:122
+#, elixir-autogen, elixir-format
+msgid "That file is larger than %{limit}. Please upload a smaller one."
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -92,12 +92,12 @@ msgstr "È già iscritto? Acceda qui."
 msgid "Are you sure?"
 msgstr "Confermi?"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:22
+#: lib/vutuv_web/templates/user/edit.html.heex:34
 #, elixir-autogen
 msgid "Avatar"
 msgstr "Immagine del profilo"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:416
+#: lib/vutuv_web/templates/user/edit.html.heex:430
 #, elixir-autogen
 msgid "Birthdate"
 msgstr "Data di nascita"
@@ -131,10 +131,10 @@ msgstr "Compleanno"
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:255
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:23
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
-#: lib/vutuv_web/templates/user/edit.html.heex:53
-#: lib/vutuv_web/templates/user/edit.html.heex:137
-#: lib/vutuv_web/templates/user/edit.html.heex:472
-#: lib/vutuv_web/templates/user/edit.html.heex:517
+#: lib/vutuv_web/templates/user/edit.html.heex:65
+#: lib/vutuv_web/templates/user/edit.html.heex:150
+#: lib/vutuv_web/templates/user/edit.html.heex:486
+#: lib/vutuv_web/templates/user/edit.html.heex:531
 #: lib/vutuv_web/templates/username/confirm.html.heex:220
 #, elixir-autogen
 msgid "Cancel"
@@ -309,7 +309,7 @@ msgid "Fax"
 msgstr "Fax"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:693
-#: lib/vutuv_web/templates/user/edit.html.heex:170
+#: lib/vutuv_web/templates/user/edit.html.heex:184
 #, elixir-autogen
 msgid "First Name"
 msgstr "Nome"
@@ -343,7 +343,7 @@ msgstr "Seguiti"
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:310
 #: lib/vutuv_web/templates/page/index.html.heex:121
-#: lib/vutuv_web/templates/user/edit.html.heex:207
+#: lib/vutuv_web/templates/user/edit.html.heex:221
 #: lib/vutuv_web/views/account_event_text.ex:219
 #, elixir-autogen
 msgid "Gender"
@@ -388,7 +388,7 @@ msgid "Language"
 msgstr "Lingua"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:695
-#: lib/vutuv_web/templates/user/edit.html.heex:175
+#: lib/vutuv_web/templates/user/edit.html.heex:189
 #, elixir-autogen
 msgid "Last Name"
 msgstr "Cognome"
@@ -455,7 +455,7 @@ msgid "Log in"
 msgstr "Accedi"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:694
-#: lib/vutuv_web/templates/user/edit.html.heex:180
+#: lib/vutuv_web/templates/user/edit.html.heex:194
 #, elixir-autogen
 msgid "Middle Name"
 msgstr "Secondo nome"
@@ -492,7 +492,7 @@ msgid "New"
 msgstr "Nuovo"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:697
-#: lib/vutuv_web/templates/user/edit.html.heex:185
+#: lib/vutuv_web/templates/user/edit.html.heex:199
 #, elixir-autogen
 msgid "Nickname"
 msgstr "Soprannome"
@@ -573,7 +573,7 @@ msgid "Phone number updated successfully."
 msgstr "Numero di telefono aggiornato."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:692
-#: lib/vutuv_web/templates/user/edit.html.heex:190
+#: lib/vutuv_web/templates/user/edit.html.heex:204
 #, elixir-autogen
 msgid "Prefix"
 msgstr "Prefisso"
@@ -636,7 +636,7 @@ msgstr "Pubblico"
 #: lib/vutuv_web/templates/settings/preferences.html.heex:362
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:61
-#: lib/vutuv_web/templates/user/edit.html.heex:467
+#: lib/vutuv_web/templates/user/edit.html.heex:481
 #: lib/vutuv_web/views/settings_html.ex:253
 #, elixir-autogen
 msgid "Save"
@@ -754,7 +754,7 @@ msgid "Submit a bugreport or a feature request."
 msgstr "Segnali un problema o proponga una funzione."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:696
-#: lib/vutuv_web/templates/user/edit.html.heex:195
+#: lib/vutuv_web/templates/user/edit.html.heex:209
 #, elixir-autogen
 msgid "Suffix"
 msgstr "Suffisso"
@@ -2019,7 +2019,7 @@ msgid "Change cover photo"
 msgstr "Cambia immagine di copertina"
 
 #: lib/vutuv_web/controllers/report_controller.ex:177
-#: lib/vutuv_web/templates/user/edit.html.heex:100
+#: lib/vutuv_web/templates/user/edit.html.heex:113
 #, elixir-autogen, elixir-format
 msgid "Cover photo"
 msgstr "Immagine di copertina"
@@ -2090,7 +2090,7 @@ msgid "September"
 msgstr "Settembre"
 
 #: lib/vutuv_web/templates/education/form_content.html.heex:32
-#: lib/vutuv_web/templates/user/edit.html.heex:263
+#: lib/vutuv_web/templates/user/edit.html.heex:277
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Markdown is supported: bold, italics, links and lists."
@@ -5608,7 +5608,7 @@ msgstr "Tipo di indirizzo e-mail"
 msgid "Type of email address"
 msgstr "Tipo di indirizzo e-mail"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:242
+#: lib/vutuv_web/templates/user/edit.html.heex:256
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr "Su di Lei"
@@ -5691,7 +5691,7 @@ msgid "View"
 msgstr "Vedi"
 
 #: lib/vutuv_web/templates/public_report/new.html.heex:92
-#: lib/vutuv_web/templates/user/edit.html.heex:167
+#: lib/vutuv_web/templates/user/edit.html.heex:181
 #, elixir-autogen, elixir-format
 msgid "Your name"
 msgstr "Il Suo nome"
@@ -5745,24 +5745,24 @@ msgstr ""
 "Imposta la lingua dell'intera interfaccia di vutuv, non del Suo profilo "
 "pubblico."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:30
-#: lib/vutuv_web/templates/user/edit.html.heex:34
+#: lib/vutuv_web/templates/user/edit.html.heex:42
+#: lib/vutuv_web/templates/user/edit.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "Current avatar"
 msgstr "Immagine del profilo attuale"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:111
-#: lib/vutuv_web/templates/user/edit.html.heex:118
+#: lib/vutuv_web/templates/user/edit.html.heex:124
+#: lib/vutuv_web/templates/user/edit.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Current cover photo"
 msgstr "Immagine di copertina attuale"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:191
+#: lib/vutuv_web/templates/user/edit.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "e.g. Dr. or Prof."
 msgstr "ad esempio Dott. o Prof."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:196
+#: lib/vutuv_web/templates/user/edit.html.heex:210
 #, elixir-autogen, elixir-format
 msgid "e.g. Jr. or PhD"
 msgstr "ad esempio Jr. o PhD"
@@ -6215,7 +6215,7 @@ msgid "Add a tagline"
 msgstr "Aggiungi una descrizione breve"
 
 #: lib/vutuv_web/live/cv_live.ex:166
-#: lib/vutuv_web/templates/user/edit.html.heex:259
+#: lib/vutuv_web/templates/user/edit.html.heex:273
 #: lib/vutuv_web/views/account_event_text.ex:212
 #, elixir-autogen, elixir-format
 msgid "Tagline"
@@ -6239,8 +6239,8 @@ msgid_plural "Posts"
 msgstr[0] "post"
 msgstr[1] "post"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:67
-#: lib/vutuv_web/templates/user/edit.html.heex:150
+#: lib/vutuv_web/templates/user/edit.html.heex:80
+#: lib/vutuv_web/templates/user/edit.html.heex:164
 #, elixir-autogen, elixir-format
 msgid "After choosing a file you can reposition and zoom it."
 msgstr "Dopo aver scelto un file può spostarlo e ingrandirlo."
@@ -6250,43 +6250,43 @@ msgstr "Dopo aver scelto un file può spostarlo e ingrandirlo."
 msgid "Also on"
 msgstr "Anche su"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:51
-#: lib/vutuv_web/templates/user/edit.html.heex:135
+#: lib/vutuv_web/templates/user/edit.html.heex:63
+#: lib/vutuv_web/templates/user/edit.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "Drag to move, use the slider to zoom. The framed area is what others see."
 msgstr ""
 "Trascini per spostare, usi il cursore per ingrandire. L'area nel riquadro è "
 "quella che vedono gli altri."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:72
+#: lib/vutuv_web/templates/user/edit.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "New avatar preview"
 msgstr "Anteprima della nuova immagine del profilo"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:155
+#: lib/vutuv_web/templates/user/edit.html.heex:169
 #, elixir-autogen, elixir-format
 msgid "New cover photo preview"
 msgstr "Anteprima della nuova immagine di copertina"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:134
+#: lib/vutuv_web/templates/user/edit.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "Position your cover photo"
 msgstr "Posizioni la Sua immagine di copertina"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:50
+#: lib/vutuv_web/templates/user/edit.html.heex:62
 #, elixir-autogen, elixir-format
 msgid "Position your photo"
 msgstr "Posizioni la Sua foto"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:52
-#: lib/vutuv_web/templates/user/edit.html.heex:136
+#: lib/vutuv_web/templates/user/edit.html.heex:64
+#: lib/vutuv_web/templates/user/edit.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "Use photo"
 msgstr "Usa questa foto"
 
 #: lib/vutuv_web/live/post_live/composer.ex:1919
-#: lib/vutuv_web/templates/user/edit.html.heex:54
-#: lib/vutuv_web/templates/user/edit.html.heex:138
+#: lib/vutuv_web/templates/user/edit.html.heex:66
+#: lib/vutuv_web/templates/user/edit.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Zoom"
 msgstr "Ingrandimento"
@@ -8703,7 +8703,7 @@ msgstr "Dati di base e foto"
 msgid "Language & display"
 msgstr "Lingua e visualizzazione"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:532
+#: lib/vutuv_web/templates/user/edit.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "More profile sections"
 msgstr "Altre sezioni del profilo"
@@ -9224,7 +9224,7 @@ msgstr ""
 "finestra di stampa del browser. Word e OpenDocument sono modificabili; LaTeX"
 " è il sorgente di impaginazione; JSON Resume è il formato aperto %{link}."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:272
+#: lib/vutuv_web/templates/user/edit.html.heex:286
 #, elixir-autogen, elixir-format
 msgid "characters"
 msgstr "caratteri"
@@ -9794,7 +9794,7 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Situazione lavorativa"
 
-#: lib/vutuv/accounts/user.ex:1278
+#: lib/vutuv/accounts/user.ex:1292
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9805,13 +9805,13 @@ msgstr "In cerca di lavoro"
 msgid "Not open to work"
 msgstr "Non in cerca di lavoro"
 
-#: lib/vutuv/accounts/user.ex:1275
+#: lib/vutuv/accounts/user.ex:1289
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
 msgstr "Aperto a proposte"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:296
+#: lib/vutuv_web/templates/user/edit.html.heex:310
 #, elixir-autogen, elixir-format
 msgid "Shown as a badge next to your tagline so people can see whether you are open to opportunities."
 msgstr ""
@@ -10085,18 +10085,18 @@ msgstr "+%{code} è il prefisso telefonico di %{region}"
 msgid "Date of birth"
 msgstr "Data di nascita"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:445
-#: lib/vutuv_web/templates/user/edit.html.heex:520
+#: lib/vutuv_web/templates/user/edit.html.heex:459
+#: lib/vutuv_web/templates/user/edit.html.heex:534
 #, elixir-autogen, elixir-format
 msgid "Remove date of birth"
 msgstr "Rimuovi la data di nascita"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:508
+#: lib/vutuv_web/templates/user/edit.html.heex:522
 #, elixir-autogen, elixir-format
 msgid "Remove your date of birth?"
 msgstr "Rimuovere la Sua data di nascita?"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:511
+#: lib/vutuv_web/templates/user/edit.html.heex:525
 #, elixir-autogen, elixir-format
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
@@ -11232,7 +11232,7 @@ msgstr "Tentativi"
 msgid "Views"
 msgstr "Visualizzazioni"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:305
+#: lib/vutuv_web/templates/user/edit.html.heex:319
 #, elixir-autogen, elixir-format
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
@@ -11240,19 +11240,19 @@ msgstr ""
 "Sua disponibilità ma non può garantirla, perché chiunque può creare un "
 "account. Scelga \"Nessuno\" per conservare lo stato senza mostrarlo."
 
-#: lib/vutuv/accounts/user.ex:1316
+#: lib/vutuv/accounts/user.ex:1330
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Tutti, compresi i visitatori non connessi"
 
-#: lib/vutuv/accounts/user.ex:1321
+#: lib/vutuv/accounts/user.ex:1335
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Nessuno"
 
-#: lib/vutuv/accounts/user.ex:1319
+#: lib/vutuv/accounts/user.ex:1333
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:823
 #, elixir-autogen, elixir-format
@@ -11260,25 +11260,25 @@ msgid "Signed-in members only"
 msgstr "Solo i membri connessi"
 
 #: lib/vutuv_web/components/welcome_components.ex:259
-#: lib/vutuv_web/templates/user/edit.html.heex:302
+#: lib/vutuv_web/templates/user/edit.html.heex:316
 #, elixir-autogen, elixir-format
 msgid "Who can see your availability?"
 msgstr "Chi può vedere la Sua disponibilità?"
 
 #: lib/vutuv_web/components/welcome_components.ex:270
-#: lib/vutuv_web/templates/user/edit.html.heex:327
+#: lib/vutuv_web/templates/user/edit.html.heex:341
 #, elixir-autogen, elixir-format
 msgid "Amount"
 msgstr "Importo"
 
 #: lib/vutuv_web/components/welcome_components.ex:278
 #: lib/vutuv_web/live/job_posting_live/form.ex:693
-#: lib/vutuv_web/templates/user/edit.html.heex:335
+#: lib/vutuv_web/templates/user/edit.html.heex:349
 #, elixir-autogen, elixir-format
 msgid "Currency"
 msgstr "Valuta"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:345
+#: lib/vutuv_web/templates/user/edit.html.heex:359
 #, elixir-autogen, elixir-format
 msgid "Hidden by default, and it still does its job while hidden. \"Signed-in members only\" adds a quiet line to your profile for members; \"Everyone\" also shows it to logged-out visitors."
 msgstr ""
@@ -11287,12 +11287,12 @@ msgstr ""
 "membri; \"Tutti\" la mostra anche ai visitatori non connessi."
 
 #: lib/vutuv_web/components/welcome_components.ex:266
-#: lib/vutuv_web/templates/user/edit.html.heex:318
+#: lib/vutuv_web/templates/user/edit.html.heex:332
 #, elixir-autogen, elixir-format
 msgid "Minimum salary expectation"
 msgstr "Retribuzione minima desiderata"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:321
+#: lib/vutuv_web/templates/user/edit.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "Optional. Even when hidden, it sharpens your own job search and alerts by filtering out postings below it. Leave the amount empty to remove it."
 msgstr ""
@@ -11302,7 +11302,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:274
 #: lib/vutuv_web/live/job_posting_live/form.ex:700
-#: lib/vutuv_web/templates/user/edit.html.heex:331
+#: lib/vutuv_web/templates/user/edit.html.heex:345
 #, elixir-autogen, elixir-format
 msgid "Per"
 msgstr "Per"
@@ -11313,7 +11313,7 @@ msgid "Salary expectation from %{amount} %{currency} per %{period}"
 msgstr ""
 "Retribuzione desiderata a partire da %{amount} %{currency} per %{period}"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:342
+#: lib/vutuv_web/templates/user/edit.html.heex:356
 #, elixir-autogen, elixir-format
 msgid "Who can see your salary expectation?"
 msgstr "Chi può vedere la Sua retribuzione desiderata?"
@@ -11382,7 +11382,7 @@ msgstr "Escludi un membro"
 msgid "Exclude an email domain"
 msgstr "Escludi un dominio e-mail"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:393
+#: lib/vutuv_web/templates/user/edit.html.heex:407
 #, elixir-autogen, elixir-format
 msgid "Hide from specific people"
 msgstr "Nascondi a persone specifiche"
@@ -11393,7 +11393,7 @@ msgstr "Nascondi a persone specifiche"
 msgid "Job-search exclusion list"
 msgstr "Elenco di esclusioni per la ricerca di lavoro"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:396
+#: lib/vutuv_web/templates/user/edit.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "Keep your availability broadly visible while making sure your own employer never sees it. Exclude specific members or email domains, and they never see your availability or salary expectation, even at \"Everyone\"."
 msgstr ""
@@ -11402,7 +11402,7 @@ msgstr ""
 "specifici: non vedranno mai la Sua disponibilità né la Sua retribuzione "
 "desiderata, nemmeno con l'impostazione \"Tutti\"."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:404
+#: lib/vutuv_web/templates/user/edit.html.heex:418
 #, elixir-autogen, elixir-format
 msgid "Manage exclusion list (1 entry)"
 msgid_plural "Manage exclusion list (%{formatted} entries)"
@@ -12619,7 +12619,7 @@ msgstr "I tag evidenziati corrispondono al Suo profilo."
 msgid "How to apply"
 msgstr "Come candidarsi"
 
-#: lib/vutuv/accounts/user.ex:1290
+#: lib/vutuv/accounts/user.ex:1304
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12741,7 +12741,7 @@ msgstr ""
 "Offri i formati leggibili dalle macchine (.md/.txt/.json/.xml) agli agenti "
 "IA."
 
-#: lib/vutuv/accounts/user.ex:1289
+#: lib/vutuv/accounts/user.ex:1303
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12825,7 +12825,7 @@ msgstr "Annuncio non trovato."
 msgid "Publish"
 msgstr "Pubblica"
 
-#: lib/vutuv/accounts/user.ex:1291
+#: lib/vutuv/accounts/user.ex:1305
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:590
 #: lib/vutuv_web/agent_docs/markdown.ex:563
@@ -13868,8 +13868,8 @@ msgstr ""
 "ultimi 7 giorni. Una coda che cresce di solito significa che Ollama non è "
 "raggiungibile."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:41
-#: lib/vutuv_web/templates/user/edit.html.heex:125
+#: lib/vutuv_web/templates/user/edit.html.heex:53
+#: lib/vutuv_web/templates/user/edit.html.heex:138
 #: lib/vutuv_web/templates/user/show.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Image awaiting review, visible only to you"
@@ -13921,13 +13921,13 @@ msgstr ""
 "Se è venuto male (ad esempio con un avviso sui cookie che copre la pagina), "
 "può rimuoverlo."
 
-#: lib/vutuv/accounts/user.ex:1334
+#: lib/vutuv/accounts/user.ex:1348
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
 msgstr "Solo l'età, senza la data"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:456
+#: lib/vutuv_web/templates/user/edit.html.heex:470
 #, elixir-autogen, elixir-format
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
@@ -13935,25 +13935,25 @@ msgstr ""
 "la data esatta, \"Giorno e mese\" nasconde l'anno (e la Sua età) e \"Non "
 "mostrare\" lo conserva ma lo tiene fuori dal profilo."
 
-#: lib/vutuv/accounts/user.ex:1337
+#: lib/vutuv/accounts/user.ex:1351
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Giorno e mese, senza l'anno"
 
-#: lib/vutuv/accounts/user.ex:1340
+#: lib/vutuv/accounts/user.ex:1354
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Non mostrare il mio compleanno"
 
-#: lib/vutuv/accounts/user.ex:1331
+#: lib/vutuv/accounts/user.ex:1345
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
 msgstr "Data completa ed età"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:453
+#: lib/vutuv_web/templates/user/edit.html.heex:467
 #, elixir-autogen, elixir-format
 msgid "Show my birthday as"
 msgstr "Mostra il mio compleanno come"
@@ -14615,7 +14615,7 @@ msgid "Are you looking for a job?"
 msgstr "È in cerca di lavoro?"
 
 #: lib/vutuv_web/components/welcome_components.ex:290
-#: lib/vutuv_web/templates/user/edit.html.heex:365
+#: lib/vutuv_web/templates/user/edit.html.heex:379
 #, elixir-autogen, elixir-format
 msgid "How do you want to work?"
 msgstr "Come vuole lavorare?"
@@ -14632,7 +14632,7 @@ msgid "Preferred workplace"
 msgstr "Modalità di lavoro preferita"
 
 #: lib/vutuv_web/components/welcome_components.ex:249
-#: lib/vutuv_web/templates/user/edit.html.heex:293
+#: lib/vutuv_web/templates/user/edit.html.heex:307
 #, elixir-autogen, elixir-format
 msgid "Availability"
 msgstr "Disponibilità"
@@ -16971,19 +16971,19 @@ msgstr "post fissato"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:657
 #: lib/vutuv_web/agent_docs/text.ex:629
-#: lib/vutuv_web/templates/user/edit.html.heex:225
+#: lib/vutuv_web/templates/user/edit.html.heex:239
 #: lib/vutuv_web/templates/user/show.html.heex:291
 #: lib/vutuv_web/views/account_event_text.ex:213
 #, elixir-autogen, elixir-format
 msgid "Name pronunciation"
 msgstr "Pronuncia del nome"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:229
+#: lib/vutuv_web/templates/user/edit.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "e.g. [SHTEH-fahn VIN-ter-my-er]"
 msgstr "ad esempio [STÈ-fan VÌN-ter-mai-er]"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:232
+#: lib/vutuv_web/templates/user/edit.html.heex:246
 #, elixir-autogen, elixir-format
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
@@ -19673,17 +19673,17 @@ msgstr ""
 "Il PIN non arriva? L'indirizzo e-mail {email} è corretto? Ha controllato la "
 "cartella dello spam?"
 
-#: lib/vutuv/accounts/user.ex:1437
+#: lib/vutuv/accounts/user.ex:1451
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Non binario"
 
-#: lib/vutuv/accounts/user.ex:1435
+#: lib/vutuv/accounts/user.ex:1449
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr "Femminile"
 
-#: lib/vutuv/accounts/user.ex:1436
+#: lib/vutuv/accounts/user.ex:1450
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Maschile"
@@ -21051,7 +21051,7 @@ msgstr ""
 "l'indirizzo di un post là fuori: vutuv lo scarica così può rispondergli da "
 "qui"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:85
+#: lib/vutuv_web/templates/user/edit.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Fetch my picture from gravatar.com"
 msgstr "Prendi la mia immagine da gravatar.com"
@@ -21076,7 +21076,7 @@ msgstr "Non è stato possibile raggiungere gravatar.com. Riprovi più tardi."
 msgid "gravatar.com has no picture for your email address."
 msgstr "gravatar.com non ha alcuna immagine per il Suo indirizzo e-mail."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:88
+#: lib/vutuv_web/templates/user/edit.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Only when you press this: we ask gravatar.com whether there is a picture for your email address, sending a hash of the address rather than the address itself. Nothing leaves this server otherwise."
 msgstr ""
@@ -21606,12 +21606,12 @@ msgstr[0] ""
 msgstr[1] ""
 "La nostra IA le sta esaminando. Compariranno qui da sé quando avrà finito."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:145
+#: lib/vutuv_web/templates/user/edit.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "Recommended: %{width} × %{height} pixels (%{ratio})."
 msgstr "Consigliato: %{width} × %{height} pixel (%{ratio})."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:63
+#: lib/vutuv_web/templates/user/edit.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Consigliato: quadrata, almeno %{width} × %{height} pixel."
@@ -22984,6 +22984,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:290
 #: lib/vutuv_web/live/press_kit_live.ex:882
+#: lib/vutuv_web/templates/user/edit.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "%{formats}, up to %{limit}"
 msgstr "%{formats}, fino a %{limit}"

--- a/priv/gettext/it/LC_MESSAGES/errors.po
+++ b/priv/gettext/it/LC_MESSAGES/errors.po
@@ -196,183 +196,195 @@ msgstr "Non è stato possibile leggerlo. Carichi un file PDF, JPG, PNG o WebP."
 msgid "is larger than 10 MB. Please upload a smaller file."
 msgstr "Supera i 10 MB. Carichi un file più piccolo."
 
-#: lib/vutuv_web/views/error_helpers.ex:122
+#: lib/vutuv_web/views/error_helpers.ex:131
 #, elixir-autogen, elixir-format
 msgid "must not be a web or email address"
 msgstr "Non può essere un indirizzo web o e-mail"
 
-#: lib/vutuv_web/views/error_helpers.ex:123
+#: lib/vutuv_web/views/error_helpers.ex:132
 #, elixir-autogen, elixir-format
 msgid "can't be only a link. Please describe yourself in a few words."
 msgstr "Non può essere solo un link. Si descriva in poche parole."
 
-#: lib/vutuv_web/views/error_helpers.ex:127
+#: lib/vutuv_web/views/error_helpers.ex:136
 #, elixir-autogen, elixir-format
 msgid "\"%{tag}\" is a web address, not a tag. Please describe yourself with words."
 msgstr "\"%{tag}\" è un indirizzo web, non un tag. Si descriva a parole."
 
-#: lib/vutuv_web/views/error_helpers.ex:134
+#: lib/vutuv_web/views/error_helpers.ex:143
 #, elixir-autogen, elixir-format
 msgid "must not be only punctuation"
 msgstr "Non può essere composto solo da segni di punteggiatura"
 
-#: lib/vutuv_web/views/error_helpers.ex:135
+#: lib/vutuv_web/views/error_helpers.ex:144
 #, elixir-autogen, elixir-format
 msgid "\"%{tag}\" is only punctuation, not a tag."
 msgstr "\"%{tag}\" è solo punteggiatura, non un tag."
 
-#: lib/vutuv_web/views/error_helpers.ex:164
+#: lib/vutuv_web/views/error_helpers.ex:173
 #, elixir-autogen, elixir-format
 msgid "\"%{uri}\" is not a valid https account address."
 msgstr "\"%{uri}\" non è un indirizzo https valido per un account."
 
-#: lib/vutuv_web/views/error_helpers.ex:163
+#: lib/vutuv_web/views/error_helpers.ex:172
 #, elixir-autogen, elixir-format
 msgid "Please list at most %{max} accounts."
 msgstr "Indichi al massimo %{max} account."
 
-#: lib/vutuv_web/views/error_helpers.ex:132
+#: lib/vutuv_web/views/error_helpers.ex:141
 #, elixir-autogen, elixir-format
 msgid "must spell out how the name sounds"
 msgstr "Deve indicare come si pronuncia il nome"
 
-#: lib/vutuv_web/views/error_helpers.ex:156
+#: lib/vutuv_web/views/error_helpers.ex:165
 #, elixir-autogen, elixir-format
 msgid "Please use at most %{max} tags."
 msgstr "Usi al massimo %{max} tag."
 
-#: lib/vutuv_web/views/error_helpers.ex:166
+#: lib/vutuv_web/views/error_helpers.ex:175
 #, elixir-autogen, elixir-format
 msgid "Enter your Signal link, it starts with https://signal.me/#"
 msgstr "Inserisca il Suo link Signal: inizia con https://signal.me/#"
 
-#: lib/vutuv_web/views/error_helpers.ex:158
+#: lib/vutuv_web/views/error_helpers.ex:167
 #, elixir-autogen, elixir-format
 msgid "We allow at most %{max} accounts per post. Please remove some mentions."
 msgstr ""
 "Sono ammessi al massimo %{max} account per post. Rimuova qualche menzione."
 
-#: lib/vutuv_web/views/error_helpers.ex:169
+#: lib/vutuv_web/views/error_helpers.ex:178
 #, elixir-autogen, elixir-format
 msgid "Enter your Bluesky handle, e.g. name.bsky.social"
 msgstr "Inserisca il Suo handle Bluesky, ad esempio nome.bsky.social"
 
-#: lib/vutuv_web/views/error_helpers.ex:182
+#: lib/vutuv_web/views/error_helpers.ex:191
 #, elixir-autogen, elixir-format
 msgid "Enter your Codeberg username, not a full URL with extra path segments"
 msgstr ""
 "Inserisca il Suo nome utente Codeberg, non un URL completo con altri "
 "segmenti di percorso"
 
-#: lib/vutuv_web/views/error_helpers.ex:178
+#: lib/vutuv_web/views/error_helpers.ex:187
 #, elixir-autogen, elixir-format
 msgid "Enter your GitHub username, not a full URL with extra path segments"
 msgstr ""
 "Inserisca il Suo nome utente GitHub, non un URL completo con altri segmenti "
 "di percorso"
 
-#: lib/vutuv_web/views/error_helpers.ex:174
+#: lib/vutuv_web/views/error_helpers.ex:183
 #, elixir-autogen, elixir-format
 msgid "Enter your GitLab username, e.g. gitlab.com/username (not a /-/u/ ID link)"
 msgstr ""
 "Inserisca il Suo nome utente GitLab, ad esempio gitlab.com/nomeutente (non "
 "un link ID /-/u/)"
 
-#: lib/vutuv_web/views/error_helpers.ex:168
+#: lib/vutuv_web/views/error_helpers.ex:177
 #, elixir-autogen, elixir-format
 msgid "Enter your full Mastodon handle, e.g. @user@instance.social"
 msgstr ""
 "Inserisca l'handle Mastodon completo, ad esempio @utente@istanza.social"
 
-#: lib/vutuv_web/views/error_helpers.ex:170
+#: lib/vutuv_web/views/error_helpers.ex:179
 #, elixir-autogen, elixir-format
 msgid "Enter your username and your instance, e.g. name@git.example.com"
 msgstr ""
 "Inserisca il Suo nome utente e la Sua istanza, ad esempio "
 "nome@git.esempio.com"
 
-#: lib/vutuv_web/views/error_helpers.ex:186
+#: lib/vutuv_web/views/error_helpers.ex:195
 #, elixir-autogen, elixir-format
 msgid "Invalid account name"
 msgstr "Nome account non valido"
 
-#: lib/vutuv_web/views/error_helpers.ex:187
+#: lib/vutuv_web/views/error_helpers.ex:196
 #, elixir-autogen, elixir-format
 msgid "Someone has already claimed this account"
 msgstr "Questo account è già stato rivendicato da qualcun altro"
 
-#: lib/vutuv_web/views/error_helpers.ex:194
+#: lib/vutuv_web/views/error_helpers.ex:203
 #, elixir-autogen, elixir-format
 msgid "That instance did not answer. Please try again in a moment."
 msgstr "L'istanza non ha risposto. Riprovi tra poco."
 
-#: lib/vutuv_web/views/error_helpers.ex:195
+#: lib/vutuv_web/views/error_helpers.ex:204
 #, elixir-autogen, elixir-format
 msgid "Too many checks for now. Please try again later."
 msgstr "Per ora troppi controlli. Riprovi più tardi."
 
-#: lib/vutuv_web/views/error_helpers.ex:190
+#: lib/vutuv_web/views/error_helpers.ex:199
 #, elixir-autogen, elixir-format
 msgid "We could not find this account on that instance. Please check the address."
 msgstr ""
 "Non abbiamo trovato questo account su quell'istanza. Controlli l'indirizzo."
 
-#: lib/vutuv_web/views/error_helpers.ex:119
+#: lib/vutuv_web/views/error_helpers.ex:128
 #, elixir-autogen, elixir-format
 msgid "Only one email address can be given at sign-up."
 msgstr "Alla registrazione può indicare un solo indirizzo email."
 
-#: lib/vutuv_web/views/error_helpers.ex:143
+#: lib/vutuv_web/views/error_helpers.ex:152
 #, elixir-autogen, elixir-format
 msgid "Please confirm that you are making this claim in good faith."
 msgstr "Conferma di presentare questa segnalazione in buona fede."
 
-#: lib/vutuv_web/views/error_helpers.ex:137
+#: lib/vutuv_web/views/error_helpers.ex:146
 #, elixir-autogen, elixir-format
 msgid "Please pick a category."
 msgstr "Scelga una categoria."
 
-#: lib/vutuv_web/views/error_helpers.ex:139
+#: lib/vutuv_web/views/error_helpers.ex:148
 #, elixir-autogen, elixir-format
 msgid "Please tell us which work it is and where the original can be seen."
 msgstr "Indica di quale opera si tratta e dove si può vedere l'originale."
 
-#: lib/vutuv_web/views/error_helpers.ex:138
+#: lib/vutuv_web/views/error_helpers.ex:147
 #, elixir-autogen, elixir-format
 msgid "Your note is too long."
 msgstr "La tua nota è troppo lunga."
 
-#: lib/vutuv_web/views/error_helpers.ex:146
+#: lib/vutuv_web/views/error_helpers.ex:155
 #, elixir-autogen, elixir-format
 msgid "Please give us an email address."
 msgstr "Indichi un indirizzo e-mail."
 
-#: lib/vutuv_web/views/error_helpers.ex:150
+#: lib/vutuv_web/views/error_helpers.ex:159
 #, elixir-autogen, elixir-format
 msgid "Please tell us what is wrong with this content, in your own words."
 msgstr "Ci dica con parole Sue che cosa non va in questo contenuto."
 
-#: lib/vutuv_web/views/error_helpers.ex:145
+#: lib/vutuv_web/views/error_helpers.ex:154
 #, elixir-autogen, elixir-format
 msgid "Please tell us your name."
 msgstr "Ci dica il Suo nome."
 
-#: lib/vutuv_web/views/error_helpers.ex:148
+#: lib/vutuv_web/views/error_helpers.ex:157
 #, elixir-autogen, elixir-format
 msgid "That address is too long."
 msgstr "Questo indirizzo è troppo lungo."
 
-#: lib/vutuv_web/views/error_helpers.ex:147
+#: lib/vutuv_web/views/error_helpers.ex:156
 #, elixir-autogen, elixir-format
 msgid "That does not look like an email address."
 msgstr "Questo non sembra un indirizzo e-mail."
 
-#: lib/vutuv_web/views/error_helpers.ex:154
+#: lib/vutuv_web/views/error_helpers.ex:163
 #, elixir-autogen, elixir-format
 msgid "You already reported this."
 msgstr "Ha già segnalato questo contenuto."
 
-#: lib/vutuv_web/views/error_helpers.ex:149
+#: lib/vutuv_web/views/error_helpers.ex:158
 #, elixir-autogen, elixir-format
 msgid "Your name is too long."
 msgstr "Il Suo nome è troppo lungo."
+
+#: lib/vutuv_web/views/error_helpers.ex:123
+#, elixir-autogen, elixir-format
+msgid "We cannot read this file. Please upload one of these formats: %{formats}."
+msgstr ""
+"Non riusciamo a leggere questo file. Carichi uno di questi formati: "
+"%{formats}."
+
+#: lib/vutuv_web/views/error_helpers.ex:122
+#, elixir-autogen, elixir-format
+msgid "That file is larger than %{limit}. Please upload a smaller one."
+msgstr "Questo file è più grande di %{limit}. Ne carichi uno più piccolo."

--- a/test/vutuv/accounts_avatar_test.exs
+++ b/test/vutuv/accounts_avatar_test.exs
@@ -10,6 +10,7 @@ defmodule Vutuv.AccountsAvatarTest do
   alias Vutuv.Accounts
   alias Vutuv.Accounts.User
   alias Vutuv.Uploads
+  alias VutuvWeb.UI
 
   setup do
     tmp =
@@ -26,13 +27,15 @@ defmodule Vutuv.AccountsAvatarTest do
     :ok
   end
 
-  # A real, decodable JPEG upload (so it passes the in-changeset validation).
-  defp jpeg_upload(name \\ "selfie.jpg") do
-    src = Path.join(System.tmp_dir!(), "src_#{System.unique_integer([:positive])}.jpg")
+  # A real, decodable upload (so it passes the in-changeset validation), in
+  # whatever format the filename names — libvips writes by extension.
+  defp image_upload(name \\ "selfie.jpg") do
+    ext = Path.extname(name)
+    src = Path.join(System.tmp_dir!(), "src_#{System.unique_integer([:positive])}#{ext}")
     {:ok, img} = Image.new(600, 400, color: [10, 120, 200])
     {:ok, _} = Image.write(img, src)
     on_exit(fn -> File.rm(src) end)
-    %Plug.Upload{filename: name, path: src, content_type: "image/jpeg"}
+    %Plug.Upload{filename: name, path: src, content_type: MIME.from_path(name)}
   end
 
   defp avatar_dir(user), do: Uploads.disk_dir("avatars/#{user.id}")
@@ -56,7 +59,7 @@ defmodule Vutuv.AccountsAvatarTest do
 
     # Valid avatar, but the name is too long: the changeset fails validation
     # after the avatar is validated, so the update rolls back.
-    attrs = %{"avatar" => jpeg_upload(), "first_name" => String.duplicate("a", 51)}
+    attrs = %{"avatar" => image_upload(), "first_name" => String.duplicate("a", 51)}
 
     assert {:error, %Ecto.Changeset{}} = Accounts.update_user(user, attrs)
 
@@ -71,13 +74,28 @@ defmodule Vutuv.AccountsAvatarTest do
     user = insert_activated_user(first_name: "Ada")
 
     assert {:ok, updated} =
-             Accounts.update_user(user, %{"avatar" => jpeg_upload(), "headline" => "Hi"})
+             Accounts.update_user(user, %{"avatar" => image_upload(), "headline" => "Hi"})
 
     assert updated.avatar == "selfie.jpg"
     assert Repo.get!(User, user.id).avatar == "selfie.jpg"
     assert File.ls!(avatar_dir(user)) != []
     assert Uploads.Originals.path("avatars/#{user.id}")
     assert updated.headline == "Hi"
+  end
+
+  # The profile picture was the strictest upload on the site: JPEG and PNG and
+  # nothing else, while a post photo has taken WebP (and HEIC where the box can
+  # decode it) all along. A member re-branding with a WebP logo got "is not a
+  # valid image" and, right under it, the gravatar.com button — which reads as
+  # "you need a Gravatar account to have a picture here".
+  test "a WebP avatar is accepted and stored" do
+    user = insert_activated_user(first_name: "Ada")
+
+    assert {:ok, updated} = Accounts.update_user(user, %{"avatar" => image_upload("logo.webp")})
+
+    assert updated.avatar == "logo.webp"
+    assert File.ls!(avatar_dir(user)) != []
+    assert Uploads.Originals.path("avatars/#{user.id}")
   end
 
   test "an undecodable image is rejected in the changeset and writes nothing" do
@@ -89,10 +107,36 @@ defmodule Vutuv.AccountsAvatarTest do
     bad = %Plug.Upload{filename: "broken.jpg", path: src, content_type: "image/jpeg"}
 
     assert {:error, changeset} = Accounts.update_user(user, %{"avatar" => bad})
-    assert "is not a valid image" in errors_on(changeset).avatar
+
+    # The refusal names the formats this installation takes, because the member
+    # has to decide what to do next and "is not a valid image" told them
+    # nothing. Derived from the whitelist: an installation whose libvips
+    # decodes HEIC accepts more than this one does.
+    assert errors_on(changeset).avatar == [
+             "We cannot read this file. Please upload one of these formats: " <>
+               UI.format_list(Uploads.extension_whitelist()) <> "."
+           ]
 
     refute File.exists?(avatar_dir(user))
     assert Repo.get!(User, user.id).avatar == nil
+  end
+
+  test "a file over the size cap is refused with the cap in the sentence" do
+    user = insert_activated_user(first_name: "Ada")
+
+    src = Path.join(System.tmp_dir!(), "huge_#{System.unique_integer([:positive])}.jpg")
+    File.write!(src, :binary.copy("x", Uploads.max_filesize() + 1))
+    on_exit(fn -> File.rm(src) end)
+    huge = %Plug.Upload{filename: "huge.jpg", path: src, content_type: "image/jpeg"}
+
+    assert {:error, changeset} = Accounts.update_user(user, %{"avatar" => huge})
+
+    assert errors_on(changeset).avatar == [
+             "That file is larger than #{UI.megabyte_label(Uploads.max_filesize())}. " <>
+               "Please upload a smaller one."
+           ]
+
+    refute File.exists?(avatar_dir(user))
   end
 
   test "a chosen avatar crop is normalised and persisted alongside the file" do
@@ -100,7 +144,7 @@ defmodule Vutuv.AccountsAvatarTest do
 
     assert {:ok, updated} =
              Accounts.update_user(user, %{
-               "avatar" => jpeg_upload(),
+               "avatar" => image_upload(),
                "avatar_crop" => "0.25,0,0.5,1"
              })
 
@@ -112,7 +156,7 @@ defmodule Vutuv.AccountsAvatarTest do
     user = insert_activated_user(first_name: "Ada")
 
     assert {:ok, updated} =
-             Accounts.update_user(user, %{"avatar" => jpeg_upload(), "avatar_crop" => "garbage"})
+             Accounts.update_user(user, %{"avatar" => image_upload(), "avatar_crop" => "garbage"})
 
     assert updated.avatar == "selfie.jpg"
     assert updated.avatar_crop == nil
@@ -122,7 +166,7 @@ defmodule Vutuv.AccountsAvatarTest do
     user = insert_activated_user(first_name: "Ada")
     # Reuse one upload (the file on disk survives store), so the original bytes
     # are byte-identical across the three saves and the crop is the only variable.
-    upload = jpeg_upload()
+    upload = image_upload()
 
     assert {:ok, a} =
              Accounts.update_user(user, %{"avatar" => upload, "avatar_crop" => "0,0,0.5,0.5"})
@@ -158,7 +202,7 @@ defmodule Vutuv.AccountsAvatarTest do
     # derived wide version keeps the cropped 600x100 instead of the full 600x400.
     assert {:ok, updated} =
              Accounts.update_user(user, %{
-               "cover_photo" => jpeg_upload("banner.jpg"),
+               "cover_photo" => image_upload("banner.jpg"),
                "cover_crop" => "0,0.3,1,0.25"
              })
 
@@ -171,7 +215,7 @@ defmodule Vutuv.AccountsAvatarTest do
 
     assert {:ok, _} =
              Accounts.update_user(user, %{
-               "cover_photo" => jpeg_upload("banner.jpg"),
+               "cover_photo" => image_upload("banner.jpg"),
                "cover_crop" => "0,0.3,1,0.25"
              })
 
@@ -187,7 +231,7 @@ defmodule Vutuv.AccountsAvatarTest do
     user = insert_activated_user(first_name: "Ada")
 
     attrs = %{
-      "cover_photo" => jpeg_upload("banner.jpg"),
+      "cover_photo" => image_upload("banner.jpg"),
       "first_name" => String.duplicate("a", 51)
     }
 

--- a/test/vutuv/uploaders/avatar_test.exs
+++ b/test/vutuv/uploaders/avatar_test.exs
@@ -457,7 +457,9 @@ defmodule Vutuv.AvatarTest do
       changeset = User.changeset(@user, %{"avatar" => upload})
 
       refute changeset.valid?
-      assert {"is not a valid image", _} = changeset.errors[:avatar]
+
+      assert {"We cannot read this file. Please upload one of these formats: %{formats}.", _} =
+               changeset.errors[:avatar]
     end
   end
 

--- a/test/vutuv/uploaders/cover_test.exs
+++ b/test/vutuv/uploaders/cover_test.exs
@@ -277,7 +277,9 @@ defmodule Vutuv.CoverTest do
       changeset = User.changeset(@user, %{"cover_photo" => upload})
 
       refute changeset.valid?
-      assert {"is not a valid image", _} = changeset.errors[:cover_photo]
+
+      assert {"We cannot read this file. Please upload one of these formats: %{formats}.", _} =
+               changeset.errors[:cover_photo]
     end
   end
 

--- a/test/vutuv/uploaders/uploads_integration_test.exs
+++ b/test/vutuv/uploaders/uploads_integration_test.exs
@@ -141,7 +141,8 @@ defmodule Vutuv.UploadsIntegrationTest do
              |> User.changeset(%{avatar: upload})
              |> Repo.update()
 
-    assert "is not a valid image" in errors_on(changeset).avatar
+    assert [refusal] = errors_on(changeset).avatar
+    assert refusal =~ "We cannot read this file."
   end
 
   test "uploading a cover photo stores the file name and writes files to disk", %{tmp: tmp} do
@@ -239,7 +240,8 @@ defmodule Vutuv.UploadsIntegrationTest do
              |> User.changeset(%{cover_photo: upload})
              |> Repo.update()
 
-    assert "is not a valid image" in errors_on(changeset).cover_photo
+    assert [refusal] = errors_on(changeset).cover_photo
+    assert refusal =~ "We cannot read this file."
   end
 
   test "a legacy screenshot value resolves and uploads store a fingerprint", %{tmp: tmp} do

--- a/test/vutuv_web/controllers/picture_upload_hint_test.exs
+++ b/test/vutuv_web/controllers/picture_upload_hint_test.exs
@@ -1,0 +1,72 @@
+defmodule VutuvWeb.PictureUploadHintTest do
+  use VutuvWeb.ConnCase, async: true
+
+  alias Vutuv.Uploads
+  alias VutuvWeb.UI
+
+  # What /settings/profile promises about a picture, and what it says when it
+  # refuses one. The avatar was the strictest upload on the site and said so
+  # nowhere: the picker offered every image the phone held, the server took two
+  # formats, and the refusal ("is not a valid image", in English on a German
+  # page) named neither the formats nor the cap. Directly under it sat the
+  # "Fetch my picture from gravatar.com" button, so the dead end read as "you
+  # need a Gravatar account to have a picture here" — which is how it was
+  # reported.
+
+  # A refused avatar upload, rendered in German: the msgids live in
+  # Vutuv.Accounts.User, so only a rendered page proves the errors.po anchors in
+  # VutuvWeb.ErrorHelpers are in place.
+  defp refuse_avatar(conn, user, contents) do
+    src = Path.join(System.tmp_dir!(), "refused_#{System.unique_integer([:positive])}.jpg")
+    File.write!(src, contents)
+    on_exit(fn -> File.rm(src) end)
+
+    conn
+    |> recycle()
+    |> put_req_header("accept-language", "de-DE,de;q=0.9")
+    |> put(~p"/settings/profile", %{
+      "user" => %{
+        "first_name" => user.first_name,
+        "avatar" => %Plug.Upload{filename: "refused.jpg", path: src, content_type: "image/jpeg"}
+      }
+    })
+    |> html_response(422)
+  end
+
+  test "the form offers what the server takes, and says so before a file is picked", %{conn: conn} do
+    {conn, _user} = create_and_login_user(conn)
+
+    html = conn |> get(~p"/settings/profile") |> html_response(200)
+    accept = Enum.join(Uploads.extension_whitelist(), ",")
+
+    for field <- ~w(user_avatar user_cover_photo) do
+      assert [tag] = Regex.run(~r/<input[^>]*id="#{field}"[^>]*>/, html)
+
+      assert tag =~ ~s(accept="#{accept}"),
+             "#{field} must offer the whitelist, not image/*: #{tag}"
+    end
+
+    hint =
+      "#{UI.format_list(Uploads.extension_whitelist())}, up to " <>
+        UI.megabyte_label(Uploads.max_filesize())
+
+    assert html |> String.split(hint) |> length() == 3, "expected the hint under both fields"
+  end
+
+  test "an unreadable file is refused in German, naming the formats", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+
+    html = refuse_avatar(conn, user, "kein Bild")
+
+    assert html =~ "Diese Datei können wir nicht lesen."
+    assert html =~ UI.format_list(Uploads.extension_whitelist())
+  end
+
+  test "a file over the cap is refused in German, naming the cap", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+
+    html = refuse_avatar(conn, user, :binary.copy("x", Uploads.max_filesize() + 1))
+
+    assert html =~ "Diese Datei ist größer als #{UI.megabyte_label(Uploads.max_filesize())}."
+  end
+end


### PR DESCRIPTION
A member wrote in that they could not replace their avatar and got "some message regarding Gravatar". It is not a Gravatar problem.

Reproduced on /settings/profile: avatar and cover took only `.jpg .jpeg .png` at 2 MB — the narrowest upload on the site, while a post photo takes WebP and HEIC at 50 MB. The browser decodes WebP fine, so the crop dialog opens and everything looks right until the server refuses with `is not a valid image`: English on a German page, naming neither the formats nor the cap. The only prominent button under it is "Fetch my picture from gravatar.com", which is how the dead end reads as "you need a Gravatar account".

`Vutuv.Uploads.extension_whitelist/0` now delegates to the post photo's list, `max_filesize/0` reads a new `:profile_images` key at 8 MB, the field's `accept` names that list, and both refusals are translated and concrete. The three `image_rejected` mails no longer say JPEG or PNG only.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01Ks5HruByrC7ddPS1DAmFeA
