### PR TITLE
The first pages of a file show as pictures under the post

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -778,6 +778,14 @@ config :vutuv, :press_kit, max_filesize: 30_000_000, max_photos: 10, max_logos: 
 # them; admins have none. `pdfinfo` comes from poppler-utils, the package
 # `pdftoppm` (qualification proofs) already asks for — without it PDFs are not
 # offered at all, and text and Markdown carry on.
+#
+# `preview_pages` is how many of a file's first pages are rendered as pictures
+# under the post (issue #2105): three is enough to tell a paper from a price
+# list, five is the ceiling the code clamps to, and 0 turns previews off for an
+# installation that wants none. A PDF page is rendered by `pdftoppm` (the same
+# poppler-utils package as `pdfinfo` above); a text or Markdown file is drawn
+# by the headless Chromium the screenshot pipeline already runs, and where
+# neither is on the box the file simply has no preview.
 config :vutuv, :attachments,
   enabled: true,
   uploaders: :admins,
@@ -785,8 +793,11 @@ config :vutuv, :attachments,
   max_per_post: 5,
   daily_budget: 100_000_000,
   monthly_budget: 500_000_000,
+  preview_pages: 3,
+  render_concurrency: 1,
   pdfinfo: "pdfinfo",
-  pdfdetach: "pdfdetach"
+  pdfdetach: "pdfdetach",
+  pdftoppm: "pdftoppm"
 
 # Job postings (Vutuv.Jobs, milestone 11).
 #   * default_runtime_days — how long a published posting stays live before it

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -807,8 +807,14 @@ if config_env() == :prod do
            daily_budget: env_mb.("ATTACHMENT_DAILY_MB") || attachment_defaults[:daily_budget],
            monthly_budget:
              env_mb.("ATTACHMENT_MONTHLY_MB") || attachment_defaults[:monthly_budget],
+           preview_pages:
+             env_int.("ATTACHMENT_PREVIEW_PAGES") || attachment_defaults[:preview_pages],
+           render_concurrency:
+             env_int.("ATTACHMENT_RENDER_CONCURRENCY") ||
+               attachment_defaults[:render_concurrency],
            pdfinfo: System.get_env("PDFINFO_PATH") || attachment_defaults[:pdfinfo],
-           pdfdetach: System.get_env("PDFDETACH_PATH") || attachment_defaults[:pdfdetach]
+           pdfdetach: System.get_env("PDFDETACH_PATH") || attachment_defaults[:pdfdetach],
+           pdftoppm: System.get_env("PDFTOPPM_PATH") || attachment_defaults[:pdftoppm]
          )
 
   # Post images are auth-proxied: the app checks the post's audience, then

--- a/config/test.exs
+++ b/config/test.exs
@@ -18,6 +18,10 @@ config :vutuv, :sweep_post_drafts, false
 # Vutuv.Videos.Job.run/1 directly on tiny clips. Videos.Pipeline.nudge/0 casts
 # into the void then.
 config :vutuv, :video_pipeline, false
+# The same for a file's preview pages (issue #2105): a polling GenServer that
+# would claim rows from outside the sandbox and shell out to poppler or
+# Chromium. Tests drive Vutuv.Attachments.Pages.render/1 and sweep/1 directly.
+config :vutuv, :attachment_pipeline, false
 # The composer's draft autosave (issue #1148) normally waits for a pause in the
 # typing. Zero means it writes as part of the `validate` that changed something,
 # so a test can assert on the stored draft right after `render_change` instead

--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -31,8 +31,10 @@ Related documents: [README](../README.md) (overview) ·
   profile or post). The cards use **Inter** when the host has it
   (`apt-get install fonts-inter`, optional) and the system's sans-serif
   otherwise; nothing breaks without it, the type just looks different.
-- **Chromium** (optional) — only for URL screenshots and moderation evidence
-  screenshots. Without it those features quietly do nothing.
+- **Chromium** (optional) — URL screenshots, moderation evidence screenshots,
+  and the preview page a text or Markdown file attached to a post is drawn as.
+  Without it those features quietly do nothing: a text file keeps its chip and
+  simply shows no preview.
 - **poppler-utils** (optional, `apt-get install poppler-utils`) — renders the
   first page of PDF proof documents that members can attach to their
   certificates & licenses. Without `pdftoppm` on `$PATH`, PDF uploads are
@@ -42,6 +44,9 @@ Related documents: [README](../README.md) (overview) ·
   (encrypted, carrying a program, carrying another file). Without them **PDF
   attachments are not offered at all** — the composer's picker does not accept
   `.pdf` and the server refuses one — while text and Markdown files carry on.
+  `pdftoppm` renders the preview pages shown under a post's file as well
+  (`ATTACHMENT_PREVIEW_PAGES`); without it a PDF is still accepted and simply
+  shows no preview.
   A check that cannot run is never treated as a check that passed.
 - **ffmpeg** (optional, `apt-get install ffmpeg`) — video on posts: converts
   a member's clip into the files browsers play and pulls the stills the AI
@@ -133,7 +138,9 @@ Everything else has a default (the vutuv.de production value):
 | `ATTACHMENTS_PER_POST` | `5` | How many files one post may carry |
 | `ATTACHMENT_DAILY_MB` | `100` | How much a member may upload in **any 24 hours**, in megabytes. The window rolls rather than resetting at midnight, so there is no hour at which twice the allowance fits. Counted as *accepted uploads*: deleting a file does not give the megabytes back, which is what stops an upload-and-delete loop from filling your disk. Admins have no allowance |
 | `ATTACHMENT_MONTHLY_MB` | `500` | The same over any 30 days |
-| `PDFINFO_PATH` / `PDFDETACH_PATH` | `pdfinfo` / `pdfdetach` | The two poppler binaries the PDF check runs, if not on `$PATH` under those names. Missing either one means PDFs are not offered (see the dependency list above) |
+| `ATTACHMENT_PREVIEW_PAGES` | `3` | How many of a file's first pages are shown as pictures under the post. `0` turns previews off; more than `5` is treated as `5`. A PDF page is rendered by `pdftoppm`, a text or Markdown file by the headless Chromium the link previews use — where neither is installed the file simply shows no preview, and nothing else changes |
+| `ATTACHMENT_RENDER_CONCURRENCY` | `1` | How many files have their preview pages rendered at once. Everything past that queues. Raise it on a machine with cores to spare |
+| `PDFINFO_PATH` / `PDFDETACH_PATH` / `PDFTOPPM_PATH` | `pdfinfo` / `pdfdetach` / `pdftoppm` | The three poppler binaries — the first two run the PDF check, the third renders preview pages — if not on `$PATH` under those names. Missing either of the first two means PDFs are not offered (see the dependency list above); missing the third only means no preview pages |
 | `SCREENSHOT_BLOCKLIST` | – | Extra pages never to take a link-preview screenshot of, on top of the shipped `reddit.com` and `heise.de`. Comma-separated domains and/or URLs, copied into the blocklist table the first time you migrate; afterwards the live list is edited in the admin area (see "Screenshot blocklist" below) and this variable is inert. `SCREENSHOT_BLOCKED_HOSTS` is the older name and still works |
 | `SCREENSHOT_PAGE_CHECK` | `true` | Whether each link-preview capture is judged by the Ollama vision model on whether it shows the page or a consent / ad / login wall or a bot check, and the site blocklisted when it does not (see "The list mostly writes itself" below). `false` leaves the blocklist entirely hand-written — the setting for an installation without Ollama. Independent of `IMAGE_MODERATION_ENABLED`: that one is the safety gate, this one is a quality filter |
 | `SCREENSHOT_CHECK_VOTES` | `3` | How many opinions must agree before a site is blocklisted automatically. The first is deterministic, the rest are independent draws; a single dissent leaves the site alone. `1` acts on one opinion |
@@ -626,7 +633,10 @@ vutuv runs fine without internet access:
   virus scanner behind it — the short format whitelist (PDF, plain text,
   Markdown) and that check are the defence — so an installation that would
   rather take no files at all sets `ATTACHMENT_UPLOADS=false`, and one that
-  wants text files but not PDFs simply leaves poppler-utils uninstalled.
+  wants text files but not PDFs simply leaves poppler-utils uninstalled. The
+  preview pages under a file are local too — poppler for a PDF, and for a text
+  file a headless Chromium launched with name resolution switched off, so a
+  Markdown image reference cannot make the server fetch anything.
 - Set `FETCH_BOOK_METADATA=false`: the cover fetch and the
   page-count/publisher lookup behind book-review posts call Open Library, and
   an audiobook's running time is read from a library catalogue (`DNB_SRU_URL`).

