### PR TITLE
A followed tag remembers which servers it should come from

### DIFF
--- a/docs/architecture/social-graph.md
+++ b/docs/architecture/social-graph.md
@@ -142,12 +142,28 @@ saved searches).
 
 A follow also carries its **sources** (issue #2125, `Vutuv.Tags.TagFollowSource`,
 table `tag_follow_sources`): one row per source, `"vutuv"` — this installation,
-written inside the follow's own transaction, so no follow exists without it —
-plus any server the member picked. `source` is either that literal or a bare
-lowercased hostname, and `normalize_source/1` is the one place that turns a
-pasted URL or `@user@host` address into one of the two. An address of **our
-own** becomes the local source rather than a server to poll, `Vutuv.Fediverse.own_host?/1`
-deciding that, so no installation ever asks itself for its own posts.
+written inside the follow's own transaction — plus any server the member picked.
+`source` is either that literal or a bare lowercased hostname, and
+`normalize_source/1` is the one place that turns a pasted URL or `@user@host`
+address into one of the two. An address of **our own** becomes the local source
+rather than a server to poll, `Vutuv.Fediverse.own_host?/1` deciding that, so no
+installation ever asks itself for its own posts; a remote host is folded the same
+way, `www.mastodon.social` storing as `mastodon.social`, because two spellings
+would mean two rows and two fetches of the same posts.
+
+**vutuv is always on and cannot be switched off** (#2128), from both sides:
+`remove_tag_follow_source/2` refuses the local source, and a follow with no rows
+at all reads as `["vutuv"]` — which is what the release before this one keeps
+writing during the blue/green window, knowing nothing about the table.
+
+What a member types here is fetched later by us, so the changeset carries the
+same two-layer guard `Vutuv.Organizations.OrganizationDomain` uses: the
+server-name grammar from `Vutuv.Fediverse.BlockedInstance`, plus
+`Vutuv.Ssrf.internal_host?/1` — the grammar alone accepts `169.254.169.254` and
+every private range. That check is literal-only (no DNS in a changeset), so the
+fetcher still vets the host at fetch time. A tag merge that drops a duplicate
+follow captures its sources first (`Merge.rescue_tag_follow_sources/3`, beside
+the endorsement rescue), so a revert brings the follow back reading what it read.
 
 A table and not a list on the follow, because the fetcher's question is the
 other way round — which server-and-tag pairs does anybody here want? —

--- a/docs/architecture/social-graph.md
+++ b/docs/architecture/social-graph.md
@@ -138,6 +138,26 @@ to `/tag_follows`), the feed's reload-free **"Tags you follow"** rail (a
 (a settings-hub row that appears only once you follow at least one tag, like
 saved searches).
 
+### Where a followed tag reads from
+
+A follow also carries its **sources** (issue #2125, `Vutuv.Tags.TagFollowSource`,
+table `tag_follow_sources`): one row per source, `"vutuv"` — this installation,
+written inside the follow's own transaction, so no follow exists without it —
+plus any server the member picked. `source` is either that literal or a bare
+lowercased hostname, and `normalize_source/1` is the one place that turns a
+pasted URL or `@user@host` address into one of the two. An address of **our
+own** becomes the local source rather than a server to poll, `Vutuv.Fediverse.own_host?/1`
+deciding that, so no installation ever asks itself for its own posts.
+
+A table and not a list on the follow, because the fetcher's question is the
+other way round — which server-and-tag pairs does anybody here want? —
+and `Vutuv.Tags.wanted_tag_sources/0` answers it with one grouped query
+(`%{source:, tag_id:, tag_name:, follow_count:}`, busiest first, the local
+source left out), instead of unpacking every member's array. The context side is
+`add_tag_follow_source/2`, `remove_tag_follow_source/2` and
+`tag_follow_sources/1`. Nothing fetches anything yet; the card and the fetcher
+are #2126–#2129.
+
 ## The tag page (`/tags/:slug`)
 
 A tag's public page is the topic page: its description, the most endorsed

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -2429,8 +2429,14 @@ defmodule Vutuv.Fediverse do
   defp same_site?(host, host), do: true
   defp same_site?(host, other), do: strip_www(host) == strip_www(other)
 
-  defp strip_www("www." <> rest), do: rest
-  defp strip_www(host), do: host
+  @doc """
+  A host without its `www.` — the fold `same_site?/2` above applies to our own
+  address, published so anything else deciding whether two spellings name one
+  server (`Vutuv.Tags.TagFollowSource`) applies the same rule rather than
+  keeping its own copy of it.
+  """
+  def strip_www("www." <> rest), do: rest
+  def strip_www(host), do: host
 
   # Keyed on whoever is asking — a member or a page (issue #1336) — so a page
   # gets its own hourly budget rather than spending somebody's.

--- a/lib/vutuv/fediverse/blocked_instance.ex
+++ b/lib/vutuv/fediverse/blocked_instance.ex
@@ -20,9 +20,15 @@ defmodule Vutuv.Fediverse.BlockedInstance do
   @max_reason 255
 
   # A real server name: dot-separated labels of letters, digits and hyphens.
-  # Deliberately strict — a blocklist entry that can never match anything (an
-  # IP literal, "localhost", a typo with a slash left in) is worse than an
-  # error, because it reads as protection that isn't there.
+  # Deliberately strict — a blocklist entry that can never match anything
+  # ("localhost", a typo with a slash left in) is worse than an error, because
+  # it reads as protection that isn't there.
+  #
+  # It does **not** reject an IP literal: `169.254.169.254` is digits and dots
+  # and matches. Harmless in a blocklist, which only ever compares this value
+  # with the host of an inbound actor id, and not harmless anywhere that stores
+  # a host to fetch from later — so such a caller adds `Vutuv.Ssrf.internal_host?/1`
+  # on top (`OrganizationDomain`, `Vutuv.Tags.TagFollowSource`).
   @host_format ~r/\A[a-z0-9]([a-z0-9\-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9\-]*[a-z0-9])?)+\z/
 
   @doc """

--- a/lib/vutuv/fediverse/blocked_instance.ex
+++ b/lib/vutuv/fediverse/blocked_instance.ex
@@ -25,6 +25,17 @@ defmodule Vutuv.Fediverse.BlockedInstance do
   # error, because it reads as protection that isn't there.
   @host_format ~r/\A[a-z0-9]([a-z0-9\-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9\-]*[a-z0-9])?)+\z/
 
+  @doc """
+  What a server name may look like, and how long it may be — published because
+  this module already owns `normalize_host/1`, so anything else storing a
+  hostname (`Vutuv.Tags.TagFollowSource`) validates the same shape rather than
+  keeping a second copy of it that drifts.
+  """
+  def host_format, do: @host_format
+
+  @doc "The longest hostname there is — see `host_format/0`."
+  def max_host, do: @max_host
+
   schema "fediverse_blocked_instances" do
     field(:host, :string)
     field(:reason, :string)

--- a/lib/vutuv/organizations/organization_domain.ex
+++ b/lib/vutuv/organizations/organization_domain.ex
@@ -19,6 +19,7 @@ defmodule Vutuv.Organizations.OrganizationDomain do
 
   use VutuvWeb, :model
 
+  alias Vutuv.Fediverse.BlockedInstance
   alias Vutuv.Ssrf
 
   @methods ~w(dns well_known)
@@ -103,10 +104,10 @@ defmodule Vutuv.Organizations.OrganizationDomain do
 
       domain ->
         cond do
-          not Regex.match?(
-            ~r/\A[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+\z/,
-            domain
-          ) ->
+          # The one definition of a server name (`Vutuv.Fediverse.BlockedInstance`),
+          # not a second copy of it: the day an intranet or IDN address needs
+          # that grammar loosened, every host somebody types has to move with it.
+          not Regex.match?(BlockedInstance.host_format(), domain) ->
             add_error(changeset, :domain, "is not a valid domain")
 
           Ssrf.internal_host?(domain) ->

--- a/lib/vutuv/tags.ex
+++ b/lib/vutuv/tags.ex
@@ -1014,11 +1014,15 @@ defmodule Vutuv.Tags do
     |> insert_follow_with_local_source(user_id: user_id, tag_id: tag_id)
   end
 
-  # Writes one follow and the source it is born with, in one transaction: a
-  # follow with no source at all reads as "wants nothing" (issue #2125), which
-  # is not what somebody who just pressed follow meant. Member and page follows
-  # differ only in `lookup`, which names both the conflict target and the row to
-  # read back, so the rule lives here once rather than in each of them.
+  # Writes one follow and the source it is born with, in one transaction, so the
+  # table says what the follow reads from rather than leaving it to be inferred:
+  # the grouped query the fetcher runs reads rows, and so does an operator
+  # looking at the table. `tag_follow_sources/1` still supplies the local source
+  # for a row-less follow — it has to, for what the previous release writes
+  # during a deploy — but that is a rule for rows we did not write, not a licence
+  # to stop writing them. Member and page follows differ only in `lookup`, which
+  # names both the conflict target and the row to read back, so the rule lives
+  # here once rather than in each of them.
   #
   # After the insert the row is guaranteed to exist (a fresh insert, or an ON
   # CONFLICT no-op because it already did), so the get_by re-reads the
@@ -1234,24 +1238,30 @@ defmodule Vutuv.Tags do
   end
 
   @doc """