--- a/docs/architecture/attachments.md
+++ b/docs/architecture/attachments.md
@@ -2,10 +2,10 @@
 
 A post can carry files as well as photos and a clip: PDF, plain text and
 Markdown to begin with (milestone #2102). This document covers the part that
-exists today — how a file gets in — and grows as the rest of the milestone
-lands: the preview pages (#2105), the post that waits for them (#2106), what
-a post shows and hands out (#2108), reports and copyright (#2109), messages
-(#2110).
+exists today — how a file gets in and how its preview pages are rendered — and
+grows as the rest of the milestone lands: the post that waits for them (#2106),
+what a post shows and hands out (#2108), reports and copyright (#2109),
+messages (#2110).
 
 ## One chokepoint
 
@@ -67,6 +67,10 @@ removed, and the private tree's promise — this is exactly what the member sent
 byte will go through an authorizing proxy (#2108). Both are gitignored, and
 `test/vutuv/uploads_gitignore_test.exs` fails the build if that slips.
 
+A file's preview pages (#2105) live under the same two roots —
+`attachments/<token>/pages/<n>/` — so they need **no new upload tree** and
+nothing new in `.gitignore` or that test.
+
 ## The budget
 
 Two rolling windows per member, 24 hours and 30 days, counted from
@@ -87,7 +91,9 @@ Everything is per installation, read in `config/runtime.exs` with the
 `config/config.exs` values as defaults, and documented in the env-var table in
 [ADMINS.md](../ADMINS.md): `ATTACHMENT_UPLOADS`, `ATTACHMENT_UPLOADERS`,
 `ATTACHMENT_MAX_MB`, `ATTACHMENTS_PER_POST`, `ATTACHMENT_DAILY_MB`,
-`ATTACHMENT_MONTHLY_MB`, `PDFINFO_PATH`, `PDFDETACH_PATH`.
+`ATTACHMENT_MONTHLY_MB`, `ATTACHMENT_PREVIEW_PAGES`,
+`ATTACHMENT_RENDER_CONCURRENCY`, `PDFINFO_PATH`, `PDFDETACH_PATH`,
+`PDFTOPPM_PATH`.
 
 `ATTACHMENT_UPLOADERS` is `admins` while the milestone is being built, the way
 video was introduced: a post cannot show or hand out its files until #2106 and
@@ -102,9 +108,96 @@ later reader cannot write its own `is_nil/1` pair and get one of them wrong —
 an inner join to `posts` would silently drop every message's file, and a
 `NOT IN` over these ids without an `is_nil/1` branch is false for every row.
 
+## The preview pages
+
+`Vutuv.Attachments.Pages` renders the first pages of a file as pictures, so a
+reader can tell what it is without downloading it: three by default
+(`ATTACHMENT_PREVIEW_PAGES`), five at most, none at zero.
+
+**A PDF page is rendered by `pdftoppm`, not by libvips.** The issue asked for
+libvips' Poppler loader, and that loader is not in this application: `vix`
+generates its `Vix.Vips.Operation` functions from the operation table of the
+libvips it links, and the precompiled one it ships (8.17.1) has no PDF loader
+at all — `pdfload/1` is undefined rather than failing, and `otool -L` on the
+bundled library shows no poppler. The Homebrew `vips` CLI on the same machine
+*does* list `pdfload`, which is what makes the claim look true from outside.
+`pdftoppm` is what this project already renders PDF pages with in three other
+places, ships in the same package as the `pdfinfo` the gate needs, and CI
+already installs it.
+
+A **text or Markdown** file is rendered as one page: the document goes through
+`VutuvWeb.Markdown.render/1` (or a `<pre>` for plain text) and headless
+Chromium photographs it, through the raw `Vutuv.PageScreenshot.capture/3` that
+moderation evidence already uses. One page, not three, because a text file has
+no pagination of its own — what is captured is the first screenful, and slicing
+a README into three would produce two pictures of nothing in particular.
+
+That page's content is a member's file, so it is rendered **offline twice
+over**: the document carries `Content-Security-Policy: default-src 'none'` and
+the browser is launched with `--host-resolver-rules=MAP * ~NOTFOUND`
+(`offline: true`). Either alone would stop a Markdown image reference from
+making this server fetch an address the member chose; neither alone fails
+closed.
+
+### Each page is a picture
+
+A rendered page is a row on the shared `images` table of kind
+`attachment_page`, parented by `attachment_id` and ordered by `position` — the
+second kind **born** on that table (`Vutuv.PressKit` was the first), stored
+under the file's own token at
+`attachments/<token>/pages/<position>/<version>.avif`.
+
+What that gets it, and what it does not, is worth being exact about, because
+five of the six behaviours are per-kind lists rather than generic machinery:
+
+* the **AI scan** reaches it because `attachment_page` is in
+  `Vutuv.Moderation.ImageScan.kinds/0` and has a clause each in
+  `ImageSubjects`' `source/1`, `apply_approved/1`, `apply_rejected/1` and
+  `stranded_pending/0`;
+* the **pixelated wait** because `AttachmentStore.store_page/3` writes the
+  stand-in;
+* the **lite version** because `Vutuv.Uploads.Spec` declares one for
+  `:attachment_page` (which has no `xl` — the file itself is what somebody who
+  wants to *read* it takes);
+* the **regenerator** because `Vutuv.Uploads.Regenerator` names it in four
+  places — and it is the one type there with no stored original, so a
+  regeneration really re-runs poppler or Chromium;
+* the **lightbox** genuinely is generic;
+* the **copyright freeze does not reach it yet, deliberately.** Adding a kind
+  to `Vutuv.Images`' `@takedown` map makes it reportable by anyone who can name
+  a row id, with no visibility check at all — and a preview page can belong to
+  a file no post has claimed. #2109 wires the strategy and the visibility clause
+  in one change; until then `takedown_ready?/1` answers false and nothing offers
+  a report button for a page.
+
+A refused page has its row and its derived sizes deleted and **the file left
+alone**: the model judged the picture we derived, not the upload.
+
+### Surviving a deploy
+
+Rendering takes seconds to tens of seconds, so a blue/green deploy stops the
+slot in the middle of it. The recovery is `Vutuv.Videos`' shape: the row
+carries the state (`stage`), each finished page has its own row so a resumed
+render skips it, the due list is a query (`Pages.due/1`) and a claim is a
+compare-and-set on `attachments.worked_at`, so two slots cannot render the same
+file. `attachments_test`'s sibling kills the render mid-loop and asserts the
+sweeper finishes exactly the rest.
+
+`stage` always reaches a terminal value — `ready` (however many pages, zero
+included) or `failed` — **including the outcomes where nothing could be done**:
+previews switched off, or a host with neither `pdftoppm` nor Chromium. A file
+that could not be worked on and stayed due would hold the front of every
+oldest-first batch for ever. A strike (`render_attempts`, three of them) is
+taken only when the renderer itself ran and failed.
+
+The consequence to know: a file uploaded on a host with no renderer is settled
+`ready` with no pages and is **not** re-rendered if poppler is installed later.
+`mix vutuv.regenerate` re-derives existing pages, not missing ones.
+
 ## The media job
 
-The intake writes one `Vutuv.MediaJobs` row of kind `attachment_intake`, so
+The intake writes one `Vutuv.MediaJobs` row of kind `attachment_intake`, and
+the page rendering one of kind `attachment_pages` per file, so
 `/admin/media` shows it beside the photo scans and video conversions. A
 refusal is a **finished** job with the reason in `detail` — the pipeline did
 its work and the answer was no; only a step that could not be run at all is

--- a/docs/architecture/images.md
+++ b/docs/architecture/images.md
@@ -1029,6 +1029,29 @@ literal `**` in the one place a journalist pastes from is a rendering fault.
 `text`) rather than three keys, so a kit with only a medium one renders in every
 format without a branch, and `agent_docs_drift_test.exs` holds the four siblings
 to the HTML page.
+### A file's preview page (issue #2105)
+
+The second kind born on this table, and the first with a **non-picture parent**:
+`attachment_page` is one rendered page of a file somebody attached to a post,
+parented by `attachment_id` and ordered by `position`, with a partial unique
+index on the pair. `Vutuv.Attachments.Pages` writes the row and
+`Vutuv.AttachmentStore` the files, under the *file's* token
+(`attachments/<token>/pages/<n>/`) rather than the row's — which is why
+`Pages.bytes_path/2` is the one function that owns a page's path. It reuses
+`token`, `moderation`, `position`, the four `width`/`height`/`content_type`/
+`size_bytes` columns and nothing else; the only schema change it needs is the
+`attachment_id` column itself.
+
+Two things are deliberately **not** wired, and both are the same decision.
+There is no `@takedown` entry, so `takedown_ready?/1` answers false and
+`bytes_path/1`/`preview_url/1` on this module answer `nil` — because that map is
+also what `Vutuv.Moderation.reportable_by?/2`'s catch-all `%Image{}` clause
+reads, and a kind added to it becomes reportable by anyone who can name a row
+id, with no visibility check, on a page that may belong to a file no post has
+claimed yet. Reporting a file is #2109, and the strategy and the visibility
+clause belong in one change. Consequently the AI gate's refusal path does not go
+through `purge/1`: `Pages.discard/1` deletes the row and the page's files
+itself, and leaves the file they were rendered from alone.
 
 ### The takedown hold (issue #2012)
 

--- a/lib/vutuv/application.ex
+++ b/lib/vutuv/application.ex
@@ -141,6 +141,7 @@ defmodule Vutuv.Application do
         optional_child(:organization_screenshot_worker, Vutuv.Organizations.ScreenshotWorker) ++
         optional_child(:image_scan_worker, Vutuv.Moderation.ImageScanWorker) ++
         optional_child(:video_pipeline, Vutuv.Videos.Pipeline) ++
+        optional_child(:attachment_pipeline, Vutuv.Attachments.PagePipeline) ++
         optional_child(:translation_worker, Vutuv.Translations.Worker) ++
         optional_child(:reference_check_worker, Vutuv.References.CheckWorker) ++
         optional_child(:reference_skill_refresher, Vutuv.References.SkillRefresher) ++

--- a/lib/vutuv/attachments.ex
+++ b/lib/vutuv/attachments.ex
@@ -43,6 +43,7 @@ defmodule Vutuv.Attachments do
   alias Vutuv.Accounts.User
   alias Vutuv.Attachments.Attachment
   alias Vutuv.Attachments.Format
+  alias Vutuv.Attachments.PagePipeline
   alias Vutuv.Attachments.Upload
   alias Vutuv.AttachmentStore
   alias Vutuv.MediaJobs
@@ -161,6 +162,11 @@ defmodule Vutuv.Attachments do
     case insert do
       {:ok, attachment} ->
         record_upload!(user, size)
+        # The preview pages (#2105) are rendered in the background, not here:
+        # poppler and Chromium both take seconds, and the composer's socket
+        # already waits for the PDF gate. The pipeline would find the row at
+        # its next poll anyway — this only saves the wait.
+        PagePipeline.nudge()
         {:ok, attachment}
 
       {:error, _changeset} = error ->

--- a/lib/vutuv/attachments/attachment.ex
+++ b/lib/vutuv/attachments/attachment.ex
@@ -25,9 +25,12 @@ defmodule Vutuv.Attachments.Attachment do
     * **`page_count`** — `pdfinfo`'s answer for a PDF, `nil` for text. What
       #2105 renders its preview pages from.
     * **`token`** — the URL key and the on-disk directory name, never the id.
-    * **`stage`** — where the pipeline is. Today `stored` the moment the file
-      lands, which is the column's default; #2105 puts the page rendering
-      between that and `ready`, and is what will first write it.
+    * **`stage`** — where the pipeline is. `stored` the moment the file lands
+      (the column's default), `rendering` while a slot is making its preview
+      pages, then `ready` — however many pages that turned out to be, zero
+      included — or `failed` when the renderer could not do it. The last two
+      are terminal, and that is what takes the row out of the render pipeline's
+      due query (`Vutuv.Attachments.Pages`, #2105).
   """
 
   use VutuvWeb, :model
@@ -51,6 +54,13 @@ defmodule Vutuv.Attachments.Attachment do
     field(:page_count, :integer)
 
     field(:stage, :string, default: "stored")
+
+    # The render pipeline's own two columns (#2105). `worked_at` is the claim
+    # heartbeat a compare-and-set is done on, so two slots of a deploy overlap
+    # cannot render the same file; `render_attempts` counts only the passes
+    # where the renderer itself failed.
+    field(:worked_at, :utc_datetime)
+    field(:render_attempts, :integer, default: 0)
 
     timestamps()
   end

--- a/lib/vutuv/attachments/page_pipeline.ex
+++ b/lib/vutuv/attachments/page_pipeline.ex
@@ -1,0 +1,99 @@
+defmodule Vutuv.Attachments.PagePipeline do
+  @moduledoc """
+  The scheduler behind a file's preview pages (issue #2105): renders at most
+  `concurrency` files at once, looks for work every few seconds or when an
+  upload nudges it, and after a deploy or a crash picks up every file whose
+  render died with its process.
+
+  Copied from `Vutuv.Videos.Pipeline`, and for the same reason: the due list is
+  a query (`Vutuv.Attachments.Pages.claim_due/1`), never state in this process,
+  and a claim is a compare-and-set on the row's heartbeat, so the two slots of
+  a blue/green deploy can overlap without rendering the same file twice.
+
+  One at a time by default. A page render is `pdftoppm` plus three AVIF
+  encodes, or a headless Chromium — cheaper than a transcode and dearer than a
+  thumbnail — and a burst of uploads should queue rather than take the site
+  down.
+
+  Off in tests (`:attachment_pipeline`), which drive `Pages.sweep/1` and
+  `Pages.render/1` directly.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias Vutuv.Attachments
+  alias Vutuv.Attachments.Pages
+
+  @poll_ms :timer.seconds(5)
+
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+
+  @doc "A file landed: look for work now rather than at the next poll."
+  def nudge do
+    if Process.whereis(__MODULE__), do: GenServer.cast(__MODULE__, :nudge)
+    :ok
+  end
+
+  @impl true
+  def init(_opts) do
+    send(self(), :poll)
+    {:ok, %{running: %{}}}
+  end
+
+  @impl true
+  def handle_cast(:nudge, state), do: {:noreply, fill(state)}
+
+  @impl true
+  def handle_info(:poll, state) do
+    Process.send_after(self(), :poll, @poll_ms)
+    {:noreply, fill(state)}
+  end
+
+  # A render finished (everything it decided is on the row, so its result is
+  # irrelevant) or died. Either way the slot is free, and the next poll
+  # re-claims the file if it still has pages left — a stale heartbeat is how a
+  # crash is found.
+  def handle_info({ref, _result}, state) when is_reference(ref) do
+    Process.demonitor(ref, [:flush])
+    {:noreply, fill(drop(state, ref))}
+  end
+
+  def handle_info({:DOWN, ref, :process, _pid, reason}, state) do
+    if reason != :normal,
+      do:
+        Logger.warning(
+          "attachment page render crashed attachment=#{state.running[ref]} " <>
+            "reason=#{inspect(reason)}"
+        )
+
+    {:noreply, fill(drop(state, ref))}
+  end
+
+  def handle_info(_other, state), do: {:noreply, state}
+
+  defp drop(state, ref), do: %{state | running: Map.delete(state.running, ref)}
+
+  defp fill(state) do
+    free = concurrency() - map_size(state.running)
+
+    if free > 0 and Attachments.enabled?() do
+      free
+      |> Pages.claim_due()
+      |> Enum.reduce(state, fn attachment, acc ->
+        task = Task.Supervisor.async_nolink(Vutuv.TaskSupervisor, Pages, :render, [attachment])
+        %{acc | running: Map.put(acc.running, task.ref, attachment.id)}
+      end)
+    else
+      state
+    end
+  end
+
+  defp concurrency do
+    :vutuv
+    |> Application.fetch_env!(:attachments)
+    |> Keyword.get(:render_concurrency, 1)
+    |> max(1)
+  end
+end

--- a/lib/vutuv/attachments/page_render.ex
+++ b/lib/vutuv/attachments/page_render.ex
@@ -1,0 +1,230 @@
+defmodule Vutuv.Attachments.PageRender do
+  @moduledoc """
+  Turns one page of an uploaded file into one raster (issue #2105). Two
+  backends, one per format, and both of them answer `nil` from `renderer/1`
+  on a host that cannot run them at all — which is what lets
+  `Vutuv.Attachments.Pages` settle such a file instead of queueing it for ever.
+
+  ## A PDF page: poppler, not libvips
+
+  The issue this was built from says libvips renders a PDF through its Poppler
+  loader. **It does not, here, and this was measured** (2026-09-10): `vix`
+  builds its `Vix.Vips.Operation` functions from the operation table of the
+  libvips it is linked against, and the precompiled libvips it ships
+  (8.17.1, the default `VIX_COMPILATION_MODE=PRECOMPILED_NIF_AND_LIBVIPS`)
+  has no PDF loader at all — `Vix.Vips.Operation.pdfload/1` is *undefined*,
+  not merely failing, and `otool -L` on the bundled `libvips.42.dylib` shows
+  no poppler linked. The Homebrew `vips` CLI on the same machine does list
+  `pdfload`, which is what makes the claim look true from outside. It is the
+  same gap the post-image store already records for HEIC.
+
+  So a page is rendered by **`pdftoppm`**, which this project already shells
+  out to in three places (`Vutuv.QualificationDocument`,
+  `Vutuv.JobReferenceDocument`, `Vutuv.References.TextExtraction`), which ships
+  in the same `poppler-utils` package as the `pdfinfo` the upload gate already
+  needs, and which CI already installs. Nothing new has to be on any box.
+
+  ## A text or Markdown page: the Chromium the screenshot pipeline runs
+
+  `Vutuv.PageScreenshot.capture/3` — the raw entry point
+  `Vutuv.Moderation.EvidenceScreenshot` already uses, deliberately neither
+  gated on `:generate_screenshots` (that flag is about fetching *other
+  people's* pages, and an air-gapped installation still wants to see its own
+  files) nor routed through the SSRF proxy (there is no host to vet in a
+  `file://` URL).
+
+  **The page is rendered offline, twice over.** Its content is a member's file,
+  so a Markdown image or a stylesheet reference would otherwise make this
+  server fetch an address the member chose — a beacon at best. The document
+  carries `Content-Security-Policy: default-src 'none'`, which Chromium
+  enforces on every subresource, and the browser is launched with
+  `offline: true`, which fails every name resolution. Either alone would do;
+  neither alone fails closed.
+  """
+
+  alias Vutuv.Attachments.Attachment
+  alias Vutuv.AttachmentStore
+  alias Vutuv.PageScreenshot
+
+  require Logger
+
+  # A4 at 150 dpi, and the resolution `pdftoppm` renders at: a letter page
+  # comes out 1275x1650, so the 1600px `large` version is a downscale rather
+  # than an upscale, and body text stays legible in it.
+  @dpi "150"
+  @window {1240, 1754}
+
+  # How much of a text file reaches the document. Only the first screenful is
+  # captured, so anything past this could not be seen — and a 20 MB text file
+  # would otherwise be parsed into a DOM to photograph the top of. Cut by
+  # graphemes, never by bytes, so the cut cannot land inside a codepoint.
+  @text_limit 20_000
+
+  @doc """
+  The binary that would render this file's pages, or `nil` when this host has
+  none — a PDF needs `pdftoppm`, anything else needs Chromium.
+
+  Deliberately **not** cached in `:persistent_term` like the four other
+  capability probes in this tree: this runs once per uploaded file rather than
+  once per request, `System.find_executable/1` is a `$PATH` walk, and a cached
+  probe is a fifth thing a test has to remember to forget.
+  """
+  def renderer(%Attachment{content_type: "application/pdf"}), do: executable(pdftoppm())
+  def renderer(%Attachment{}), do: executable(PageScreenshot.binary())
+
+  # `PageScreenshot.binary/0` hands back a configured path unchecked, so ask
+  # the filesystem: a `CHROMIUM_PATH` pointing at nothing must read as "no
+  # browser here", not as a browser that fails on every file.
+  defp executable(nil), do: nil
+
+  defp executable(name) do
+    cond do
+      System.find_executable(name) -> name
+      File.exists?(name) -> name
+      true -> nil
+    end
+  end
+
+  defp pdftoppm, do: Keyword.get(config(), :pdftoppm, "pdftoppm")
+  defp config, do: Application.fetch_env!(:vutuv, :attachments)
+
+  @doc """
+  Renders page `position` (counted from zero) of `attachment` into `dest`, a
+  path ending in `.png`. `:ok`, or `{:error, reason}` — and the reason is what
+  the pipeline decides a strike on, so it names the renderer that failed.
+  """
+  def render(%Attachment{content_type: "application/pdf"} = attachment, position, dest) do
+    case AttachmentStore.served_path(attachment.token) do
+      nil -> {:error, :file_gone}
+      source -> render_pdf(source, position, dest)
+    end
+  end
+
+  def render(%Attachment{} = attachment, _position, dest) do
+    case AttachmentStore.served_path(attachment.token) do
+      nil -> {:error, :file_gone}
+      source -> render_text(attachment, source, dest)
+    end
+  end
+
+  # One poppler run per page, deliberately, although `-f 1 -l 3` would parse the
+  # document once instead of three times: a resumed render (the whole point of
+  # the pipeline's claim) has to be able to make *page 4 alone*, and a failure
+  # has to name the page it happened on. Three parses of a 20 MB PDF is the
+  # price, and it is paid in a background task at concurrency 1.
+  #
+  # `-singlefile` writes exactly `<base>.png` rather than a zero-padded name
+  # that depends on the document's page count, so there is no wildcard to guess
+  # and nothing left behind when the run fails.
+  defp render_pdf(source, position, dest) do
+    page = Integer.to_string(position + 1)
+    base = Path.rootname(dest)
+
+    case System.cmd(
+           pdftoppm(),
+           ["-f", page, "-l", page, "-r", @dpi, "-png", "-singlefile", source, base],
+           stderr_to_stdout: true
+         ) do
+      {_out, 0} ->
+        if File.exists?(dest), do: :ok, else: {:error, :no_page}
+
+      {out, status} ->
+        Logger.info("pdftoppm failed (#{status}): #{String.slice(out, 0, 200)}")
+        {:error, {:pdftoppm, status}}
+    end
+  rescue
+    # An unusable `PDFTOPPM_PATH` (a directory, a file with no exec bit) raises
+    # rather than answering non-zero, and a render must never take the pipeline
+    # process down with it.
+    exception -> {:error, {:pdftoppm, Exception.message(exception)}}
+  end
+
+  defp render_text(attachment, source, dest) do
+    html = Path.rootname(dest) <> ".html"
+    File.write!(html, document(attachment, head_of(source)))
+
+    try do
+      PageScreenshot.capture("file://" <> html, dest, window: @window, offline: true)
+    after
+      File.rm(html)
+    end
+  end
+
+  # Only as much of the file as could possibly be seen. A text file may be 20 MB
+  # and every byte past the cut would be parsed into a DOM to photograph the top
+  # of it. Four bytes per grapheme is UTF-8's widest, so this is always enough
+  # to fill `@text_limit`; the cut can land inside a codepoint, and
+  # `String.replace_invalid/2` drops the half that is left.
+  defp head_of(path) do
+    {:ok, file} = File.open(path, [:read, :binary])
+
+    try do
+      case IO.binread(file, @text_limit * 4) do
+        :eof -> ""
+        data -> String.replace_invalid(data, "")
+      end
+    after
+      File.close(file)
+    end
+  end
+
+  @doc """
+  The page a text or Markdown file is drawn as. Public so the document itself
+  can be asserted on without a browser — the capture is the one step a test
+  cannot run where Chromium is absent, which includes CI.
+  """
+  # `VutuvWeb.Markdown.render/1` is a web module called from a context, which
+  # this project otherwise reserves for `VutuvWeb.Gettext` and `Endpoint.url/0`.
+  # The alternative is a second Markdown-to-HTML path in `Vutuv.*`, and two
+  # renderers that could disagree about what a member's Markdown means is a far
+  # worse trade than one import: what a reader sees under the post has to be
+  # what the preview shows.
+  def document(%Attachment{content_type: "text/markdown"} = attachment, body) do
+    body
+    |> String.slice(0, @text_limit)
+    |> VutuvWeb.Markdown.render()
+    |> Phoenix.HTML.safe_to_string()
+    |> page(attachment.file_name)
+  end
+
+  def document(%Attachment{} = attachment, body) do
+    escaped = body |> String.slice(0, @text_limit) |> Plug.HTML.html_escape()
+
+    page("<pre>#{escaped}</pre>", attachment.file_name)
+  end
+
+  defp page(inner, file_name) do
+    """
+    <!doctype html>
+    <html lang="en">
+    <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'">
+    <title>#{Plug.HTML.html_escape(file_name)}</title>
+    <style>
+      html { background: #fff; }
+      body {
+        margin: 0;
+        padding: 64px 72px;
+        color: #111827;
+        background: #fff;
+        font: 17px/1.6 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        word-wrap: break-word;
+      }
+      h1, h2, h3, h4 { line-height: 1.25; margin: 1.4em 0 0.5em; }
+      h1 { font-size: 2em; margin-top: 0; }
+      p, li, blockquote { margin: 0 0 0.9em; }
+      pre { white-space: pre-wrap; font: 15px/1.55 ui-monospace, SFMono-Regular, Menlo, monospace; }
+      code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+      blockquote { border-left: 3px solid #d1d5db; padding-left: 1em; color: #4b5563; }
+      table { border-collapse: collapse; }
+      td, th { border: 1px solid #d1d5db; padding: 4px 8px; }
+      a { color: #1d4ed8; }
+      img { display: none; }
+    </style>
+    </head>
+    <body>#{inner}</body>
+    </html>
+    """
+  end
+end

--- a/lib/vutuv/attachments/pages.ex
+++ b/lib/vutuv/attachments/pages.ex
@@ -1,0 +1,523 @@
+defmodule Vutuv.Attachments.Pages do
+  @moduledoc """
+  The preview pages under a post's file (issue #2105): the first pages of a
+  PDF, or a text/Markdown file drawn as one page, so a reader can tell what a
+  file is without downloading it.
+
+  Each page is a row on the shared `images` table of kind `attachment_page`,
+  parented by `attachment_id` and ordered by `position` — the shape #2083 gave
+  the press kit, and the second kind **born** on that table rather than
+  mirrored into it. What that buys, and what it does not, is worth stating
+  plainly, because the issue this was built from assumed all six:
+
+    * **The AI image scan** reaches it — but only because this change adds
+      `attachment_page` to `Vutuv.Moderation.ImageScan.kinds/0` and a clause
+      each to `source/1`, `apply_approved/1`, `apply_rejected/1` and
+      `stranded_pending/0` in `Vutuv.Moderation.ImageSubjects`. Nothing there
+      is generic.
+    * **The pixelated wait** reaches it because `store_page/3` writes the
+      stand-in; the markup that shows it is #2108's.
+    * **The lite version** reaches it because the `:attachment_page` entry in
+      `Vutuv.Uploads.Spec` declares one.
+    * **The regenerator** reaches it because `Vutuv.Uploads.Regenerator` names
+      it in four places.
+    * **The lightbox** is the one thing that really is generic: the JS reads
+      data attributes off whatever markup carries them.
+    * **The copyright freeze does not reach it, on purpose.** A kind in
+      `Vutuv.Images`' `@takedown` map is reportable by anyone who can name a
+      row id, with no visibility check at all
+      (`Vutuv.Moderation.reportable_by?/2`'s catch-all `%Image{}` clause) — and
+      a preview page can belong to a file no post has claimed yet. Reporting a
+      file is #2109, and it wires the strategy and the visibility clause
+      together. Until then nothing offers a report button for a page, and
+      `Vutuv.Images.takedown_ready?/1` answers false, which is the honest state.
+
+  ## Surviving a deploy
+
+  Rendering three PDF pages plus their AVIF derivations takes seconds and a
+  Chromium capture takes longer, so a blue/green deploy stops the slot in the
+  middle of it and nothing logs a thing. The recovery is the shape
+  `Vutuv.Videos` already uses and `Vutuv.Newsletters.BroadcastResumer`
+  established:
+
+    * the **row** carries the state (`stage`), never a process;
+    * each finished page gets its **own row** (`images`), so a resumed render
+      skips what is already there rather than deriving it twice;
+    * the due list is a **query** (`due/1`), and a claim is a compare-and-set
+      on `worked_at`, so the two slots of a deploy overlap cannot render the
+      same file;
+    * the staleness window is longer than one file takes, which is what makes
+      the resume safe while the old slot is still working.
+
+  ## The clock advances on every outcome
+
+  `stage` reaches `ready` or `failed` — both terminal, both out of `due/1` —
+  whatever happened, **including the outcomes where nothing could be done at
+  all**: previews switched off, or a host with no `pdftoppm` and no Chromium.
+  A file that could not be worked on and stayed due would hold the front of
+  every oldest-first batch for ever, which is the deadlock `CLAUDE.md` records
+  from `Vutuv.Fediverse.refresh_counts/1`. A strike (`render_attempts`) is
+  taken only when the renderer itself ran and failed, so a transient failure is
+  retried and a permanent impossibility is not counted against anybody.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias Vutuv.Attachments.Attachment
+  alias Vutuv.Attachments.PageRender
+  alias Vutuv.AttachmentStore
+  alias Vutuv.Images.Image
+  alias Vutuv.MediaJobs
+  alias Vutuv.Moderation.ImageScans
+  alias Vutuv.Moderation.Pixelation
+  alias Vutuv.Repo
+  alias Vutuv.Uploads
+  alias Vutuv.UUIDv7
+
+  require Logger
+
+  @kind "attachment_page"
+
+  # The ceiling issue #2105 sets: "start with three, at most five". Three pages
+  # tell a reader what a document is; five is where a preview strip stops being
+  # a preview and starts being the document.
+  @max_pages 5
+  @default_pages 3
+
+  # Longer than one file takes, which is what makes a claim safe across a
+  # blue/green overlap: while the old slot is still rendering, its heartbeat is
+  # fresh and the new slot leaves the file alone. Three minutes is the video
+  # pipeline's number, and a page render is far quicker than a transcode.
+  @stale_after_seconds 180
+
+  # How often the renderer may fail before the file gives up its previews. A
+  # damaged PDF fails identically every time and three poppler runs cost
+  # nothing; a Chromium that was merely busy gets its retries.
+  @max_attempts 3
+
+  # The version a page's bytes are judged and shown at — the largest derived
+  # size, since there is no private original behind a page.
+  @preview_version "large"
+
+  @doc "This kind's name in `Vutuv.Images.kinds/0`."
+  def kind, do: @kind
+
+  @doc """
+  How many of a file's first pages this installation renders
+  (`ATTACHMENT_PREVIEW_PAGES`). `0` turns previews off; anything above five is
+  five.
+  """
+  def preview_pages do
+    config()
+    |> Keyword.get(:preview_pages, @default_pages)
+    |> min(@max_pages)
+    |> max(0)
+  end
+
+  @doc "The hard ceiling `preview_pages/0` clamps to."
+  def max_pages, do: @max_pages
+
+  @doc "How long a claim stands before another slot may take the file over."
+  def stale_after_seconds, do: @stale_after_seconds
+
+  @doc "How often the renderer may fail before the file gives up its previews."
+  def max_attempts, do: @max_attempts
+
+  defp config, do: Application.fetch_env!(:vutuv, :attachments)
+
+  ## Reading
+
+  @doc "This file's preview pages, first page first."
+  def list(%Attachment{id: id}), do: Repo.all(page_query(id))
+
+  # Which pages this file already has, and nothing else about them: the resume
+  # only needs the numbers, and a page row carries thirty columns.
+  defp rendered_positions(%Attachment{id: id}),
+    do: Repo.all(from(i in page_query(id), select: i.position))
+
+  defp page_query(attachment_id) do
+    from(i in Image,
+      where: i.kind == ^@kind and i.attachment_id == ^attachment_id,
+      order_by: [asc: i.position]
+    )
+  end
+
+  @doc """
+  Where one page's bytes are, or `nil`. **The one function that owns a page's
+  path**: a page is stored under its *file's* token, so every caller that built
+  the path itself would have to remember that.
+  """
+  def bytes_path(page, version \\ @preview_version)
+
+  def bytes_path(%Image{kind: @kind} = page, version) do
+    with token when is_binary(token) <- token_of(page),
+         do: AttachmentStore.page_version_path(token, page.position, version)
+  end
+
+  def bytes_path(%Image{}, _version), do: nil
+
+  # Takes the preload when a caller remembered one and looks it up when nobody
+  # did: half the callers hand over a bare row straight from a query, and an
+  # answer that depends on a preload is not an answer.
+  defp token_of(%Image{attachment: %Attachment{token: token}}), do: token
+
+  defp token_of(%Image{attachment_id: id}) when is_binary(id),
+    do: Repo.one(from(a in Attachment, where: a.id == ^id, select: a.token))
+
+  defp token_of(%Image{}), do: nil
+
+  ## The scan's verdicts (`Vutuv.Moderation.ImageSubjects`)
+
+  @doc """
+  Lets a cleared page out of the AI gate. Guarded on the row still waiting, so
+  a verdict that lost a race against a delete flips nothing and answers
+  `:stale`.
+  """
+  def release(page_id) when is_binary(page_id) do
+    from(i in Image, where: i.id == ^page_id and i.kind == ^@kind and i.moderation == "pending")
+    |> Repo.update_all(set: [moderation: "approved", updated_at: NaiveDateTime.utc_now(:second)])
+    |> case do
+      {1, _} -> :ok
+      _none -> :stale
+    end
+  end
+
+  @doc """
+  Deletes one page for good — the row first, then every derived size and the
+  stand-in. That order is what an interruption can survive: it leaves files
+  nothing points at rather than a row naming files that are gone.
+
+  The **file itself is untouched**. The model judged the picture we derived
+  from it, and what happens to a file whose contents are refused is the upload
+  gate's question, not a preview's.
+  """
+  def discard(%Image{kind: @kind} = page) do
+    token = token_of(page)
+    Repo.delete_all(from(i in Image, where: i.id == ^page.id))
+    if token, do: AttachmentStore.delete_page(token, page.position)
+    :ok
+  end
+
+  @doc "Drops the pixelated stand-in a verdict has ended the wait for."
+  def drop_pixelated(%Image{kind: @kind} = page) do
+    case token_of(page) do
+      nil -> :ok
+      token -> token |> AttachmentStore.page_dir(page.position) |> Pixelation.clear()
+    end
+  end
+
+  @doc """
+  One page row of this kind by id, or `nil` — never a row of another kind, so a
+  scan can neither read nor write over a row of another one that happens to
+  share the id.
+
+  The file comes with it, because every caller (`source/1`, `apply_approved/1`,
+  `apply_rejected/1` in `Vutuv.Moderation.ImageSubjects`) needs its token next
+  and `token_of/1` would otherwise pay a second query for it.
+  """
+  def get_page(page_id) when is_binary(page_id) do
+    Repo.one(
+      from(i in Image,
+        where: i.id == ^page_id and i.kind == ^@kind,
+        preload: :attachment
+      )
+    )
+  end
+
+  ## The pipeline
+
+  @doc """
+  Files whose pages are still to be rendered, oldest first — the due list, as a
+  query rather than as state in a process that a deploy takes with it.
+  """
+  def due(limit) when is_integer(limit) and limit > 0 do
+    stale = DateTime.add(DateTime.utc_now(:second), -@stale_after_seconds, :second)
+
+    Repo.all(
+      from(a in Attachment,
+        # The two stages a file still has render work in — `ready` and `failed`
+        # are terminal, and leaving this set is what takes a row out of the due
+        # list for good. Spelled as **literals**, matching
+        # `attachments_render_due_index`'s own predicate word for word: an
+        # `in ^list` binds them as a parameter, and Postgres can only
+        # prove a parameterised list implies a partial index's predicate while
+        # it is re-planning — the poller runs this statement for ever, so it
+        # ends up on a generic plan and the index the migration built for it
+        # would go unused.
+        where: fragment("? IN ('stored', 'rendering')", a.stage),
+        where: is_nil(a.worked_at) or a.worked_at < ^stale,
+        order_by: [asc: a.inserted_at],
+        limit: ^limit
+      )
+    )
+  end
+
+  @doc """
+  The same, claimed: a compare-and-set on `worked_at`, so two slots of a deploy
+  overlap can never render the same file. Reads twice the batch, because a row
+  another slot took between the query and the update is skipped rather than
+  retried.
+  """
+  def claim_due(limit) when is_integer(limit) and limit > 0 do
+    now = DateTime.utc_now(:second)
+
+    (limit * 2)
+    |> due()
+    |> Enum.reduce_while([], &claim_into(&1, &2, limit, now))
+    |> Enum.reverse()
+  end
+
+  defp claim_into(_attachment, claimed, limit, _now) when length(claimed) >= limit,
+    do: {:halt, claimed}
+
+  defp claim_into(attachment, claimed, _limit, now) do
+    case claim(attachment, now) do
+      {:ok, claimed_row} -> {:cont, [claimed_row | claimed]}
+      :taken -> {:cont, claimed}
+    end
+  end
+
+  defp claim(%Attachment{worked_at: nil} = attachment, now) do
+    from(a in Attachment, where: a.id == ^attachment.id and is_nil(a.worked_at))
+    |> Repo.update_all(set: [stage: "rendering", worked_at: now])
+    |> claimed(attachment, now)
+  end
+
+  defp claim(%Attachment{worked_at: seen} = attachment, now) do
+    from(a in Attachment, where: a.id == ^attachment.id and a.worked_at == ^seen)
+    |> Repo.update_all(set: [stage: "rendering", worked_at: now])
+    |> claimed(attachment, now)
+  end
+
+  defp claimed({1, _}, attachment, now),
+    do: {:ok, %{attachment | stage: "rendering", worked_at: now}}
+
+  defp claimed(_none, _attachment, _now), do: :taken
+
+  @doc "One pass: render every file that is due. Answers how many it worked on."
+  def sweep(limit \\ 2) do
+    claimed = claim_due(limit)
+    Enum.each(claimed, &render/1)
+    length(claimed)
+  end
+
+  @doc """
+  Renders whatever of this file's pages is still missing and settles the row.
+  Answers the file as it now stands.
+
+  Safe to run again after an interruption, and that is the whole point: the
+  pages that already have a row are skipped, so a slot killed after page two of
+  five costs two renders, not five.
+  """
+  def render(%Attachment{} = attachment) do
+    attachment = start_render(attachment)
+    wanted = wanted_positions(attachment)
+
+    job =
+      MediaJobs.start("attachment_pages",
+        user_id: attachment.user_id,
+        post_id: attachment.post_id,
+        subject_type: "attachment",
+        subject_id: attachment.id,
+        detail: attachment.content_type
+      )
+
+    cond do
+      wanted == [] ->
+        settle(attachment, job, "no pages wanted")
+
+      is_nil(PageRender.renderer(attachment)) ->
+        # Not a strike and not a failure: the pipeline asked, and this
+        # installation has nothing that renders this format. Retrying changes
+        # nothing, so the file leaves the queue rather than holding its front.
+        settle(attachment, job, "no renderer for #{attachment.content_type}")
+
+      true ->
+        render_pages(attachment, wanted, job)
+    end
+  end
+
+  # Which pages this file gets, as positions counted from zero.
+  #
+  # A PDF has its own pagination, and `pdfinfo` already counted it at upload.
+  # A text or Markdown file has none: what is rendered is the document, and
+  # what a page-sized viewport shows of it is one page — so slicing a long
+  # README into three would produce two pictures of nothing in particular.
+  defp wanted_positions(%Attachment{content_type: "application/pdf"} = attachment) do
+    positions(min(preview_pages(), attachment.page_count || 1))
+  end
+
+  defp wanted_positions(%Attachment{}), do: positions(min(preview_pages(), 1))
+
+  defp positions(count) when count > 0, do: Enum.to_list(0..(count - 1))
+  defp positions(_none), do: []
+
+  defp render_pages(attachment, wanted, job) do
+    rendered = MapSet.new(rendered_positions(attachment))
+    todo = Enum.reject(wanted, &MapSet.member?(rendered, &1))
+
+    todo
+    |> Enum.reduce_while(:ok, fn position, :ok ->
+      case render_page(attachment, position) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      :ok -> settle(attachment, job, page_count_detail(length(wanted)))
+      {:error, reason} -> strike(attachment, job, reason)
+    end
+  end
+
+  # The operator reads this in `/admin/media`'s Ergebnis column, so it says
+  # "1 page" rather than "1 pages". Not a gettext string: every other `detail`
+  # this table stores is untranslated English ("stored application/pdf",
+  # "refused: too_large"), and one translated cell among them would be the odd
+  # one out — and `ngettext/3` would bind `%{count}` to a raw integer anyway.
+  defp page_count_detail(1), do: "1 page"
+  defp page_count_detail(count), do: "#{count} pages"
+
+  defp render_page(%Attachment{} = attachment, position) do
+    dest =
+      Path.join(
+        System.tmp_dir!(),
+        "vutuv-page-#{attachment.token}-#{position}-#{System.unique_integer([:positive])}.png"
+      )
+
+    try do
+      with :ok <- PageRender.render(attachment, position, dest),
+           {:ok, meta} <- AttachmentStore.store_page(attachment.token, position, dest) do
+        record_page(attachment, position, meta)
+      end
+    after
+      File.rm(dest)
+    end
+  end
+
+  # `insert_all` rather than a changeset: nothing here comes from a form, and
+  # the partial unique index is the conflict target that makes a resumed — or
+  # doubly claimed — render idempotent. `on_conflict: :nothing` means the slot
+  # that lost writes no second row and queues no second scan.
+  defp record_page(%Attachment{} = attachment, position, meta) do
+    now = NaiveDateTime.utc_now(:second)
+
+    entry = %{
+      id: UUIDv7.generate(),
+      kind: @kind,
+      attachment_id: attachment.id,
+      user_id: attachment.user_id,
+      token: Uploads.gen_token(),
+      position: position,
+      moderation: ImageScans.initial_state(),
+      width: meta.width,
+      height: meta.height,
+      content_type: meta.content_type,
+      size_bytes: meta.size_bytes,
+      inserted_at: now,
+      updated_at: now
+    }
+
+    case Repo.insert_all(Image, [entry],
+           on_conflict: :nothing,
+           conflict_target:
+             {:unsafe_fragment, "(attachment_id, position) WHERE kind = 'attachment_page'"},
+           returning: [:id]
+         ) do
+      {1, [%Image{id: id}]} ->
+        ImageScans.enqueue(@kind, id, attachment.user_id)
+        :ok
+
+      _lost_the_race ->
+        :ok
+    end
+  end
+
+  ## Settling
+
+  # The claim, unconditional: `render/1` is reached both from the sweeper
+  # (which has already claimed) and directly, and a second stamp costs one
+  # statement and removes a branch.
+  defp start_render(%Attachment{} = attachment) do
+    now = DateTime.utc_now(:second)
+
+    Repo.update_all(from(a in Attachment, where: a.id == ^attachment.id),
+      set: [stage: "rendering", worked_at: now]
+    )
+
+    %{attachment | stage: "rendering", worked_at: now}
+  end
+
+  # Done, however many pages that turned out to be. A refusal-shaped outcome
+  # ("no renderer") is a **finished** job rather than a failed one, the
+  # convention #2103 set: the pipeline did its work and the answer was none.
+  defp settle(%Attachment{} = attachment, job, detail) do
+    MediaJobs.finish(job, detail: detail)
+
+    Repo.update_all(from(a in Attachment, where: a.id == ^attachment.id),
+      set: [stage: "ready", worked_at: nil]
+    )
+
+    %{attachment | stage: "ready", worked_at: nil}
+  end
+
+  defp strike(%Attachment{} = attachment, job, reason) do
+    MediaJobs.fail(job, reason)
+    attempts = (attachment.render_attempts || 0) + 1
+
+    if attempts >= @max_attempts do
+      Logger.warning(
+        "attachment pages gave up attachment=#{attachment.id} reason=#{inspect(reason)}"
+      )
+
+      write_strike(attachment, attempts, stage: "failed", worked_at: nil)
+    else
+      # The claim stamp is deliberately left where `start_render/1` put it. It
+      # is the *scheduler's* clock, not a claim that the work happened, so the
+      # retry is due one staleness window from now instead of on the very next
+      # pass — which is what keeps a file that cannot be rendered from spending
+      # the whole batch on itself.
+      write_strike(attachment, attempts, [])
+    end
+  end
+
+  defp write_strike(%Attachment{} = attachment, attempts, extra) do
+    sets = Keyword.put(extra, :render_attempts, attempts)
+
+    Repo.update_all(from(a in Attachment, where: a.id == ^attachment.id), set: sets)
+
+    struct!(attachment, sets)
+  end
+
+  ## The regenerator's hook
+
+  @doc """
+  Re-renders one stored page and re-derives its sizes — what
+  `Vutuv.Uploads.Regenerator` runs so a resolution or quality change in
+  `Vutuv.Uploads.Spec` reaches preview pages too.
+
+  There is no private original behind a page (the *file* is the original, and
+  it is kept verbatim), so this really does run poppler or Chromium again. A
+  page whose file is gone is left exactly as it is: `:skipped`.
+  """
+  def regenerate(%Image{kind: @kind} = page, _opts \\ []) do
+    case attachment_of(page) do
+      nil -> {:skipped, :missing_original}
+      attachment -> rerender(attachment, page.position, page.token)
+    end
+  end
+
+  defp rerender(%Attachment{} = attachment, position, name) do
+    dest = Path.join(System.tmp_dir!(), "vutuv-regen-#{name}-#{position}.png")
+
+    try do
+      with :ok <- PageRender.render(attachment, position, dest),
+           {:ok, _meta} <- AttachmentStore.store_page(attachment.token, position, dest),
+           do: :ok
+    after
+      File.rm(dest)
+    end
+  end
+
+  defp attachment_of(%Image{attachment_id: id}) when is_binary(id), do: Repo.get(Attachment, id)
+  defp attachment_of(%Image{}), do: nil
+end

--- a/lib/vutuv/images.ex
+++ b/lib/vutuv/images.ex
@@ -66,7 +66,11 @@ defmodule Vutuv.Images do
   # arrived as a mirror of a table of its own or as columns on a parent row, so
   # it is also the first with no source to keep in step, no backfill class and
   # no contract release. `Vutuv.PressKit` is its context.
-  @kinds ~w(avatar cover job_posting_image organization_image post_image press_kit review_cover)
+  # `attachment_page` (#2105) is the second, and its context is
+  # `Vutuv.Attachments.Pages`: one row per rendered preview page of an uploaded
+  # file, parented by `attachment_id` and ordered by `position`.
+  @kinds ~w(attachment_page avatar cover job_posting_image organization_image post_image
+            press_kit review_cover)
 
   # Of those, the kinds every byte of which already goes through a controller
   # that authorizes the reader first (`VutuvWeb.JobPostingImageController` asks
@@ -83,8 +87,11 @@ defmodule Vutuv.Images do
   # `press_kit` (`VutuvWeb.PressKitImageController` asks whether the reader may
   # see the picture, `Vutuv.PressKit.visible_to?/2`) is in no registry but this
   # one: it has no old table and no parent row, so `images` **is** its truth
-  # from the first row.
-  @proxy_kinds ~w(job_posting_image organization_image post_image press_kit review_cover)
+  # from the first row. `attachment_page` (#2105) is the same shape: a file's
+  # preview pages are stored under the file's own token in a tree nginx has no
+  # location for, and #2108 puts the authorizing proxy in front of them.
+  @proxy_kinds ~w(attachment_page job_posting_image organization_image post_image press_kit
+                  review_cover)
 
   # Of those, the kinds whose truth is still a table of their own, and
   # everything about the copy: which columns it carries, where the source rows

--- a/lib/vutuv/images/image.ex
+++ b/lib/vutuv/images/image.ex
@@ -32,6 +32,11 @@ defmodule Vutuv.Images.Image do
     # match the two sides on. Exactly one cover per review, by unique index.
     belongs_to(:post_review, Vutuv.Posts.PostReview)
 
+    # The file a rendered preview page belongs to (#2105). Like the review
+    # above it is the join key as well as the parent: a page is named by its
+    # file and its `position`, and the two together are unique.
+    belongs_to(:attachment, Vutuv.Attachments.Attachment)
+
     # Who uploaded an organization image — **not** who owns it (#2053). The
     # page owns its logo, which is why `organization_images.user_id` is
     # `ON DELETE SET NULL` and this column copies that: a page keeps its

--- a/lib/vutuv/media_jobs.ex
+++ b/lib/vutuv/media_jobs.ex
@@ -52,7 +52,7 @@ defmodule Vutuv.MediaJobs do
   # What may open a row. A closed vocabulary rather than a free string, so a
   # typo at a call site shows up as a missing row here instead of as a second
   # kind nobody can filter by.
-  @kinds ~w(image_scan video_conversion screenshot attachment_intake)
+  @kinds ~w(image_scan video_conversion screenshot attachment_intake attachment_pages)
 
   # The columns the table can be sorted by — every column it shows.
   @sort_columns ~w(started member kind outcome duration)

--- a/lib/vutuv/moderation/image_scan.ex
+++ b/lib/vutuv/moderation/image_scan.ex
@@ -36,7 +36,7 @@ defmodule Vutuv.Moderation.ImageScan do
   @kinds ~w(avatar cover post_image job_posting_image organization_image
             url_screenshot post_screenshot organization_screenshot review_cover
             qualification_document job_reference_document remote_post_image
-            remote_avatar post_video_frame press_kit)
+            remote_avatar post_video_frame press_kit attachment_page)
   @statuses ~w(pending scanning approved rejected canceled)
   @open_statuses ~w(pending scanning)
 

--- a/lib/vutuv/moderation/image_subjects.ex
+++ b/lib/vutuv/moderation/image_subjects.ex
@@ -20,6 +20,7 @@ defmodule Vutuv.Moderation.ImageSubjects do
   import Ecto.Query
 
   alias Vutuv.Accounts.User
+  alias Vutuv.Attachments.Pages
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Fediverse.RemoteImage
@@ -59,6 +60,7 @@ defmodule Vutuv.Moderation.ImageSubjects do
   @profile_images Vutuv.Images.member_columns()
 
   @press_kit "press_kit"
+  @attachment_page "attachment_page"
 
   @gallery_images %{
     # `pixelated: true` marks the one gallery kind a stranger meets while the
@@ -261,6 +263,18 @@ defmodule Vutuv.Moderation.ImageSubjects do
           PressKitStore.original_path(image.token),
           PressKitStore.version_path(image.token, "large")
         ])
+    end
+  end
+
+  # A file's preview page (issue #2105). There is no private original behind
+  # one — the *file* is the original and it is kept verbatim — so what the
+  # model judges is the largest derived size, which is also what a reader is
+  # shown. `Vutuv.Attachments.Pages.bytes_path/2` owns that path, because a
+  # page lives under its **file's** token rather than its own.
+  def source(%ImageScan{kind: @attachment_page} = scan) do
+    case Pages.get_page(scan.subject_id) do
+      nil -> :gone
+      page -> first_existing([Pages.bytes_path(page)])
     end
   end
 
@@ -606,6 +620,24 @@ defmodule Vutuv.Moderation.ImageSubjects do
     end
   end
 
+  # A file's preview page (#2105). Same order and same reasoning as the press
+  # picture above: the stand-in goes first, then the one guarded flip that owns
+  # this kind's row.
+  def apply_approved(%ImageScan{kind: @attachment_page} = scan) do
+    case Pages.get_page(scan.subject_id) do
+      nil ->
+        :stale
+
+      page ->
+        Pages.drop_pixelated(page)
+
+        with :ok <- Pages.release(page.id) do
+          broadcast(scan, :approved)
+          :ok
+        end
+    end
+  end
+
   @doc """
   Deletes the rejected image on the spot: files (served, quarantined and the
   private original — nothing unsafe stays at rest) and the asset's
@@ -863,6 +895,24 @@ defmodule Vutuv.Moderation.ImageSubjects do
     end
   end
 
+  # A refused preview page: the row and every derived size go, and **the file
+  # they were rendered from stays**. The model judged the picture we made, not
+  # the upload — what happens to a file whose contents are refused is the
+  # upload gate's question (`Vutuv.Uploads.PdfGate`), and deleting a member's
+  # document on a verdict about one rendered page would be a far larger claim
+  # than the scan makes.
+  def apply_rejected(%ImageScan{kind: @attachment_page} = scan) do
+    case Pages.get_page(scan.subject_id) do
+      nil ->
+        :stale
+
+      page ->
+        :ok = Pages.discard(page)
+        broadcast(scan, :rejected)
+        :ok
+    end
+  end
+
   # The one write behind both remote-picture verdicts (issue #1163): flip the
   # moderation column, guarded on the fingerprint so a verdict can never touch
   # bytes that changed under it. `clear_file: true` also drops the reference, so
@@ -1101,6 +1151,7 @@ defmodule Vutuv.Moderation.ImageSubjects do
       gallery_stranded("job_posting_image") ++
       gallery_stranded("organization_image") ++
       press_kit_stranded() ++
+      attachment_page_stranded() ++
       post_screenshot_stranded() ++
       review_cover_stranded() ++
       video_frame_stranded() ++
@@ -1178,6 +1229,25 @@ defmodule Vutuv.Moderation.ImageSubjects do
     )
     |> Repo.all()
     |> Enum.map(fn {id, owner_id} -> {@press_kit, id, owner_id, nil} end)
+  end
+
+  # A preview page waiting on a scan nobody queued — the render writes the row
+  # and enqueues the scan in two statements, so a slot that dies between them
+  # leaves exactly this. Owned by whoever uploaded the file.
+  #
+  # No `frozen_at` clause, unlike the press picture above: a page has no
+  # takedown strategy yet (#2109), so nothing can freeze one and a stamped row
+  # cannot exist. When #2109 wires it, this query needs the same guard for the
+  # same reason.
+  defp attachment_page_stranded do
+    from(i in Images.Image,
+      as: :subject,
+      where: i.kind == ^@attachment_page and i.moderation == "pending",
+      where: not exists(open_scan_exists(@attachment_page)),
+      select: {i.id, i.user_id}
+    )
+    |> Repo.all()
+    |> Enum.map(fn {id, owner_id} -> {@attachment_page, id, owner_id, nil} end)
   end
 
   defp flat_stranded(kind) do

--- a/lib/vutuv/page_screenshot.ex
+++ b/lib/vutuv/page_screenshot.ex
@@ -609,8 +609,22 @@ defmodule Vutuv.PageScreenshot do
       "--force-device-scale-factor=1",
       "--user-agent=#{Http.user_agent()}",
       "--window-size=#{width},#{height}"
-    ] ++ proxy_args(Keyword.get(opts, :proxy_port))
+    ] ++ proxy_args(Keyword.get(opts, :proxy_port)) ++ offline_args(Keyword.get(opts, :offline))
   end
+
+  # `offline: true` — for a capture of a **local** document whose content came
+  # from a member (`Vutuv.Attachments.PageRender`, issue #2105). Chromium's own
+  # documented recipe for "resolve nothing": every name fails, so a stylesheet
+  # link or a Markdown image in the file cannot make this server fetch an
+  # address the member chose. The document also carries
+  # `default-src 'none'`; this is the half that does not depend on the page.
+  #
+  # No `--proxy-bypass-list=<-loopback>` beside it, unlike the vetting proxy
+  # above: an IP literal is the one thing this cannot stop, and closing that
+  # too means running the SOCKS proxy, which is a network control for a render
+  # that wants no network at all.
+  defp offline_args(true), do: ["--host-resolver-rules=MAP * ~NOTFOUND"]
+  defp offline_args(_off), do: []
 
   defp proxy_args(nil), do: []
 

--- a/lib/vutuv/uploaders/attachment_store.ex
+++ b/lib/vutuv/uploaders/attachment_store.ex
@@ -17,13 +17,33 @@ defmodule Vutuv.AttachmentStore do
 
   The served copy is written beside its target and renamed, so a process
   killed mid-copy leaves no half file a proxy could hand out.
+
+  A file's rendered preview pages (issue #2105) hang under the served copy's
+  own directory, one per page:
+
+      <uploads_dir_prefix>/attachments/<token>/pages/<n>/thumb.avif /lite.avif
+                                                        /large.avif
+                                                        /pixelated.avif
+
+  So they need no upload tree of their own — nothing new in `.gitignore` and
+  nothing new in `test/vutuv/uploads_gitignore_test.exs` — and `delete/1`
+  already takes them with the file.
   """
 
+  alias Vutuv.Moderation.Pixelation
   alias Vutuv.Uploads
   alias Vutuv.Uploads.Originals
+  alias Vutuv.Uploads.Spec
 
   @served_name "file"
   @root "attachments"
+  @pages "pages"
+
+  # The served sizes of one preview page, read off `Vutuv.Uploads.Spec` at
+  # compile time rather than written out again — the mistake `Vutuv.PressKitStore`
+  # records, where a hand-kept second list left the organization store deriving
+  # a version no URL of its own could serve.
+  @page_versions Enum.map(Spec.versions(:attachment_page), &to_string(&1.name))
 
   @doc """
   Keeps `path` under `token`: the verbatim original in the private tree and
@@ -58,6 +78,85 @@ defmodule Vutuv.AttachmentStore do
   def served_path(token) do
     token |> dir() |> Path.join(@served_name <> ".*") |> Path.wildcard() |> List.first()
   end
+
+  ## The preview pages (issue #2105)
+
+  @doc """
+  Derives every served size of one already-rendered page and keeps them under
+  the file's own token:
+
+      <uploads_dir_prefix>/attachments/<token>/pages/<position>/thumb.avif
+                                                              /lite.avif
+                                                              /large.avif
+                                                              /pixelated.avif
+
+  `source` is the raster the renderer just produced (poppler's PNG of a PDF
+  page, or Chromium's capture of a text file). It is a temporary file the
+  caller removes: unlike a member's upload there is nothing verbatim to keep,
+  because the file it was rendered *from* is already in the private tree and
+  re-rendering the page is what `Vutuv.Attachments.Pages.regenerate/2` does.
+
+  Answers `{:ok, %{width:, height:, content_type:, size_bytes:}}`, or
+  `{:error, reason}` with the half-written directory removed — a page that
+  exists in some sizes and not others is worse than no page.
+  """
+  def store_page(token, position, source) when is_integer(position) and position >= 0 do
+    dir = page_dir(token, position)
+    File.mkdir_p!(dir)
+
+    case derive_page(source, dir) do
+      {:ok, meta} ->
+        {:ok, meta}
+
+      {:error, reason} ->
+        File.rm_rf(dir)
+        {:error, reason}
+    end
+  end
+
+  defp derive_page(source, dir) do
+    with {:ok, rotated} <- Spec.open_rotated(source),
+         :ok <- Spec.write_all(:attachment_page, rotated, &version_dest(dir, &1)) do
+      # The stand-in a reader meets while the model looks at this page
+      # (issue #1720). Outside the derive loop on purpose, as in every other
+      # store: a mosaic is not a version of the picture, it is the temporary
+      # absence of one.
+      Pixelation.write_if_enabled(rotated, dir)
+
+      {:ok,
+       %{
+         width: Image.width(rotated),
+         height: Image.height(rotated),
+         content_type: "image/avif",
+         # The largest served size, which is what a reader actually fetches;
+         # there is no upload behind a page to report the size of instead.
+         size_bytes: File.stat!(version_dest(dir, %{name: :large})).size
+       }}
+    end
+  end
+
+  defp version_dest(dir, %{name: name}), do: Path.join(dir, "#{name}#{Spec.served_ext()}")
+
+  @doc "One served size of one page, or `nil` when it is not there."
+  def page_version_path(token, position, version)
+      when is_binary(token) and is_integer(position) and version in @page_versions do
+    exists(Path.join(page_dir(token, position), version <> Spec.served_ext()))
+  end
+
+  def page_version_path(_token, _position, _version), do: nil
+
+  @doc "Removes every stored size of one page. A no-op when there is none."
+  def delete_page(token, position) when is_binary(token) and is_integer(position) do
+    File.rm_rf(page_dir(token, position))
+    :ok
+  end
+
+  @doc "The directory one page's sizes live in."
+  def page_dir(token, position) when is_integer(position) and position >= 0 do
+    token |> dir() |> Path.join(@pages) |> Path.join(Integer.to_string(position))
+  end
+
+  defp exists(path), do: if(File.exists?(path), do: path)
 
   @doc "Removes both copies of `token`. A no-op when nothing is stored."
   def delete(token) when is_binary(token) do

--- a/lib/vutuv/uploads/regenerator.ex
+++ b/lib/vutuv/uploads/regenerator.ex
@@ -34,6 +34,7 @@ defmodule Vutuv.Uploads.Regenerator do
 
   import Ecto.Query
 
+  alias Vutuv.Attachments.Pages
   alias Vutuv.Images
   alias Vutuv.Organizations.OrganizationScreenshot
   alias Vutuv.Posts.PostImage
@@ -43,7 +44,7 @@ defmodule Vutuv.Uploads.Regenerator do
   alias Vutuv.Repo
   alias Vutuv.Uploads.Originals
 
-  @types ~w(avatars covers screenshots post_images job_posting_images qualification_documents job_reference_documents organization_images press_kit)a
+  @types ~w(avatars covers screenshots post_images job_posting_images qualification_documents job_reference_documents organization_images press_kit attachment_pages)a
 
   # Where each public tree may still hold an original-pattern file (the
   # pre-private-tree layouts). Scanned by the final orphan pass.
@@ -152,6 +153,13 @@ defmodule Vutuv.Uploads.Regenerator do
   # what had happened to every organization logo and every Arbeitszeugnis.
   defp do_regenerate(:press_kit, image, opts), do: Vutuv.PressKitStore.regenerate(image, opts)
 
+  # A file's preview pages (#2105). The only type here with no stored original
+  # of its own: a page is re-rendered from the **file** it came from (poppler or
+  # Chromium runs again) and then re-derived, so a Spec change reaches it like
+  # any other picture. `{:skipped, :missing_original}` when the file is gone.
+  defp do_regenerate(:attachment_pages, page, opts),
+    do: Pages.regenerate(page, opts)
+
   # Originals that no DB row claims must still never stay publicly
   # downloadable: move them into the private tree. Derived files of unknown
   # rows are left alone — nothing serves them, and deleting data without a
@@ -226,10 +234,22 @@ defmodule Vutuv.Uploads.Regenerator do
     )
   end
 
+  # Every stored preview page, filtered out of the shared picture table the way
+  # the press-kit rows are, and only the columns the re-render reads.
+  defp rows(:attachment_pages) do
+    Repo.all(
+      from(i in Vutuv.Images.Image,
+        where: i.kind == ^Pages.kind(),
+        select: [:id, :kind, :token, :position, :attachment_id]
+      )
+    )
+  end
+
   defp row_id(:post_images, image), do: image.token
   defp row_id(:job_posting_images, image), do: image.token
   defp row_id(:organization_images, image), do: image.token
   defp row_id(:press_kit, image), do: image.token
+  defp row_id(:attachment_pages, page), do: page.token
   defp row_id(_type, row), do: row.id
 
   # Operator stdout progress (mix task / `bin/vutuv eval`); the quiet-flag logic

--- a/lib/vutuv/uploads/spec.ex
+++ b/lib/vutuv/uploads/spec.ex
@@ -168,6 +168,24 @@ defmodule Vutuv.Uploads.Spec do
     remote_avatar: [
       %{name: :image, fit: {:crop, 192, 192, :center}, quality: 62}
     ],
+    # A rendered preview page of an uploaded file (issue #2105): a page of a
+    # PDF, or a text/Markdown file drawn as a page. Three sizes and **no crop
+    # of any kind**, for the reason the press logo below gives in the same
+    # words: a square thumb would cut a portrait page in half, and half a page
+    # is not a preview of the page.
+    #
+    # There is deliberately no `xl`. On a photo post the picture is the content
+    # and 2560px is what a 4K lightbox wants; a page is a raster of text, its
+    # `large` long edge lands on the 1600 px cap (`Vutuv.Attachments.PageRender`
+    # renders at 150 dpi, so an A4 or letter page arrives just above it), and
+    # the file itself is one click away as a download (#2108) — which is what
+    # somebody who wants to *read* it will take. The extra encode is the most
+    # expensive of the set and would be paid on every page of every file.
+    attachment_page: [
+      %{name: :thumb, fit: {:box_down, 480}, quality: 58},
+      %{name: :lite, fit: {:box_down, 640}, quality: @lite_quality},
+      %{name: :large, fit: {:box_down, 1600}, quality: 58}
+    ],
     post_image: @photo_versions,
     # Job-posting gallery images: same sizes as post images.
     job_posting_image: @page_image_versions,

--- a/lib/vutuv_web/live/admin/media_live.ex
+++ b/lib/vutuv_web/live/admin/media_live.ex
@@ -252,6 +252,7 @@ defmodule VutuvWeb.Admin.MediaLive do
   defp kind_label("video_conversion"), do: gettext("Video conversion")
   defp kind_label("screenshot"), do: gettext("Link screenshot")
   defp kind_label("attachment_intake"), do: gettext("File check")
+  defp kind_label("attachment_pages"), do: gettext("File preview pages")
   defp kind_label(other), do: other
 
   # What the step worked on: the subject's kind, and enough of its id to tell

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -7683,7 +7683,7 @@ msgstr ""
 "der Versand läuft weiter."
 
 #: lib/vutuv_web/components/welcome_components.ex:362
-#: lib/vutuv_web/live/admin/media_live.ex:269
+#: lib/vutuv_web/live/admin/media_live.ex:270
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
 #: lib/vutuv_web/live/post_live/feed.ex:3888
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
@@ -11168,7 +11168,7 @@ msgstr ""
 "Jeder aufgenommene Link-Screenshot, neueste zuerst. Jeder verlinkt auf die "
 "Seite und den zugehörigen Beitrag."
 
-#: lib/vutuv_web/live/admin/media_live.ex:270
+#: lib/vutuv_web/live/admin/media_live.ex:271
 #: lib/vutuv_web/live/admin/screenshot_live.ex:551
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -24871,7 +24871,7 @@ msgstr "Ergebnis"
 msgid "Photo scan"
 msgstr "Fotoprüfung"
 
-#: lib/vutuv_web/live/admin/media_live.ex:271
+#: lib/vutuv_web/live/admin/media_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Running"
 msgstr "Läuft"
@@ -25137,3 +25137,8 @@ msgstr "Zwei Sätze, die in eine Bildunterschrift passen."
 #, elixir-autogen, elixir-format
 msgid "Write"
 msgstr "Schreiben"
+
+#: lib/vutuv_web/live/admin/media_live.ex:255
+#, elixir-autogen, elixir-format
+msgid "File preview pages"
+msgstr "Dateivorschau"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -7384,7 +7384,7 @@ msgid "This updates on its own. You can leave this page; the send keeps running.
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:362
-#: lib/vutuv_web/live/admin/media_live.ex:269
+#: lib/vutuv_web/live/admin/media_live.ex:270
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
 #: lib/vutuv_web/live/post_live/feed.ex:3888
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
@@ -10611,7 +10611,7 @@ msgstr ""
 msgid "Every captured link screenshot, newest first. Each links to the page and its post."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/media_live.ex:270
+#: lib/vutuv_web/live/admin/media_live.ex:271
 #: lib/vutuv_web/live/admin/screenshot_live.ex:551
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -24038,7 +24038,7 @@ msgstr ""
 msgid "Photo scan"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/media_live.ex:271
+#: lib/vutuv_web/live/admin/media_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Running"
 msgstr ""
@@ -24303,4 +24303,9 @@ msgstr ""
 #: lib/vutuv_web/live/press_kit_live.ex:641
 #, elixir-autogen, elixir-format
 msgid "Write"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/media_live.ex:255
+#, elixir-autogen, elixir-format
+msgid "File preview pages"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -7382,7 +7382,7 @@ msgid "This updates on its own. You can leave this page; the send keeps running.
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:362
-#: lib/vutuv_web/live/admin/media_live.ex:269
+#: lib/vutuv_web/live/admin/media_live.ex:270
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
 #: lib/vutuv_web/live/post_live/feed.ex:3888
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
@@ -10609,7 +10609,7 @@ msgstr ""
 msgid "Every captured link screenshot, newest first. Each links to the page and its post."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/media_live.ex:270
+#: lib/vutuv_web/live/admin/media_live.ex:271
 #: lib/vutuv_web/live/admin/screenshot_live.ex:551
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -24036,7 +24036,7 @@ msgstr ""
 msgid "Photo scan"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/media_live.ex:271
+#: lib/vutuv_web/live/admin/media_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Running"
 msgstr ""
@@ -24301,4 +24301,9 @@ msgstr ""
 #: lib/vutuv_web/live/press_kit_live.ex:641
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Write"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/media_live.ex:255
+#, elixir-autogen, elixir-format
+msgid "File preview pages"
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -7668,7 +7668,7 @@ msgid "This updates on its own. You can leave this page; the send keeps running.
 msgstr "Si aggiorna da sola. Può lasciare questa pagina: l'invio prosegue."
 
 #: lib/vutuv_web/components/welcome_components.ex:362
-#: lib/vutuv_web/live/admin/media_live.ex:269
+#: lib/vutuv_web/live/admin/media_live.ex:270
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
 #: lib/vutuv_web/live/post_live/feed.ex:3888
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
@@ -11134,7 +11134,7 @@ msgstr ""
 "Ogni screenshot di link acquisito, dal più recente. Ciascuno rimanda alla "
 "pagina e al relativo post."
 
-#: lib/vutuv_web/live/admin/media_live.ex:270
+#: lib/vutuv_web/live/admin/media_live.ex:271
 #: lib/vutuv_web/live/admin/screenshot_live.ex:551
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -25549,7 +25549,7 @@ msgstr "Esito"
 msgid "Photo scan"
 msgstr "Controllo delle foto"
 
-#: lib/vutuv_web/live/admin/media_live.ex:271
+#: lib/vutuv_web/live/admin/media_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Running"
 msgstr "In corso"
@@ -25815,3 +25815,8 @@ msgstr "Due frasi che entrano in una didascalia."
 #, elixir-autogen, elixir-format
 msgid "Write"
 msgstr "Scrivi"
+
+#: lib/vutuv_web/live/admin/media_live.ex:255
+#, elixir-autogen, elixir-format
+msgid "File preview pages"
+msgstr "Anteprima file"

--- a/priv/repo/migrations/20260910132032_add_attachment_pages_to_images.exs
+++ b/priv/repo/migrations/20260910132032_add_attachment_pages_to_images.exs
@@ -1,0 +1,81 @@
+defmodule Vutuv.Repo.Migrations.AddAttachmentPagesToImages do
+  use Ecto.Migration
+
+  # The preview pages a file shows under a post (issue #2105). Each rendered
+  # page is a row on `images` of a new kind, `attachment_page`, so the AI scan,
+  # the pixelated wait, the lite version and the lightbox reach it the way they
+  # reach a photo — the shape #2083 established for the press kit, which is the
+  # only other kind **born** on this table rather than mirrored into it.
+  #
+  # Expand only, and N-1 safe throughout: one nullable column and one integer
+  # with a default on tables the previously deployed release still writes
+  # (metadata-only since Postgres 11), two partial indexes, and a check
+  # constraint restricted to a `kind` string no deployed release writes. The
+  # release one step back neither reads nor writes any of it.
+  def change do
+    alter table(:images) do
+      # The file this page was rendered from. A page has no life of its own:
+      # delete the file and its previews go with it, which is why this cascades
+      # rather than nilifying. It is deliberately **not** `post_id` as well —
+      # an attachment carries the nullable post/message pair and is claimed by
+      # one of them later (#2106, #2110), so a page that copied a parent at
+      # render time would copy `nil` and then be wrong for ever.
+      add(:attachment_id, references(:attachments, type: :binary_id, on_delete: :delete_all))
+    end
+
+    # The cascade's own lookup, and the "every page of this file" query. Partial
+    # because almost no row in this table is an attachment page, and a bare
+    # `WHERE attachment_id = $1` can use it: the predicate implies NOT NULL.
+    create(
+      index(:images, [:attachment_id],
+        where: "attachment_id IS NOT NULL",
+        name: :images_attachment_id_index
+      )
+    )
+
+    # One row per page of a file, and the conflict target the render upserts on.
+    # This is what makes a **resumed** render safe: a slot killed mid-loop is
+    # picked up again, and a page that already has its row can never be written
+    # twice — including by the two slots of a blue/green deploy overlap.
+    create(
+      unique_index(:images, [:attachment_id, :position],
+        where: "kind = 'attachment_page'",
+        name: :images_attachment_page_index
+      )
+    )
+
+    # A page with no file is a picture nothing can find the bytes of and nothing
+    # can delete: the scan reads its path through the file's token, and the
+    # cascade above is the only thing that ever removes it.
+    create(
+      constraint(:images, :images_attachment_page_has_file,
+        check: "kind <> 'attachment_page' OR attachment_id IS NOT NULL"
+      )
+    )
+
+    alter table(:attachments) do
+      # The claim heartbeat, exactly `post_videos.worked_at`: a claim is a
+      # compare-and-set on this column, so the two slots of a deploy overlap can
+      # never render the same file, and a row nobody has touched for the
+      # staleness window is simply claimed again. That is the whole recovery
+      # story for a render a deploy killed — the due list is a query, never
+      # state in a process that dies with it.
+      add(:worked_at, :utc_datetime)
+
+      # How often the renderer was asked and failed. A strike is taken only when
+      # the **external** side failed (poppler or Chromium ran and answered
+      # non-zero); a host that has no renderer at all takes none, because that
+      # is not a failure that retrying could fix.
+      add(:render_attempts, :integer, null: false, default: 0)
+    end
+
+    # The due query, oldest first. Partial on the two unfinished stages, so the
+    # index holds only work — every finished file leaves it.
+    create(
+      index(:attachments, [:inserted_at],
+        where: "stage IN ('stored', 'rendering')",
+        name: :attachments_render_due_index
+      )
+    )
+  end
+end

--- a/test/support/attachment_fixtures.ex
+++ b/test/support/attachment_fixtures.ex
@@ -147,6 +147,15 @@ defmodule Vutuv.AttachmentFixtures do
     write(dir, "invoice.pdf", "PK\x05\x06" <> :binary.copy(<<0>>, 18))
   end
 
+  @doc """
+  A PDF with `count` real pages, each numbered — what #2105's preview
+  rendering is measured against, since the cap only shows on a file that has
+  more pages than the installation renders.
+  """
+  def multi_page_pdf(dir, count) when is_integer(count) and count > 0 do
+    write(dir, "multi-#{count}.pdf", multi_page(count))
+  end
+
   @doc "A plain text file."
   def text_file(dir, body \\ "Just some notes.\nOn two lines.\n"),
     do: write(dir, "notes.txt", body)
@@ -227,6 +236,35 @@ defmodule Vutuv.AttachmentFixtures do
   defp page(_kind) do
     "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R " <>
       "/Resources << /Font << /F1 5 0 R >> >> >>"
+  end
+
+  # A document of `count` pages, each with its own content stream saying which
+  # page it is, so a rendered preview can be told from its neighbours. Object
+  # numbers: 1 catalog, 2 the page tree, 3 the shared font, then a page and a
+  # content object per page.
+  defp multi_page(count) do
+    pages = for index <- 0..(count - 1), do: {4 + index * 2, 5 + index * 2}
+    kids = Enum.map_join(pages, " ", fn {page, _content} -> "#{page} 0 R" end)
+
+    page_objects =
+      Enum.flat_map(Enum.with_index(pages, 1), fn {{page, content}, number} ->
+        text = "BT /F1 96 Tf 72 400 Td (#{number}) Tj ET"
+
+        [
+          {page,
+           "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents #{content} 0 R " <>
+             "/Resources << /Font << /F1 3 0 R >> >> >>"},
+          {content, "<< /Length #{byte_size(text)} >>\nstream\n#{text}\nendstream"}
+        ]
+      end)
+
+    build(
+      [
+        {1, "<< /Type /Catalog /Pages 2 0 R >>"},
+        {2, "<< /Type /Pages /Kids [#{kids}] /Count #{count} >>"},
+        {3, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>"}
+      ] ++ page_objects
+    )
   end
 
   defp catalog(:plain), do: {"<< /Type /Catalog /Pages 2 0 R >>", []}

--- a/test/vutuv/attachments/pages_test.exs
+++ b/test/vutuv/attachments/pages_test.exs
@@ -30,8 +30,10 @@ defmodule Vutuv.Attachments.PagesTest do
   alias Vutuv.Attachments.PageRender
   alias Vutuv.Attachments.Pages
   alias Vutuv.AttachmentStore
+  alias Vutuv.Images
   alias Vutuv.Images.Image
   alias Vutuv.MediaJobs.MediaJob
+  alias Vutuv.Moderation
   alias Vutuv.Moderation.ImageScan
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Moderation.ImageSubjects
@@ -285,6 +287,37 @@ defmodule Vutuv.Attachments.PagesTest do
       assert reload(attachment).stage == "failed"
       assert Pages.due(4) == []
       assert %MediaJob{status: "failed"} = last_page_job()
+    end
+  end
+
+  describe "the takedown a page does not have yet (#2109)" do
+    # Written down because the absence is a *decision*, not an oversight, and
+    # because every symptom of it is a quiet `nil` rather than an error: since
+    # #2089 `Images.bytes_path/1` and `preview_url/1` answer `nil` for a kind
+    # with no `@takedown` strategy instead of raising, so an admin surface
+    # pointed at a page would read "no picture here" rather than "this kind is
+    # not wired". `Vutuv.Moderation.reportable_by?/2`'s catch-all `%Image{}`
+    # clause is the reason it must stay that way until #2109: it is
+    # `takedown_ready?/1` and nothing else, so a kind put in the map becomes
+    # reportable by anybody who can name a row id, with no visibility check, on
+    # a page that may belong to a file no post has claimed. #2109 adds the
+    # strategy and the visibility clause together; when it does, this test is
+    # the one to invert.
+    test "is refused everywhere rather than half-wired", %{user: user, files: files} do
+      Fixtures.put_config(preview_pages: 1)
+      attachment = stored!(user, Fixtures.multi_page_pdf(files, 1))
+      Pages.render(attachment)
+      [page] = Pages.list(attachment)
+
+      refute Images.takedown_ready?(page)
+      assert Images.bytes_path(page) == nil
+      assert Images.preview_url(page) == nil
+      refute Moderation.can_report?(insert_activated_user(), page)
+      refute Moderation.can_report?(user, page)
+
+      # The bytes are there all the same — the `nil` above is the missing
+      # strategy, not a missing picture.
+      assert is_binary(Pages.bytes_path(page))
     end
   end
 

--- a/test/vutuv/attachments/pages_test.exs
+++ b/test/vutuv/attachments/pages_test.exs
@@ -1,0 +1,361 @@
+defmodule Vutuv.Attachments.PagesTest do
+  @moduledoc """
+  The preview pages a file gets under a post (issue #2105): a PDF's first
+  pages rendered by poppler, a text or Markdown file rendered by headless
+  Chromium, each page a row of kind `attachment_page` on the shared `images`
+  table so the AI scan applies to it as it does to a photo.
+
+  `async: false`, and for the reason the rules file names: this module flips
+  `:vutuv, :attachments` (read by the chokepoint, the composer and the
+  sweeper) and `:vutuv, :chromium_path` (read by every screenshot pipeline),
+  and `Application.put_env/3` is global state the SQL sandbox does not roll
+  back.
+
+  Two of these tests are about a deploy rather than about a picture. The
+  **interrupt** test kills the rendering task mid-loop and asserts the sweeper
+  finishes exactly the rest without re-rendering what already has its row; the
+  **clock** test asserts that work nothing on this host can ever do leaves the
+  due query after one pass, instead of holding the front of every batch for
+  ever.
+  """
+
+  use Vutuv.DataCase
+
+  import Vutuv.WebPushHelpers, only: [put_config: 2]
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Vutuv.AttachmentFixtures, as: Fixtures
+  alias Vutuv.Attachments
+  alias Vutuv.Attachments.Attachment
+  alias Vutuv.Attachments.PageRender
+  alias Vutuv.Attachments.Pages
+  alias Vutuv.AttachmentStore
+  alias Vutuv.Images.Image
+  alias Vutuv.MediaJobs.MediaJob
+  alias Vutuv.Moderation.ImageScan
+  alias Vutuv.Moderation.ImageScans
+  alias Vutuv.Moderation.ImageSubjects
+  alias Vutuv.Repo
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "vutuv_pages_#{System.unique_integer([:positive])}")
+    files = Path.join(tmp, "files")
+    File.mkdir_p!(files)
+    put_config(:uploads_dir_prefix, tmp)
+    on_exit(fn -> File.rm_rf(tmp) end)
+
+    %{user: insert_activated_user(admin?: true), tmp: tmp, files: files}
+  end
+
+  defp upload(user, path), do: Attachments.create_pending(user, path, Path.basename(path))
+
+  defp stored!(user, path) do
+    {:ok, attachment} = upload(user, path)
+    attachment
+  end
+
+  # The claim heartbeat backdated past the staleness window — what a deploy
+  # that stopped the slot mid-render leaves behind, minus the wait.
+  defp age_claim!(%Attachment{id: id}) do
+    stale =
+      DateTime.add(DateTime.utc_now(:second), -(Pages.stale_after_seconds() + 60), :second)
+
+    Repo.update_all(from(a in Attachment, where: a.id == ^id), set: [worked_at: stale])
+  end
+
+  defp reload(%Attachment{id: id}), do: Repo.get!(Attachment, id)
+
+  describe "a PDF's first pages" do
+    test "become image rows parented by the file", %{user: user, files: files} do
+      Fixtures.put_config(preview_pages: 3)
+      attachment = stored!(user, Fixtures.multi_page_pdf(files, 5))
+
+      assert %Attachment{stage: "ready"} = Pages.render(attachment)
+
+      pages = Pages.list(attachment)
+      assert length(pages) == 3
+      assert Enum.map(pages, & &1.position) == [0, 1, 2]
+
+      for page <- pages do
+        assert %Image{kind: "attachment_page"} = page
+        assert page.attachment_id == attachment.id
+        assert page.user_id == user.id
+        # The file has no post yet — the nullable pair is empty while the
+        # composer holds it, and a page must never invent one.
+        assert page.post_id == nil
+        assert page.width > 0 and page.height > 0
+        assert page.content_type == "image/avif"
+        assert page.size_bytes > 0
+
+        assert is_binary(
+                 AttachmentStore.page_version_path(attachment.token, page.position, "large")
+               )
+      end
+    end
+
+    test "stop at five however many the installation asks for", %{user: user, files: files} do
+      Fixtures.put_config(preview_pages: 9)
+      attachment = stored!(user, Fixtures.multi_page_pdf(files, 8))
+
+      Pages.render(attachment)
+
+      assert length(Pages.list(attachment)) == Pages.max_pages()
+    end
+
+    test "never exceed what the document has", %{user: user, files: files} do
+      Fixtures.put_config(preview_pages: 3)
+      attachment = stored!(user, Fixtures.multi_page_pdf(files, 2))
+
+      Pages.render(attachment)
+
+      assert length(Pages.list(attachment)) == 2
+    end
+
+    test "are not rendered at all when the installation turned them off", %{
+      user: user,
+      files: files
+    } do
+      Fixtures.put_config(preview_pages: 0)
+      attachment = stored!(user, Fixtures.multi_page_pdf(files, 3))
+
+      assert %Attachment{stage: "ready"} = Pages.render(attachment)
+      assert Pages.list(attachment) == []
+    end
+  end
+
+  describe "the AI image scan" do
+    setup do
+      # Off in the test environment by default; these four assertions are
+      # exactly about the gate, so they turn it on for the module's lifetime
+      # (which is why this file is sync — see the moduledoc).
+      put_config(:moderate_images, true)
+    end
+
+    test "holds every page and can find its bytes", %{user: user, files: files} do
+      Fixtures.put_config(preview_pages: 2)
+      attachment = stored!(user, Fixtures.multi_page_pdf(files, 4))
+
+      Pages.render(attachment)
+
+      for page <- Pages.list(attachment) do
+        assert page.moderation == ImageScans.initial_state()
+
+        assert %ImageScan{} =
+                 scan = Repo.get_by(ImageScan, kind: "attachment_page", subject_id: page.id)
+
+        assert scan.owner_user_id == user.id
+        assert {:ok, bytes} = ImageSubjects.source(scan)
+        assert File.exists?(bytes)
+      end
+    end
+
+    test "releases a page it cleared", %{user: user, files: files} do
+      Fixtures.put_config(preview_pages: 1)
+      attachment = stored!(user, Fixtures.multi_page_pdf(files, 1))
+      Pages.render(attachment)
+
+      [page] = Pages.list(attachment)
+      scan = Repo.get_by!(ImageScan, kind: "attachment_page", subject_id: page.id)
+
+      assert :ok = ImageSubjects.apply_approved(scan)
+      assert Repo.get!(Image, page.id).moderation == "approved"
+    end
+
+    test "deletes a page it refused, bytes and row", %{user: user, files: files} do
+      Fixtures.put_config(preview_pages: 1)
+      attachment = stored!(user, Fixtures.multi_page_pdf(files, 1))
+      Pages.render(attachment)
+
+      [page] = Pages.list(attachment)
+      scan = Repo.get_by!(ImageScan, kind: "attachment_page", subject_id: page.id)
+
+      assert :ok = ImageSubjects.apply_rejected(scan)
+      assert Repo.get(Image, page.id) == nil
+      assert AttachmentStore.page_version_path(attachment.token, 0, "large") == nil
+      # The file itself is untouched: the scan judged the picture we derived.
+      assert is_binary(AttachmentStore.served_path(attachment.token))
+    end
+  end
+
+  describe "a killed render" do
+    test "is finished by the sweeper, and nothing already rendered runs twice", %{
+      user: user,
+      files: files
+    } do
+      Fixtures.put_config(preview_pages: 5)
+      attachment = stored!(user, Fixtures.multi_page_pdf(files, 5))
+
+      # The renderer waits for `:go` so its sandbox connection is granted before
+      # it touches the database, and it is monitored so the kill below is
+      # *observed* rather than assumed. An orphan still holding the connection
+      # when the test ends is what makes this shape of test flake — the twin in
+      # `Vutuv.VideosTest` fell over twice on 2026-09-10 with a
+      # `DBConnection.Holder.checkout … no process` out of the sandbox.
+      parent = self()
+
+      {:ok, pid} =
+        Task.start(fn ->
+          receive do
+            :go -> Pages.render(attachment)
+          end
+        end)
+
+      Sandbox.allow(Repo, parent, pid)
+      ref = Process.monitor(pid)
+      send(pid, :go)
+
+      wait_for(fn -> Pages.list(attachment) != [] end)
+      Process.exit(pid, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^pid, :killed}, 5_000
+
+      interrupted = Pages.list(attachment)
+      assert length(interrupted) < 5, "the render finished before it could be interrupted"
+      assert reload(attachment).stage == "rendering"
+
+      # A marker in the bytes of every page that survived the kill. A re-render
+      # writes each version over, so a marker that is still there afterwards is
+      # proof the sweeper did not derive that page a second time — which no
+      # assertion on the row could show, since the insert is idempotent either
+      # way.
+      marked =
+        Map.new(interrupted, fn page ->
+          path = AttachmentStore.page_version_path(attachment.token, page.position, "large")
+          File.write!(path, "not a real avif, page #{page.position}")
+          {page.position, {page.id, path}}
+        end)
+
+      # The slot is gone; only the stale heartbeat says so.
+      age_claim!(attachment)
+      assert [%Attachment{}] = Pages.due(4)
+
+      assert Pages.sweep() == 1
+
+      finished = Pages.list(attachment)
+      assert length(finished) == 5
+      assert reload(attachment).stage == "ready"
+
+      by_position = Map.new(finished, &{&1.position, &1.id})
+
+      for {position, {id, path}} <- marked do
+        assert by_position[position] == id, "page #{position} got a second row"
+
+        assert File.read!(path) == "not a real avif, page #{position}",
+               "page #{position} was rendered a second time"
+      end
+    end
+  end
+
+  describe "the sweeper's clock" do
+    test "drops work this host can never do out of the due query", %{user: user, files: files} do
+      # poppler renders the pages, and this host has no such binary. `pdfinfo`
+      # is a different one, so the file is still accepted.
+      Fixtures.put_config(preview_pages: 3, pdftoppm: "vutuv-no-such-pdftoppm")
+      attachment = stored!(user, Fixtures.multi_page_pdf(files, 3))
+
+      assert [%Attachment{}] = Pages.due(4)
+      assert Pages.sweep() == 1
+
+      # Aged past the staleness window first, which is the whole point: a pass
+      # that merely claimed the file and wrote nothing looks finished for three
+      # minutes and is then due again, for ever, at the front of every batch.
+      age_claim!(attachment)
+      assert Pages.due(4) == [], "a file nothing here can render is still due"
+
+      assert reload(attachment).stage == "ready"
+      assert Pages.list(attachment) == []
+
+      assert %MediaJob{status: "done", detail: detail} = last_page_job()
+      assert detail =~ "no renderer"
+    end
+
+    test "takes a strike when the renderer failed, and gives up after the cap", %{
+      user: user,
+      files: files
+    } do
+      # Present, and answers every run with a non-zero exit.
+      Fixtures.put_config(preview_pages: 2, pdftoppm: System.find_executable("false"))
+      attachment = stored!(user, Fixtures.multi_page_pdf(files, 2))
+
+      for attempt <- 1..Pages.max_attempts() do
+        age_claim!(attachment)
+        Pages.sweep()
+        assert reload(attachment).render_attempts == attempt
+      end
+
+      assert reload(attachment).stage == "failed"
+      assert Pages.due(4) == []
+      assert %MediaJob{status: "failed"} = last_page_job()
+    end
+  end
+
+  describe "a text file" do
+    test "degrades to no pages where there is no browser", %{user: user, files: files} do
+      Fixtures.put_config(preview_pages: 3)
+      put_config(:chromium_path, "/vutuv/no/such/chromium")
+      attachment = stored!(user, Fixtures.markdown_file(files))
+
+      assert %Attachment{stage: "ready"} = Pages.render(attachment)
+      assert Pages.list(attachment) == []
+      assert %MediaJob{status: "done", detail: detail} = last_page_job()
+      assert detail =~ "no renderer"
+    end
+  end
+
+  describe "the page a text file is drawn as" do
+    # The capture is the one step a host without Chromium cannot run, and CI is
+    # such a host — so what is asserted here is the document, which is where
+    # every decision about a member's file actually sits.
+    test "escapes plain text and forbids every outside reference" do
+      attachment = %Attachment{content_type: "text/plain", file_name: "notes.txt"}
+
+      html = PageRender.document(attachment, "1 < 2 & <script>alert(1)</script>")
+
+      assert html =~ ~s(content="default-src 'none'; style-src 'unsafe-inline'")
+      assert html =~ "1 &lt; 2 &amp; &lt;script&gt;"
+      refute html =~ "<script>"
+    end
+
+    test "renders Markdown through our own renderer" do
+      attachment = %Attachment{content_type: "text/markdown", file_name: "readme.md"}
+
+      html = PageRender.document(attachment, "# Title\n\nA *word*.\n")
+
+      assert html =~ "<h1>"
+      assert html =~ "<em>word</em>"
+      # A remote image is markup the renderer allows and the page must not
+      # fetch. The CSP above is what stops the request; this hides the broken
+      # frame it would otherwise leave in the middle of the preview.
+      assert html =~ "img { display: none; }"
+    end
+  end
+
+  describe "the media job" do
+    test "records one rendering per file", %{user: user, files: files} do
+      Fixtures.put_config(preview_pages: 2)
+      attachment = stored!(user, Fixtures.multi_page_pdf(files, 3))
+
+      Pages.render(attachment)
+
+      assert %MediaJob{kind: "attachment_pages", status: "done"} = job = last_page_job()
+      assert job.user_id == user.id
+      assert job.subject_id == attachment.id
+      assert job.detail =~ "2 pages"
+    end
+  end
+
+  defp last_page_job do
+    Repo.one(
+      from(j in MediaJob, where: j.kind == "attachment_pages", order_by: [desc: j.id], limit: 1)
+    )
+  end
+
+  # Polls rather than sleeps: the loop under test writes a row per page and
+  # the test has to catch it between two of them.
+  defp wait_for(fun, tries \\ 400) do
+    cond do
+      fun.() -> :ok
+      tries == 0 -> flunk("condition never became true")
+      true -> Process.sleep(5) && wait_for(fun, tries - 1)
+    end
+  end
+end

--- a/test/vutuv/images_test.exs
+++ b/test/vutuv/images_test.exs
@@ -283,7 +283,8 @@ defmodule Vutuv.ImagesTest do
       assert Images.serving("cover") == :static
 
       assert Images.kinds() ==
-               ~w(avatar cover job_posting_image organization_image post_image press_kit review_cover)
+               ~w(attachment_page avatar cover job_posting_image organization_image post_image
+                  press_kit review_cover)
     end
 
     # Every kind that has moved goes through an authorizing proxy, so the row
@@ -296,6 +297,9 @@ defmodule Vutuv.ImagesTest do
       # Born on this table rather than moved into it (#2083), and proxied for
       # the same reason: the row is what decides who may fetch the bytes.
       assert Images.serving("press_kit") == :proxy
+      # The second kind born here (#2105): a file's rendered preview page,
+      # stored in a tree nginx has no location for, proxied by #2108.
+      assert Images.serving("attachment_page") == :proxy
     end
 
     # #2055 was the last of the four, so there is no un-moved kind left to

--- a/test/vutuv/uploads/regenerator_test.exs
+++ b/test/vutuv/uploads/regenerator_test.exs
@@ -362,10 +362,12 @@ defmodule Vutuv.Uploads.RegeneratorTest do
     # the first had a written, documented `regenerate/2` that nobody called, the
     # second had no hook at all — so a Spec change never reached an
     # Arbeitszeugnis thumbnail or an organization logo, while this tool reported
-    # success on every other tree. `:press_kit` (#2083) was registered in the
-    # same change as its store, which is the point of the coverage test below.
+    # success on every other tree. `:press_kit` (#2083) and `:attachment_pages`
+    # (#2105) were each registered in the same change as their store, which is
+    # the point of the coverage test below.
     assert Map.keys(summary) |> Enum.sort() ==
              [
+               :attachment_pages,
                :avatars,
                :covers,
                :job_posting_images,


### PR DESCRIPTION
A file under a post is a name and a size, so a reader has to download it to learn what it is. Its first three pages (at most five, `ATTACHMENT_PREVIEW_PAGES`) now render as pictures on upload — a row each on the shared `images` table, kind `attachment_page`, under `Vutuv.Attachments.Pages`. Rendering runs in the background and a deploy that kills it mid-loop is finished by the sweeper: the due list is a query, a claim is a compare-and-set on `attachments.worked_at`, and a page that already has its row is never derived twice. `/admin/media` shows one job per file.

**The issue's central claim is wrong and the fix differs.** libvips has no PDF loader here: `vix` ships its own precompiled libvips and `Vix.Vips.Operation.pdfload/1` is undefined, not failing. PDF pages render with `pdftoppm`, which this project already uses in three places and CI installs. Text and Markdown render through `VutuvWeb.Markdown` into the headless Chromium the link previews use, offline twice over (`default-src 'none'` plus no name resolution), so a member's file cannot make the server fetch anything.

**To decide:** a preview page is deliberately *not* reportable yet — adding it to `Vutuv.Images`' `@takedown` opens `reportable_by?/2` with no visibility check. #2109 wires both together.

Closes #2105

https://claude.ai/code/session_013VnEsuePUe2CB2QvDcshcp