-  Removes one source from `follow`, reading a pasted address the same way
+  Removes one **server** from `follow`, reading a pasted address the same way
   `add_tag_follow_source/2` did. Idempotent; returns the number of rows removed
-  (0 or 1). Removing the last source is allowed and leaves a follow that wants
-  nothing — whether a card offers that is the card's business.
+  (0 or 1).
+
+  The local source is not removable and answers 0: vutuv is always on and cannot
+  be switched off (#2128), so a follow is never remote-only. That is the same
+  rule `tag_follow_sources/1` applies from the other side, where a follow with
+  no rows at all still reads as vutuv.
   """
   def remove_tag_follow_source(%TagFollow{} = follow, source) do
-    case TagFollowSource.normalize_source(source) do
-      nil ->
-        0
+    normalized = TagFollowSource.normalize_source(source)
 
-      normalized ->
-        {count, _} =
-          from(s in TagFollowSource,
-            where: s.tag_follow_id == ^follow.id and s.source == ^normalized
-          )
-          |> Repo.delete_all()
+    # Nothing host-shaped names no row; the local source names one that must
+    # stay. Both are "removed nothing", which is what the count says.
+    if is_nil(normalized) or normalized == local_tag_follow_source() do
+      0
+    else
+      {count, _} =
+        from(s in TagFollowSource,
+          where: s.tag_follow_id == ^follow.id and s.source == ^normalized
+        )
+        |> Repo.delete_all()
 
-        count
+      count
     end
   end
 
@@ -1259,15 +1269,41 @@ defmodule Vutuv.Tags do
   The sources of `follow`, in the order they were added — so the local one
   comes first, having been written with the follow. Ids are `Vutuv.UUIDv7`, so
   ordering by one is ordering by when it was written.
+
+  The local source is always in the answer, whether or not a row says so —
+  vutuv is always on and cannot be switched off (#2128). That is not a cosmetic
+  default: through the blue/green window the previous release keeps writing
+  follows, knowing nothing about this table, so those rows arrive source-less
+  and nothing backfills them afterwards. Every reader gets the rule here rather
+  than each remembering it, `follow.sources` preloaded included.
   """
+  def tag_follow_sources(%TagFollow{sources: sources}) when is_list(sources) do
+    # A preloaded follow answers from what it carries — a page listing many of
+    # them loads the sources in the query it already runs, and must not get a
+    # different answer than the one-follow path for it.
+    sources |> Enum.map(& &1.source) |> with_local_source()
+  end
+
   def tag_follow_sources(%TagFollow{id: id}) do
-    Repo.all(
-      from(s in TagFollowSource,
-        where: s.tag_follow_id == ^id,
-        order_by: [asc: s.id],
-        select: s.source
-      )
+    from(s in TagFollowSource,
+      where: s.tag_follow_id == ^id,
+      order_by: [asc: s.id],
+      select: s.source
     )
+    |> Repo.all()
+    |> with_local_source()
+  end
+
+  # vutuv is always on and cannot be switched off (#2128), so the answer carries
+  # it whatever the rows say — first, where it was written. Not only for a
+  # follow with no rows at all: the release before this one keeps writing
+  # source-less follows through the blue/green window, and the moment such a
+  # follow gains its first server an "empty means vutuv" rule would stop firing
+  # and quietly switch this installation off for it.
+  defp with_local_source(sources) do
+    local = local_tag_follow_source()
+
+    if local in sources, do: sources, else: [local | sources]
   end
 
   @doc """

--- a/lib/vutuv/tags.ex
+++ b/lib/vutuv/tags.ex
@@ -26,6 +26,7 @@ defmodule Vutuv.Tags do
   alias Vutuv.Tags.MatchKey
   alias Vutuv.Tags.Tag
   alias Vutuv.Tags.TagFollow
+  alias Vutuv.Tags.TagFollowSource
   alias Vutuv.Tags.UserTag
   alias Vutuv.Tags.UserTagEndorsement
 
@@ -997,14 +998,8 @@ defmodule Vutuv.Tags do
   def follow_tag(%User{} = user, %Tag{id: tag_id}), do: follow_tag(user, tag_id)
 
   def follow_tag(%User{} = user, tag_id) when is_binary(tag_id) do
-    # After the insert the row is guaranteed to exist (a fresh insert, or an ON
-    # CONFLICT no-op because it already did), so the get_by re-reads the
-    # authoritative row to return; an unknown tag id trips the tag_id
-    # foreign_key_constraint and comes back as {:error, changeset}. Both the
-    # `nil` from a non-UUID id and a vanished row map to {:error, :invalid}.
     with tag_id when not is_nil(tag_id) <- Vutuv.UUIDv7.cast_or_nil(tag_id),
-         {:ok, _} <- insert_tag_follow(user.id, tag_id),
-         %TagFollow{} = follow <- Repo.get_by(TagFollow, user_id: user.id, tag_id: tag_id) do
+         {:ok, follow} <- insert_tag_follow(user.id, tag_id) do
       broadcast_tag_follows_changed(user.id)
       {:ok, follow}
     else
@@ -1016,7 +1011,32 @@ defmodule Vutuv.Tags do
   defp insert_tag_follow(user_id, tag_id) do
     %TagFollow{}
     |> TagFollow.changeset(%{user_id: user_id, tag_id: tag_id})
-    |> Repo.insert(on_conflict: :nothing, conflict_target: [:user_id, :tag_id])
+    |> insert_follow_with_local_source(user_id: user_id, tag_id: tag_id)
+  end
+
+  # Writes one follow and the source it is born with, in one transaction: a
+  # follow with no source at all reads as "wants nothing" (issue #2125), which
+  # is not what somebody who just pressed follow meant. Member and page follows
+  # differ only in `lookup`, which names both the conflict target and the row to
+  # read back, so the rule lives here once rather than in each of them.
+  #
+  # After the insert the row is guaranteed to exist (a fresh insert, or an ON
+  # CONFLICT no-op because it already did), so the get_by re-reads the
+  # authoritative row to return; an unknown tag id trips the tag_id
+  # foreign_key_constraint and comes back as {:error, changeset}, a vanished row
+  # as {:error, :invalid}.
+  defp insert_follow_with_local_source(changeset, lookup) do
+    Repo.transaction(fn ->
+      with {:ok, _} <-
+             Repo.insert(changeset, on_conflict: :nothing, conflict_target: Keyword.keys(lookup)),
+           %TagFollow{} = follow <- Repo.get_by(TagFollow, lookup),
+           {:ok, _} <- insert_tag_follow_source(follow.id, local_tag_follow_source()) do
+        follow
+      else
+        nil -> Repo.rollback(:invalid)
+        {:error, changeset} -> Repo.rollback(changeset)
+      end
+    end)
   end
 
   @doc """
@@ -1111,9 +1131,7 @@ defmodule Vutuv.Tags do
   """
   def follow_tag_as_organization(%Organization{} = page, tag_id) when is_binary(tag_id) do
     with tag_id when not is_nil(tag_id) <- Vutuv.UUIDv7.cast_or_nil(tag_id),
-         {:ok, _} <- insert_organization_tag_follow(page.id, tag_id),
-         %TagFollow{} = follow <-
-           Repo.get_by(TagFollow, organization_id: page.id, tag_id: tag_id) do
+         {:ok, follow} <- insert_organization_tag_follow(page.id, tag_id) do
       {:ok, follow}
     else
       nil -> {:error, :invalid}
@@ -1127,7 +1145,7 @@ defmodule Vutuv.Tags do
   defp insert_organization_tag_follow(organization_id, tag_id) do
     %TagFollow{}
     |> TagFollow.organization_changeset(%{organization_id: organization_id, tag_id: tag_id})
-    |> Repo.insert(on_conflict: :nothing, conflict_target: [:organization_id, :tag_id])
+    |> insert_follow_with_local_source(organization_id: organization_id, tag_id: tag_id)
   end
 
   @doc "Unfollows a tag as `page`. Idempotent; returns the number of rows removed."
@@ -1175,6 +1193,111 @@ defmodule Vutuv.Tags do
   @doc "The ids of the tags `page` follows — the set its feed's tag source joins against."
   def organization_followed_tag_ids(%Organization{id: page_id}) do
     Repo.all(from(tf in TagFollow, where: tf.organization_id == ^page_id, select: tf.tag_id))
+  end
+
+  # --- Where a followed tag reads from (issue #2125) ------------------------
+  #
+  # A follow carries sources, one row each — see `Vutuv.Tags.TagFollowSource`
+  # for what a source is and why it is a table.
+
+  @doc "The source that means this installation."
+  def local_tag_follow_source, do: TagFollowSource.local_source()
+
+  @doc """
+  Adds a source to `follow` and returns its row. Idempotent: adding a source
+  twice keeps one row and still answers `{:ok, source}`.
+
+  `source` is whatever the member handed over — a bare host, a URL, a
+  `@user@host` address — and `TagFollowSource.normalize_source/1` reduces it to
+  the stored shape. **An address of this installation becomes the local
+  source**, so pasting our own server adds nothing and asks nobody for our own
+  posts. Anything that is not a server name comes back as `{:error, changeset}`.
+  """
+  def add_tag_follow_source(%TagFollow{} = follow, source) do
+    # The insert answers with the stored shape of what was offered, so the
+    # read-back looks the row up by the same value the changeset normalized —
+    # rather than the context normalizing a second time to guess it.
+    with {:ok, %TagFollowSource{source: stored}} <- insert_tag_follow_source(follow.id, source),
+         %TagFollowSource{} = row <-
+           Repo.get_by(TagFollowSource, tag_follow_id: follow.id, source: stored) do
+      {:ok, row}
+    else
+      nil -> {:error, :invalid}
+      {:error, _} = error -> error
+    end
+  end
+
+  defp insert_tag_follow_source(tag_follow_id, source) do
+    %TagFollowSource{}
+    |> TagFollowSource.changeset(%{tag_follow_id: tag_follow_id, source: source})
+    |> Repo.insert(on_conflict: :nothing, conflict_target: [:tag_follow_id, :source])
+  end
+
+  @doc """
+  Removes one source from `follow`, reading a pasted address the same way
+  `add_tag_follow_source/2` did. Idempotent; returns the number of rows removed
+  (0 or 1). Removing the last source is allowed and leaves a follow that wants
+  nothing — whether a card offers that is the card's business.
+  """
+  def remove_tag_follow_source(%TagFollow{} = follow, source) do
+    case TagFollowSource.normalize_source(source) do
+      nil ->
+        0
+
+      normalized ->
+        {count, _} =
+          from(s in TagFollowSource,
+            where: s.tag_follow_id == ^follow.id and s.source == ^normalized
+          )
+          |> Repo.delete_all()
+
+        count
+    end
+  end
+
+  @doc """
+  The sources of `follow`, in the order they were added — so the local one
+  comes first, having been written with the follow. Ids are `Vutuv.UUIDv7`, so
+  ordering by one is ordering by when it was written.
+  """
+  def tag_follow_sources(%TagFollow{id: id}) do
+    Repo.all(
+      from(s in TagFollowSource,
+        where: s.tag_follow_id == ^id,
+        order_by: [asc: s.id],
+        select: s.source
+      )
+    )
+  end
+
+  @doc """
+  Every server-and-tag pair somebody here wants, with how many follows want it:
+  `[%{source:, tag_id:, tag_name:, follow_count:}]`, busiest pair first.
+
+  The local source is left out, so every `source` in the answer is a hostname a
+  fetcher can ask. Member follows and page follows count alike — the pair is
+  wanted, whoever wants it.
+  """
+  def wanted_tag_sources do
+    local = local_tag_follow_source()
+
+    Repo.all(
+      from(s in TagFollowSource,
+        join: tf in TagFollow,
+        on: tf.id == s.tag_follow_id,
+        join: t in Tag,
+        on: t.id == tf.tag_id,
+        where: s.source != ^local,
+        group_by: [s.source, t.id, t.name],
+        order_by: [desc: count(s.id), asc: s.source],
+        select: %{
+          source: s.source,
+          tag_id: t.id,
+          tag_name: t.name,
+          follow_count: count(s.id)
+        }
+      )
+    )
   end
 
   # Tell `user`'s open feed (and any other subscriber) that their followed-tag

--- a/lib/vutuv/tags/merge.ex
+++ b/lib/vutuv/tags/merge.ex
@@ -409,7 +409,11 @@ defmodule Vutuv.Tags.Merge do
 
   defp drop_leftovers(repo, table, _owner, absorbed, canonical, acc) do
     acc =
-      if table == "user_tags", do: rescue_endorsements(repo, absorbed, canonical, acc), else: acc
+      case table do
+        "user_tags" -> rescue_endorsements(repo, absorbed, canonical, acc)
+        "tag_follows" -> rescue_tag_follow_sources(repo, absorbed, acc)
+        _other -> acc
+      end
 
     rows =
       repo
@@ -493,14 +497,37 @@ defmodule Vutuv.Tags.Merge do
     end
   end
 
+  # A member who followed both spellings loses one `tag_follows` row, and
+  # deleting it cascades the sources under it — where the tag's posts should
+  # come from (issue #2125), including the `vutuv` row every follow carries. A
+  # revert would otherwise put the follow back reading nothing, so the sources
+  # are captured whole first, exactly as the endorsements above are, and go back
+  # with their row.
+  defp rescue_tag_follow_sources(repo, absorbed, acc) do
+    rows =
+      query_column(
+        repo,
+        """
+        select to_jsonb(s)
+        from tag_follow_sources s
+        join tag_follows f on f.id = s.tag_follow_id
+        where f.tag_id = $1::text::uuid
+        """,
+        [absorbed.id]
+      )
+
+    add_delete(acc, "tag_follow_sources", rows)
+  end
+
   # --- reverting ------------------------------------------------------------
 
+  # A re-inserted child points at a parent row that has to exist again first.
+  @child_tables ["user_tag_endorsements", "tag_follow_sources"]
+
   defp restore(repo, undo) do
-    # Parents before children: a re-inserted endorsement points at a `user_tags`
-    # row that has to exist again first.
     undo
     |> Map.get("deletes", [])
-    |> Enum.sort_by(&(&1["table"] == "user_tag_endorsements"))
+    |> Enum.sort_by(&(&1["table"] in @child_tables))
     |> Enum.each(fn %{"table" => table, "rows" => rows} ->
       Enum.each(rows, fn row ->
         repo.query!(
@@ -529,7 +556,7 @@ defmodule Vutuv.Tags.Merge do
   # so the table and column names it names are checked against the compile-time
   # list before they reach a query rather than trusted for having been written
   # by us once.
-  @tables ["user_tag_endorsements" | Enum.map(@movable, &elem(&1, 0))]
+  @tables @child_tables ++ Enum.map(@movable, &elem(&1, 0))
   @columns %{"user_tag_endorsements" => "user_tag_id"}
 
   # Fail closed: an unknown name raises rather than being skipped, so a payload
@@ -577,6 +604,9 @@ defmodule Vutuv.Tags.Merge do
     move = %{"table" => table, "column" => column, "to" => to, "ids" => ids}
     Map.update!(acc, :moves, &(&1 ++ [move]))
   end
+
+  # An empty capture is nothing to put back, like `add_move/5` above.
+  defp add_delete(acc, _table, []), do: acc
 
   defp add_delete(acc, table, rows) do
     Map.update!(acc, :deletes, &(&1 ++ [%{"table" => table, "rows" => rows}]))

--- a/lib/vutuv/tags/tag_follow.ex
+++ b/lib/vutuv/tags/tag_follow.ex
@@ -21,6 +21,11 @@ defmodule Vutuv.Tags.TagFollow do
     belongs_to(:organization, Vutuv.Organizations.Organization)
     belongs_to(:tag, Vutuv.Tags.Tag)
 
+    # Where this follow's posts should come from (issue #2125): `vutuv` plus any
+    # server the member picked. Declared so a page listing many follows can
+    # preload them in the query it already runs.
+    has_many(:sources, Vutuv.Tags.TagFollowSource)
+
     timestamps()
   end
 

--- a/lib/vutuv/tags/tag_follow.ex
+++ b/lib/vutuv/tags/tag_follow.ex
@@ -24,7 +24,7 @@ defmodule Vutuv.Tags.TagFollow do
     # Where this follow's posts should come from (issue #2125): `vutuv` plus any
     # server the member picked. Declared so a page listing many follows can
     # preload them in the query it already runs.
-    has_many(:sources, Vutuv.Tags.TagFollowSource)
+    has_many(:sources, Vutuv.Tags.TagFollowSource, preload_order: [asc: :id])
 
     timestamps()
   end

--- a/lib/vutuv/tags/tag_follow_source.ex
+++ b/lib/vutuv/tags/tag_follow_source.ex
@@ -18,6 +18,18 @@ defmodule Vutuv.Tags.TagFollowSource do
   own becomes the local source** rather than a server to poll: asking this
   installation for its own posts is the failure v7.197.0 already produced once,
   via `www.`, so `Vutuv.Fediverse.own_host?/1` answers that question here too.
+  A remote host is folded the same way — `www.mastodon.social` is stored as
+  `mastodon.social`, because `www.` is the same site on both sides of the
+  question and two spellings would be a duplicate row and a duplicate fetch.
+
+  What a member types here is **fetched later, by us** (#2126), so the row is a
+  stored SSRF target and the changeset carries the same two-layer guard
+  `Vutuv.Organizations.OrganizationDomain` uses for a domain somebody claims:
+  the server-name grammar, and `Vutuv.Ssrf.internal_host?/1` on top of it — the
+  grammar alone accepts `169.254.169.254`. That check is literal-only (no DNS in
+  a changeset), so a hostname that *resolves* somewhere internal still has to be
+  vetted at fetch time with `Vutuv.Ssrf.resolves_to_internal?/1` or
+  `vetted_address/1`.
 
   Nothing is stored per source but the source itself. What was fetched from it,
   and when, belongs to the fetcher (#2126) and not to the member's subscription.
@@ -27,6 +39,7 @@ defmodule Vutuv.Tags.TagFollowSource do
 
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.BlockedInstance
+  alias Vutuv.Ssrf
 
   # The one spelling of "this installation". Not a hostname on purpose: it means
   # "here" on every installation, so it survives a rename of the site's host and
@@ -62,31 +75,50 @@ defmodule Vutuv.Tags.TagFollowSource do
   @doc """
   The stored shape of whatever was offered: `"vutuv"` for the local source and
   for any address of this installation, a bare lowercased hostname for a remote
-  server, `nil` when nothing host-shaped is left.
+  server (its `www.` folded away), `nil` when nothing host-shaped is left.
   """
   def normalize_source(@local_source), do: @local_source
 
   def normalize_source(value) when is_binary(value) do
     case BlockedInstance.normalize_host(value) do
       nil -> nil
-      host -> if Fediverse.own_host?(host), do: @local_source, else: host
+      # Serving a site at both the apex and its `www.` alias is the oldest
+      # convention on the web, and `own_host?/1` already reads the two as one
+      # for our own address. Nothing about that is local, so a remote server is
+      # folded by the same function: otherwise `www.mastodon.social` is a
+      # second row beside `mastodon.social`, fetched separately, answering with
+      # the same posts.
+      host -> if Fediverse.own_host?(host), do: @local_source, else: Fediverse.strip_www(host)
     end
   end
 
   def normalize_source(_), do: nil
 
-  # Anything but the sentinel has to be a server name, in the one shape the
-  # instance blocklist already defines — two definitions of "a real host" would
-  # have to be loosened together the day an intranet or an IDN address needs one.
+  # Two layers, the shape `Vutuv.Organizations.OrganizationDomain` already uses
+  # for a member-supplied host that we will later fetch from: the server-name
+  # grammar the instance blocklist defines (one definition of "a real host", so
+  # an intranet or IDN address loosens both at once), and then the SSRF check —
+  # the grammar accepts `169.254.169.254` and every private range, since it was
+  # written to keep useless entries out of a blocklist, not to keep a fetcher
+  # off the metadata service.
   defp validate_source(changeset) do
     case get_field(changeset, :source) do
-      @local_source ->
-        changeset
+      nil -> changeset
+      @local_source -> changeset
+      host -> validate_remote_host(changeset, host)
+    end
+  end
 
-      _remote ->
-        validate_format(changeset, :source, BlockedInstance.host_format(),
-          message: "is not a server name"
-        )
+  defp validate_remote_host(changeset, host) do
+    cond do
+      not Regex.match?(BlockedInstance.host_format(), host) ->
+        add_error(changeset, :source, "is not a server name")
+
+      Ssrf.internal_host?(host) ->
+        add_error(changeset, :source, "is not an allowed server")
+
+      true ->
+        changeset
     end
   end
 end

--- a/lib/vutuv/tags/tag_follow_source.ex
+++ b/lib/vutuv/tags/tag_follow_source.ex
@@ -1,0 +1,92 @@
+defmodule Vutuv.Tags.TagFollowSource do
+  @moduledoc """
+  Where a followed tag's posts should come from (issue #2125): one row per
+  source of one `Vutuv.Tags.TagFollow`.
+
+  A follow used to be a member and a topic with nowhere to say *where*. It now
+  carries sources — `"vutuv"`, this installation, plus any server the member
+  picked. A table rather than a list on the follow, because the fetcher asks the
+  question the other way round: which server-and-tag pairs does anybody here
+  want? That is one grouped query (`Vutuv.Tags.wanted_tag_sources/0`) instead of
+  unpacking every member's array.
+
+  `source` is either the literal `"vutuv"` or a bare, lowercased hostname —
+  never a URL, never a handle. It is deliberately not called `host`: the local
+  row is no host, and a caller building `https://\#{source}/tags/…` out of it
+  would fetch nonsense. `normalize_source/1` is the one place that turns
+  whatever a member pasted into one of the two shapes, and **an address of our
+  own becomes the local source** rather than a server to poll: asking this
+  installation for its own posts is the failure v7.197.0 already produced once,
+  via `www.`, so `Vutuv.Fediverse.own_host?/1` answers that question here too.
+
+  Nothing is stored per source but the source itself. What was fetched from it,
+  and when, belongs to the fetcher (#2126) and not to the member's subscription.
+  """
+
+  use VutuvWeb, :model
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.BlockedInstance
+
+  # The one spelling of "this installation". Not a hostname on purpose: it means
+  # "here" on every installation, so it survives a rename of the site's host and
+  # never has to be rewritten when `PHX_HOST` changes. It carries no dot, so it
+  # cannot collide with a server name either.
+  @local_source "vutuv"
+
+  schema "tag_follow_sources" do
+    field(:source, :string)
+
+    belongs_to(:tag_follow, Vutuv.Tags.TagFollow)
+
+    timestamps()
+  end
+
+  @doc "The source that means this installation."
+  def local_source, do: @local_source
+
+  def changeset(model, params \\ %{}) do
+    model
+    |> cast(params, [:tag_follow_id, :source])
+    |> update_change(:source, &normalize_source/1)
+    |> validate_required([:tag_follow_id, :source])
+    |> validate_length(:source, max: BlockedInstance.max_host())
+    |> validate_source()
+    |> unique_constraint(:source,
+      name: :tag_follow_sources_tag_follow_id_source_index,
+      message: "This follow already reads that source."
+    )
+    |> foreign_key_constraint(:tag_follow_id)
+  end
+
+  @doc """
+  The stored shape of whatever was offered: `"vutuv"` for the local source and
+  for any address of this installation, a bare lowercased hostname for a remote
+  server, `nil` when nothing host-shaped is left.
+  """
+  def normalize_source(@local_source), do: @local_source
+
+  def normalize_source(value) when is_binary(value) do
+    case BlockedInstance.normalize_host(value) do
+      nil -> nil
+      host -> if Fediverse.own_host?(host), do: @local_source, else: host
+    end
+  end
+
+  def normalize_source(_), do: nil
+
+  # Anything but the sentinel has to be a server name, in the one shape the
+  # instance blocklist already defines — two definitions of "a real host" would
+  # have to be loosened together the day an intranet or an IDN address needs one.
+  defp validate_source(changeset) do
+    case get_field(changeset, :source) do
+      @local_source ->
+        changeset
+
+      _remote ->
+        validate_format(changeset, :source, BlockedInstance.host_format(),
+          message: "is not a server name"
+        )
+    end
+  end
+end

--- a/priv/repo/migrations/20260910120353_create_tag_follow_sources.exs
+++ b/priv/repo/migrations/20260910120353_create_tag_follow_sources.exs
@@ -1,0 +1,113 @@
+defmodule Vutuv.Repo.Migrations.CreateTagFollowSources do
+  use Ecto.Migration
+
+  # Where a followed tag's posts should come from (issue #2125). A follow was a
+  # member (or a page) and a topic, with nowhere to say *where*; it now carries
+  # sources, one row each: `vutuv` for this installation plus any server the
+  # member picked.
+  #
+  # A table rather than a list on the follow, because the fetcher's question is
+  # the other way round — which server-and-tag pairs does anybody here want? —
+  # and that is one grouped query instead of unpacking every member's array.
+  #
+  # The backfill writes exactly one source, `vutuv`, to every follow that
+  # already exists, members and pages alike, so nothing changes for anybody
+  # until they add a server themselves. Plain addition, and the currently
+  # deployed release does not know the table exists, so this is N-1 safe and
+  # needs no second deploy.
+
+  # `vutuv` spelled out rather than read from the app: a migration must keep
+  # meaning what it meant the day it ran, whatever the constant later becomes.
+  @local_source "vutuv"
+
+  # Ids per statement. The ids are minted here because they must be UUID v7 and
+  # Postgres has no generator for that.
+  @chunk 1000
+
+  def up do
+    create table(:tag_follow_sources) do
+      add(
+        :tag_follow_id,
+        references(:tag_follows, on_delete: :delete_all, type: :binary_id),
+        null: false
+      )
+
+      # Either the literal `vutuv` or a bare lowercased hostname — never a URL.
+      add(:source, :string, null: false)
+
+      timestamps()
+    end
+
+    # One row per source of a follow; adding a server twice is a no-op, not a
+    # duplicate. The leading tag_follow_id also serves "the sources of this
+    # follow", so no separate index is needed for the card.
+    create(unique_index(:tag_follow_sources, [:tag_follow_id, :source]))
+
+    # The fetcher's side of the question, and partial on purpose: it asks only
+    # about servers, and a plain index on `source` would be almost entirely the
+    # local sentinel — which no query ever looks up, since the only predicate
+    # against it is `<>` and a btree cannot answer that. Measured on 200,000
+    # follows: 112 kB against 1,384 kB, and `wanted_tag_sources/0` reads 32
+    # buffers on this side instead of seq-scanning 1,685.
+    create(
+      index(:tag_follow_sources, [:source, :tag_follow_id], where: "source <> '#{@local_source}'")
+    )
+
+    flush()
+
+    IO.puts("create_tag_follow_sources: #{backfill(repo())} follow(s) given the local source")
+  end
+
+  def down do
+    drop(table(:tag_follow_sources))
+  end
+
+  @doc """
+  Gives every follow that has no source at all the local one, and answers how
+  many rows that was. Idempotent, so a re-run adds nothing and a follow written
+  by the new release (which sets its own source) is left alone.
+
+  Takes the repo rather than reading `repo()`, so the test can drive the
+  migration's own code instead of a copy of it.
+  """
+  def backfill(repo) do
+    %{rows: rows} =
+      repo.query!(
+        """
+        SELECT tf.id::text
+        FROM tag_follows tf
+        WHERE NOT EXISTS (
+          SELECT 1 FROM tag_follow_sources s WHERE s.tag_follow_id = tf.id
+        )
+        """,
+        []
+      )
+
+    rows
+    |> List.flatten()
+    |> Enum.chunk_every(@chunk)
+    |> Enum.reduce(0, fn follow_ids, written -> written + insert_local(repo, follow_ids) end)
+  end
+
+  defp insert_local(repo, follow_ids) do
+    ids = Enum.map(follow_ids, fn _ -> Vutuv.UUIDv7.generate() end)
+    now = NaiveDateTime.utc_now(:second)
+
+    # `::text::uuid` and not a bare `::uuid`: Postgres reports the parameter
+    # type of `$1::uuid[]` as uuid[], and Postgrex then demands the raw 16-byte
+    # form, so the readable `019f…` strings minted above would raise an
+    # EncodeError. Casting from text hands Postgres the string it can parse.
+    %{num_rows: num_rows} =
+      repo.query!(
+        """
+        INSERT INTO tag_follow_sources (id, tag_follow_id, source, inserted_at, updated_at)
+        SELECT new_id::uuid, follow_id::uuid, $3, $4::timestamp, $4::timestamp
+        FROM unnest($1::text[], $2::text[]) AS minted(new_id, follow_id)
+        ON CONFLICT DO NOTHING
+        """,
+        [ids, follow_ids, @local_source, now]
+      )
+
+    num_rows
+  end
+end

--- a/test/vutuv/repo/create_tag_follow_sources_test.exs
+++ b/test/vutuv/repo/create_tag_follow_sources_test.exs
@@ -1,0 +1,74 @@
+defmodule Vutuv.Repo.CreateTagFollowSourcesTest do
+  @moduledoc """
+  Covers the backfill half of `create_tag_follow_sources` (issue #2125): every
+  follow that existed before the table gets exactly one source, `vutuv`, so
+  nothing changes for anybody until they add a server themselves.
+
+  A fresh test database holds no old follows, so the migration's own run here
+  would touch nothing — the run that counts is against `vutuv1_dev` (see
+  CLAUDE.md). What this file builds is the state the migration meets in
+  production: follows written straight into the table, a member's and a page's,
+  and one that already carries its source because it was made after the deploy.
+
+  It drives `backfill/1`, the migration's own code, so the two cannot drift.
+
+  `async: false`: the module is loaded from `priv/repo/migrations` with
+  `Code.require_file/1`, which is global.
+  """
+  use Vutuv.DataCase, async: false
+
+  alias Vutuv.Tags
+  alias Vutuv.Tags.TagFollowSource
+
+  @migration Vutuv.Repo.Migrations.CreateTagFollowSources
+
+  setup_all do
+    unless Code.ensure_loaded?(@migration) do
+      [file] = Path.wildcard("priv/repo/migrations/*_create_tag_follow_sources.exs")
+      Code.require_file(file)
+    end
+
+    :ok
+  end
+
+  test "gives a member's and a page's existing follow the local source" do
+    tag = insert(:tag)
+    member_follow = insert(:tag_follow, user: insert(:user), tag: tag)
+    page_follow = insert(:tag_follow, organization: insert(:organization), tag: tag)
+
+    assert @migration.backfill(Repo) == 2
+
+    assert Tags.tag_follow_sources(member_follow) == ["vutuv"]
+    assert Tags.tag_follow_sources(page_follow) == ["vutuv"]
+  end
+
+  test "a second run adds nothing" do
+    insert(:tag_follow, user: insert(:user), tag: insert(:tag))
+
+    assert @migration.backfill(Repo) == 1
+    assert @migration.backfill(Repo) == 0
+    assert Repo.aggregate(TagFollowSource, :count) == 1
+  end
+
+  test "leaves a follow made after the deploy alone" do
+    {:ok, follow} = Tags.follow_tag(insert(:user), insert(:tag))
+    {:ok, _} = Tags.add_tag_follow_source(follow, "mastodon.social")
+
+    assert @migration.backfill(Repo) == 0
+    assert Tags.tag_follow_sources(follow) == ["vutuv", "mastodon.social"]
+  end
+
+  test "mints v7 ids, so the source rows sort by when they were written" do
+    tag = insert(:tag)
+    for _ <- 1..3, do: insert(:tag_follow, user: insert(:user), tag: tag)
+
+    assert @migration.backfill(Repo) == 3
+
+    ids = Repo.all(from(s in TagFollowSource, select: s.id))
+    assert length(ids) == 3
+
+    for id <- ids do
+      assert %NaiveDateTime{} = Vutuv.UUIDv7.timestamp(id)
+    end
+  end
+end

--- a/test/vutuv/tag_follow_sources_test.exs
+++ b/test/vutuv/tag_follow_sources_test.exs
@@ -1,0 +1,198 @@
+defmodule Vutuv.TagFollowSourcesTest do
+  @moduledoc """
+  A followed tag remembers **where** its posts should come from (issue #2125):
+  one row per source, `vutuv` for this installation plus any server the member
+  picked. `Vutuv.Tags.TagFollowSource` says why that is a table.
+
+  Nothing user-facing stands on this yet; the tag card and the fetcher
+  (#2126–#2129) do.
+  """
+  use Vutuv.DataCase, async: true
+
+  alias Vutuv.Tags
+  alias Vutuv.Tags.TagFollow
+  alias Vutuv.Tags.TagFollowSource
+
+  defp member_follow(tag) do
+    {:ok, follow} = Tags.follow_tag(insert(:user), tag)
+    follow
+  end
+
+  describe "the local source comes with the follow" do
+    test "a member's new follow is a vutuv source and nothing else" do
+      follow = member_follow(insert(:tag))
+
+      assert Tags.tag_follow_sources(follow) == ["vutuv"]
+      assert Tags.local_tag_follow_source() == "vutuv"
+    end
+
+    test "a page's new follow gets the same one" do
+      page = insert(:organization)
+
+      assert {:ok, follow} = Tags.follow_tag_as_organization(page, insert(:tag))
+      assert Tags.tag_follow_sources(follow) == ["vutuv"]
+    end
+
+    test "following twice keeps exactly one local source row" do
+      user = insert(:user)
+      tag = insert(:tag)
+
+      assert {:ok, _} = Tags.follow_tag(user, tag)
+      assert {:ok, follow} = Tags.follow_tag(user, tag)
+
+      assert Tags.tag_follow_sources(follow) == ["vutuv"]
+      assert Repo.aggregate(TagFollowSource, :count) == 1
+    end
+
+    test "unfollowing takes the sources with it" do
+      user = insert(:user)
+      tag = insert(:tag)
+      {:ok, follow} = Tags.follow_tag(user, tag)
+      {:ok, _} = Tags.add_tag_follow_source(follow, "mastodon.social")
+
+      assert Tags.unfollow_tag(user, tag) == 1
+      assert Repo.aggregate(TagFollowSource, :count) == 0
+    end
+  end
+
+  describe "add_tag_follow_source/2" do
+    test "adds a server after the local source, idempotently" do
+      follow = member_follow(insert(:tag))
+
+      assert {:ok, %TagFollowSource{}} = Tags.add_tag_follow_source(follow, "mastodon.social")
+      assert {:ok, %TagFollowSource{}} = Tags.add_tag_follow_source(follow, "mastodon.social")
+
+      assert Tags.tag_follow_sources(follow) == ["vutuv", "mastodon.social"]
+    end
+
+    test "takes whatever the member pasted and keeps the hostname" do
+      follow = member_follow(insert(:tag))
+
+      assert {:ok, _} = Tags.add_tag_follow_source(follow, "https://Mastodon.Social/tags/elixir")
+      assert {:ok, _} = Tags.add_tag_follow_source(follow, "  @bob@Troet.Cafe ")
+
+      assert Tags.tag_follow_sources(follow) == ["vutuv", "mastodon.social", "troet.cafe"]
+    end
+
+    test "our own address is the local source, not a server to fetch from" do
+      follow = member_follow(insert(:tag))
+
+      for ours <- ["localhost", "www.localhost", "http://localhost:4001/tags/elixir"] do
+        assert {:ok, %TagFollowSource{source: "vutuv"}} = Tags.add_tag_follow_source(follow, ours)
+      end
+
+      assert Tags.tag_follow_sources(follow) == ["vutuv"]
+    end
+
+    test "refuses what is not a server name" do
+      follow = member_follow(insert(:tag))
+
+      for junk <- ["not a server", "", "mastodon"] do
+        assert {:error, %Ecto.Changeset{} = changeset} = Tags.add_tag_follow_source(follow, junk)
+        assert errors_on(changeset).source != []
+      end
+
+      assert Tags.tag_follow_sources(follow) == ["vutuv"]
+    end
+
+    test "refuses a hostname longer than its column" do
+      follow = member_follow(insert(:tag))
+      long = String.duplicate("a", 250) <> ".example"
+
+      assert {:error, changeset} = Tags.add_tag_follow_source(follow, long)
+      assert errors_on(changeset).source != []
+    end
+  end
+
+  describe "remove_tag_follow_source/2" do
+    test "removes one named source and is idempotent" do
+      follow = member_follow(insert(:tag))
+      {:ok, _} = Tags.add_tag_follow_source(follow, "mastodon.social")
+
+      assert Tags.remove_tag_follow_source(follow, "mastodon.social") == 1
+      assert Tags.remove_tag_follow_source(follow, "mastodon.social") == 0
+      assert Tags.tag_follow_sources(follow) == ["vutuv"]
+    end
+
+    test "reads a pasted address the same way adding did" do
+      follow = member_follow(insert(:tag))
+      {:ok, _} = Tags.add_tag_follow_source(follow, "mastodon.social")
+
+      assert Tags.remove_tag_follow_source(follow, "https://Mastodon.Social/") == 1
+      assert Tags.tag_follow_sources(follow) == ["vutuv"]
+    end
+
+    test "leaves another follow's source alone" do
+      tag = insert(:tag)
+      mine = member_follow(tag)
+      theirs = member_follow(tag)
+      {:ok, _} = Tags.add_tag_follow_source(mine, "mastodon.social")
+      {:ok, _} = Tags.add_tag_follow_source(theirs, "mastodon.social")
+
+      assert Tags.remove_tag_follow_source(mine, "mastodon.social") == 1
+      assert Tags.tag_follow_sources(theirs) == ["vutuv", "mastodon.social"]
+    end
+  end
+
+  describe "wanted_tag_sources/0" do
+    test "answers one row per server-and-tag pair, with how many want it" do
+      tag = insert(:tag, name: "Elixir")
+      other = insert(:tag, name: "Bahn")
+      page = insert(:organization)
+      {:ok, page_follow} = Tags.follow_tag_as_organization(page, tag)
+
+      for follow <- [member_follow(tag), member_follow(tag), page_follow] do
+        {:ok, _} = Tags.add_tag_follow_source(follow, "mastodon.social")
+      end
+
+      {:ok, _} = Tags.add_tag_follow_source(member_follow(other), "troet.cafe")
+
+      assert [bahn, elixir] = Enum.sort_by(Tags.wanted_tag_sources(), & &1.tag_name)
+
+      assert bahn == %{
+               source: "troet.cafe",
+               tag_id: other.id,
+               tag_name: "Bahn",
+               follow_count: 1
+             }
+
+      assert elixir == %{
+               source: "mastodon.social",
+               tag_id: tag.id,
+               tag_name: "Elixir",
+               follow_count: 3
+             }
+    end
+
+    test "never asks this installation for its own posts" do
+      member_follow(insert(:tag))
+
+      assert Tags.wanted_tag_sources() == []
+    end
+
+    test "forgets a pair once the last follower drops it" do
+      follow = member_follow(insert(:tag))
+      {:ok, _} = Tags.add_tag_follow_source(follow, "mastodon.social")
+      assert Tags.remove_tag_follow_source(follow, "mastodon.social") == 1
+
+      assert Tags.wanted_tag_sources() == []
+    end
+  end
+
+  describe "the row itself" do
+    test "the database refuses the same source twice on one follow" do
+      follow = member_follow(insert(:tag))
+
+      assert_raise Ecto.ConstraintError, fn ->
+        Repo.insert!(%TagFollowSource{tag_follow_id: follow.id, source: "vutuv"})
+      end
+    end
+
+    test "a follow with no sources is possible and simply wants nothing" do
+      follow = insert(:tag_follow, user: insert(:user), tag: insert(:tag))
+
+      assert %TagFollow{} = follow
+      assert Tags.tag_follow_sources(follow) == []
+    end
+  end
+end

--- a/test/vutuv/tag_follow_sources_test.exs
+++ b/test/vutuv/tag_follow_sources_test.exs
@@ -9,6 +9,7 @@ defmodule Vutuv.TagFollowSourcesTest do
   """
   use Vutuv.DataCase, async: true
 
+  alias Vutuv.Fediverse
   alias Vutuv.Tags
   alias Vutuv.Tags.TagFollow
   alias Vutuv.Tags.TagFollowSource
@@ -74,10 +75,25 @@ defmodule Vutuv.TagFollowSourcesTest do
       assert Tags.tag_follow_sources(follow) == ["vutuv", "mastodon.social", "troet.cafe"]
     end
 
-    test "our own address is the local source, not a server to fetch from" do
+    test "folds www. away, so one server is one row" do
       follow = member_follow(insert(:tag))
 
-      for ours <- ["localhost", "www.localhost", "http://localhost:4001/tags/elixir"] do
+      assert {:ok, %TagFollowSource{source: "mastodon.social"}} =
+               Tags.add_tag_follow_source(follow, "www.mastodon.social")
+
+      assert {:ok, _} = Tags.add_tag_follow_source(follow, "mastodon.social")
+      assert Tags.tag_follow_sources(follow) == ["vutuv", "mastodon.social"]
+    end
+
+    test "every spelling of this installation's own address is the local source" do
+      follow = member_follow(insert(:tag))
+      # Taken from the endpoint, not written out: the rule under test is
+      # `Fediverse.own_host?/1`, and hardcoding the test host ("localhost")
+      # would pass on a fixture rather than on the rule. The tag host is here
+      # because it is us too, and it is the spelling a hardcoded test misses.
+      host = VutuvWeb.Endpoint.host()
+
+      for ours <- [host, "www." <> host, "https://#{host}/tags/elixir", Fediverse.tag_host()] do
         assert {:ok, %TagFollowSource{source: "vutuv"}} = Tags.add_tag_follow_source(follow, ours)
       end
 
@@ -87,12 +103,30 @@ defmodule Vutuv.TagFollowSourcesTest do
     test "refuses what is not a server name" do
       follow = member_follow(insert(:tag))
 
-      for junk <- ["not a server", "", "mastodon"] do
+      for junk <- ["not a server", "", "mastodon", "[::1]"] do
         assert {:error, %Ecto.Changeset{} = changeset} = Tags.add_tag_follow_source(follow, junk)
         assert errors_on(changeset).source != []
       end
 
       assert Tags.tag_follow_sources(follow) == ["vutuv"]
+    end
+
+    test "refuses an address inside our own network — the fetcher would go there" do
+      follow = member_follow(insert(:tag))
+
+      # A source is a host #2126 will fetch from, so this is a stored SSRF
+      # target. The server-name grammar alone accepts every one of these, which
+      # is why the error asserted here is the SSRF layer's own and not "is not
+      # a server name".
+      for internal <- ["169.254.169.254", "127.0.0.1", "10.0.0.5", "192.168.1.1"] do
+        assert {:error, %Ecto.Changeset{} = changeset} =
+                 Tags.add_tag_follow_source(follow, internal)
+
+        assert "is not an allowed server" in errors_on(changeset).source
+      end
+
+      assert Tags.tag_follow_sources(follow) == ["vutuv"]
+      assert Tags.wanted_tag_sources() == []
     end
 
     test "refuses a hostname longer than its column" do
@@ -188,11 +222,42 @@ defmodule Vutuv.TagFollowSourcesTest do
       end
     end
 
-    test "a follow with no sources is possible and simply wants nothing" do
+    test "a follow written with no sources at all still reads as vutuv" do
+      # What the previous release keeps writing during a blue/green deploy: it
+      # knows nothing about this table, and nothing backfills those rows
+      # afterwards. vutuv is always on (#2128), so this is the same answer.
       follow = insert(:tag_follow, user: insert(:user), tag: insert(:tag))
 
       assert %TagFollow{} = follow
-      assert Tags.tag_follow_sources(follow) == []
+      assert Tags.tag_follow_sources(follow) == ["vutuv"]
+
+      # And still after it gains its first server: an "empty means vutuv" rule
+      # would stop firing right here and switch this installation off for a
+      # follow whose owner never asked for that.
+      {:ok, _} = Tags.add_tag_follow_source(follow, "mastodon.social")
+      assert Tags.tag_follow_sources(follow) == ["vutuv", "mastodon.social"]
+    end
+
+    test "a preloaded follow answers the same, without a second query" do
+      follow = member_follow(insert(:tag))
+      {:ok, _} = Tags.add_tag_follow_source(follow, "mastodon.social")
+      bare = insert(:tag_follow, user: insert(:user), tag: insert(:tag))
+
+      preloaded = Repo.preload([follow, bare], :sources)
+
+      assert Enum.map(preloaded, &Tags.tag_follow_sources/1) == [
+               ["vutuv", "mastodon.social"],
+               ["vutuv"]
+             ]
+    end
+
+    test "the local source cannot be switched off" do
+      follow = member_follow(insert(:tag))
+      {:ok, _} = Tags.add_tag_follow_source(follow, "mastodon.social")
+
+      assert Tags.remove_tag_follow_source(follow, "vutuv") == 0
+      assert Tags.remove_tag_follow_source(follow, VutuvWeb.Endpoint.host()) == 0
+      assert Tags.tag_follow_sources(follow) == ["vutuv", "mastodon.social"]
     end
   end
 end

--- a/test/vutuv/tags/merge_test.exs
+++ b/test/vutuv/tags/merge_test.exs
@@ -10,6 +10,7 @@ defmodule Vutuv.Tags.MergeTest do
   alias Vutuv.Newsletters.NewsletterGroup
   alias Vutuv.Posts.PostHashtag
   alias Vutuv.Posts.PostTag
+  alias Vutuv.Tags
   alias Vutuv.Tags.Merge
   alias Vutuv.Tags.Tag
   alias Vutuv.Tags.TagFollow
@@ -286,6 +287,23 @@ defmodule Vutuv.Tags.MergeTest do
       assert restored.tag_id == ctx.absorbed.id
       assert restored.user_id == both.id
       assert Repo.get!(UserTagEndorsement, endorsement.id).user_tag_id == doomed.id
+    end
+
+    test "restores a dropped follow's sources, so it reads from where it did", ctx do
+      member = insert(:activated_user)
+      {:ok, _} = Tags.follow_tag(member, ctx.canonical)
+      {:ok, doomed} = Tags.follow_tag(member, ctx.absorbed)
+      {:ok, _} = Tags.add_tag_follow_source(doomed, "mastodon.social")
+
+      {:ok, merge} = Merge.merge(ctx.absorbed, ctx.canonical, actor: ctx.admin)
+      refute Repo.get(TagFollow, doomed.id)
+
+      assert {:ok, _} = Merge.revert(merge)
+
+      # Without the sources the follow would come back reading nothing at all —
+      # not even this installation.
+      assert Repo.get!(TagFollow, doomed.id).tag_id == ctx.absorbed.id
+      assert Tags.tag_follow_sources(doomed) == ["vutuv", "mastodon.social"]
     end
 
     test "a merge is reverted once", ctx do


### PR DESCRIPTION
A followed tag was a member (or a page) and a topic, with nowhere to say where its posts should come from. It now carries sources, one row each in `tag_follow_sources`: `vutuv` — this installation, written inside the follow's own transaction — plus any server somebody picks. A table and not a list on the follow, because the fetcher asks the question the other way round, and `Vutuv.Tags.wanted_tag_sources/0` answers it with one grouped query.

Nothing user-facing changes. The migration gives every existing follow exactly one `vutuv` source; run against a copy of production it wrote 139 rows and left none over. Pure addition, N-1 safe.

A pasted address of our own becomes the local source, `Vutuv.Fediverse.own_host?/1` deciding that, so no installation asks itself for its own posts.

Closes #2125

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01AW11tx7rYiSEaRDjPFNghY
