### PR TITLE
A member decides once in settings whether machines may read their posts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,11 @@ jobs:
       # pdftoppm renders the qualification proof-document PDFs
       # (Vutuv.QualificationDocument); without it the PDF test paths
       # capability-skip and lose their coverage.
-      - name: Install poppler-utils (PDF rendering) and ffmpeg (video on posts)
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends poppler-utils ffmpeg
+      # qpdf joins them for issue #2107: it is what takes the author's name,
+      # the software and the dates out of a PDF, and several fixtures already
+      # built their hostile PDFs with it and skipped themselves without it.
+      - name: Install poppler-utils (PDF rendering), ffmpeg (video on posts) and qpdf (PDF metadata)
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends poppler-utils ffmpeg qpdf
 
       - name: Set up Elixir/OTP
         uses: erlef/setup-beam@v1

--- a/config/config.exs
+++ b/config/config.exs
@@ -897,7 +897,12 @@ config :vutuv, :attachments,
   render_concurrency: 1,
   pdfinfo: "pdfinfo",
   pdfdetach: "pdfdetach",
-  pdftoppm: "pdftoppm"
+  pdftoppm: "pdftoppm",
+  # `qpdf` takes the author's name, the software and the dates out of a PDF
+  # (issue #2107). Optional like the rest: without it the composer hides that
+  # switch rather than offering an answer this installation cannot honour, and
+  # every file is served exactly as it was uploaded.
+  qpdf: "qpdf"
 
 # Job postings (Vutuv.Jobs, milestone 11).
 #   * default_runtime_days — how long a published posting stays live before it

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -968,7 +968,8 @@ if config_env() == :prod do
                attachment_defaults[:render_concurrency],
            pdfinfo: System.get_env("PDFINFO_PATH") || attachment_defaults[:pdfinfo],
            pdfdetach: System.get_env("PDFDETACH_PATH") || attachment_defaults[:pdfdetach],
-           pdftoppm: System.get_env("PDFTOPPM_PATH") || attachment_defaults[:pdftoppm]
+           pdftoppm: System.get_env("PDFTOPPM_PATH") || attachment_defaults[:pdftoppm],
+           qpdf: System.get_env("QPDF_PATH") || attachment_defaults[:qpdf]
          )
 
   # Post images are auth-proxied: the app checks the post's audience, then

--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -48,6 +48,16 @@ Related documents: [README](../README.md) (overview) ·
   (`ATTACHMENT_PREVIEW_PAGES`); without it a PDF is still accepted and simply
   shows no preview.
   A check that cannot run is never treated as a check that passed.
+- **qpdf** (optional, `apt-get install qpdf`) — takes the author's name, the
+  software and the dates out of a PDF attached to a post, which is what the
+  composer's "Remove the metadata from the files" switch does. Without `qpdf`
+  on `$PATH` (or `QPDF_PATH`) that switch is not shown at all and every file is
+  served exactly as it was uploaded; nothing else changes. Debian stable ships
+  12.2.0, which is what the flags used here are chosen against. The private
+  copy of the upload is never rewritten, so a member who turns the switch off
+  gets their file back byte for byte. Note the modification date survives:
+  removing it as well would mean rebuilding the document from its pages alone,
+  which drops the bookmarks and the page labels of a long PDF.
 - **ffmpeg** (optional, `apt-get install ffmpeg`) — video on posts: converts
   a member's clip into the files browsers play and pulls the stills the AI
   check looks at. Debian's build carries `libx264` and `libsvtav1`; without
@@ -140,6 +150,7 @@ Everything else has a default (the vutuv.de production value):
 | `ATTACHMENT_MONTHLY_MB` | `500` | The same over any 30 days |
 | `ATTACHMENT_PREVIEW_PAGES` | `3` | How many of a file's first pages are shown as pictures under the post. A picture sent in a message always has exactly one preview page, which is the picture itself. `0` turns previews off; more than `5` is treated as `5`. A PDF page is rendered by `pdftoppm`, a text or Markdown file by the headless Chromium the link previews use — where neither is installed the file simply shows no preview, and nothing else changes |
 | `ATTACHMENT_RENDER_CONCURRENCY` | `1` | How many files have their preview pages rendered at once. Everything past that queues. Raise it on a machine with cores to spare |
+| `QPDF_PATH` | `qpdf` | The binary that removes a PDF's metadata, if not on `$PATH` under that name. Missing it means the composer does not offer the switch and files are served exactly as uploaded |
 | `PDFINFO_PATH` / `PDFDETACH_PATH` / `PDFTOPPM_PATH` | `pdfinfo` / `pdfdetach` / `pdftoppm` | The three poppler binaries — the first two run the PDF check, the third renders preview pages — if not on `$PATH` under those names. Missing either of the first two means PDFs are not offered (see the dependency list above); missing the third only means no preview pages |
 | `SCREENSHOT_BLOCKLIST` | – | Extra pages never to take a link-preview screenshot of, on top of the shipped `reddit.com` and `heise.de`. Comma-separated domains and/or URLs, copied into the blocklist table the first time you migrate; afterwards the live list is edited in the admin area (see "Screenshot blocklist" below) and this variable is inert. `SCREENSHOT_BLOCKED_HOSTS` is the older name and still works |
 | `SCREENSHOT_PAGE_CHECK` | `true` | Whether each link-preview capture is judged by the Ollama vision model on whether it shows the page or a consent / ad / login wall or a bot check, and the site blocklisted when it does not (see "The list mostly writes itself" below). `false` leaves the blocklist entirely hand-written — the setting for an installation without Ollama. Independent of `IMAGE_MODERATION_ENABLED`: that one is the safety gate, this one is a quality filter |
@@ -884,7 +895,17 @@ every member who has not decided for themselves is unnamed, with the switch
 still theirs to turn back on. It never changes the **count**: a post always
 shows how many likes it got, whoever may be named.
 
-A third is about how loud the feed is: **whether the source tabs quote what
+A third is the one an intranet is most likely to want the other way round:
+**whether search engines and AI may read what a member posts**. vutuv ships this
+on, because the site is a public network and a post is meant to be found. Turn
+*Search engines and AI may read my posts* off at `/admin/preferences` and every
+member who has not decided for themselves publishes posts that ask crawlers to
+stay away — and that are **not sent to other networks at all**, because a server
+elsewhere keeps its copy for good and no instruction of ours reaches it. It
+applies to posts written from then on: the answer is stored on each post as it
+is published, so nothing already written changes, in either direction.
+
+A fourth is about how loud the feed is: **whether the source tabs quote what
 lands on the one a member is not reading**. Something arriving on the tab they
 are not on marks it with a dot either way; on top of that, the bar can quote
 the arrival — author and first words — for a few seconds before folding back.
@@ -893,7 +914,7 @@ feed turns *Quote what arrives on the other tab* off at `/admin/preferences`,
 or shortens the window there; the dot is unaffected, and every member can set
 both for themselves.
 
-A fourth is about what the site costs to load: **data-saving mode**
+A fifth is about what the site costs to load: **data-saving mode**
 (`low_bandwidth?`, its own page at `/settings/bandwidth`). A member with the
 mode on gets three things. Every post photo, picture from another network,
 URL screenshot and profile cover loads as its **lite version** — the same

--- a/docs/architecture/agents-and-seo.md
+++ b/docs/architecture/agents-and-seo.md
@@ -43,6 +43,19 @@ agents/LLMs → `ai-train=`/`ai-input=`, robots `noai, noimageai`) — any
 combination is valid; pages that are noindexed page-level (profile sections,
 people lists, restricted posts) send every signal as `no`.
 
+A **post** carries a third choice of its own, `posts.noindex_noai?` (issue
+#2107): one switch for both machine audiences, taken once by the member on
+`/settings/privacy` and stamped onto the row at publish time. It only ever
+*adds* — `PostDoc.robots_axes/3` ors it into the author's two, and nothing about
+a post re-opens what its author closed. A post that says no also leaves the
+sitemap, both RSS feeds, every shared listing document and the Fediverse
+entirely; where it still appears inside somebody else's document (a
+conversation, a reply, a repost, a pinned-post excerpt) its words are replaced
+by one sentence rather than the row being dropped, so the totals stay honest.
+The HTML conversation on a permalink is the deliberate exception and shows it,
+because the promise is about machines and not about readers. See
+[attachments.md](attachments.md#machines-and-the-metadata-in-a-file-2107).
+
 The per-user detail sub-pages (`/:slug/emails`, `/tags`, `/work_experiences`,
 `/followers`, …) are kept out of search by that page-level `X-Robots-Tag:
 noindex` (`VutuvWeb.Plug.NoIndex` on the `:user_pipe` pipeline), **not** by a

--- a/docs/architecture/attachments.md
+++ b/docs/architecture/attachments.md
@@ -60,10 +60,11 @@ is that page 1 renders. Neither calls it yet.
 `Vutuv.AttachmentStore` keeps the upload verbatim in the private
 `originals/attachments/<token>/` tree and a served copy under
 `attachments/<token>/`, both keyed by the row's URL token, never its id.
-They are byte-identical today; they are still two files, because the served
-copy is what #2107 rewrites when an author asks for the metadata to be
-removed, and the private tree's promise — this is exactly what the member sent
-— has to survive that. Neither tree gets a `Plug.Static` mount: every served
+The served copy is a **derivation** of the original: it is what
+`Vutuv.Attachments.Metadata` rewrites when a PDF has its metadata taken out
+(#2107), while the private tree keeps its promise through all of it — that is
+exactly what the member sent, byte for byte. Neither tree gets a `Plug.Static`
+mount: every served
 byte will go through an authorizing proxy (#2108). Both are gitignored, and
 `test/vutuv/uploads_gitignore_test.exs` fails the build if that slips.
 
@@ -93,7 +94,7 @@ Everything is per installation, read in `config/runtime.exs` with the
 `ATTACHMENT_MAX_MB`, `ATTACHMENTS_PER_POST`, `ATTACHMENT_DAILY_MB`,
 `ATTACHMENT_MONTHLY_MB`, `ATTACHMENT_PREVIEW_PAGES`,
 `ATTACHMENT_RENDER_CONCURRENCY`, `PDFINFO_PATH`, `PDFDETACH_PATH`,
-`PDFTOPPM_PATH`.
+`PDFTOPPM_PATH`, `QPDF_PATH`.
 
 `ATTACHMENT_UPLOADERS` is `admins` while the milestone is being built, the way
 video was introduced: a post cannot show or hand out its files until #2108
@@ -116,6 +117,91 @@ an inner join to `posts` would silently drop every message's file, and a
 what keeps the daily sweep and a re-mounted composer off it. Setting `post_id`
 clears it in the same statement, so exactly one column ever answers "who holds
 this file".
+
+## Machines, and the metadata in a file (#2107)
+
+### One standing decision, stamped onto each post
+
+**"Search engines and AI may read my posts"** is a `Vutuv.Prefs` key,
+`posts_machines_allowed?`, on `/settings/privacy`. It is asked **once**, not per
+post: a composer that asked would put the same question in front of a member
+several times a day, and the answer almost never changes between two posts.
+
+The member's answer is copied onto the row **as the post is published**
+(`Vutuv.Posts` private `seed_post/1`, the seed struct both member-post paths
+build from) into `posts.noindex_noai?`, read back through
+`Vutuv.Posts.machines_allowed?/1` and its query twin
+`scope_machines_allowed/1`. Nothing re-reads the setting when a post is
+rendered, and that is the design rather than an optimisation: a live read would
+mean flipping the switch silently rewrote every older post, and for the ones
+already federated it would promise a withdrawal nothing can perform. So each
+post keeps what it went out with, an edit keeps it too, and the setting is only
+ever the default for the next one. An explicit `noindex_noai` attr still wins,
+which is what `POST /api/2.0/posts` sends.
+
+A **page's** post does not take it: an organization has its own `seo?`/`geo?`,
+and one publisher's private posture must not mute the brand they publish for.
+
+A pref rather than a plain column because `nil` has to mean "never asked":
+`noai?`'s column default is `true`, so 5,867 of 6,026 members on the dev copy of
+production "carry" an answer nobody gave, and nothing can tell that from a real
+one. Here NULL inherits the installation default, which an operator moves at
+`/admin/preferences` — worth having, since an intranet installation may well
+want the opposite posture.
+
+### What "no machines" costs, and why the settings page says it
+
+Saying no means `noindex, noai, noimageai` on the permalink and on every
+`.md`/`.txt`/`.json`/`.xml` sibling, no sitemap entry, no place in the two RSS
+feeds or on a tag page (both carry one all-yes `Content-Signal` for a whole
+list), and no first line quoted on any shared listing surface. And it means the
+post **is not federated at all** — not the Create, not a later Update, not the
+unfreeze's republish, not a topic actor's Announce, not somebody else's boost,
+not the `featured` collection, not the outbox count, and not the Note served on
+request to an ActivityPub `Accept` header. A header is advisory and re-read on
+every visit; a copy on somebody else's server is neither, so this has to be a
+gate and not a directive. That sentence is the registry `hint` on
+`posts_machines_allowed?`, so the member and the admin read the same words.
+
+### Where a withheld post is redacted, and where it is not
+
+The switch protects the post's own documents; what it did not protect at first
+was the post as it appears **inside somebody else's**, because a document's
+robots axes are computed from its *subject* post and a conversation quotes other
+people's. So `PostDoc` redacts **per entry**: `thread_entries/1` and
+`reply_entry/1` hand back the sentence "Post not open to search engines" in
+place of a withheld body, `withheld_excerpt/1` does the same for a quoted line
+(`ProfileDoc` shares it for the pinned post), the reposts leg of
+`author_timeline_query/3` drops a withheld post outright, and the archive's
+one-level ancestor fallback stops printing a withheld parent above a reply card.
+
+The **HTML conversation on a permalink still shows every word**. Page and doc
+differ there on purpose: the promise is about machines, not about readers. The
+archive listing is the one place they must agree, because that page is a crawl
+surface — which is also why its withheld rows leave it.
+
+### The metadata in a file
+
+**"Remove the metadata from the files"** is `posts.strip_metadata?`, the
+author's *answer*, and the one question the composer still asks — it is about
+*these* files, so it belongs beside them, and it only shows on a new post
+carrying one. What actually happened to a given file is
+`attachments.metadata_stripped_at`. `Vutuv.Attachments.Metadata` is the one
+place vutuv talks to `qpdf`, probed once per VM the way ffmpeg is, and the
+switch is hidden where the binary is absent **or too old** — the probe asks
+qpdf whether it knows the flags (`--help=--remove-info`), not whether the file
+exists, because Debian 12 ships 11.3.0 and Ubuntu 24.04 ships 11.9.0 while
+`--remove-info` arrived in 11.10.0. The run happens at **intake**, on every PDF,
+deriving the served copy from the verbatim original with
+`--remove-info --remove-metadata --deterministic-id --linearize`; an author who
+says no gets the original copied back at claim time, which costs a `File.cp`
+rather than a shell-out on the publish path. `--remove-structure` is
+deliberately not used (that is the tagged-PDF tree a screen reader follows),
+and `/ModDate` survives by qpdf's own design.
+
+That answer travels through `post_drafts.strip_metadata?`, so a reload brings it
+back beside the words it was chosen with; it does not count as content, so
+flipping it on an empty composer creates no draft.
 
 ## The post waits for its files
 

--- a/docs/architecture/attachments.md
+++ b/docs/architecture/attachments.md
@@ -163,6 +163,31 @@ every visit; a copy on somebody else's server is neither, so this has to be a
 gate and not a directive. That sentence is the registry `hint` on
 `posts_machines_allowed?`, so the member and the admin read the same words.
 
+### The chokepoint
+
+**A post's body leaves the database toward a surface a machine can read only
+through a query that has been piped through `Vutuv.Posts.scope_machines_for/2`**
+(or its anonymous case `scope_machines_allowed/1`). That is the invariant, and
+it is enforced rather than remembered: `test/vutuv/post_body_chokepoint_test.exs`
+reads the source, collects every function under `lib/vutuv/` that selects a post
+`body`, and fails the build for any that does not pipe through the gate.
+
+It is a property and not a list because three review rounds each produced a
+complete measurement and each missed the next surface — the archive, the tag
+pages and the calendar; then the conversation, the reply, the repost and the
+profile document; then the profile HTML. The last pair is why the gate is in the
+**query**: `recent_posts_by_authors/3` selects `body:` into bare maps, which no
+struct-taking helper can reach, and `pinned_post/2` fetches by id rather than
+through a timeline, so no listing gate applied. Both put a withheld post's whole
+text on `/:slug`, which is public, anonymous, in the sitemap and carries no
+`X-Robots-Tag`.
+
+`scope_visible/2` is its mandatory partner and answers a different question — may
+this **viewer** see it — so neither substitutes for the other. An exception is
+explicit and carries its reason in the test's own `@deliberate` and
+`@exempt_queries` maps; the silent absence of a check is what the guard exists to
+stop.
+
 ### Where a withheld post is redacted, and where it is not
 
 The switch protects the post's own documents; what it did not protect at first

--- a/docs/architecture/settings-and-account.md
+++ b/docs/architecture/settings-and-account.md
@@ -151,13 +151,27 @@ confirmation flow are described in
 ### Member preferences with installation defaults (`Vutuv.Prefs`)
 
 The map and post-display settings are the first citizens of the generic
-**preferences system**; the third group is `:privacy`, which holds
+**preferences system**; the third group is `:privacy`, which holds two.
 `like_attribution?` — whether a post permalink names this member among the
 people who liked it (issue #1233, see the "Who liked it" section in
-[posts-and-feed.md](posts-and-feed.md)). It is the one pref whose home is not
-`/settings/preferences` but the visibility page (`/settings/privacy`, reset via
-POST `/settings/privacy/reset`), because it is a privacy posture rather than a
-display detail. The `:bandwidth` group holds one knob with a different shape
+[posts-and-feed.md](posts-and-feed.md)). And `posts_machines_allowed?` — whether
+search engines and AI may read the posts this member writes from now on (issue
+#2107): the answer is copied onto each post as it is published, so changing it
+leaves everything already written exactly as it went out, and saying no also
+keeps a new post off the other networks entirely, which the card's hint says in
+words because nothing else can tell the member. The detail is in
+[attachments.md](attachments.md). Neither pref's home is
+`/settings/preferences`: both live on the visibility page (`/settings/privacy`,
+reset via POST `/settings/privacy/reset`), because they are privacy postures
+rather than display details.
+
+Note the shape difference on that page. The two crawler switches above them,
+`noindex?` and `noai?`, are plain opt-**out** columns rendered positively with
+`checked_value: "false"`, while a `Vutuv.Prefs` boolean is stored the way it
+reads — which is why the posts setting is named positively and sits in a card of
+its own rather than as a third row in theirs.
+
+The `:bandwidth` group holds one knob with a different shape
 again: `low_bandwidth?` (data-saving mode) decides whether this member's
 browser is ever told where the 155 kB WYSIWYG editor bundle lives (see
 "Low-bandwidth mode" in [posts-and-feed.md](posts-and-feed.md)) and whether

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -413,6 +413,13 @@ defmodule Vutuv.Accounts.User do
     # `Vutuv.Posts.post_likers/2`. It never changes the count. Read through
     # `Vutuv.Prefs.get/2`, never straight off the struct.
     field(:like_attribution?, :boolean)
+    # Whether search engines and AI crawlers may read this member's posts
+    # (issue #2107). Asked once on /settings/privacy and copied onto each post
+    # as it is published (`posts.noindex_noai?`), never read back when an older
+    # post is rendered — a post keeps the answer it went out with. Read through
+    # `Vutuv.Prefs.get/2`, never straight off the struct; NULL means the member
+    # was never asked and the installation default applies.
+    field(:posts_machines_allowed?, :boolean)
     # The license this member last published photos under (issue #1104),
     # offered as the pre-selection on their next photo post so a professional
     # sets it once. Written by Vutuv.Posts on save, never by a settings form —
@@ -602,7 +609,7 @@ defmodule Vutuv.Accounts.User do
   # :email_confirmed? is NOT here either: it flips only via the login-PIN path
   # (Accounts.activate_user/1, its own narrow cast) — castable, it would let a
   # registration self-activate without ever proving control of an email.
-  @optional_fields ~w(noindex? noai? notification_emails? dm_email_each_message? dm_email_delay_minutes email_on_endorsement? email_on_follower? email_on_reference_check? newsletter_emails? saved_search_emails? cv_update_notifications? thread_notifications? browser_notifications? show_online_status? show_mastodon_feed? mastodon_clients? show_code_stats? fediverse_followers? fediverse_reactions? fediverse_replies? also_known_as_input map_google? map_openstreetmap? map_apple? default_map_service post_lines_desktop post_lines_mobile post_hyphenate_desktop post_hyphenate_mobile notification_post_lines like_attribution? headline employment_status employment_status_visibility desired_salary_min desired_salary_currency desired_salary_period desired_salary_visibility desired_workplace_types first_name last_name middle_name nickname honorific_prefix honorific_suffix name_pronunciation gender birthdate birthdate_visibility locale date_region time_zone tag_list auto_post_deletion? auto_post_deletion_after_days auto_post_deletion_keep_photos? auto_post_deletion_keep_answered? auto_post_deletion_keep_bookmarked? auto_post_deletion_delete_replies? auto_post_deletion_min_likes auto_post_deletion_min_bookmarks auto_post_deletion_min_reposts feed_foreign_posts feed_languages feed_tab_ticker? feed_tab_ticker_seconds feed_page_size browser_tab_teaser? low_bandwidth?)a
+  @optional_fields ~w(noindex? noai? notification_emails? dm_email_each_message? dm_email_delay_minutes email_on_endorsement? email_on_follower? email_on_reference_check? newsletter_emails? saved_search_emails? cv_update_notifications? thread_notifications? browser_notifications? show_online_status? show_mastodon_feed? mastodon_clients? show_code_stats? fediverse_followers? fediverse_reactions? fediverse_replies? also_known_as_input map_google? map_openstreetmap? map_apple? default_map_service post_lines_desktop post_lines_mobile post_hyphenate_desktop post_hyphenate_mobile notification_post_lines like_attribution? posts_machines_allowed? headline employment_status employment_status_visibility desired_salary_min desired_salary_currency desired_salary_period desired_salary_visibility desired_workplace_types first_name last_name middle_name nickname honorific_prefix honorific_suffix name_pronunciation gender birthdate birthdate_visibility locale date_region time_zone tag_list auto_post_deletion? auto_post_deletion_after_days auto_post_deletion_keep_photos? auto_post_deletion_keep_answered? auto_post_deletion_keep_bookmarked? auto_post_deletion_delete_replies? auto_post_deletion_min_likes auto_post_deletion_min_bookmarks auto_post_deletion_min_reposts feed_foreign_posts feed_languages feed_tab_ticker? feed_tab_ticker_seconds feed_page_size browser_tab_teaser? low_bandwidth?)a
 
   # The ages the automatic post deletion offers (issue #1255), in days. A fixed
   # list rather than a free number field on purpose: this setting deletes

--- a/lib/vutuv/attachments.ex
+++ b/lib/vutuv/attachments.ex
@@ -46,6 +46,7 @@ defmodule Vutuv.Attachments do
   alias Vutuv.Accounts.User
   alias Vutuv.Attachments.Attachment
   alias Vutuv.Attachments.Format
+  alias Vutuv.Attachments.Metadata
   alias Vutuv.Attachments.PagePipeline
   alias Vutuv.Attachments.Pages
   alias Vutuv.Attachments.Upload
@@ -55,6 +56,7 @@ defmodule Vutuv.Attachments do
   alias Vutuv.Images.Image
   alias Vutuv.MediaJobs
   alias Vutuv.Posts.Pending
+  alias Vutuv.Posts.Post
   alias Vutuv.Repo
   alias Vutuv.Uploads.PdfGate
   alias Vutuv.Uploads.Spec
@@ -87,6 +89,13 @@ defmodule Vutuv.Attachments do
 
   @doc "Whether PDFs can be checked here — without poppler they are not offered."
   defdelegate pdf_supported?, to: PdfGate, as: :available?
+
+  @doc """
+  Whether a file's metadata can be removed here (issue #2107) — `qpdf` on the
+  box. Without it the composer hides the switch rather than offering an answer
+  this installation cannot honour.
+  """
+  defdelegate metadata_removal_supported?, to: Metadata, as: :available?
 
   @doc "Drops the cached poppler probe. For tests that move the binary."
   defdelegate forget_capability, to: PdfGate
@@ -191,6 +200,13 @@ defmodule Vutuv.Attachments do
       %Attachment{user_id: user.id}
       |> Attachment.changeset(%{
         token: token,
+        # The metadata comes out here, before anybody has been asked — the
+        # answer defaults to yes and a cleaned file is what the post is meant
+        # to be waiting for (#2102). An author who says no is given the
+        # verbatim upload back at claim time, which costs a copy rather than a
+        # second qpdf run on the publish path. `nil` when there was nothing to
+        # do: not a PDF, or no qpdf on this box.
+        metadata_stripped_at: Metadata.strip(token, kind),
         # Cut rather than raise 22001 on a name the member did not choose to
         # be long: a browser will happily hand over 400 characters.
         file_name: String.slice(Path.basename(filename), 0, Attachment.name_max()),
@@ -305,6 +321,60 @@ defmodule Vutuv.Attachments do
       |> NaiveDateTime.add(-Keyword.get(opts, :hours_ago, 0) * 3600, :second)
 
     Repo.insert!(%Upload{user_id: user.id, size_bytes: size, inserted_at: at})
+  end
+
+  ## The metadata answer
+
+  @doc """
+  Makes the files a post claimed agree with what its author answered about
+  their metadata (issue #2107). Called after the post is committed, from
+  `Vutuv.Posts`, on both the create and the update path.
+
+  It reads **both** columns, never one: `posts.strip_metadata?` is what was
+  asked and `attachments.metadata_stripped_at` is what was done, and the two
+  can legitimately differ — a file uploaded on a box without qpdf was never
+  stripped whatever the post says. So a row is only worked on where the two
+  disagree, in either direction: an author who says no gets the verbatim upload
+  put back (a `File.cp`, no qpdf), and one who turns the switch back on through
+  the API gets the file cleaned after all. Doing only the first was a post whose
+  row claimed its files were clean while the bytes still carried the author's
+  name.
+
+  Both directions are idempotent — the served copy is only ever a derivation of
+  the private original — so a re-run is free and a half-finished run heals on
+  the next edit. In the overwhelming case there is nothing to do and it costs
+  one query.
+  """
+  def apply_metadata_choice(%Post{id: post_id, strip_metadata?: strip?}) do
+    from(a in Attachment,
+      where: a.post_id == ^post_id,
+      select: {a.token, a.content_type, not is_nil(a.metadata_stripped_at)}
+    )
+    |> Repo.all()
+    |> Enum.each(&reconcile_metadata(&1, strip?))
+  end
+
+  defp reconcile_metadata({_token, _type, stripped?}, strip?) when stripped? == strip?, do: :ok
+
+  defp reconcile_metadata({token, _type, true}, false) do
+    Metadata.restore(token)
+    stamp_metadata(token, nil)
+  end
+
+  defp reconcile_metadata({token, content_type, false}, true) do
+    case Metadata.strip(token, Format.kind_of_content_type(content_type)) do
+      nil -> :ok
+      at -> stamp_metadata(token, at)
+    end
+  end
+
+  defp stamp_metadata(token, at) do
+    Repo.update_all(
+      from(a in Attachment, where: a.token == ^token),
+      set: [metadata_stripped_at: at]
+    )
+
+    :ok
   end
 
   ## Reading
@@ -481,12 +551,22 @@ defmodule Vutuv.Attachments do
   clears that in the same statement it claims them, so a reserved file is
   exactly what it is entitled to take. A message never reserves anything, so a
   reserved file is somebody's waiting post's and must not be taken from it.
+
+  A file the AI check **refused** is claimable by neither parent (issue #2107).
+  Deliberately not the video path's `stage == "ready"`, which would roll back a
+  real publish: a file's stages are `stored → rendering → ready | failed`, and
+  `failed` (nothing on this box could render a preview) is a legitimately
+  publishable terminal state. `refused_at` is the one that never is — without
+  this the composer's own "publish without it" offer could be walked round with
+  a plain `POST /api/2.0/posts` naming the refused id.
   """
   def claim(_parent, _uploader_id, []), do: :ok
 
   def claim(parent, uploader_id, ids) when is_binary(uploader_id) and is_list(ids) do
     {count, _} =
-      from(a in Attachment, where: a.id in ^ids and a.user_id == ^uploader_id)
+      from(a in Attachment,
+        where: a.id in ^ids and a.user_id == ^uploader_id and is_nil(a.refused_at)
+      )
       |> unclaimed()
       |> claim_scope(parent)
       |> Repo.update_all(set: claim_set(parent))

--- a/lib/vutuv/attachments/attachment.ex
+++ b/lib/vutuv/attachments/attachment.ex
@@ -73,6 +73,13 @@ defmodule Vutuv.Attachments.Attachment do
 
     field(:stage, :string, default: "stored")
 
+    # When this file's **served** copy was rewritten without its metadata
+    # (#2107). NULL means it is still the verbatim upload — no qpdf on this
+    # box, not a PDF, or the author asked for the metadata to stay. The private
+    # original is never touched either way, so this column is what tells the
+    # two states apart once the bytes are on disk.
+    field(:metadata_stripped_at, :utc_datetime)
+
     # When the AI check refused one of this file's preview pages. The verdict
     # deletes the page itself, so without this the file would look untouched
     # and the post waiting on it would wait for a page that is never coming
@@ -105,7 +112,15 @@ defmodule Vutuv.Attachments.Attachment do
   @doc "The insert the upload chokepoint writes; every value here is already checked."
   def changeset(attachment, params) do
     attachment
-    |> cast(params, [:token, :file_name, :content_type, :size_bytes, :page_count, :stage])
+    |> cast(params, [
+      :token,
+      :file_name,
+      :content_type,
+      :size_bytes,
+      :page_count,
+      :stage,
+      :metadata_stripped_at
+    ])
     |> validate_required([:token, :file_name, :content_type, :size_bytes])
     |> validate_length(:file_name, max: @name_max)
     |> validate_length(:content_type, max: @name_max)

--- a/lib/vutuv/attachments/format.ex
+++ b/lib/vutuv/attachments/format.ex
@@ -168,5 +168,18 @@ defmodule Vutuv.Attachments.Format do
   @doc "The downcased extension of `file_name`, `\"\"` when it has none."
   def extension(file_name), do: file_name |> Path.extname() |> String.downcase()
 
+  @doc """
+  Whether a stored row's `content_type` is a PDF — what a caller that has the
+  row rather than the upload asks (`Vutuv.Attachments.apply_metadata_choice/1`).
+
+  Deliberately **not** the full inverse of `content_type/2`, which also emits
+  the picture types: the one consumer asks only "is there metadata in here for
+  qpdf to remove", so everything that is not a PDF answers `:text` and is left
+  alone. Widen it when a second caller needs `:picture` told apart, rather than
+  leaving a promise the code does not keep.
+  """
+  def kind_of_content_type("application/pdf"), do: :pdf
+  def kind_of_content_type(_not_a_pdf), do: :text
+
   defp text?(bytes), do: String.valid?(bytes) and not Regex.match?(@control_regex, bytes)
 end

--- a/lib/vutuv/attachments/metadata.ex
+++ b/lib/vutuv/attachments/metadata.ex
@@ -1,0 +1,228 @@
+defmodule Vutuv.Attachments.Metadata do
+  @moduledoc """
+  The one place vutuv talks to `qpdf` (issue #2107): taking the author's name,
+  the software that wrote it and the dates out of a PDF before anybody can
+  download it.
+
+  ## Two copies, and which one is rewritten
+
+  `Vutuv.AttachmentStore` keeps every file twice — the verbatim upload under
+  `originals/` and the copy a reader is handed under `attachments/`. **Only
+  the served copy is ever rewritten.** The private tree's promise is that what
+  the member sent is kept exactly as they sent it, which is also what makes
+  this operation reversible: the served copy is a *derivation* of the original
+  under the author's answer, so `strip/2` and `restore/1` can be run any
+  number of times in any order and the result is the same.
+
+  ## When it runs
+
+  At intake, on every PDF, before the author has answered — because the answer
+  defaults to yes and the parent milestone (#2102) wants a file *cleaned* by
+  the time its post publishes, beside its preview pages and its AI check. The
+  switch turning it off then costs a `File.cp` from the original at claim time
+  (`Vutuv.Attachments.apply_metadata_choice/1`) rather than a shell-out on the
+  publish path.
+
+  ## The flags, and what they leave behind
+
+      qpdf --remove-info --remove-metadata --deterministic-id --linearize
+
+  `--remove-info` empties the trailer's `/Info` dictionary (Title, Author,
+  Creator, Producer, CreationDate, Subject, Keywords) and `--remove-metadata`
+  drops the catalog's XMP packet (`dc:creator`, `xmp:CreatorTool`,
+  `xmp:CreateDate`). `--deterministic-id` replaces the trailer's `/ID`, which
+  is otherwise derived from the writing machine's clock and file path, with a
+  hash of the content. `--linearize` writes a web-optimised file, and rewriting
+  it at all is what drops any incremental-update history — the earlier
+  revisions of a document, which are where a "redacted" paragraph usually
+  still is.
+
+  Two deliberate departures from the obvious maximum:
+
+    * **`/ModDate` survives.** qpdf's `--remove-info` keeps it on purpose
+      (documented: "except modification date"). Removing it needs
+      `--empty --pages in.pdf 1-z --`, which rebuilds the document from its
+      pages alone and drops the outline, the page labels and the named
+      destinations with it. A thesis silently losing its bookmarks is a worse
+      trade than a surviving modification date, and the author who disagrees
+      has the switch.
+    * **`--remove-structure` is not used.** It removes the *tagged-PDF
+      structure tree*, which is what a screen reader follows. That is an
+      accessibility feature, not metadata.
+
+  ## The version this needs, and why the probe runs a command
+
+  `--remove-info` and `--remove-metadata` arrived in **qpdf 11.10.0**
+  (2025-02-08); `--deterministic-id` (6.0.0) and `--linearize` are far older.
+  Production runs Debian stable's 12.2.0 and is fine, but plenty of boxes are
+  not: **Debian 12 ships 11.3.0 and Ubuntu 24.04 ships 11.9.0**, both of which
+  have the binary and neither of which has the flags.
+
+  So `available?/0` asks whether this qpdf can do the **work**, not whether the
+  file exists: `qpdf --help=--remove-info` exits 0 for a flag it knows and 2
+  for one it does not. Probing with `System.find_executable/1` alone — which is
+  what `Vutuv.Uploads.PdfGate` can afford, its poppler tools having had their
+  flags for a decade — left the switch **visible and inert** on every one of
+  those boxes: the member ticked "remove the metadata", the run died with
+  `unrecognized argument --remove-info`, and the file was served with the
+  author's name still in it. Our own CI found that before a member did.
+
+  A capability, not a feature: there is no product flag to turn it off, and an
+  installation whose qpdf is too old is treated exactly like one with no qpdf
+  at all.
+
+  ## Without qpdf, or with one too old
+
+  `available?/0` is probed once per VM and cached, the `:persistent_term`
+  pattern `Vutuv.Videos.FFmpeg` established. Nothing is stripped, nothing
+  fails, and the composer hides the switch rather than offering an answer this
+  installation cannot honour. `QPDF_PATH` names the binary when it is not on
+  `$PATH`.
+  """
+
+  require Logger
+
+  alias Vutuv.AttachmentStore
+
+  # qpdf exits 0 on success and **3** when it wrote the output but had warnings
+  # about the input (a recovered stream length, a broken xref it repaired).
+  # A file poppler already accepted and qpdf could rewrite is a cleaned file;
+  # treating 3 as failure would leave the metadata on every slightly untidy PDF.
+  @written_exit_codes [0, 3]
+
+  # The two flags that do the actual removing, and the two that are not old
+  # enough to be assumed. `--help=<flag>` is qpdf's own way of being asked
+  # whether it knows one: exit 0 if it does, 2 if it does not.
+  @required_flags ["--remove-info", "--remove-metadata"]
+
+  @doc """
+  Whether this machine has a qpdf that can do the work (probed once per VM):
+  the binary is there **and** it knows the flags that remove the metadata. See
+  the moduledoc for why the second half is not optional.
+  """
+  def available? do
+    case :persistent_term.get({__MODULE__, :available}, :unknown) do
+      :unknown ->
+        verdict = capable?(qpdf())
+        :persistent_term.put({__MODULE__, :available}, verdict)
+        verdict
+
+      verdict ->
+        verdict
+    end
+  end
+
+  @doc "Drops the cached probe. For tests that point `QPDF_PATH` somewhere else."
+  def forget_capability, do: :persistent_term.erase({__MODULE__, :available})
+
+  @doc """
+  Rewrites the served copy of `token` without its metadata, deriving it from
+  the verbatim original. Answers the moment it was done, or `nil` when nothing
+  was done — not a PDF, no qpdf on this box, or qpdf could not read the file.
+  A failure is never fatal: the member keeps a publishable file that simply
+  still carries its metadata, and the NULL column says so.
+  """
+  def strip(token, :pdf) do
+    with true <- available?(),
+         source when is_binary(source) <- AttachmentStore.original_path(token),
+         :ok <- run(source, token) do
+      DateTime.utc_now(:second)
+    else
+      _nothing_done -> nil
+    end
+  end
+
+  def strip(_token, _not_a_pdf), do: nil
+
+  @doc """
+  Puts the verbatim upload back on the served copy — what the author asking to
+  keep the metadata costs. `:ok` either way; a file whose original is gone
+  (swept, or never stored) keeps whatever it has.
+  """
+  def restore(token) do
+    case AttachmentStore.original_path(token) do
+      nil -> :ok
+      source -> AttachmentStore.replace_served(token, source)
+    end
+  end
+
+  # qpdf writes a whole new file, so it writes it straight where it is wanted —
+  # a scratch name **in the served copy's own directory**, renamed onto the
+  # target on success. Two things follow. It is never written beside the
+  # *input*, which lives in `originals/`, whose whole promise is that it holds
+  # what the member sent and nothing else (and whose own `original*` glob would
+  # have matched the leftover); and the commit is a rename rather than a copy,
+  # which for a 20 MB PDF is the difference between free and reading and
+  # writing it a third time. `after` removes the scratch on every path, so an
+  # exception mid-run leaks nothing.
+  #
+  # The run itself is the shape `Vutuv.Uploads.PdfGate` runs poppler with: no
+  # shell, a bounded argument list, and a crash or a non-zero exit caught here
+  # rather than taking the caller down. Every path comes from the store, never
+  # from a member.
+  defp run(source, token) do
+    scratch = AttachmentStore.scratch_path(token)
+
+    args = [
+      "--remove-info",
+      "--remove-metadata",
+      "--deterministic-id",
+      "--linearize",
+      source,
+      scratch
+    ]
+
+    try do
+      case System.cmd(qpdf(), args, stderr_to_stdout: true) do
+        {_out, code} when code in @written_exit_codes ->
+          AttachmentStore.commit_scratch(token, scratch)
+
+        {out, code} ->
+          Logger.warning(
+            "qpdf could not clean a file (exit #{code}): #{String.slice(out, 0, 200)}"
+          )
+
+          :error
+      end
+    rescue
+      exception ->
+        Logger.warning("qpdf run failed: #{Exception.message(exception)}")
+        :error
+    catch
+      :exit, reason ->
+        Logger.warning("qpdf run exited: #{inspect(reason)}")
+        :error
+    after
+      File.rm(scratch)
+    end
+  end
+
+  # Deliberately more than `Vutuv.Uploads.PdfGate.available?/0`'s
+  # `find_executable/1`: a qpdf that exists is not a qpdf that can do this, and
+  # the two Debian and Ubuntu releases most installations run ship exactly that
+  # combination. Fails closed on anything unexpected — a probe that cannot
+  # answer is not a probe that said yes.
+  defp capable?(binary) do
+    case System.find_executable(binary) do
+      nil -> false
+      path -> Enum.all?(@required_flags, &knows_flag?(path, &1))
+    end
+  end
+
+  defp knows_flag?(path, flag) do
+    case System.cmd(path, ["--help=#{flag}"], stderr_to_stdout: true) do
+      {_out, 0} -> true
+      _unknown_flag -> false
+    end
+  rescue
+    _ -> false
+  catch
+    :exit, _ -> false
+  end
+
+  # `fetch_env!` like every sibling in this namespace (`Vutuv.Attachments`,
+  # `Vutuv.Attachments.PageRender`): a missing `:attachments` block is a broken
+  # installation and should say so, not read as "this box has no qpdf" and
+  # silently serve every PDF with its author's name still in it.
+  defp qpdf, do: Keyword.get(Application.fetch_env!(:vutuv, :attachments), :qpdf, "qpdf")
+end

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -991,6 +991,12 @@ defmodule Vutuv.Fediverse do
   def public_post_count(%User{id: user_id}) do
     from(p in Post, where: p.user_id == ^user_id)
     |> Posts.scope_visible(nil)
+    # …and the machines switch (issue #2107), by the same rule this function's
+    # docstring already records: the count and the notes it counts have to
+    # answer one question by mechanism, not by two spellings that happen to
+    # agree. A post `/posts/:id` refuses to hand over must not be counted in
+    # the collection that advertises it.
+    |> Posts.scope_machines_allowed()
     |> Repo.aggregate(:count)
   end
 
@@ -1019,8 +1025,16 @@ defmodule Vutuv.Fediverse do
   """
   def featured_posts(%User{} = user) do
     case Posts.pinned_post(user, nil) do
-      %Post{} = post -> [Repo.preload(post, Docs.note_preloads())]
-      nil -> []
+      %Post{} = post ->
+        # A post kept off the Fediverse (issue #2107) is absent from the
+        # collection too — otherwise pinning it would hand its whole Note to
+        # anybody who reads the profile's `featured` URL.
+        if Posts.machines_allowed?(post),
+          do: [Repo.preload(post, Docs.note_preloads())],
+          else: []
+
+      nil ->
+        []
     end
   end
 
@@ -10463,8 +10477,12 @@ defmodule Vutuv.Fediverse do
   without an account here. A tag actor boosting a note is exactly an `Announce`,
   so it reuses the one the repost path already builds.
 
-  Three gates, and each is load-bearing:
+  Four gates, and each is load-bearing:
 
+  - **The post must allow machines** (`Posts.machines_allowed?/1`, issue
+    #2107). A post its author kept off the Fediverse must not leave through a
+    topic actor instead — the topics are a second audience, not a second
+    decision.
   - **The author must federate.** A tag actor announcing indiscriminately would
     carry out the posts of the very members who chose not to, which is why there
     is no per-tag opt-in and why this check cannot move.
@@ -10481,6 +10499,7 @@ defmodule Vutuv.Fediverse do
   """
   def announce_to_tag_followers(%Post{} = post) do
     with true <- enabled?(),
+         true <- Posts.machines_allowed?(post),
          false <- Posts.restricted?(post),
          author when not is_nil(author) <- Posts.author(post),
          true <- federated?(author) do
@@ -10532,7 +10551,13 @@ defmodule Vutuv.Fediverse do
   deletion is advisory by protocol).
   """
   def federate_post_update(%Post{} = post) do
-    if Posts.restricted?(post) do
+    # An author turning the machines switch on after the fact (issue #2107) is
+    # the same act as closing the audience, and takes the same path: what has
+    # already left has to be **called back**, not merely not sent again. The
+    # `:skip` this used to land on left the remote copies standing while the
+    # row said the author had refused them — the one thing the composer's
+    # warning says cannot be undone, silently not even attempted.
+    if Posts.restricted?(post) or not Posts.machines_allowed?(post) do
       revoke_post(post)
     else
       maybe_federate(post, &Docs.update_activity/2, "post_update")
@@ -10549,6 +10574,15 @@ defmodule Vutuv.Fediverse do
   # about an account. What a page needs instead is its own opt-in and its own
   # followers — and no `restricted?` check, because an organization post carries
   # no audience by construction.
+  # The author said no search engines and no AI (issue #2107), and that answer
+  # has to be a **gate** rather than a directive: an `X-Robots-Tag` is re-read
+  # by a crawler on every visit, while a federated copy is handed to a server
+  # that keeps it for ever and that no header of ours reaches. So the post does
+  # not go out at all — not the Create, not a later Update, not the unfreeze's
+  # republish. First clause on purpose: it must answer before either owner
+  # branch, member or page. The composer says this in words before publishing.
+  defp maybe_federate(%Post{noindex_noai?: true}, _builder, _kind), do: :skip
+
   defp maybe_federate(%Post{organization_id: id} = post, builder, kind) when is_binary(id) do
     with true <- enabled?(),
          %Organization{} = page <- Organizations.get_organization(id),
@@ -10955,6 +10989,9 @@ defmodule Vutuv.Fediverse do
 
   defp maybe_federate_repost(%Post{} = post, reposter, builder) do
     with true <- enabled?(),
+         # Somebody else resharing it is still this post leaving for other
+         # servers, and the author's answer decides that (issue #2107).
+         true <- Posts.machines_allowed?(post),
          true <- federated?(reposter),
          false <- resharer_moved?(reposter),
          false <- Posts.restricted?(post),
@@ -10993,7 +11030,8 @@ defmodule Vutuv.Fediverse do
     # it costs a query, and for the overwhelming majority (members who do not
     # federate at all) there is nothing to decide.
     pin_activity(user, fn user ->
-      if Posts.visible_to?(post, nil), do: Docs.add_featured_activity(post, user)
+      if Posts.machines_allowed?(post) and Posts.visible_to?(post, nil),
+        do: Docs.add_featured_activity(post, user)
     end)
   end
 
@@ -11323,10 +11361,13 @@ defmodule Vutuv.Fediverse do
   end
 
   # The gates are re-checked here rather than when the row was queued: the post
-  # may have been deleted or had its audience closed during the hold, and then
-  # this delivery must not go out at all.
+  # may have been deleted, had its audience closed, or had its machines switch
+  # turned on (issue #2107) during the hold, and then this delivery must not go
+  # out at all. Every gate that can change while a row waits belongs here, not
+  # only at the four places that queue one.
   defp rebuild_now(delivery, builder, post_id, user) do
     with %Post{} = post <- Posts.get_post(post_id),
+         true <- Posts.machines_allowed?(post),
          false <- Posts.restricted?(post) do
       post = Repo.preload(post, Docs.note_preloads())
       {:ok, %{delivery | activity_json: Jason.encode!(builder.(post, user))}}

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -1793,20 +1793,70 @@ defmodule Vutuv.Posts do
   card component's own fallback: no machine reads a login-only page, and the
   promise is about machines rather than readers. The permalink's conversation
   is unaffected for the same reason.
+
+  Takes the **viewer** for the same reason `scope_machines_for/2` does, and
+  gets it wrong without one: an author reading their own archive is shown their
+  own withheld posts, so dropping the quoted parent above their own reply to one
+  made a single page disagree with itself — the post stood there, and its quote
+  one row down did not.
   """
-  def public_ancestors(%Post{} = post) do
+  def public_ancestors(%Post{} = post, viewer \\ nil) do
     case reply_ref_state(post) do
-      {:parent, parent} -> if machines_allowed?(parent), do: [parent], else: []
+      {:parent, parent} -> if ancestor_shown?(parent, viewer), do: [parent], else: []
       _no_visible_parent -> []
     end
   end
 
+  defp ancestor_shown?(%Post{user_id: author_id}, %User{id: author_id})
+       when is_binary(author_id),
+       do: true
+
+  defp ancestor_shown?(parent, _viewer), do: machines_allowed?(parent)
+
   @doc """
-  The same question as a query (issue #2107) — the twin of
-  `machines_allowed?/1`, the way `organization_public_row/1` is the twin of
-  `Organizations.public_visible?/1`. Kept beside it so a widened boundary is
+  **The chokepoint: a post's body leaves this module toward a surface a machine
+  can read only through a query that has been piped through here** (issue
+  #2107).
+
+  The mandatory partner of `scope_visible/2`. That one answers "may this viewer
+  see it"; this one answers "may a **crawler** reading over their shoulder see
+  it", and the two are not the same question — a withheld post is public, it
+  simply is not for machines.
+
+  Why a scope and not a per-entry redaction: three rounds of review found three
+  more surfaces, and the last pair could not have been caught downstream at all.
+  `recent_posts_by_authors/3` selects `body:` into **bare maps**, which no
+  struct-taking helper can reach, and `pinned_post/2` fetches by id rather than
+  through a timeline, so no listing gate applied — both put the whole text of a
+  withheld post on `/:slug`, which is public, anonymous, in the sitemap and
+  carries no `X-Robots-Tag`. The sites cannot be enumerated; the property can,
+  so it is enforced at the one place a body can leave.
+
+  **Per row, and the author keeps their own.** Deliberately not a match on the
+  shape of the id list: `author_timeline_query/3` answers one profile *and*
+  `author_post_counts/2`'s figure for a page of accounts, so a list-shaped test
+  made the same member's posts count for them on `verify_credentials` and vanish
+  from a timeline's account list. The answer must not depend on how many authors
+  travelled with them.
+
+  `test/vutuv/post_body_chokepoint_test.exs` fails the build when a new query
+  carries a body past this without either piping through it or being named, with
+  a reason, as a surface that deliberately shows the text to a **person**.
+  """
+  def scope_machines_for(query, %User{id: viewer_id}),
+    do: where(query, [p], not p.noindex_noai? or p.user_id == ^viewer_id)
+
+  def scope_machines_for(query, _anonymous), do: scope_machines_allowed(query)
+
+  @doc """
+  The anonymous case of `scope_machines_for/2`, and the twin of
+  `machines_allowed?/1` the way `organization_public_row/1` is the twin of
+  `Organizations.public_visible?/1`. Kept beside them so a widened boundary is
   one edit here plus the struct predicate, rather than a column name spelled
   out in every module that has to ask.
+
+  Reach for it directly only where there is no viewer to make an exception for:
+  a sitemap, a feed, a topic page, somebody else's repost.
   """
   def scope_machines_allowed(query), do: where(query, [p], not p.noindex_noai?)
 
@@ -5469,6 +5519,14 @@ defmodule Vutuv.Posts do
   def pinned_post(%User{pinned_post_id: post_id}, viewer) do
     from(p in Post, where: p.id == ^post_id)
     |> scope_visible(viewer)
+    # …and the machines chokepoint. This one is fetched **by id** rather than
+    # through a timeline, so no listing gate ever reached it: `/:slug` carried
+    # the whole text of a withheld pinned post to an anonymous visitor while the
+    # same page's `profile.json` redacted it and the ActivityPub `featured`
+    # collection left it out — the HTML was the one surface of three that handed
+    # it over. Gating the query fixes all three at once, so the showcase slot
+    # simply stands empty rather than showing words it should not.
+    |> scope_machines_for(viewer)
     |> Repo.one()
     |> preload_post()
   end
@@ -5605,6 +5663,13 @@ defmodule Vutuv.Posts do
       |> where([post: p], p.user_id in ^author_ids and p.body != "")
       |> where([reply_ref: r], is_nil(r.id))
       |> scope_visible(viewer)
+      # …and the machines chokepoint, which this query needs more than any
+      # other: it selects `body:` into **bare maps**, so nothing downstream is
+      # struct-shaped and no per-entry redaction could ever have reached it. The
+      # rail renders on `/:slug`, which is public, anonymous and in the sitemap,
+      # so a withheld post stood there in full on every profile that suggested
+      # its author.
+      |> scope_machines_for(viewer)
       |> select([post: p], %{
         id: p.id,
         user_id: p.user_id,
@@ -5846,21 +5911,6 @@ defmodule Vutuv.Posts do
       do: query,
       else: where(query, [p], is_nil(p.frozen_at))
   end
-
-  # The archive's own half of the machines gate: kept for the author reading
-  # their own timeline, dropped for everybody else.
-  #
-  # Expressed **per row**, the way `scope_visible/2` expresses the same shape of
-  # exception, and deliberately not as a match on the id list: this query
-  # answers one profile timeline *and* `author_post_counts/2`'s figure for a
-  # whole page of authors, so a list-shaped test made the same member's own
-  # withheld posts count for them on `verify_credentials` (one id) and vanish
-  # from a timeline's account list (many ids). The answer must not depend on how
-  # many authors happened to travel with them.
-  defp scope_machines_for(query, %User{id: viewer_id}),
-    do: where(query, [p], not p.noindex_noai? or p.user_id == ^viewer_id)
-
-  defp scope_machines_for(query, _anonymous), do: scope_machines_allowed(query)
 
   # The same for a page's timeline, where "the author" is anyone who publishes
   # for it.

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -393,7 +393,7 @@ defmodule Vutuv.Posts do
 
     with :ok <- check_image_count(media.images),
          {:ok, changeset} <-
-           build_changeset(%Post{user_id: author.id}, attrs, denials, media) do
+           build_changeset(seed_post(author), attrs, denials, media) do
       case insert_post(changeset, media, nil, remote_target) do
         {:ok, post} ->
           post = preload_post(post)
@@ -419,6 +419,26 @@ defmodule Vutuv.Posts do
     end
   end
 
+  # The row a member's post starts from, carrying their standing answer about
+  # machines (issue #2107) **stamped at publish time**. This is the only place
+  # the setting is read: a rendered post answers from its own column, so
+  # changing the setting later leaves every older post exactly as it went out,
+  # and an edit keeps what the post already holds. An explicit `noindex_noai`
+  # attr (the API's) still wins, because `post_params/1` puts it as a change on
+  # top of this struct value.
+  #
+  # `Vutuv.Prefs.get/2` and not the column, so a member who was never asked
+  # follows the installation default (NULL = inherit). A post published for an
+  # organization deliberately does not take this: the page has its own `seo?`
+  # and `geo?`, and one team member's private posture must not silently mute
+  # the brand they publish for.
+  defp seed_post(%User{} = author) do
+    %Post{
+      user_id: author.id,
+      noindex_noai?: not Prefs.get(author, :posts_machines_allowed?)
+    }
+  end
+
   defp do_create_reply(%User{} = author, %Post{} = parent, attrs, note) do
     media = media_ids(attrs)
 
@@ -429,7 +449,7 @@ defmodule Vutuv.Posts do
          # params are dropped, so the public reply count and the parent-author
          # notification only ever concern content the author can see (issue #774).
          {:ok, changeset} <-
-           build_changeset(%Post{user_id: author.id}, attrs, [], media) do
+           build_changeset(seed_post(author), attrs, [], media) do
       case insert_post(changeset, media, parent, note) do
         {:ok, post} ->
           post = preload_post(post)
@@ -603,6 +623,10 @@ defmodule Vutuv.Posts do
         updated = %{preload_post(updated) | images_pending?: pending?}
 
         remember_license(updated.user, updated)
+        # An edit may carry a different answer about the files' metadata (the
+        # API's PATCH can; the composer does not offer it on an edit), so the
+        # served copies follow it here too.
+        Attachments.apply_metadata_choice(updated)
         # The edit can add a name, drop one, or (by changing the audience)
         # move a named member out of the post's reach: re-derive the set.
         sync_mentions(updated)
@@ -800,7 +824,9 @@ defmodule Vutuv.Posts do
     license: :license,
     layout: :gallery_layout,
     language: :language,
-    fill: :gallery_fill?
+    fill: :gallery_fill?,
+    noindex_noai: :noindex_noai?,
+    strip_metadata: :strip_metadata?
   ]
 
   defp post_params(attrs) do
@@ -860,23 +886,34 @@ defmodule Vutuv.Posts do
   # network, the PostRemoteReply sidecar) in one transaction, so post and
   # references land (or roll back) together.
   defp insert_post(changeset, media, parent, remote_target) do
-    Repo.transaction(fn ->
-      changeset
-      |> Ecto.Changeset.change(published_on: Vutuv.BerlinTime.today())
-      |> Repo.insert()
-      |> case do
-        {:ok, post} ->
-          attach_images!(post, media.images)
-          attach_video!(post, media.video)
-          attach_attachments!(post, media.attachments)
-          insert_reply_ref!(post, parent)
-          insert_remote_reply_ref!(post, remote_target)
-          mark_images_pending!(post)
+    result =
+      Repo.transaction(fn ->
+        changeset
+        |> Ecto.Changeset.change(published_on: Vutuv.BerlinTime.today())
+        |> Repo.insert()
+        |> case do
+          {:ok, post} ->
+            attach_images!(post, media.images)
+            attach_video!(post, media.video)
+            attach_attachments!(post, media.attachments)
+            insert_reply_ref!(post, parent)
+            insert_remote_reply_ref!(post, remote_target)
+            mark_images_pending!(post)
 
-        {:error, changeset} ->
-          Repo.rollback(changeset)
-      end
-    end)
+          {:error, changeset} ->
+            Repo.rollback(changeset)
+        end
+      end)
+
+    # After the commit, never inside it: this touches files, and a rolled-back
+    # transaction would leave a served copy the rows no longer explain. Skipped
+    # outright for a post carrying no file, which is nearly every post — the
+    # ids are right here, so the create path needs no query to know (issue
+    # #2107). The update path has no such free signal and legitimately asks.
+    with {:ok, post} <- result do
+      if media.attachments != [], do: Attachments.apply_metadata_choice(post)
+      {:ok, post}
+    end
   end
 
   defp insert_remote_reply_ref!(_post, nil), do: :ok
@@ -1717,6 +1754,61 @@ defmodule Vutuv.Posts do
   def restricted?(%Post{id: id}) do
     Repo.exists?(from(d in PostDenial, where: d.post_id == ^id))
   end
+
+  @doc """
+  Whether machines may have this post at all (issue #2107) — search engines,
+  AI crawlers and, the part an author would not guess, other servers.
+
+  The header a crawler reads is advisory and re-read on every visit, so a
+  `noindex, noai` post can still be served to people and simply asks the
+  crawler to stay away. **A federated copy is not like that**: it is handed to
+  a remote server that keeps it for ever, on which no header of ours has any
+  say. So an answer of "no machines" has to be a gate before delivery rather
+  than a directive attached to it, which is why `Vutuv.Fediverse` gates on this
+  column on every outbound path (the create clause matches it in a function
+  head, where a call cannot go) and the composer says so in words before the
+  post goes out.
+
+  Matches the **column**, never a preloaded association, so it answers for the
+  bare `%Post{}` a query hands over (CLAUDE.md's standing rule). Its query twin
+  is `scope_machines_allowed/1` — a function call is impossible inside a
+  `where`, so the two spellings travel together and are changed together.
+  """
+  def machines_allowed?(%Post{noindex_noai?: blocked?}), do: not blocked?
+
+  @doc """
+  The one-level parent a **public** page may quote above a reply card, `[]`
+  when that parent's author keeps machines out (issue #2107).
+
+  `/:slug/posts` and a tag timeline are crawl surfaces, which is why this
+  switch already drops a withheld post from the listing itself — so printing
+  one as the quoted parent of somebody else's reply put back exactly what the
+  listing had removed. It also ends a disagreement, since an archive entry
+  carries no ancestors and `VutuvWeb.AgentDocs.PostDoc.timeline_entry/1`
+  therefore renders `thread: []` for it: the page quoted everything and the
+  document quoted nothing.
+
+  Reads the preloaded `reply_ref`, so it costs no query. The **private** saved
+  hub (`/likes`, `/bookmarks`) deliberately does not call this and keeps the
+  card component's own fallback: no machine reads a login-only page, and the
+  promise is about machines rather than readers. The permalink's conversation
+  is unaffected for the same reason.
+  """
+  def public_ancestors(%Post{} = post) do
+    case reply_ref_state(post) do
+      {:parent, parent} -> if machines_allowed?(parent), do: [parent], else: []
+      _no_visible_parent -> []
+    end
+  end
+
+  @doc """
+  The same question as a query (issue #2107) — the twin of
+  `machines_allowed?/1`, the way `organization_public_row/1` is the twin of
+  `Organizations.public_visible?/1`. Kept beside it so a widened boundary is
+  one edit here plus the struct predicate, rather than a column name spelled
+  out in every module that has to ask.
+  """
+  def scope_machines_allowed(query), do: where(query, [p], not p.noindex_noai?)
 
   ## Likes, bookmarks, reposts
 
@@ -2781,6 +2873,11 @@ defmodule Vutuv.Posts do
   """
   def tag_posts_query(%Tag{} = tag) do
     from([post_tag: pt] in visible_tagged_posts_query(), where: pt.tag_id == ^tag.id)
+    # A tag page is a public topic surface with no owner to make an exception
+    # for, and it ships every body in full besides — so a post that refused
+    # machines (issue #2107) is simply not on it, in HTML or in any of its four
+    # agent formats. Attaching a tag must not be a way round the switch.
+    |> scope_machines_allowed()
   end
 
   @doc """
@@ -5396,6 +5493,9 @@ defmodule Vutuv.Posts do
   nothing — neither of search engines (`noindex?`) nor of AI use
   (`noai?`); an opted-out member's posts still serve through their own
   feed, which signals their choices per response.
+  A post whose **own** answer was no (`noindex_noai?`, issue #2107) is out
+  of both feeds: a member feed carries one all-yes signal for its author
+  and cannot signal around a single item either.
   Preloaded like every rendered post; ordered by creation (the UUID v7 id).
   """
   def recent_public_posts(author_or_all, opts \\ [])
@@ -5429,6 +5529,10 @@ defmodule Vutuv.Posts do
   # feed by. Without one this is the plain newest-first page it always was.
   defp recent_public(query, opts) do
     query
+    # Both feeds carry one all-yes Content-Signal for a whole list, so a post
+    # whose own answer was no is out of both. One gate here rather than one per
+    # clause: a third feed added later inherits it instead of forgetting it.
+    |> scope_machines_allowed()
     |> scope_visible(nil)
     |> Keyset.scope(opts)
     |> Repo.all()
@@ -5661,7 +5765,20 @@ defmodule Vutuv.Posts do
   def organization_posts_page(%Organization{} = organization, viewer, opts \\ []) do
     limit = Keyword.get(opts, :limit, @organization_posts_per_page)
     offset = Keyword.get(opts, :offset, 0)
-    query = organization_posts_query(organization, viewer)
+
+    # A post that refused machines (issue #2107) leaves the page's **listing**
+    # — and with it the RSS feed and the page's agent document, both of which
+    # quote the body in full under one all-yes signal for the whole list. Its
+    # own permalink still serves: the switch is about machines, not about
+    # hiding the post from people, which is exactly why this sits here and not
+    # in `organization_posts_query/2`, where it would have 404ed that page.
+    # The page's publishers keep seeing it in their own timeline, as they do a
+    # frozen one.
+    query =
+      organization
+      |> organization_posts_query(viewer)
+      |> scope_machines_for_page(organization, viewer)
+
     total = Repo.aggregate(query, :count)
 
     entries =
@@ -5730,6 +5847,29 @@ defmodule Vutuv.Posts do
       else: where(query, [p], is_nil(p.frozen_at))
   end
 
+  # The archive's own half of the machines gate: kept for the author reading
+  # their own timeline, dropped for everybody else.
+  #
+  # Expressed **per row**, the way `scope_visible/2` expresses the same shape of
+  # exception, and deliberately not as a match on the id list: this query
+  # answers one profile timeline *and* `author_post_counts/2`'s figure for a
+  # whole page of authors, so a list-shaped test made the same member's own
+  # withheld posts count for them on `verify_credentials` (one id) and vanish
+  # from a timeline's account list (many ids). The answer must not depend on how
+  # many authors happened to travel with them.
+  defp scope_machines_for(query, %User{id: viewer_id}),
+    do: where(query, [p], not p.noindex_noai? or p.user_id == ^viewer_id)
+
+  defp scope_machines_for(query, _anonymous), do: scope_machines_allowed(query)
+
+  # The same for a page's timeline, where "the author" is anyone who publishes
+  # for it.
+  defp scope_machines_for_page(query, organization, viewer) do
+    if match?(%User{}, viewer) and Organizations.publisher?(organization, viewer),
+      do: query,
+      else: scope_machines_allowed(query)
+  end
+
   defp scope_period(query, nil), do: query
 
   defp scope_period(query, {%Date{} = from, %Date{} = to}) do
@@ -5766,6 +5906,14 @@ defmodule Vutuv.Posts do
       )
       |> scope_visible(viewer)
       |> scope_original_kind(filter)
+      # A post that refused machines (issue #2107) leaves the public archive:
+      # that page ships every body in full, so a crawler reading `/:slug/posts`
+      # gets the whole of a post the switch was meant to keep from it, and its
+      # `.md`/`.json` siblings quote it under one all-yes signal. The **author**
+      # still sees it in their own archive — hiding somebody's post from their
+      # own page would be a different feature — which is also why this sits
+      # here rather than in the shared `scope_visible/2`.
+      |> scope_machines_for(viewer)
 
     reposts =
       from(p in Post,
@@ -5783,6 +5931,15 @@ defmodule Vutuv.Posts do
         }
       )
       |> scope_visible(viewer)
+      # …and the machines gate (issue #2107), which the originals leg above had
+      # and this one did not — so a repost carried a withheld post's whole body
+      # onto the reposter's public archive and its first line into the
+      # reposter's profile document, both of which a crawler reads. Flatly
+      # `scope_machines_allowed/1` and **not** `scope_machines_for/3`: the
+      # exception that leg makes is "the author reading their own archive", and
+      # on this leg the post belongs to somebody else entirely. Whoever reshared
+      # it never gave the answer and cannot overrule it.
+      |> scope_machines_allowed()
 
     # A third leg (issue #1166): posts from another network this member shared
     # onward. Same five columns as the others so the union holds, with
@@ -7124,11 +7281,16 @@ defmodule Vutuv.Posts do
                :body,
                :tags,
                :license,
+               # `:language` was missing here, so changing it on an existing
+               # draft row was silently dropped — it only ever landed on the
+               # first insert.
+               :language,
                :image_ids,
                :video_id,
                :photos,
                :layout,
                :fill?,
+               :strip_metadata?,
                :updated_at
              ]},
           conflict_target: draft_conflict_target(context)
@@ -7815,8 +7977,19 @@ defmodule Vutuv.Posts do
 
   ## Param helpers (attrs arrive with atom keys from code, string keys from forms)
 
+  # A **present** atom key wins, whatever it holds — `||` could not carry a
+  # `false`, so an atom-keyed `false` fell through to the string key, found
+  # nothing, and read as "the caller did not send this". Every attrs map the
+  # composer builds is atom-keyed (a parked post's is not: it round-trips
+  # through JSONB), so the composer's "no" to a boolean switch was dropped on
+  # the publish-now path and kept on the parked one — the switch worked or not
+  # depending on how fast the file finished. `gallery_fill?` had the same hole
+  # since it was added.
   defp fetch(attrs, key) when is_map(attrs) and is_atom(key) do
-    Map.get(attrs, key) || Map.get(attrs, Atom.to_string(key))
+    case attrs do
+      %{^key => value} -> value
+      _string_keyed -> Map.get(attrs, Atom.to_string(key))
+    end
   end
 
   defp parse_ids(ids) when is_list(ids),

--- a/lib/vutuv/posts/pending.ex
+++ b/lib/vutuv/posts/pending.ex
@@ -585,9 +585,22 @@ defmodule Vutuv.Posts.Pending do
   @doc """
   Publishes the waiting text as it is, without whatever was refused — the
   clip, the files, or both. Those go with their bytes.
+
+  The "would this actually publish anything?" question is asked **here**, not
+  only in the card that offers the button: `leftover?/2` was a template
+  condition, so the API path could ask for a publish the create path then
+  refuses, and the author got the opaque "could not be published" row this
+  check exists to prevent. `{:error, :nothing_left}` says which of the two it
+  was — nothing survives the refusal, or something that is not refused is
+  still being worked on.
   """
-  def publish_without_refused(%PendingPost{status: "waiting"} = pending),
-    do: Publisher.publish(pending, without_refused: true)
+  def publish_without_refused(%PendingPost{status: "waiting"} = pending) do
+    if reading(pending).publishable_without_refused? do
+      Publisher.publish(pending, without_refused: true)
+    else
+      {:error, :nothing_left}
+    end
+  end
 
   def publish_without_refused(%PendingPost{}), do: {:error, :not_waiting}
 

--- a/lib/vutuv/posts/post.ex
+++ b/lib/vutuv/posts/post.ex
@@ -50,6 +50,28 @@ defmodule Vutuv.Posts.Post do
     # publishing, and a per-photo licence picker would be a forest of selects
     # for a case nobody has.
     field(:license, :string, default: "arr")
+
+    # The author's answer to "may search engines and AI see this post?"
+    # (issue #2107), true meaning **no**. One switch for both machine
+    # audiences, where a member has two (`noindex?` / `noai?`): a post is one
+    # act of publishing, and asking twice per post would be a forest of
+    # checkboxes for a distinction nobody draws about a single post.
+    #
+    # It covers everything the post is — the words, the pictures, the files
+    # and the `.md`/`.json`/`.xml` siblings — and it is the one flag with a
+    # consequence the author would not guess: a post that says no is not
+    # handed to the Fediverse at all, because a remote server keeps its copy
+    # for ever and no `X-Robots-Tag` reaches it. `Vutuv.Posts.machines_allowed?/1`
+    # is where that is read; the composer says it in words before publishing.
+    field(:noindex_noai?, :boolean, default: false)
+
+    # Whether the files posted together should have their metadata removed —
+    # the author name, the software and the dates a PDF carries (issue #2107).
+    # On the post rather than the file, as the licence is: a set of files
+    # posted together is one act of publishing. This is the *answer*; what
+    # actually happened to a given file is `attachments.metadata_stripped_at`.
+    field(:strip_metadata?, :boolean, default: true)
+
     # The archive coordinate (/:slug/posts/2026/06/06): the UTC date at
     # insert time, set programmatically, never cast from params. The
     # permalink itself is the post id (a UUID v7).
@@ -140,7 +162,17 @@ defmodule Vutuv.Posts.Post do
     post
     # empty_values: [] so clearing the body on edit is a real change ("" must
     # not be swallowed as "no change") — a photo-only post has an empty body.
-    |> cast(params, [:body, :license, :gallery_layout, :gallery_fill?, :language],
+    |> cast(
+      params,
+      [
+        :body,
+        :license,
+        :gallery_layout,
+        :gallery_fill?,
+        :language,
+        :noindex_noai?,
+        :strip_metadata?
+      ],
       empty_values: []
     )
     |> update_change(:body, &String.trim/1)

--- a/lib/vutuv/posts/post_draft.ex
+++ b/lib/vutuv/posts/post_draft.ex
@@ -64,6 +64,12 @@ defmodule Vutuv.Posts.PostDraft do
     # Whether the bento tiles are filled (cropped) rather than showing whole
     # photos — the composer's fit pair, default whole.
     field(:fill?, :boolean, default: false)
+    # The composer's metadata switch (issue #2107), nullable rather than
+    # defaulted: `nil` means this draft predates it (or was written before the
+    # switch was touched), and the composer then falls back to its own default
+    # rather than to a stored `false` that nobody chose. The machines question
+    # has no column here — it is not asked in the composer.
+    field(:strip_metadata?, :boolean)
 
     timestamps()
   end
@@ -89,7 +95,8 @@ defmodule Vutuv.Posts.PostDraft do
       :video_id,
       :photos,
       :layout,
-      :fill?
+      :fill?,
+      :strip_metadata?
     ])
     |> validate_length(:body, max: Post.max_body_length())
     |> validate_length(:tags, max: @max_tags_length)

--- a/lib/vutuv/prefs.ex
+++ b/lib/vutuv/prefs.ex
@@ -77,6 +77,24 @@ defmodule Vutuv.Prefs do
     # same card. An installation that wants the opposite posture flips this one
     # default at /admin/preferences and every untouched member follows.
     %Pref{key: :like_attribution?, type: :boolean, default: true, group: :privacy},
+    # Whether search engines and AI crawlers may read this member's posts
+    # (issue #2107). Asked once here rather than per post in the composer, and
+    # **stamped onto each post as it is published** (`posts.noindex_noai?`), so
+    # changing it later leaves every older post exactly as it went out. It is
+    # therefore the default for new posts, never a live filter over old ones.
+    #
+    # A pref rather than a `users` column on purpose. The two crawler opt-outs
+    # beside it (`noindex?`/`noai?`) carry hard column defaults, and `noai?`'s
+    # is `true` — so 5,867 of 6,026 members on the dev copy of production
+    # "carry" an answer nobody ever gave, and nothing can tell that from a real
+    # one. NULL here means "never asked", which is what lets an installation
+    # move the default (an intranet may well want the opposite posture) without
+    # touching a single member row.
+    #
+    # Positively named, unlike its two neighbours on the same settings page:
+    # `Vutuv.Prefs` booleans are stored as they read, and mixing an opt-out
+    # column into that card is how an inverted checkbox gets flipped.
+    %Pref{key: :posts_machines_allowed?, type: :boolean, default: true, group: :privacy},
     # What the feed does with posts outside the member's chosen languages
     # (issue #1461): show the original (shipped default), auto-translate into
     # the UI language, or hide them. The chosen-languages list itself is a
@@ -208,6 +226,9 @@ defmodule Vutuv.Prefs do
   def label(:like_attribution?),
     do: Gettext.gettext(VutuvWeb.Gettext, "Show my name on posts I like")
 
+  def label(:posts_machines_allowed?),
+    do: Gettext.gettext(VutuvWeb.Gettext, "Search engines and AI may read my posts")
+
   def label(:feed_foreign_posts),
     do: Gettext.gettext(VutuvWeb.Gettext, "Posts in other languages")
 
@@ -276,6 +297,22 @@ defmodule Vutuv.Prefs do
       Gettext.gettext(
         VutuvWeb.Gettext,
         "When off, other members no longer see you among the likes of a post. The author of the post still does: we named you in the notification they got when you liked it. Either way the post keeps the same number of likes."
+      )
+
+  # Three things a member cannot find out afterwards, so the hint says all
+  # three here (issue #2107): the answer is taken at publish time and older
+  # posts keep theirs, it covers everything a post is rather than the words
+  # alone, and — the one nobody would guess — saying no also keeps the post off
+  # the other networks entirely. A header is advisory and re-read on every
+  # visit; a copy on somebody else's server is neither, and no instruction of
+  # ours reaches it, so "no machines" has to be a gate before delivery rather
+  # than a directive attached to it. The composer used to say this in a warning
+  # panel; the decision is made here now, so the sentence lives here.
+  def hint(:posts_machines_allowed?),
+    do:
+      Gettext.gettext(
+        VutuvWeb.Gettext,
+        "Covers the words, the pictures, the files and the machine formats of every post you write from now on. When off, your new posts also stay out of other networks completely: a server elsewhere keeps its copy for good and no instruction of ours reaches it. Posts you have already published keep the answer they went out with."
       )
 
   def hint(:date_region),

--- a/lib/vutuv/sitemap.ex
+++ b/lib/vutuv/sitemap.ex
@@ -287,6 +287,9 @@ defmodule Vutuv.Sitemap do
     |> Posts.scope_visible(nil)
     |> join(:inner, [p], u in assoc(p, :user))
     |> where([p, u], account_confirmed_row(u) and not u.noindex?)
+    # The post's own answer, beside its author's (issue #2107): a sitemap entry
+    # is an invitation to index exactly what the switch declined.
+    |> Posts.scope_machines_allowed()
   end
 
   # A post published in an organization's name (issue #1334) is public by
@@ -297,6 +300,7 @@ defmodule Vutuv.Sitemap do
     |> join(:inner, [p], o in Organization, on: o.id == p.organization_id)
     |> where([p, o], o.status == "active" and is_nil(o.frozen_at) and o.seo?)
     |> where([p], is_nil(p.frozen_at))
+    |> Posts.scope_machines_allowed()
   end
 
   defp chunks(0), do: 0

--- a/lib/vutuv/uploaders/attachment_store.ex
+++ b/lib/vutuv/uploaders/attachment_store.ex
@@ -10,10 +10,11 @@ defmodule Vutuv.AttachmentStore do
       <uploads_dir_prefix>/attachments/<token>/file.<ext>            the served copy
       <uploads_dir_prefix>/originals/attachments/<token>/original.<ext>   the upload, verbatim
 
-  They are byte-identical today. They are still two files, because the served
-  copy is the one #2107 rewrites when an author asks for the metadata to be
-  removed, and the promise the private tree makes — that what the member sent
-  is kept exactly as they sent it — has to survive that.
+  The served copy is the one `Vutuv.Attachments.Metadata` rewrites when a PDF
+  has its author, its software and its dates taken out (#2107) — a derivation
+  of the original, so the answer can be changed either way afterwards. The
+  private tree keeps its promise through all of it: what the member sent is
+  what is stored there, byte for byte.
 
   The served copy is written beside its target and renamed, so a process
   killed mid-copy leaves no half file a proxy could hand out.
@@ -63,11 +64,54 @@ defmodule Vutuv.AttachmentStore do
   end
 
   defp write_served(token, path, ext) do
+    write_at(Path.join(dir(token), @served_name <> ext), path)
+  end
+
+  @doc """
+  Replaces the served copy with the bytes at `path`, keeping its extension —
+  what the metadata strip and its undo write through (issue #2107). Beside and
+  renamed like the first write, so a proxy never hands out half a file. `:ok`
+  even when there is no served copy to replace: the file is gone, and a caller
+  deriving a copy of nothing has nothing to do.
+  """
+  def replace_served(token, path) when is_binary(path) do
+    case served_path(token) do
+      nil -> :ok
+      dest -> write_at(dest, path)
+    end
+  end
+
+  @doc """
+  A scratch path **inside** the served copy's own directory, for a tool that
+  writes a whole new file (`Vutuv.Attachments.Metadata`'s qpdf run). Beside the
+  target on purpose: `commit_scratch/2` can then rename rather than copy, which
+  costs nothing where a copy costs the whole file twice over, and a rename is
+  only atomic within one filesystem. The name cannot collide with the served
+  copy's own `file.<ext>`, so `served_path/1` never picks one up.
+  """
+  def scratch_path(token) do
     dir = dir(token)
     File.mkdir_p!(dir)
-    dest = Path.join(dir, @served_name <> ext)
+    Path.join(dir, "scratch.#{System.unique_integer([:positive])}")
+  end
+
+  @doc """
+  Makes `scratch` the served copy, or drops it when there is nothing to replace
+  (the file was deleted while the tool ran). `:ok` either way.
+  """
+  def commit_scratch(token, scratch) do
+    case served_path(token) do
+      nil -> File.rm(scratch)
+      dest -> File.rename!(scratch, dest)
+    end
+
+    :ok
+  end
+
+  defp write_at(dest, source) do
+    File.mkdir_p!(Path.dirname(dest))
     temp = "#{dest}.#{System.unique_integer([:positive])}"
-    File.cp!(path, temp)
+    File.cp!(source, temp)
     File.rename!(temp, dest)
   end
 

--- a/lib/vutuv_web/agent_docs/feed_doc.ex
+++ b/lib/vutuv_web/agent_docs/feed_doc.ex
@@ -43,7 +43,12 @@ defmodule VutuvWeb.AgentDocs.FeedDoc do
       viewer: AgentDocs.person_ref(viewer),
       more: page.more?,
       next_cursor: ApiV2.encode_cursor(page.more? && page.next_cursor),
-      posts: Enum.map(page.entries, &PostDoc.timeline_entry/1)
+      # The viewer travels with the row (issue #2107). This document is
+      # login-only and declares `noindex: true, noai: true` over the whole
+      # response, so a withheld post needs no redaction here — the member can
+      # open it and read every word one click further, and handing them "Post
+      # not open to search engines" would take something away for nothing.
+      posts: Enum.map(page.entries, &PostDoc.timeline_entry(&1, viewer))
     })
   end
 end

--- a/lib/vutuv_web/agent_docs/list_docs.ex
+++ b/lib/vutuv_web/agent_docs/list_docs.ex
@@ -121,7 +121,9 @@ defmodule VutuvWeb.AgentDocs.ListDocs do
       also_known_as: tag |> Tag.aliases_of() |> Enum.map(& &1.name),
       most_endorsed_users: Enum.map(recommended_users, &person_entry(&1, work_info_by_id)),
       post_count: post_count,
-      posts: Enum.map(entries, &PostDoc.timeline_entry/1),
+      # `nil`: a tag page is the anonymous public view whatever the reader's
+      # session, so a withheld post is redacted here (issue #2107).
+      posts: Enum.map(entries, &PostDoc.timeline_entry(&1, nil)),
       open_positions: Enum.map(open_positions, &JobPostingDoc.summary/1),
       jobs_url: AgentDocs.abs_url("/jobs?" <> URI.encode_query(%{"tag" => tag.slug}))
     })

--- a/lib/vutuv_web/agent_docs/post_doc.ex
+++ b/lib/vutuv_web/agent_docs/post_doc.ex
@@ -54,6 +54,19 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
     do: {restricted? or author.noindex?, restricted? or author.noai?}
 
   @doc """
+  The same for one post, which has an answer of its own (issue #2107). It only
+  ever adds: the post's switch closes **both** axes at once — it is one
+  question about machines, where a member has two — and nothing about a post
+  can re-open what its author closed.
+  """
+  def robots_axes(author, %Post{} = post, restricted?) do
+    {noindex?, noai?} = robots_axes(author, restricted?)
+    blocked? = not Posts.machines_allowed?(post)
+
+    {noindex? or blocked?, noai? or blocked?}
+  end
+
+  @doc """
   The permalink page: the post itself plus its visible replies. Anonymous
   by default; `viewer:` switches the reply list (and its count) to what
   that user sees — the authenticated `/api/2.0` reads. Never pass a viewer
@@ -63,7 +76,7 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
     viewer = Keyword.get(opts, :viewer)
     replies = Posts.list_replies(post, viewer)
     %{posts: thread, truncated?: thread_truncated?} = Posts.list_thread(post, viewer)
-    {noindex?, noai?} = robots_axes(author, Posts.restricted?(post))
+    {noindex?, noai?} = robots_axes(author, post, Posts.restricted?(post))
     engagement = Posts.engagement_counts(post.id)
     counts = Posts.shown_counts(engagement)
 
@@ -186,9 +199,17 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
     %{posts: thread, truncated?: thread_truncated?} = Posts.list_thread(post, nil)
     remote_replies = [post.id] |> Fediverse.list_notes(nil) |> remote_entries(post.id)
 
+    # The page's two switches **and the post's own** (issue #2107). A page post
+    # carries the same answer a member's does — the composer offers the switch
+    # whoever is being published for — and without this half the document
+    # declared `ai-train=yes` over the whole body of a post that had refused
+    # exactly that. `or` and not a replacement: a page that opted out is not
+    # re-opened by a post that did not.
+    blocked? = not Posts.machines_allowed?(post)
+
     AgentDocs.doc_meta("organization_post", Posts.path(post),
-      noindex: not organization.seo?,
-      noai: not organization.geo?
+      noindex: not organization.seo? or blocked?,
+      noai: not organization.geo? or blocked?
     )
     |> Map.merge(%{
       id: post.id,
@@ -335,7 +356,7 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       # internal, exactly as on the HTML card. Reposters can be pages too.
       author: UserHelpers.author_name(post),
       published_on: post.published_on,
-      excerpt: PostTeaser.line(post),
+      excerpt: PostTeaser.machine_line(post),
       # Same reason as the remote clause above (issue #1163), pointed the other
       # way: a vutuv post can be a photograph and nothing else, its body is then
       # genuinely empty and `PostTeaser.line/1` answers "" — so the HTML archive
@@ -403,7 +424,7 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
         url: AgentDocs.abs_url(Posts.path(post)),
         author: UserHelpers.author_name(post),
         published_on: post.published_on,
-        excerpt: PostTeaser.line(post)
+        excerpt: PostTeaser.machine_line(post)
       }
     end)
   end
@@ -495,7 +516,7 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
         # it either way.
         author_username: author_username(Posts.author(post)),
         published_on: post.published_on,
-        body_markdown: post.body,
+        body_markdown: PostTeaser.machine_body(post),
         depth: depths[post.id],
         in_reply_to_id: parent_id,
         in_reply_to_author: parent_id && authors[parent_id]
@@ -562,7 +583,7 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       author: UserHelpers.full_name(reply.user),
       author_username: reply.user.username,
       published_on: reply.published_on,
-      body_markdown: reply.body
+      body_markdown: PostTeaser.machine_body(reply)
     }
   end
 

--- a/lib/vutuv_web/agent_docs/post_doc.ex
+++ b/lib/vutuv_web/agent_docs/post_doc.ex
@@ -128,13 +128,13 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       # list. The page has always shown the true count beside a window of the
       # thread; this document does the same, and `replies` below is that window.
       reply_count: counts.replies,
-      replies: Enum.map(replies, &reply_entry/1),
+      replies: Enum.map(replies, &reply_entry(&1, viewer)),
       # The whole conversation the HTML permalink renders (issue #1006), in
       # the same reading order (the reply tree depth-first, issue #1027);
       # every entry carries its parent pointer and its nesting depth, so the
       # tree is recoverable without re-deriving it. `replies` above stays the
       # one-level list for API consumers that relied on it.
-      thread: thread_entries(thread),
+      thread: thread_entries(thread, viewer),
       thread_truncated: thread_truncated?,
       # The public engagement counters the HTML action bar shows to everyone —
       # vutuv's own tally **and** what other networks did, in one figure each,
@@ -228,8 +228,8 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       # Counted off the two loaded lists rather than re-queried, the same way
       # `build/3` does it, so the figure and the entries under it cannot drift.
       reply_count: length(replies) + length(remote_replies),
-      replies: Enum.map(replies, &reply_entry/1),
-      thread: thread_entries(thread),
+      replies: Enum.map(replies, &reply_entry(&1, nil)),
+      thread: thread_entries(thread, nil),
       thread_truncated: thread_truncated?,
       like_count: counts.likes,
       # A liker is a member or a page (issue #1410); the md/txt renderers read
@@ -266,7 +266,7 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       author: Vutuv.Identity.ref(author),
       period: period_label,
       total: total,
-      posts: Enum.map(entries, &timeline_entry/1)
+      posts: Enum.map(entries, &timeline_entry(&1, nil))
     })
   end
 
@@ -310,8 +310,17 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
   `reposters` is every reposter behind the entry (the feed carries the whole
   follow-scoped roster; the archive a single one), newest first, as names —
   `reposted_by` stays the newest for callers that want just the one name.
+
+  `viewer` decides whether a withheld post keeps its words (issue #2107) and
+  **defaults to `nil`, the redacting side**: a caller that forgets it
+  over-redacts rather than leaks, which is the only direction a safety gate may
+  fail in. Pass a member only where the document is login-gated and per-viewer —
+  `VutuvWeb.AgentDocs.FeedDoc` and the `/api/2.0` reads — because there the
+  reader can open the post and read every word anyway.
   """
-  def timeline_entry(%{remote_post: %RemotePost{} = remote} = entry) do
+  def timeline_entry(entry, viewer \\ nil)
+
+  def timeline_entry(%{remote_post: %RemotePost{} = remote} = entry, _viewer) do
     entry
     |> remote_timeline_entry(remote)
     |> Map.merge(%{
@@ -333,7 +342,7 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
   #
   # A note is a reply and nothing more: no cached pictures of its own and
   # nothing it quotes, so it takes the shared shape unchanged.
-  def timeline_entry(%{note: %Note{} = note} = entry),
+  def timeline_entry(%{note: %Note{} = note} = entry, _viewer),
     do: remote_timeline_entry(entry, note)
 
   # The **third** remote row shape (issue #2127): a post one of the reader's
@@ -341,13 +350,13 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
   # else, so like a note it takes the shared shape unchanged — what is new is
   # `found_via`, the server we read it from, which is not where its author
   # lives and is the one fact this row carries that no other does.
-  def timeline_entry(%{external_post: %ExternalPost{} = post} = entry) do
+  def timeline_entry(%{external_post: %ExternalPost{} = post} = entry, _viewer) do
     entry
     |> remote_timeline_entry(post)
     |> Map.put(:found_via, post.source)
   end
 
-  def timeline_entry(%{post: post} = entry) do
+  def timeline_entry(%{post: post} = entry, viewer) do
     %{
       id: post.id,
       url: AgentDocs.abs_url(Posts.path(post)),
@@ -356,7 +365,7 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       # internal, exactly as on the HTML card. Reposters can be pages too.
       author: UserHelpers.author_name(post),
       published_on: post.published_on,
-      excerpt: PostTeaser.machine_line(post),
+      excerpt: PostTeaser.machine_line(post, viewer),
       # Same reason as the remote clause above (issue #1163), pointed the other
       # way: a vutuv post can be a photograph and nothing else, its body is then
       # genuinely empty and `PostTeaser.line/1` answers "" — so the HTML archive
@@ -371,7 +380,7 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       # stacks them above the answer. This document drew the answer alone, so
       # the post it replied to was on no page of the feed at all and never came
       # back: the cursor had already walked past it.
-      thread: thread_context(entry)
+      thread: thread_context(entry, viewer)
     }
   end
 
@@ -417,14 +426,14 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
   # The conversation folded into a local row, oldest first — each post as the
   # same four facts the entry line carries, so a reader meets one shape twice
   # rather than two. `Posts.feed_subjects/1` is what says this must exist.
-  defp thread_context(entry) do
+  defp thread_context(entry, viewer) do
     Enum.map(entry[:ancestors] || [], fn post ->
       %{
         id: post.id,
         url: AgentDocs.abs_url(Posts.path(post)),
         author: UserHelpers.author_name(post),
         published_on: post.published_on,
-        excerpt: PostTeaser.machine_line(post)
+        excerpt: PostTeaser.machine_line(post, viewer)
       }
     end)
   end
@@ -496,7 +505,7 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
   # branch's parent without another lookup, and `depth` is how deep the entry
   # hangs in the thread — the nesting the HTML page draws, as a number the
   # other formats can indent by.
-  defp thread_entries(posts) do
+  defp thread_entries(posts, viewer) do
     # `UserHelpers.author_name/1`, not `full_name/1`: a conversation can hold a
     # post published in a page's name (issue #1336 — a member may answer one),
     # and `full_name/1` raised on it, so the `.md`/`.txt`/`.json`/`.xml` sibling
@@ -516,7 +525,7 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
         # it either way.
         author_username: author_username(Posts.author(post)),
         published_on: post.published_on,
-        body_markdown: PostTeaser.machine_body(post),
+        body_markdown: PostTeaser.machine_body(post, viewer),
         depth: depths[post.id],
         in_reply_to_id: parent_id,
         in_reply_to_author: parent_id && authors[parent_id]
@@ -577,13 +586,13 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
     end)
   end
 
-  defp reply_entry(%Post{} = reply) do
+  defp reply_entry(%Post{} = reply, viewer) do
     %{
       url: AgentDocs.abs_url(Posts.path(reply)),
       author: UserHelpers.full_name(reply.user),
       author_username: reply.user.username,
       published_on: reply.published_on,
-      body_markdown: PostTeaser.machine_body(reply)
+      body_markdown: PostTeaser.machine_body(reply, viewer)
     }
   end
 

--- a/lib/vutuv_web/agent_docs/profile_doc.ex
+++ b/lib/vutuv_web/agent_docs/profile_doc.ex
@@ -180,7 +180,7 @@ defmodule VutuvWeb.AgentDocs.ProfileDoc do
       # nil otherwise. An agent handing a human "where else can I follow this
       # person" needs exactly the handle; the actor URL is the machine sibling.
       fediverse: fediverse_entry(user),
-      posts: post_entries(pinned_post, posts)
+      posts: post_entries(pinned_post, posts, viewer)
     })
     |> Map.merge(birthday_fields(user))
     |> maybe_include_photo(user, opts)
@@ -340,22 +340,22 @@ defmodule VutuvWeb.AgentDocs.ProfileDoc do
   # The profile's post list: the pinned post first (issue #1110), then the
   # timeline without it — one post, listed once, the way the page shows it.
   # A repost of the pinned post stays: it is a different timeline event.
-  defp post_entries(nil, entries), do: Enum.map(entries, &post_entry/1)
+  defp post_entries(nil, entries, viewer), do: Enum.map(entries, &post_entry(&1, viewer))
 
-  defp post_entries(pinned_post, entries) do
+  defp post_entries(pinned_post, entries, viewer) do
     rest =
       Enum.reject(
         entries,
         &(is_nil(&1.reposted_by) and not remote?(&1) and &1.post.id == pinned_post.id)
       )
 
-    [pinned_entry(pinned_post) | Enum.map(rest, &post_entry/1)]
+    [pinned_entry(pinned_post, viewer) | Enum.map(rest, &post_entry(&1, viewer))]
   end
 
   defp remote?(entry), do: Vutuv.Posts.remote_feed_entry?(entry)
 
-  defp pinned_entry(post) do
-    %{post: post, reposted_by: nil} |> post_entry() |> Map.put(:pinned, true)
+  defp pinned_entry(post, viewer) do
+    %{post: post, reposted_by: nil} |> post_entry(viewer) |> Map.put(:pinned, true)
   end
 
   # A post from another network this member reshared (issue #1166). It has no
@@ -363,7 +363,7 @@ defmodule VutuvWeb.AgentDocs.ProfileDoc do
   # lives — the same shape `PostDoc.timeline_entry/1` produces for the feed's
   # remote entries, and the reason this clause exists at all: without it every
   # agent-format sibling of a profile with one reshare on it raised.
-  defp post_entry(%{remote_post: %RemotePost{} = remote} = entry) do
+  defp post_entry(%{remote_post: %RemotePost{} = remote} = entry, _viewer) do
     %{
       url: RemotePost.origin(remote),
       published_on: DateTime.to_date(remote.published_at),
@@ -386,11 +386,11 @@ defmodule VutuvWeb.AgentDocs.ProfileDoc do
   # the **pinned** post is fetched by id and reaches this line whatever it
   # says, so the one sentence the archive and the tag page use is what a
   # showcased post that refused machines gives instead of its first line.
-  defp post_entry(entry) do
+  defp post_entry(entry, viewer) do
     %{
       url: AgentDocs.abs_url(Vutuv.Posts.path(entry.post)),
       published_on: entry.post.published_on,
-      excerpt: PostTeaser.machine_line(entry.post),
+      excerpt: PostTeaser.machine_line(entry.post, viewer),
       reposted_by: entry.reposted_by && UserHelpers.full_name(entry.reposted_by),
       pinned: false
     }

--- a/lib/vutuv_web/agent_docs/profile_doc.ex
+++ b/lib/vutuv_web/agent_docs/profile_doc.ex
@@ -378,11 +378,19 @@ defmodule VutuvWeb.AgentDocs.ProfileDoc do
     }
   end
 
+  # `PostTeaser.machine_line/1` and not `PostTeaser.line/1` (issue #2107): a
+  # profile document is one of the machine surfaces that carries a single
+  # all-yes `Content-Signal` for a whole list and cannot signal per row. The
+  # timeline's own withheld posts are already gone by the time they get here —
+  # `Posts.profile_posts/2` scopes them out for anybody but their author — but
+  # the **pinned** post is fetched by id and reaches this line whatever it
+  # says, so the one sentence the archive and the tag page use is what a
+  # showcased post that refused machines gives instead of its first line.
   defp post_entry(entry) do
     %{
       url: AgentDocs.abs_url(Vutuv.Posts.path(entry.post)),
       published_on: entry.post.published_on,
-      excerpt: PostTeaser.line(entry.post),
+      excerpt: PostTeaser.machine_line(entry.post),
       reposted_by: entry.reposted_by && UserHelpers.full_name(entry.reposted_by),
       pinned: false
     }

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -4395,7 +4395,7 @@ defmodule VutuvWeb.PostComponents do
   # permalink, where the parent is the page) or the post is not a reply.
   #
   # Policy-free on purpose: a **public** surface passes `ancestors` from
-  # `Posts.public_ancestors/1`, which drops a parent whose author keeps machines
+  # `Posts.public_ancestors/2`, which drops a parent whose author keeps machines
   # out (issue #2107). Putting that test here instead would have applied it to
   # the private saved hub (`/likes`, `/bookmarks`) as well, where no machine
   # reads anything and a member would have lost the quoted parent of their own

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -4393,6 +4393,13 @@ defmodule VutuvWeb.PostComponents do
   # Fallback when a caller does not compute the full visible chain: the single
   # preloaded `reply_ref` parent (one level), or none when nesting is off (the
   # permalink, where the parent is the page) or the post is not a reply.
+  #
+  # Policy-free on purpose: a **public** surface passes `ancestors` from
+  # `Posts.public_ancestors/1`, which drops a parent whose author keeps machines
+  # out (issue #2107). Putting that test here instead would have applied it to
+  # the private saved hub (`/likes`, `/bookmarks`) as well, where no machine
+  # reads anything and a member would have lost the quoted parent of their own
+  # bookmarked reply.
   defp one_level_ancestors(_post, false), do: []
 
   defp one_level_ancestors(post, true) do

--- a/lib/vutuv_web/components/ui.ex
+++ b/lib/vutuv_web/components/ui.ex
@@ -5619,8 +5619,11 @@ defmodule VutuvWeb.UI do
       {gettext("Privacy"),
        [
          row(:privacy, gettext("Visibility"), ~p"/settings/privacy",
-           hint: gettext("Search engines, AI, online status"),
-           terms: gettext("privacy google search engine ai llm crawler noindex online dot public")
+           hint: gettext("Search engines and AI, your posts, online status"),
+           terms:
+             gettext(
+               "privacy google search engine ai llm crawler noindex online dot public posts beiträge indexieren fediverse mastodon suchmaschine"
+             )
          ),
          row(:blocks, gettext("Blocked members"), ~p"/blocks",
            hint: gettext("People who cannot interact with you"),

--- a/lib/vutuv_web/content_policy.ex
+++ b/lib/vutuv_web/content_policy.ex
@@ -70,6 +70,34 @@ defmodule VutuvWeb.ContentPolicy do
     end
   end
 
+  @doc """
+  The header **and** the matching `<meta name="robots">`, from one derivation.
+
+  `VutuvWeb.LayoutHTML.robots_directives/1` falls back to the member the page is
+  about, which is an answer a page whose own axes are narrower than its member's
+  does not have — an organization post, or a member post that is withheld or
+  followers-only. Stamping only the header then leaves the tag saying something
+  else, which is the drift `VutuvWeb.AgentDocs.PostDoc` records happening once
+  already.
+
+  The assign is **skipped on `nil`** rather than written as `nil`: an assigned
+  `nil` matches the layout's first clause and would suppress the member fallback
+  for every page that has nothing of its own to declare.
+
+  Deliberately additive. The layout's docstring argues this belongs inside
+  `put_robots_header/3` for all thirteen of its call sites, which would start
+  rendering a tag on pages that have never had one (`/:slug/links`,
+  `/:slug/cv`); that is a change to those pages, not to this one.
+  """
+  def put_robots(conn, noindex?, noai?) do
+    conn = put_robots_header(conn, noindex?, noai?)
+
+    case robots_directives(noindex?, noai?) do
+      nil -> conn
+      directives -> Plug.Conn.assign(conn, :robots_directives, directives)
+    end
+  end
+
   @doc false
   def render_signals(train?, search?, input?) do
     "ai-train=#{yn(train?)}, search=#{yn(search?)}, ai-input=#{yn(input?)}"

--- a/lib/vutuv_web/controllers/organization_controller.ex
+++ b/lib/vutuv_web/controllers/organization_controller.ex
@@ -231,8 +231,14 @@ defmodule VutuvWeb.OrganizationController do
         # every post a page had ever federated. The member permalink
         # (`VutuvWeb.PostController`) has answered the same request with the
         # Note from the start; this is that arrangement for a page.
+        # …and the post's own answer about machines (issue #2107), which a page
+        # post carries exactly as a member's does: the composer offers the
+        # switch whoever is being published for. `maybe_federate/3` already
+        # withholds the delivery, so without this the Note was refused to the
+        # followers it was meant for and handed in full to anyone who asked
+        # for the same URL — which is no withholding at all.
         FediverseController.ap_request?(conn) and Fediverse.federated?(organization) and
-            not Posts.moderation_hidden?(post) ->
+          Posts.machines_allowed?(post) and not Posts.moderation_hidden?(post) ->
           send_note(conn, organization, post)
 
         FediverseController.ap_request?(conn) ->
@@ -261,9 +267,20 @@ defmodule VutuvWeb.OrganizationController do
   end
 
   defp send_post_document(conn, organization, post, id) do
+    blocked? = not Posts.machines_allowed?(post)
+
     case AgentDocs.negotiate(conn) do
       :html ->
         conn
+        # The post's own answer about machines (issue #2107) as the HTML page's
+        # `X-Robots-Tag` **and** its `<meta name="robots">`. The page's
+        # `seo?`/`geo?` already reach a crawler through the organization's own
+        # pages; this is the one axis that is the post's, and without it the
+        # switch said nothing at all on the surface a crawler actually reads.
+        # `put_robots/3` rather than the header alone because this page has no
+        # `:user` assign for the layout to fall back to, so a bare header would
+        # have left the tag silent while the header said `noindex`.
+        |> VutuvWeb.ContentPolicy.put_robots(blocked?, blocked?)
         |> AgentDocs.put_html_alternates()
         |> ControllerHelpers.render_live(VutuvWeb.OrganizationLive.Post, %{
           "organization_id" => organization.id,

--- a/lib/vutuv_web/controllers/post_calendar_controller.ex
+++ b/lib/vutuv_web/controllers/post_calendar_controller.ex
@@ -113,10 +113,15 @@ defmodule VutuvWeb.PostCalendarController do
   # carry it into an index anyway: `path` is nil, so nothing links it, and its
   # own first line gives way to the line saying why. One nil decides both, in
   # both renderings.
+  #
+  # …and the same for a post whose **own** answer was no (issue #2107). This
+  # page is the one the router itself calls a crawl surface, so a withheld post
+  # quoting its first line here would be the plainest possible contradiction of
+  # the switch. Two questions, one outcome, so they share the branch.
   defp entry(post) do
     author = Posts.author(post)
 
-    if Identity.indexable?(author) do
+    if Identity.indexable?(author) and Posts.machines_allowed?(post) do
       %{id: post.id, author: author, path: Posts.path(post), text: teaser(post)}
     else
       %{

--- a/lib/vutuv_web/controllers/post_controller.ex
+++ b/lib/vutuv_web/controllers/post_controller.ex
@@ -341,14 +341,19 @@ defmodule VutuvWeb.PostController do
 
   defp render_post(conn, post, author, viewer) do
     restricted? = Posts.restricted?(post)
-    {noindex?, noai?} = PostDoc.robots_axes(author, restricted?)
+    {noindex?, noai?} = PostDoc.robots_axes(author, post, restricted?)
 
     # The conversation itself is the embedded `VutuvWeb.PostLive.Thread`
     # LiveView (windowed for long threads, expanders load more on the fly);
     # the controller only hands it the post id through the template's
     # live_render session.
     conn
-    |> VutuvWeb.ContentPolicy.put_robots_header(noindex?, noai?)
+    # Header **and** `<meta name="robots">` from the one derivation above. The
+    # layout would otherwise derive a third answer from the author alone, with
+    # no `restricted?` to derive it from, so a followers-only post's header said
+    # `noindex` while its tag said nothing — the drift
+    # `VutuvWeb.AgentDocs.PostDoc` records happening once before.
+    |> VutuvWeb.ContentPolicy.put_robots(noindex?, noai?)
     |> render("show.html",
       post: post,
       author: author,
@@ -375,7 +380,13 @@ defmodule VutuvWeb.PostController do
   # The agent formats render strictly the anonymous view: a post a
   # logged-out visitor cannot see has no agent documents either.
   defp federated_note_request?(conn, author, post) do
+    # A post its author kept off the Fediverse (issue #2107) is not handed
+    # over on request either: withholding the delivery and then serving the
+    # whole Note to whoever asks for the same URL would be no withholding at
+    # all. The HTML page is unaffected — this is about the AP document. Asked
+    # ahead of `visible_to?/2`, which costs a query where this is a column.
     FediverseController.ap_request?(conn) and Fediverse.federated?(author) and
+      Posts.machines_allowed?(post) and
       Posts.visible_to?(post, nil)
   end
 

--- a/lib/vutuv_web/gettext_extraction_anchors.ex
+++ b/lib/vutuv_web/gettext_extraction_anchors.ex
@@ -76,6 +76,11 @@ defmodule VutuvWeb.GettextExtractionAnchors do
       gettext(
         "When off, other members no longer see you among the likes of a post. The author of the post still does: we named you in the notification they got when you liked it. Either way the post keeps the same number of likes."
       ),
+      # Vutuv.Prefs — whether machines may read this member's posts (issue #2107)
+      gettext("Search engines and AI may read my posts"),
+      gettext(
+        "Covers the words, the pictures, the files and the machine formats of every post you write from now on. When off, your new posts also stay out of other networks completely: a server elsewhere keeps its copy for good and no instruction of ours reaches it. Posts you have already published keep the answer they went out with."
+      ),
       gettext("Privacy"),
       # Vutuv.Prefs — the feed language preference (issue #1461)
       gettext("Posts in other languages"),

--- a/lib/vutuv_web/live/post_live/composer.ex
+++ b/lib/vutuv_web/live/post_live/composer.ex
@@ -223,6 +223,13 @@ defmodule VutuvWeb.PostLive.Composer do
     # drag, so it works the same on a phone and a desktop.
     |> assign(:license, initial_license(post, socket.assigns.current_user))
     |> assign(:language, initial_language(post))
+    # Whether the files travelling with this post have their metadata removed
+    # (issue #2107), defaulting to cleaning them. Event-driven like the photo
+    # switches — an unchecked checkbox submits nothing, so driving it by event
+    # keeps "no" an actual state rather than an absence. The composer asks
+    # nothing about search engines and AI: that is one standing decision the
+    # member takes on /settings/privacy, stamped onto the post at publish time.
+    |> assign(:strip_metadata?, initial_strip_metadata(post))
     |> assign(:preset, preset)
     |> assign(:deny_wildcards, wildcards)
     |> assign(:denied_users, denied_users)
@@ -404,6 +411,11 @@ defmodule VutuvWeb.PostLive.Composer do
       |> assign(:language, Post.cast_language(draft.language) || assigns.language)
       |> assign(:layout, GalleryLayout.cast(draft.layout))
       |> assign(:fill?, draft.fill? == true)
+      # Nullable in the draft: a row written before this existed (or before the
+      # switch was touched) means "nobody chose", and the switch's own default
+      # is on — so only a stored `false` turns it off. `draftable?/1` already
+      # holds `@post == nil`, so the composer's own value here is that default.
+      |> assign(:strip_metadata?, draft.strip_metadata? != false)
       |> assign(:restored_draft?, true)
     else
       _no_draft -> socket
@@ -478,7 +490,8 @@ defmodule VutuvWeb.PostLive.Composer do
         "video_id" => assigns.video && assigns.video.id,
         "photos" => Map.new(assigns.photos, fn {id, settings} -> {id, stringify(settings)} end),
         "layout" => assigns.layout,
-        "fill?" => assigns.fill?
+        "fill?" => assigns.fill?,
+        "strip_metadata?" => assigns.strip_metadata?
       })
     end
 
@@ -527,6 +540,12 @@ defmodule VutuvWeb.PostLive.Composer do
   # last pick, so a professional sets it once and never again.
   defp initial_license(%Post{license: license}, _author) when is_binary(license), do: license
   defp initial_license(_post, author), do: Posts.default_license(author)
+
+  # The metadata answer has no member-level default to take: an edited post
+  # keeps its own, a new one starts at "clean them", which is what the parent
+  # milestone decided the switch means when nobody has touched it.
+  defp initial_strip_metadata(%Post{strip_metadata?: answer}) when is_boolean(answer), do: answer
+  defp initial_strip_metadata(_post), do: true
 
   ## Per-photo settings (issue #1104)
 
@@ -1136,6 +1155,13 @@ defmodule VutuvWeb.PostLive.Composer do
     {:noreply, assign(socket, :closing?, false)}
   end
 
+  def handle_event("toggle-strip-metadata", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:strip_metadata?, not socket.assigns.strip_metadata?)
+     |> schedule_draft_save()}
+  end
+
   def handle_event("save", %{"post" => params} = payload, socket) do
     # The submitted texts are the truth (a keystroke may not have round-tripped
     # through `validate` yet), so merge them before writing.
@@ -1162,7 +1188,10 @@ defmodule VutuvWeb.PostLive.Composer do
       # Event-driven like the person denials (the chips are buttons, not form
       # fields), so the assign is the truth; "" clears back to automatic.
       layout: socket.assigns.layout || "",
-      fill: socket.assigns.fill?
+      fill: socket.assigns.fill?,
+      # The metadata switch (issue #2107), also event-driven. On an edit the
+      # assign was seeded from the post, so sending it changes nothing.
+      strip_metadata: socket.assigns.strip_metadata?
     }
 
     save_with_media(socket, attrs)
@@ -2254,6 +2283,38 @@ defmodule VutuvWeb.PostLive.Composer do
           after a reconnect, and `adopt_recovered_images/2` re-adopts the
           pending rows the re-mount dropped from socket state. --%>
           <input :for={image <- @images} type="hidden" name="post[image_ids][]" value={image.id} />
+
+          <%!-- The one question asked before publishing (issue #2107), and only
+          on a new post carrying a file: rewriting a file already handed out is
+          not an edit. Whether machines may read the post is NOT asked here —
+          the member answers that once on /settings/privacy and it is stamped
+          onto the row as the post is published, so an older post keeps what it
+          went out with and nobody is asked the same thing twice a day. Plain
+          checkbox and Tailwind utilities, no stylesheet and no hook of its own,
+          so nothing here needs `static_changed?/1` to survive a deploy into an
+          open tab. --%>
+          <label
+            :if={
+              @post == nil and @attachments != [] and Attachments.metadata_removal_supported?()
+            }
+            id={"#{@id}-strip-metadata"}
+            class="mt-3 flex items-start gap-2 border-t border-slate-200 py-1 pt-3 text-sm text-slate-700 dark:border-slate-700 dark:text-slate-200"
+          >
+            <input
+              type="checkbox"
+              checked={@strip_metadata?}
+              phx-click="toggle-strip-metadata"
+              phx-target={@myself}
+              class={checkbox_class()}
+              data-strip-metadata-switch
+            />
+            <span class="min-w-0">
+              <span class="font-semibold">{gettext("Remove the metadata from the files")}</span>
+              <span class="mt-0.5 block text-xs text-slate-600 dark:text-slate-400">
+                {gettext("Your name, the software you used and the dates come out of a PDF.")}
+              </span>
+            </span>
+          </label>
 
           <%!-- Bottom row: the photo picker and the language select on the
           left (once photos are attached, the grid's add tile takes over —

--- a/lib/vutuv_web/live/shell_live.ex
+++ b/lib/vutuv_web/live/shell_live.ex
@@ -1737,13 +1737,14 @@ defmodule VutuvWeb.ShellLive do
 
   # Its own msgid rather than the video one it replaces: this counts POSTS
   # waiting, not clips, and the German for the old one says "Videos".
+  # `ngettext/4` binds the raw integer to %{count}, hence the %{formatted} one.
   defp media_in_progress_label(%{count: count, progress: percent}) do
     base =
       ngettext(
-        "%{count} post is being prepared",
-        "%{count} posts are being prepared",
+        "%{formatted} post is being prepared",
+        "%{formatted} posts are being prepared",
         count,
-        count: count
+        formatted: delimited_count(count)
       )
 
     if is_integer(percent), do: "#{base} · #{percent} %", else: base

--- a/lib/vutuv_web/live/tag_live/timeline.ex
+++ b/lib/vutuv_web/live/tag_live/timeline.ex
@@ -424,7 +424,7 @@ defmodule VutuvWeb.TagLive.Timeline do
               itself already drops such a post (issue #2107). --%>
               <.post_thread_entry
                 post={entry.post}
-                ancestors={Posts.public_ancestors(entry.post)}
+                ancestors={Posts.public_ancestors(entry.post, @current_user)}
                 viewer={@current_user}
                 entry_id={entry.id}
                 conn_or_socket={@socket}

--- a/lib/vutuv_web/live/tag_live/timeline.ex
+++ b/lib/vutuv_web/live/tag_live/timeline.ex
@@ -419,8 +419,12 @@ defmodule VutuvWeb.TagLive.Timeline do
                 following?={false}
               />
             <% true -> %>
+              <%!-- A tag page is a public topic surface, so a quoted parent
+              whose author keeps machines out is dropped, the way the timeline
+              itself already drops such a post (issue #2107). --%>
               <.post_thread_entry
                 post={entry.post}
+                ancestors={Posts.public_ancestors(entry.post)}
                 viewer={@current_user}
                 entry_id={entry.id}
                 conn_or_socket={@socket}

--- a/lib/vutuv_web/post_teaser.ex
+++ b/lib/vutuv_web/post_teaser.ex
@@ -67,6 +67,8 @@ defmodule VutuvWeb.PostTeaser do
   decision about how a tab strip reads, not about the feed.
   """
 
+  use Gettext, backend: VutuvWeb.Gettext
+
   alias Vutuv.ContentFilters
   alias Vutuv.Fediverse.Handle
   alias Vutuv.Fediverse.RemoteAccount
@@ -136,6 +138,53 @@ defmodule VutuvWeb.PostTeaser do
   answers `""`; anything else raises rather than teasing quietly.
   """
   def line(post, opts \\ []), do: teaser(post, &fold/1, opts)
+
+  @doc """
+  `line/2` for a **machine** audience (issue #2107): the teaser, unless the
+  post's author keeps search engines and AI out, in which case one sentence
+  saying so.
+
+  The third audience this module answers "whether" for, beside the reader whose
+  filters `quote_for/4` applies. It lives here for the same reason those do: a
+  doc builder that reaches for `line/2` — the documented owner of a post's one
+  line — must not be able to quote a withheld post by simply not knowing about
+  a gate kept somewhere else.
+
+  A list document is where it is needed, and it keeps the row rather than
+  dropping it: an archive, a tag page, a profile and the API all carry one
+  all-yes `Content-Signal` for the whole list and cannot signal per row, so the
+  words have to go instead of the signal. Its place in the list stays, which
+  keeps the totals honest — the trade
+  `VutuvWeb.PostCalendarController.entry/1` already makes for an author who
+  opted out, down to the sentence.
+  """
+  def machine_line(%Post{} = post) do
+    if Posts.machines_allowed?(post), do: line(post), else: withheld_sentence()
+  end
+
+  @doc """
+  The same answer for a post's **whole body**, which is what a document
+  embedding somebody else's post hands over (`VutuvWeb.AgentDocs.PostDoc`'s
+  conversation and reply entries).
+
+  Those entries are the leak `machine_line/1` is not: a document's robots axes
+  are computed from its **subject** post, and a conversation is full of other
+  people's, so a reply to a withheld post published the withheld body in full
+  under `ai-train=yes`. Neither the reply's author nor its reader can be asked
+  to carry somebody else's answer.
+
+  It reads `post.body`, matching the ungated sites beside it, rather than
+  `Vutuv.Posts.text/1` — widening what a document quotes is a separate change.
+  The HTML conversation deliberately still shows every word: page and doc
+  differ because the promise is about machines, not about readers.
+  """
+  def machine_body(%Post{} = post) do
+    if Posts.machines_allowed?(post), do: post.body, else: withheld_sentence()
+  end
+
+  # One sentence, one msgid, shared by both halves and with
+  # `VutuvWeb.PostCalendarController.entry/1`.
+  defp withheld_sentence, do: gettext("Post not open to search engines")
 
   @doc """
   `line/2` flattened to plain text: Markdown markers gone, whitespace folded to

--- a/lib/vutuv_web/post_teaser.ex
+++ b/lib/vutuv_web/post_teaser.ex
@@ -69,6 +69,7 @@ defmodule VutuvWeb.PostTeaser do
 
   use Gettext, backend: VutuvWeb.Gettext
 
+  alias Vutuv.Accounts.User
   alias Vutuv.ContentFilters
   alias Vutuv.Fediverse.Handle
   alias Vutuv.Fediverse.RemoteAccount
@@ -158,8 +159,10 @@ defmodule VutuvWeb.PostTeaser do
   `VutuvWeb.PostCalendarController.entry/1` already makes for an author who
   opted out, down to the sentence.
   """
-  def machine_line(%Post{} = post) do
-    if Posts.machines_allowed?(post), do: line(post), else: withheld_sentence()
+  def machine_line(post, viewer \\ nil)
+
+  def machine_line(%Post{} = post, viewer) do
+    if shown_to?(post, viewer), do: line(post), else: withheld_sentence()
   end
 
   @doc """
@@ -178,9 +181,30 @@ defmodule VutuvWeb.PostTeaser do
   The HTML conversation deliberately still shows every word: page and doc
   differ because the promise is about machines, not about readers.
   """
-  def machine_body(%Post{} = post) do
-    if Posts.machines_allowed?(post), do: post.body, else: withheld_sentence()
+  def machine_body(post, viewer \\ nil)
+
+  def machine_body(%Post{} = post, viewer) do
+    if shown_to?(post, viewer), do: post.body, else: withheld_sentence()
   end
+
+  # **A redaction that hits somebody entitled to read the text is as wrong as a
+  # missing one**, so both halves take the viewer the document was built for.
+  #
+  # A document built for a signed-in member is login-gated and per-viewer: the
+  # feed doc declares `noindex: true, noai: true` over the whole response, and
+  # `/api/2.0` is a token read on that member's behalf. Either way the reader
+  # can open the permalink and read every word, so handing them "Post not open
+  # to search engines" tells them nothing and takes something away. Only the
+  # **anonymous** public view — the cache-safe `.md`/`.txt`/`.json`/`.xml` URLs,
+  # which carry one all-yes `Content-Signal` for a whole list and cannot signal
+  # per row — is the surface the switch is about.
+  #
+  # The trade worth naming: a third-party app holding an API token is a machine,
+  # and it keeps the words. It is acting for a member who may read them anyway,
+  # and that response is `private`; treating it as a crawler would punish the
+  # member for reading through an app instead of a browser.
+  defp shown_to?(_post, %User{}), do: true
+  defp shown_to?(post, _anonymous), do: Posts.machines_allowed?(post)
 
   # One sentence, one msgid, shared by both halves and with
   # `VutuvWeb.PostCalendarController.entry/1`.

--- a/lib/vutuv_web/templates/post/index.html.heex
+++ b/lib/vutuv_web/templates/post/index.html.heex
@@ -77,11 +77,11 @@
         (`archive_engagement/2`), so no action bar runs its own mount query. --%>
         <%!-- `ancestors` rather than the card's own fallback: this page is a
         crawl surface, so a quoted parent whose author keeps machines out is
-        dropped (issue #2107, `Posts.public_ancestors/1`). --%>
+        dropped (issue #2107, `Posts.public_ancestors/2`). --%>
         <.post_thread_entry
           :if={!Vutuv.Posts.remote_feed_entry?(entry)}
           post={entry.post}
-          ancestors={Vutuv.Posts.public_ancestors(entry.post)}
+          ancestors={Vutuv.Posts.public_ancestors(entry.post, @current_user)}
           reposted_by={entry.reposted_by}
           entry_id={entry.id}
           conn_or_socket={@conn}

--- a/lib/vutuv_web/templates/post/index.html.heex
+++ b/lib/vutuv_web/templates/post/index.html.heex
@@ -75,9 +75,13 @@
         />
         <%!-- The counts arrive batched from the controller
         (`archive_engagement/2`), so no action bar runs its own mount query. --%>
+        <%!-- `ancestors` rather than the card's own fallback: this page is a
+        crawl surface, so a quoted parent whose author keeps machines out is
+        dropped (issue #2107, `Posts.public_ancestors/1`). --%>
         <.post_thread_entry
           :if={!Vutuv.Posts.remote_feed_entry?(entry)}
           post={entry.post}
+          ancestors={Vutuv.Posts.public_ancestors(entry.post)}
           reposted_by={entry.reposted_by}
           entry_id={entry.id}
           conn_or_socket={@conn}

--- a/lib/vutuv_web/templates/settings/privacy.html.heex
+++ b/lib/vutuv_web/templates/settings/privacy.html.heex
@@ -71,6 +71,33 @@ than its own heading. --%>
       </.form>
     </.card>
 
+    <%!-- Your posts (issue #2107). The card above is about the profile page;
+          this is the same question asked about everything you write, and it is
+          asked here rather than in the composer because it is one standing
+          decision, not one per post. A Vutuv.Prefs boolean, so it reads and is
+          stored positively — unlike the two inverted opt-out checkboxes above,
+          which is exactly why it is its own card rather than a third row in
+          theirs.
+
+          Two consequences the member cannot discover afterwards, so both are on
+          screen: every post keeps the answer it was published with (the intro),
+          and saying no keeps new posts out of the other networks entirely (the
+          registry hint, shared word for word with /admin/preferences). --%>
+    <.toggle_form_card
+      changeset={@changeset}
+      field={:posts_machines_allowed?}
+      form_id="posts-machines-form"
+      action={~p"/settings/privacy"}
+      title={gettext("Your posts")}
+      intro={
+        gettext(
+          "Whether search engines and AI may read what you post. Each post keeps the answer it was published with, so changing this leaves everything you have already written exactly as it is."
+        )
+      }
+      label={Vutuv.Prefs.label(:posts_machines_allowed?)}
+      hint={Vutuv.Prefs.hint(:posts_machines_allowed?)}
+    />
+
     <%!-- Likes: whether other members see your name and picture in the row of
           faces a post permalink shows under its like count (issue #1233).
           Default on, like every other network people come from — and like the

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -118,7 +118,7 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/live/job_posting_live/form.ex:857
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
-#: lib/vutuv_web/live/post_live/composer.ex:2049
+#: lib/vutuv_web/live/post_live/composer.ex:2078
 #: lib/vutuv_web/live/press_kit_live.ex:729
 #: lib/vutuv_web/live/press_kit_live.ex:1139
 #: lib/vutuv_web/templates/ad/new.html.heex:136
@@ -165,7 +165,7 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
-#: lib/vutuv_web/components/post_components.ex:4593
+#: lib/vutuv_web/components/post_components.ex:4600
 #: lib/vutuv_web/components/ui.ex:5042
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
@@ -206,14 +206,14 @@ msgid "Disable"
 msgstr "Inaktivieren"
 
 #: lib/vutuv_web/live/cv_live.ex:446
-#: lib/vutuv_web/live/post_live/composer.ex:3228
+#: lib/vutuv_web/live/post_live/composer.ex:3289
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/views/qualification_html.ex:354
 #, elixir-autogen
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:4558
+#: lib/vutuv_web/components/post_components.ex:4565
 #: lib/vutuv_web/components/ui.ex:5033
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
@@ -609,7 +609,7 @@ msgstr "Profile von "
 msgid "Provider"
 msgstr "Provider"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2361
+#: lib/vutuv_web/live/post_live/composer.ex:2422
 #: lib/vutuv_web/live/section_reorder_live.ex:272
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -621,7 +621,7 @@ msgstr "Öffentlich"
 
 #: lib/vutuv_web/components/ui.ex:4934
 #: lib/vutuv_web/live/organization_live/edit.ex:376
-#: lib/vutuv_web/live/post_live/composer.ex:2376
+#: lib/vutuv_web/live/post_live/composer.ex:2437
 #: lib/vutuv_web/live/press_kit_live.ex:727
 #: lib/vutuv_web/live/press_kit_live.ex:1138
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -1208,7 +1208,7 @@ msgstr "Alle Tag-Synonyme"
 msgid "All tag urls"
 msgstr "Alle Tag-URLs"
 
-#: lib/vutuv_web/components/post_components.ex:5211
+#: lib/vutuv_web/components/post_components.ex:5218
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:643
@@ -1637,11 +1637,11 @@ msgstr "Schauen Sie in Ihr Postfach"
 #: lib/vutuv_web/live/admin/job_live.ex:321
 #: lib/vutuv_web/live/admin/job_live.ex:477
 #: lib/vutuv_web/live/admin/organization_live.ex:296
-#: lib/vutuv_web/live/post_live/composer.ex:1905
-#: lib/vutuv_web/live/post_live/composer.ex:2007
-#: lib/vutuv_web/live/post_live/composer.ex:2008
-#: lib/vutuv_web/live/post_live/composer.ex:3105
-#: lib/vutuv_web/live/post_live/composer.ex:3371
+#: lib/vutuv_web/live/post_live/composer.ex:1934
+#: lib/vutuv_web/live/post_live/composer.ex:2036
+#: lib/vutuv_web/live/post_live/composer.ex:2037
+#: lib/vutuv_web/live/post_live/composer.ex:3166
+#: lib/vutuv_web/live/post_live/composer.ex:3432
 #: lib/vutuv_web/templates/layout/app.html.heex:200
 #: lib/vutuv_web/templates/layout/app.html.heex:206
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:28
@@ -2105,7 +2105,7 @@ msgstr "Markdown wird unterstützt: Fett, Kursiv, Links und Listen."
 msgid "Add images"
 msgstr "Bilder hinzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2490
+#: lib/vutuv_web/live/post_live/composer.ex:2551
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr "Sobald irgendetwas ausgeblendet ist, sehen auch abgemeldete Besucher und Suchmaschinen den Beitrag nicht mehr."
@@ -2116,9 +2116,9 @@ msgstr "Sobald irgendetwas ausgeblendet ist, sehen auch abgemeldete Besucher und
 msgid "Back to the post"
 msgstr "Zurück zum Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2147
-#: lib/vutuv_web/live/post_live/composer.ex:2170
-#: lib/vutuv_web/live/post_live/composer.ex:2196
+#: lib/vutuv_web/live/post_live/composer.ex:2176
+#: lib/vutuv_web/live/post_live/composer.ex:2199
+#: lib/vutuv_web/live/post_live/composer.ex:2225
 #: lib/vutuv_web/live/press_kit_live.ex:1307
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
@@ -2129,7 +2129,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:4590
+#: lib/vutuv_web/components/post_components.ex:4597
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2142,7 +2142,7 @@ msgid "Edit post"
 msgstr "Beitrag bearbeiten"
 
 #: lib/vutuv_web/components/organization_components.ex:274
-#: lib/vutuv_web/gettext_extraction_anchors.ex:87
+#: lib/vutuv_web/gettext_extraction_anchors.ex:92
 #: lib/vutuv_web/live/organization_live/feed.ex:203
 #: lib/vutuv_web/live/post_live/feed.ex:365
 #: lib/vutuv_web/live/post_live/feed.ex:3536
@@ -2164,29 +2164,29 @@ msgstr "Folgen Sie %{name}, um ihn zu lesen."
 msgid "Hidden from:"
 msgstr "Verborgen vor:"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2466
+#: lib/vutuv_web/live/post_live/composer.ex:2527
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr "Vor einer bestimmten Person verbergen…"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2394
+#: lib/vutuv_web/live/post_live/composer.ex:2455
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:4536
-#: lib/vutuv_web/components/post_components.ex:4538
+#: lib/vutuv_web/components/post_components.ex:4543
+#: lib/vutuv_web/components/post_components.ex:4545
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2436
+#: lib/vutuv_web/live/post_live/composer.ex:2497
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr "Nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1554
-#: lib/vutuv_web/live/post_live/composer.ex:1694
+#: lib/vutuv_web/live/post_live/composer.ex:1583
+#: lib/vutuv_web/live/post_live/composer.ex:1723
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
@@ -2198,23 +2198,23 @@ msgstr ""
 "Hier ist noch nichts. Folgen Sie anderen, um Ihren Feed zu füllen, oder "
 "schreiben Sie Ihren ersten Beitrag."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1517
+#: lib/vutuv_web/live/post_live/composer.ex:1546
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr "Eines der Bilder konnte nicht angehängt werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2426
+#: lib/vutuv_web/live/post_live/composer.ex:2487
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr "Personen, denen ich nicht folge"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2416
+#: lib/vutuv_web/live/post_live/composer.ex:2477
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr "Personen, die mir nicht folgen"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:441
-#: lib/vutuv_web/live/post_live/composer.ex:2378
+#: lib/vutuv_web/live/post_live/composer.ex:2439
 #, elixir-autogen, elixir-format
 msgid "Post"
 msgstr "Posten"
@@ -2224,11 +2224,11 @@ msgstr "Posten"
 msgid "Post deleted successfully."
 msgstr "Beitrag erfolgreich gelöscht."
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:243
+#: lib/vutuv_web/agent_docs/post_doc.ex:264
 #: lib/vutuv_web/controllers/post_controller.ex:69
 #: lib/vutuv_web/controllers/post_controller.ex:90
 #: lib/vutuv_web/controllers/user_controller.ex:77
-#: lib/vutuv_web/gettext_extraction_anchors.ex:113
+#: lib/vutuv_web/gettext_extraction_anchors.ex:118
 #: lib/vutuv_web/live/admin/dashboard_live.ex:270
 #: lib/vutuv_web/live/fediverse_account_live.ex:446
 #: lib/vutuv_web/live/organization_live/show.ex:733
@@ -2242,13 +2242,13 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:5084
-#: lib/vutuv_web/components/post_components.ex:5088
+#: lib/vutuv_web/components/post_components.ex:5091
+#: lib/vutuv_web/components/post_components.ex:5095
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:5085
+#: lib/vutuv_web/components/post_components.ex:5092
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2265,7 +2265,7 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/live/organization_live/domains.ex:265
 #: lib/vutuv_web/live/organization_live/edit.ex:404
 #: lib/vutuv_web/live/organization_live/roles.ex:257
-#: lib/vutuv_web/live/post_live/composer.ex:2452
+#: lib/vutuv_web/live/post_live/composer.ex:2513
 #: lib/vutuv_web/live/post_live/filter_band.ex:456
 #: lib/vutuv_web/live/post_live/saved.ex:666
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2284,7 +2284,7 @@ msgstr ""
 "Eingeschränkte Beiträge sind auch für nicht eingeloggte Besucher und "
 "Suchmaschinen unsichtbar."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2368
+#: lib/vutuv_web/live/post_live/composer.ex:2429
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr "Wird gespeichert…"
@@ -2302,14 +2302,14 @@ msgid "Sorry, that page could not be found."
 msgstr "Diese Seite konnte leider nicht gefunden werden."
 
 #: lib/vutuv_web/attachment_text.ex:73
-#: lib/vutuv_web/live/post_live/composer.ex:1615
-#: lib/vutuv_web/live/post_live/composer.ex:1720
+#: lib/vutuv_web/live/post_live/composer.ex:1644
+#: lib/vutuv_web/live/post_live/composer.ex:1749
 #: lib/vutuv_web/live/press_kit_live.ex:541
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr "Diese Datei konnte nicht verarbeitet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1499
+#: lib/vutuv_web/live/post_live/composer.ex:1528
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr "Die Sichtbarkeitsauswahl ist ungültig."
@@ -2319,17 +2319,17 @@ msgstr "Die Sichtbarkeitsauswahl ist ungültig."
 msgid "This post is for followers of %{name}"
 msgstr "Dieser Beitrag ist für Follower von %{name}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3546
+#: lib/vutuv_web/live/post_live/composer.ex:3607
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3547
+#: lib/vutuv_web/live/post_live/composer.ex:3608
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
-#: lib/vutuv_web/components/ui.ex:5865
+#: lib/vutuv_web/components/ui.ex:5868
 #: lib/vutuv_web/live/shell_live.ex:1588
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2338,37 +2338,37 @@ msgstr "Upload fehlgeschlagen."
 msgid "View profile"
 msgstr "Profil ansehen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2584
+#: lib/vutuv_web/live/post_live/composer.ex:2645
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr "Was gibt's Neues?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2585
+#: lib/vutuv_web/live/post_live/composer.ex:2646
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:4533
+#: lib/vutuv_web/components/post_components.ex:4540
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:6851
+#: lib/vutuv_web/components/post_components.ex:6858
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:6855
+#: lib/vutuv_web/components/post_components.ex:6862
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:6853
+#: lib/vutuv_web/components/post_components.ex:6860
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:6854
+#: lib/vutuv_web/components/post_components.ex:6861
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2380,21 +2380,21 @@ msgstr "Personen, denen Sie nicht folgen"
 msgid "unknown"
 msgstr "unbekannt"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2246
+#: lib/vutuv_web/live/post_live/composer.ex:2275
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr "Tags, durch Komma getrennt (max. %{max})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1612
-#: lib/vutuv_web/live/post_live/composer.ex:3513
-#: lib/vutuv_web/live/post_live/composer.ex:3531
+#: lib/vutuv_web/live/post_live/composer.ex:1641
+#: lib/vutuv_web/live/post_live/composer.ex:3574
+#: lib/vutuv_web/live/post_live/composer.ex:3592
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr "Die Datei ist größer als %{mb} MB."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3521
-#: lib/vutuv_web/live/post_live/composer.ex:3535
-#: lib/vutuv_web/live/post_live/composer.ex:3541
+#: lib/vutuv_web/live/post_live/composer.ex:3582
+#: lib/vutuv_web/live/post_live/composer.ex:3596
+#: lib/vutuv_web/live/post_live/composer.ex:3602
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr "Dateityp wird nicht unterstützt (erlaubt: %{types})."
@@ -2415,7 +2415,7 @@ msgid "All posts"
 msgstr "Alle Beiträge"
 
 #: lib/vutuv_web/components/post_components.ex:2185
-#: lib/vutuv_web/components/post_components.ex:6954
+#: lib/vutuv_web/components/post_components.ex:6961
 #: lib/vutuv_web/components/ui.ex:4476
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2434,7 +2434,7 @@ msgid "Bookmarks"
 msgstr "Lesezeichen"
 
 #: lib/vutuv_web/components/post_components.ex:2129
-#: lib/vutuv_web/components/post_components.ex:7195
+#: lib/vutuv_web/components/post_components.ex:7202
 #: lib/vutuv_web/components/ui.ex:4462
 #: lib/vutuv_web/notification_line.ex:317
 #: lib/vutuv_web/views/user_html.ex:486
@@ -2443,12 +2443,12 @@ msgid "Like"
 msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1301
-#: lib/vutuv_web/components/post_components.ex:7205
+#: lib/vutuv_web/components/post_components.ex:7212
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
 #: lib/vutuv_web/live/shell_live.ex:1596
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
-#: lib/vutuv_web/templates/settings/privacy.html.heex:91
+#: lib/vutuv_web/templates/settings/privacy.html.heex:118
 #: lib/vutuv_web/views/admin/report_html.ex:37
 #, elixir-autogen, elixir-format
 msgid "Likes"
@@ -2464,13 +2464,13 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:6942
+#: lib/vutuv_web/components/post_components.ex:6949
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
 #: lib/vutuv_web/components/post_components.ex:2184
-#: lib/vutuv_web/components/post_components.ex:6953
+#: lib/vutuv_web/components/post_components.ex:6960
 #: lib/vutuv_web/live/post_live/saved.ex:822
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2478,26 +2478,26 @@ msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
 #: lib/vutuv_web/components/post_components.ex:2165
-#: lib/vutuv_web/components/post_components.ex:6938
+#: lib/vutuv_web/components/post_components.ex:6945
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
 #: lib/vutuv_web/components/post_components.ex:2758
-#: lib/vutuv_web/components/post_components.ex:5957
+#: lib/vutuv_web/components/post_components.ex:5964
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
 #: lib/vutuv_web/components/post_components.ex:2164
-#: lib/vutuv_web/components/post_components.ex:6937
+#: lib/vutuv_web/components/post_components.ex:6944
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
 #: lib/vutuv_web/components/post_components.ex:2128
-#: lib/vutuv_web/components/post_components.ex:7194
+#: lib/vutuv_web/components/post_components.ex:7201
 #: lib/vutuv_web/live/post_live/saved.ex:821
 #: lib/vutuv_web/views/user_html.ex:486
 #, elixir-autogen, elixir-format
@@ -2525,7 +2525,7 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:7249
+#: lib/vutuv_web/components/post_components.ex:7256
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
@@ -2537,8 +2537,8 @@ msgid "Replies"
 msgstr "Antworten"
 
 #: lib/vutuv_web/components/post_components.ex:2374
-#: lib/vutuv_web/components/post_components.ex:7232
-#: lib/vutuv_web/components/post_components.ex:7233
+#: lib/vutuv_web/components/post_components.ex:7239
+#: lib/vutuv_web/components/post_components.ex:7240
 #: lib/vutuv_web/live/notification_live/index.ex:993
 #: lib/vutuv_web/live/post_live/reply.ex:49
 #: lib/vutuv_web/notification_line.ex:314
@@ -2546,18 +2546,18 @@ msgstr "Antworten"
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:4492
+#: lib/vutuv_web/components/post_components.ex:4499
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1502
-#: lib/vutuv_web/live/post_live/composer.ex:2356
+#: lib/vutuv_web/live/post_live/composer.ex:1531
+#: lib/vutuv_web/live/post_live/composer.ex:2417
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr "Solange es geteilte Beiträge oder Antworten gibt, lässt sich der Empfängerkreis nicht einschränken."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2497
+#: lib/vutuv_web/live/post_live/composer.ex:2558
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beiträge oder Antworten gibt, bleibt er öffentlich; löschen können Sie ihn weiterhin."
@@ -2575,14 +2575,14 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:4464
+#: lib/vutuv_web/components/post_components.ex:4471
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:4455
-#: lib/vutuv_web/components/post_components.ex:4484
-#: lib/vutuv_web/components/post_components.ex:4487
+#: lib/vutuv_web/components/post_components.ex:4462
+#: lib/vutuv_web/components/post_components.ex:4491
+#: lib/vutuv_web/components/post_components.ex:4494
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
@@ -2800,7 +2800,7 @@ msgstr "Ersten Beitrag schreiben"
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:109
 #: lib/vutuv_web/templates/settings/preferences.html.heex:195
-#: lib/vutuv_web/templates/settings/privacy.html.heex:179
+#: lib/vutuv_web/templates/settings/privacy.html.heex:206
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:216
 #: lib/vutuv_web/templates/user/show.html.heex:643
@@ -2861,7 +2861,7 @@ msgstr "Noch keine Vernetzungen."
 msgid "Other formats"
 msgstr "Andere Formate"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2406
+#: lib/vutuv_web/live/post_live/composer.ex:2467
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr "Personen, mit denen ich nicht vernetzt bin"
@@ -2884,7 +2884,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:6852
+#: lib/vutuv_web/components/post_components.ex:6859
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -3152,7 +3152,7 @@ msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:4431
+#: lib/vutuv_web/components/post_components.ex:4438
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solange eine Meldung zu diesem Beitrag bearbeitet wird, sehen nur Sie ihn."
@@ -3215,7 +3215,7 @@ msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 #: lib/vutuv_web/components/post_components.ex:1466
 #: lib/vutuv_web/components/post_components.ex:3418
 #: lib/vutuv_web/components/post_components.ex:3605
-#: lib/vutuv_web/components/post_components.ex:4661
+#: lib/vutuv_web/components/post_components.ex:4668
 #: lib/vutuv_web/live/organization_live/show.ex:684
 #: lib/vutuv_web/templates/user/show.html.heex:252
 #, elixir-autogen, elixir-format
@@ -3978,7 +3978,7 @@ msgstr "Am häufigsten empfohlene Mitglieder"
 msgid "People %{name} follows"
 msgstr "Wem %{name} folgt"
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:244
+#: lib/vutuv_web/agent_docs/post_doc.ex:265
 #, elixir-autogen, elixir-format
 msgid "Post archive of %{name}"
 msgstr "Beitragsarchiv von %{name}"
@@ -4603,11 +4603,11 @@ msgstr ""
 "beide Richtungen unterbunden. Eine Aufhebung der Blockierung stellt das "
 "Entfernte nicht wieder her."
 
-#: lib/vutuv_web/components/ui.ex:5625
+#: lib/vutuv_web/components/ui.ex:5628
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
-#: lib/vutuv_web/templates/settings/privacy.html.heex:176
+#: lib/vutuv_web/templates/settings/privacy.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Blocked members"
 msgstr "Blockierte Mitglieder"
@@ -5426,7 +5426,7 @@ msgstr "API-Token (%{date})"
 msgid "API documentation"
 msgstr "API-Dokumentation"
 
-#: lib/vutuv_web/components/ui.ex:5675
+#: lib/vutuv_web/components/ui.ex:5678
 #: lib/vutuv_web/controllers/settings_controller.ex:161
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:552
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5467,12 +5467,12 @@ msgstr ""
 "dauerhaft. Wir senden Ihnen zur Bestätigung eine PIN per E-Mail. Es kann "
 "nicht rückgängig gemacht werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1523
+#: lib/vutuv_web/live/post_live/composer.ex:1552
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:182
+#: lib/vutuv_web/templates/settings/privacy.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "Content under review"
 msgstr "Inhalte in Prüfung"
@@ -5510,10 +5510,10 @@ msgstr "Tastaturkürzel"
 msgid "Navigation"
 msgstr "Navigation"
 
-#: lib/vutuv_web/components/ui.ex:5772
-#: lib/vutuv_web/components/ui.ex:5777
-#: lib/vutuv_web/components/ui.ex:5856
-#: lib/vutuv_web/components/ui.ex:5920
+#: lib/vutuv_web/components/ui.ex:5775
+#: lib/vutuv_web/components/ui.ex:5780
+#: lib/vutuv_web/components/ui.ex:5859
+#: lib/vutuv_web/components/ui.ex:5923
 #: lib/vutuv_web/controllers/settings_controller.ex:68
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5583,9 +5583,9 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:4741
-#: lib/vutuv_web/components/post_components.ex:5350
-#: lib/vutuv_web/components/post_components.ex:5688
+#: lib/vutuv_web/components/post_components.ex:4748
+#: lib/vutuv_web/components/post_components.ex:5357
+#: lib/vutuv_web/components/post_components.ex:5695
 #: lib/vutuv_web/live/notification_live/index.ex:1069
 #: lib/vutuv_web/views/user_html.ex:133
 #, elixir-autogen, elixir-format
@@ -5632,7 +5632,7 @@ msgstr "Art der E-Mail-Adresse"
 msgid "About you"
 msgstr "Über Sie"
 
-#: lib/vutuv_web/components/ui.ex:5645
+#: lib/vutuv_web/components/ui.ex:5648
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:262
@@ -5673,7 +5673,7 @@ msgstr "E-Mail-Adressen"
 msgid "Notification settings saved."
 msgstr "Benachrichtigungseinstellungen gespeichert."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:177
+#: lib/vutuv_web/templates/settings/privacy.html.heex:204
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you."
 msgstr "Personen, die nicht mit Ihnen interagieren können."
@@ -5683,14 +5683,14 @@ msgstr "Personen, die nicht mit Ihnen interagieren können."
 msgid "Personal tokens for the vutuv API."
 msgstr "Persönliche Tokens für die vutuv-API."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2841
+#: lib/vutuv_web/live/post_live/composer.ex:2902
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
 msgstr "Fotos"
 
 #: lib/vutuv_web/components/ui.ex:5619
-#: lib/vutuv_web/gettext_extraction_anchors.ex:79
+#: lib/vutuv_web/gettext_extraction_anchors.ex:84
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr "Privatsphäre"
@@ -5705,7 +5705,7 @@ msgstr "Datenschutzeinstellungen gespeichert."
 msgid "Third-party apps you authorized."
 msgstr "Apps von Drittanbietern, die Sie autorisiert haben."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:185
+#: lib/vutuv_web/templates/settings/privacy.html.heex:212
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr "Ansehen"
@@ -5721,7 +5721,7 @@ msgstr "Ihr Name"
 msgid "Your post"
 msgstr "Ihr Beitrag"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:183
+#: lib/vutuv_web/templates/settings/privacy.html.heex:210
 #, elixir-autogen, elixir-format
 msgid "Your posts or profile a moderator is looking at."
 msgstr "Ihre Beiträge oder Ihr Profil, die ein Moderator gerade prüft."
@@ -5804,7 +5804,7 @@ msgstr "@%{slug} folgt Ihnen jetzt auf vutuv"
 msgid "Apps"
 msgstr "Apps"
 
-#: lib/vutuv_web/components/ui.ex:5668
+#: lib/vutuv_web/components/ui.ex:5671
 #: lib/vutuv_web/controllers/settings_controller.ex:185
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -5848,7 +5848,7 @@ msgstr "Benachrichtigungen öffnen"
 msgid "Replies to and likes on your posts"
 msgstr "Antworten und Likes zu Ihren Beiträgen"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:173
+#: lib/vutuv_web/templates/settings/privacy.html.heex:200
 #, elixir-autogen, elixir-format
 msgid "Safety"
 msgstr "Sicherheit"
@@ -5958,7 +5958,7 @@ msgid "Name (A-Z)"
 msgstr "Name (A-Z)"
 
 #: lib/vutuv_web/live/post_live/saved.ex:507
-#: lib/vutuv_web/live/tag_live/timeline.ex:448
+#: lib/vutuv_web/live/tag_live/timeline.ex:452
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr "Neueste zuerst"
@@ -5984,7 +5984,7 @@ msgid "Nothing here yet. People you like show up here."
 msgstr "Hier ist noch nichts. Personen, die Ihnen gefallen, erscheinen hier."
 
 #: lib/vutuv_web/live/post_live/saved.ex:508
-#: lib/vutuv_web/live/tag_live/timeline.ex:449
+#: lib/vutuv_web/live/tag_live/timeline.ex:453
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr "Älteste zuerst"
@@ -6100,25 +6100,25 @@ msgstr ""
 msgid "just now"
 msgstr "gerade eben"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:125
+#: lib/vutuv_web/templates/settings/privacy.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "A green dot on your avatar tells other members you are online right now."
 msgstr ""
 "Ein grüner Punkt auf Ihrem Avatar zeigt anderen Mitgliedern, dass Sie gerade"
 " online sind."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:124
+#: lib/vutuv_web/templates/settings/privacy.html.heex:151
 #: lib/vutuv_web/views/account_event_text.ex:233
 #, elixir-autogen, elixir-format
 msgid "Online status"
 msgstr "Online-Status"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:126
+#: lib/vutuv_web/templates/settings/privacy.html.heex:153
 #, elixir-autogen, elixir-format
 msgid "Show when I'm online"
 msgstr "Anzeigen, wenn ich online bin"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:127
+#: lib/vutuv_web/templates/settings/privacy.html.heex:154
 #, elixir-autogen, elixir-format
 msgid "When off, no one sees the green dot on your avatar, and you never show as online."
 msgstr ""
@@ -6310,7 +6310,7 @@ msgstr "Foto positionieren"
 msgid "Use photo"
 msgstr "Foto verwenden"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2051
+#: lib/vutuv_web/live/post_live/composer.ex:2080
 #: lib/vutuv_web/templates/user/edit.html.heex:66
 #: lib/vutuv_web/templates/user/edit.html.heex:151
 #, elixir-autogen, elixir-format
@@ -6466,7 +6466,7 @@ msgstr "Karteneinstellungen gespeichert."
 msgid "Map services to show"
 msgstr "Anzuzeigende Kartendienste"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:114
+#: lib/vutuv_web/gettext_extraction_anchors.ex:119
 #: lib/vutuv_web/templates/settings/preferences.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "Maps"
@@ -6479,7 +6479,7 @@ msgstr "Karten"
 msgid "Open in %{name}"
 msgstr "In %{name} öffnen"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:112
+#: lib/vutuv_web/gettext_extraction_anchors.ex:117
 #: lib/vutuv_web/templates/settings/preferences.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Opens first, as the main button. The others appear as alternatives."
@@ -6831,8 +6831,8 @@ msgstr ""
 "und Antworten über Sie mit. Mit beiden aus zum Beispiel:"
 
 #: lib/vutuv_web/components/post_components.ex:3345
-#: lib/vutuv_web/components/post_components.ex:4614
-#: lib/vutuv_web/components/post_components.ex:4628
+#: lib/vutuv_web/components/post_components.ex:4621
+#: lib/vutuv_web/components/post_components.ex:4635
 #: lib/vutuv_web/components/ui.ex:3226
 #: lib/vutuv_web/live/fediverse_account_live.ex:437
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6860,7 +6860,7 @@ msgstr "Neue Nachrichten und neue Vernetzungen"
 msgid "Remove this connection? You will stop following them."
 msgstr "Diese Vernetzung entfernen? Sie folgen der Person dann nicht mehr."
 
-#: lib/vutuv_web/components/post_components.ex:4614
+#: lib/vutuv_web/components/post_components.ex:4621
 #: lib/vutuv_web/components/ui.ex:3225
 #: lib/vutuv_web/live/fediverse_account_live.ex:435
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -7531,7 +7531,7 @@ msgid "Removed:"
 msgstr "Entfernt:"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:974
-#: lib/vutuv_web/live/post_live/composer.ex:1899
+#: lib/vutuv_web/live/post_live/composer.ex:1928
 #: lib/vutuv_web/live/post_live/filter_band.ex:533
 #, elixir-autogen, elixir-format
 msgid "Undo"
@@ -7578,9 +7578,9 @@ msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:7105
+#: lib/vutuv_web/components/post_components.ex:7112
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
-#: lib/vutuv_web/live/shell_live.ex:1830
+#: lib/vutuv_web/live/shell_live.ex:1831
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
 msgstr "+%{count} weitere"
@@ -8503,7 +8503,7 @@ msgstr ""
 " was Sie nicht übernehmen möchten. Einträge, die bereits in Ihrem Profil "
 "stehen, sind für Sie abgewählt."
 
-#: lib/vutuv_web/components/ui.ex:5656
+#: lib/vutuv_web/components/ui.ex:5659
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Import"
@@ -8642,7 +8642,7 @@ msgstr "Bitte prüfen Sie die rot markierten Felder."
 msgid "Loading posts"
 msgstr "Beiträge werden geladen"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:140
+#: lib/vutuv_web/templates/settings/privacy.html.heex:167
 #: lib/vutuv_web/templates/user/show.html.heex:1432
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
@@ -8741,7 +8741,7 @@ msgstr "Sprache & Anzeige"
 msgid "More profile sections"
 msgstr "Weitere Profil-Bereiche"
 
-#: lib/vutuv_web/components/ui.ex:5647
+#: lib/vutuv_web/components/ui.ex:5650
 #: lib/vutuv_web/controllers/settings_controller.ex:112
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8751,7 +8751,7 @@ msgstr "Weitere Profil-Bereiche"
 msgid "Sign-in & security"
 msgstr "Anmeldung & Sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:5660
+#: lib/vutuv_web/components/ui.ex:5663
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8778,19 +8778,19 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr "Geben Sie zur Bestätigung Ihren Benutzernamen ein:"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:142
+#: lib/vutuv_web/templates/settings/privacy.html.heex:169
 #, elixir-autogen, elixir-format
 msgid "If you list a Mastodon or Bluesky account, your profile can show your latest public posts from it."
 msgstr ""
 "Wenn Sie ein Mastodon- oder Bluesky-Konto angeben, kann Ihr Profil Ihre "
 "neuesten öffentlichen Beiträge von dort anzeigen."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:146
+#: lib/vutuv_web/templates/settings/privacy.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "Show my latest social media posts on my profile"
 msgstr "Meine neuesten Social-Media-Beiträge auf meinem Profil anzeigen"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:147
+#: lib/vutuv_web/templates/settings/privacy.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "When off, the Social Media card lists your accounts without any posts."
 msgstr ""
@@ -8983,7 +8983,7 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/agent_docs/text.ex:671
 #: lib/vutuv_web/components/organization_components.ex:285
 #: lib/vutuv_web/components/ui.ex:1825
-#: lib/vutuv_web/components/ui.ex:5637
+#: lib/vutuv_web/components/ui.ex:5640
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:366
 #: lib/vutuv_web/controllers/settings_controller.ex:433
@@ -9150,7 +9150,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:5960
+#: lib/vutuv_web/components/post_components.ex:5967
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9840,7 +9840,7 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Beschäftigungsstatus"
 
-#: lib/vutuv/accounts/user.ex:1295
+#: lib/vutuv/accounts/user.ex:1302
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9851,7 +9851,7 @@ msgstr "Auf Jobsuche"
 msgid "Not open to work"
 msgstr "Nicht offen für Angebote"
 
-#: lib/vutuv/accounts/user.ex:1292
+#: lib/vutuv/accounts/user.ex:1299
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10652,13 +10652,13 @@ msgstr[1] "%{formatted} Sterne"
 msgid "Code"
 msgstr "Code"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:159
+#: lib/vutuv_web/templates/settings/privacy.html.heex:186
 #: lib/vutuv_web/views/account_event_text.ex:236
 #, elixir-autogen, elixir-format
 msgid "Code statistics"
 msgstr "Code-Statistiken"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:161
+#: lib/vutuv_web/templates/settings/privacy.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "If you list a GitHub, GitLab or Codeberg account, your profile can show its public statistics: stars, repositories, followers, languages and recent activity."
 msgstr ""
@@ -10671,12 +10671,12 @@ msgstr ""
 msgid "Last active %{date}"
 msgstr "Zuletzt aktiv %{date}"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:165
+#: lib/vutuv_web/templates/settings/privacy.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Show code statistics on my profile"
 msgstr "Code-Statistiken auf meinem Profil anzeigen"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:166
+#: lib/vutuv_web/templates/settings/privacy.html.heex:193
 #, elixir-autogen, elixir-format
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
@@ -11111,17 +11111,17 @@ msgstr ""
 "wählt, und was ausgeloggte Besucher sehen. Änderungen gelten sofort; "
 "Mitglieder mit eigenem Wert sind nicht betroffen."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:110
+#: lib/vutuv_web/gettext_extraction_anchors.ex:115
 #, elixir-autogen, elixir-format
 msgid "0 means posts are never shortened."
 msgstr "0 bedeutet: Beiträge werden nie gekürzt."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:116
+#: lib/vutuv_web/gettext_extraction_anchors.ex:121
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr "Aus"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:115
+#: lib/vutuv_web/gettext_extraction_anchors.ex:120
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr "An"
@@ -11182,8 +11182,8 @@ msgid "Failed"
 msgstr "Fehlgeschlagen"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:198
-#: lib/vutuv_web/live/post_live/composer.ex:2130
-#: lib/vutuv_web/live/post_live/composer.ex:3099
+#: lib/vutuv_web/live/post_live/composer.ex:2159
+#: lib/vutuv_web/live/post_live/composer.ex:3160
 #, elixir-autogen, elixir-format
 msgid "Gallery"
 msgstr "Galerie"
@@ -11289,19 +11289,19 @@ msgstr ""
 " Konto anlegen kann. Wählen Sie „Niemand“, um den Status zu speichern, ohne "
 "ihn anzuzeigen."
 
-#: lib/vutuv/accounts/user.ex:1333
+#: lib/vutuv/accounts/user.ex:1340
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Alle, auch nicht angemeldete Besucher"
 
-#: lib/vutuv/accounts/user.ex:1338
+#: lib/vutuv/accounts/user.ex:1345
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Niemand"
 
-#: lib/vutuv/accounts/user.ex:1336
+#: lib/vutuv/accounts/user.ex:1343
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:823
 #, elixir-autogen, elixir-format
@@ -11557,7 +11557,7 @@ msgstr ""
 "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) anbieten und für KI-"
 "Agenten auflisten."
 
-#: lib/vutuv_web/controllers/organization_controller.ex:305
+#: lib/vutuv_web/controllers/organization_controller.ex:322
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:31
 #, elixir-autogen, elixir-format
 msgid "Please log in first."
@@ -12326,7 +12326,7 @@ msgstr "Organisation wieder freigegeben."
 #: lib/vutuv_web/agent_docs/markdown.ex:531
 #: lib/vutuv_web/agent_docs/organization_doc.ex:138
 #: lib/vutuv_web/agent_docs/text.ex:481
-#: lib/vutuv_web/components/ui.ex:5664
+#: lib/vutuv_web/components/ui.ex:5667
 #: lib/vutuv_web/controllers/settings_controller.ex:222
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
@@ -12649,7 +12649,7 @@ msgstr "Hervorgehobene Tags passen zu Ihrem Profil."
 msgid "How to apply"
 msgstr "So bewerben Sie sich"
 
-#: lib/vutuv/accounts/user.ex:1307
+#: lib/vutuv/accounts/user.ex:1314
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12768,7 +12768,7 @@ msgstr "Hier ist noch nichts. Jobs, die Ihnen gefallen, erscheinen hier."
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) für KI-Agenten anbieten."
 
-#: lib/vutuv/accounts/user.ex:1306
+#: lib/vutuv/accounts/user.ex:1313
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12850,7 +12850,7 @@ msgstr "Anzeige nicht gefunden."
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: lib/vutuv/accounts/user.ex:1308
+#: lib/vutuv/accounts/user.ex:1315
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:590
 #: lib/vutuv_web/agent_docs/markdown.ex:570
@@ -13876,7 +13876,7 @@ msgstr "Screenshot entfernt."
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr "Dieser Screenshot wurde automatisch aus dem Link in Ihrem Beitrag erstellt. Falls er unbrauchbar ist (zum Beispiel weil ein Cookie-Banner die Seite verdeckt), können Sie ihn entfernen."
 
-#: lib/vutuv/accounts/user.ex:1351
+#: lib/vutuv/accounts/user.ex:1358
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13887,19 +13887,19 @@ msgstr "Nur das Alter, ohne das Datum"
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr "Wählen Sie, wie viel von Ihrem Geburtstag Ihr Profil zeigt. „Nur das Alter“ verbirgt das genaue Datum, „Tag und Monat“ verbirgt das Jahr (und Ihr Alter), und „Nicht anzeigen“ speichert ihn weiterhin, hält ihn aber von Ihrem Profil fern."
 
-#: lib/vutuv/accounts/user.ex:1354
+#: lib/vutuv/accounts/user.ex:1361
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Tag und Monat, ohne das Jahr"
 
-#: lib/vutuv/accounts/user.ex:1357
+#: lib/vutuv/accounts/user.ex:1364
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Geburtstag nicht anzeigen"
 
-#: lib/vutuv/accounts/user.ex:1348
+#: lib/vutuv/accounts/user.ex:1355
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13964,7 +13964,7 @@ msgstr "Volle Breite"
 msgid "Insert image"
 msgstr "Bild einfügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3490
+#: lib/vutuv_web/live/post_live/composer.ex:3551
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr "In den Text einfügen"
@@ -14188,34 +14188,34 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:6648
+#: lib/vutuv_web/components/post_components.ex:6655
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6605
+#: lib/vutuv_web/components/post_components.ex:6612
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:6649
+#: lib/vutuv_web/components/post_components.ex:6656
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:6651
+#: lib/vutuv_web/components/post_components.ex:6658
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:6647
+#: lib/vutuv_web/components/post_components.ex:6654
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6604
+#: lib/vutuv_web/components/post_components.ex:6611
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
@@ -14226,12 +14226,12 @@ msgstr "Filmbesprechung"
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/components/post_components.ex:6646
+#: lib/vutuv_web/components/post_components.ex:6653
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/components/post_components.ex:6650
+#: lib/vutuv_web/components/post_components.ex:6657
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14251,7 +14251,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:6687
+#: lib/vutuv_web/components/post_components.ex:6694
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14259,30 +14259,30 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:6717
+#: lib/vutuv_web/components/post_components.ex:6724
 #: lib/vutuv_web/components/ui.ex:3884
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:6718
+#: lib/vutuv_web/components/post_components.ex:6725
 #: lib/vutuv_web/components/ui.ex:3885
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:6716
+#: lib/vutuv_web/components/post_components.ex:6723
 #: lib/vutuv_web/components/ui.ex:3877
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:6676
+#: lib/vutuv_web/components/post_components.ex:6683
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:6723
+#: lib/vutuv_web/components/post_components.ex:6730
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14312,7 +14312,7 @@ msgstr "Mit Qualifikation:"
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:6490
+#: lib/vutuv_web/components/post_components.ex:6497
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14355,7 +14355,7 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:6481
+#: lib/vutuv_web/components/post_components.ex:6488
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -14500,7 +14500,7 @@ msgstr "Nachweis"
 msgid "Lines in notifications"
 msgstr "Zeilen in Benachrichtigungen"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:111
+#: lib/vutuv_web/gettext_extraction_anchors.ex:116
 #, elixir-autogen, elixir-format
 msgid "How much of a post a notification quotes before it is cut off."
 msgstr "Wie viel von einem Beitrag eine Benachrichtigung zitiert, bevor abgeschnitten wird."
@@ -14616,13 +14616,13 @@ msgstr "Erwähnung"
 msgid "mentioned you in a post."
 msgstr "hat Sie in einem Beitrag erwähnt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1507
+#: lib/vutuv_web/live/post_live/composer.ex:1536
 #: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr "Dieser Beitrag lässt sich nicht mehr bearbeiten: jemand hat ihn geliked, geteilt oder beantwortet."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1510
+#: lib/vutuv_web/live/post_live/composer.ex:1539
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -14752,7 +14752,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:7204
+#: lib/vutuv_web/components/post_components.ex:7211
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -15611,12 +15611,12 @@ msgstr "Die Themen, für die Sie bekannt sind"
 msgid "skill topic keyword expertise endorsement"
 msgstr "fähigkeit kenntnis thema stichwort schlagwort expertise empfehlung"
 
-#: lib/vutuv_web/components/ui.ex:5665
+#: lib/vutuv_web/components/ui.ex:5668
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr "Organisationsseiten, die Sie verwalten"
 
-#: lib/vutuv_web/components/ui.ex:5666
+#: lib/vutuv_web/components/ui.ex:5669
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr "firma unternehmen arbeitgeber betrieb organisation seite"
@@ -15736,62 +15736,52 @@ msgstr "Job- und Personensuchen, die Ihnen neue Treffer mailen"
 msgid "job alert search agent watchlist"
 msgstr "job stelle stellenangebot suchauftrag suche alarm benachrichtigung merkliste"
 
-#: lib/vutuv_web/components/ui.ex:5622
-#, elixir-autogen, elixir-format
-msgid "Search engines, AI, online status"
-msgstr "Suchmaschinen, KI, Online-Status"
-
-#: lib/vutuv_web/components/ui.ex:5623
-#, elixir-autogen, elixir-format
-msgid "privacy google search engine ai llm crawler noindex online dot public"
-msgstr "privatsphäre datenschutz google suchmaschine ki ai llm crawler noindex online punkt öffentlich sichtbar"
-
-#: lib/vutuv_web/components/ui.ex:5626
+#: lib/vutuv_web/components/ui.ex:5629
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr "Personen, die nicht mit Ihnen interagieren können"
 
-#: lib/vutuv_web/components/ui.ex:5627
+#: lib/vutuv_web/components/ui.ex:5630
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr "blockieren sperren bannen stummschalten melden missbrauch belästigung"
 
-#: lib/vutuv_web/components/ui.ex:5648
+#: lib/vutuv_web/components/ui.ex:5651
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr "Passkeys, angemeldete Geräte, Anmeldecodes"
 
-#: lib/vutuv_web/components/ui.ex:5649
+#: lib/vutuv_web/components/ui.ex:5652
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr "passwort kennwort anmelden abmelden login logout sitzung gerät passkey totp 2fa pin sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:5657
+#: lib/vutuv_web/components/ui.ex:5660
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr "Ihre Daten von LinkedIn übernehmen"
 
-#: lib/vutuv_web/components/ui.ex:5658
+#: lib/vutuv_web/components/ui.ex:5661
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr "linkedin hochladen zip übernehmen importieren umzug"
 
-#: lib/vutuv_web/components/ui.ex:5661
+#: lib/vutuv_web/components/ui.ex:5664
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr "Alles herunterladen, was wir über Sie speichern"
 
-#: lib/vutuv_web/components/ui.ex:5662
+#: lib/vutuv_web/components/ui.ex:5665
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr "herunterladen download dsgvo gdpr daten sicherung json lebenslauf auskunft"
 
-#: lib/vutuv_web/components/ui.ex:5676
+#: lib/vutuv_web/components/ui.ex:5679
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr "Ihr Konto und alles darauf entfernen"
 
-#: lib/vutuv_web/components/ui.ex:5677
+#: lib/vutuv_web/components/ui.ex:5680
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr "löschen entfernen schließen kündigen beenden verlassen"
@@ -15913,7 +15903,7 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:7150
+#: lib/vutuv_web/components/post_components.ex:7157
 #: lib/vutuv_web/live/notification_live/index.ex:1592
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -15921,7 +15911,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:7154
+#: lib/vutuv_web/components/post_components.ex:7161
 #: lib/vutuv_web/live/notification_live/index.ex:1586
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15929,7 +15919,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Like"
 msgstr[1] "%{formatted} Likes"
 
-#: lib/vutuv_web/components/post_components.ex:7158
+#: lib/vutuv_web/components/post_components.ex:7165
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15937,7 +15927,7 @@ msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1339
-#: lib/vutuv_web/components/post_components.ex:7109
+#: lib/vutuv_web/components/post_components.ex:7116
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Bereits in den Zahlen oben enthalten."
@@ -16269,7 +16259,7 @@ msgstr "API-Token erstellt"
 msgid "Access token revoked"
 msgstr "API-Token widerrufen"
 
-#: lib/vutuv_web/components/ui.ex:5651
+#: lib/vutuv_web/components/ui.ex:5654
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -16483,7 +16473,7 @@ msgstr "Hier ist noch nichts. Wenn Sie sich das nächste Mal anmelden oder eine 
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/admin/media_live.ex:155
 #: lib/vutuv_web/live/fediverse_following_live.ex:351
-#: lib/vutuv_web/live/tag_live/timeline.ex:473
+#: lib/vutuv_web/live/tag_live/timeline.ex:477
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr "Dazu passt nichts. Versuchen Sie eine kürzere Suche oder setzen Sie die Filter zurück."
@@ -16615,7 +16605,7 @@ msgstr "Was sich an einem Konto geändert hat, wann, von wo und wie es bestätig
 msgid "What changed on your account, and exactly when."
 msgstr "Was sich an Ihrem Konto geändert hat, und wann genau."
 
-#: lib/vutuv_web/components/ui.ex:5652
+#: lib/vutuv_web/components/ui.ex:5655
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr "Was sich an Ihrem Konto geändert hat, und wann"
@@ -16651,7 +16641,7 @@ msgstr "durch den Betreiber"
 msgid "from a signed-in session"
 msgstr "aus einer angemeldeten Sitzung"
 
-#: lib/vutuv_web/components/ui.ex:5654
+#: lib/vutuv_web/components/ui.ex:5657
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr "protokoll verlauf historie chronik audit sicherheit war ich das wer hat wann geaendert geändert log"
@@ -16703,22 +16693,22 @@ msgstr "Was sich an welchem Konto geändert hat, wann, von welchem Gerät und wi
 msgid "device or detail"
 msgstr "Gerät oder Detail"
 
-#: lib/vutuv_web/components/post_components.ex:4443
+#: lib/vutuv_web/components/post_components.ex:4450
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Angehefteter Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:4577
+#: lib/vutuv_web/components/post_components.ex:4584
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "An Profil anheften"
 
-#: lib/vutuv_web/components/post_components.ex:4585
+#: lib/vutuv_web/components/post_components.ex:4592
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Vom Profil lösen"
 
-#: lib/vutuv_web/components/post_components.ex:4571
+#: lib/vutuv_web/components/post_components.ex:4578
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr "Es lässt sich nur ein Beitrag an Ihr Profil anheften. Diesen anheften und den anderen lösen?"
@@ -16768,7 +16758,7 @@ msgstr ""
 "in eckigen Klammern, wie eine Lautschrift geschrieben wird; die Klammern "
 "ergänzen wir für Sie. Bleibt das Feld leer, wird nichts angezeigt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3503
+#: lib/vutuv_web/live/post_live/composer.ex:3564
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr "Diese Einstellungen für alle Fotos übernehmen"
@@ -16800,12 +16790,12 @@ msgstr "CC0 1.0 (keine Rechte vorbehalten)"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1456
 #: lib/vutuv_web/agent_docs/text.ex:921
-#: lib/vutuv_web/live/post_live/composer.ex:2927
+#: lib/vutuv_web/live/post_live/composer.ex:2988
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr "Titelbild"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3341
+#: lib/vutuv_web/live/post_live/composer.ex:3402
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
@@ -16817,22 +16807,22 @@ msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 msgid "Download the original"
 msgstr "Original herunterladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3440
+#: lib/vutuv_web/live/post_live/composer.ex:3501
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr "Alle Metadaten bleiben erhalten, auch alles, was Ihre Kamera hineingeschrieben hat."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3396
+#: lib/vutuv_web/live/post_live/composer.ex:3457
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr "Alle dürfen dieses Foto herunterladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3398
+#: lib/vutuv_web/live/post_live/composer.ex:3459
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr "Volle Auflösung, direkt aus dem Beitrag."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3417
+#: lib/vutuv_web/live/post_live/composer.ex:3478
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr "Nur das Bild"
@@ -16842,7 +16832,7 @@ msgstr "Nur das Bild"
 msgid "Next photo"
 msgstr "Nächstes Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2946
+#: lib/vutuv_web/live/post_live/composer.ex:3007
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
@@ -16852,27 +16842,27 @@ msgstr "Noch keine Bildbeschreibung"
 msgid "Open Fediverse settings"
 msgstr "Fediverse-Einstellungen öffnen"
 
-#: lib/vutuv_web/components/post_components.ex:5526
-#: lib/vutuv_web/components/press_kit_components.ex:521
+#: lib/vutuv_web/components/post_components.ex:5533
+#: lib/vutuv_web/components/press_kit_components.ex:526
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:5754
-#: lib/vutuv_web/components/press_kit_components.ex:618
+#: lib/vutuv_web/components/post_components.ex:5761
+#: lib/vutuv_web/components/press_kit_components.ex:623
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2899
-#: lib/vutuv_web/live/post_live/composer.ex:2900
+#: lib/vutuv_web/live/post_live/composer.ex:2960
+#: lib/vutuv_web/live/post_live/composer.ex:2961
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr "Foto-Einstellungen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1500
 #: lib/vutuv_web/agent_docs/text.ex:909
-#: lib/vutuv_web/components/post_components.ex:5836
+#: lib/vutuv_web/components/post_components.ex:5843
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Fotos:"
@@ -16882,18 +16872,18 @@ msgstr "Fotos:"
 msgid "Previous photo"
 msgstr "Vorheriges Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2959
-#: lib/vutuv_web/live/post_live/composer.ex:2960
+#: lib/vutuv_web/live/post_live/composer.ex:3020
+#: lib/vutuv_web/live/post_live/composer.ex:3021
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr "Foto entfernen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3419
+#: lib/vutuv_web/live/post_live/composer.ex:3480
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qualität unverändert."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3360
+#: lib/vutuv_web/live/post_live/composer.ex:3421
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
@@ -16903,17 +16893,17 @@ msgstr "Kameradaten anzeigen"
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3438
+#: lib/vutuv_web/live/post_live/composer.ex:3499
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr "Die Datei genau so, wie ich sie hochgeladen habe"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3474
+#: lib/vutuv_web/live/post_live/composer.ex:3535
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen Sie das Foto, wenn Sie das nicht möchten."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3466
+#: lib/vutuv_web/live/post_live/composer.ex:3527
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
@@ -16938,12 +16928,12 @@ msgstr "Diese Seite nimmt nicht am Fediverse teil."
 msgid "Turn on Fediverse participation to answer"
 msgstr "Fediverse-Teilnahme einschalten, um zu antworten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3217
+#: lib/vutuv_web/live/post_live/composer.ex:3278
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr "Wer diese Fotos weiterverwenden darf"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1537
+#: lib/vutuv_web/live/post_live/composer.ex:1566
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
@@ -16953,7 +16943,7 @@ msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke gesc
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshalb werden von hier aus keine Antworten mehr gesendet."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1551
+#: lib/vutuv_web/live/post_live/composer.ex:1580
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
@@ -16968,64 +16958,64 @@ msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fedive
 msgid "© All rights reserved"
 msgstr "© Alle Rechte vorbehalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2842
+#: lib/vutuv_web/live/post_live/composer.ex:2903
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr "Fotos hinzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3212
+#: lib/vutuv_web/live/post_live/composer.ex:3273
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr "Lizenz"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3331
+#: lib/vutuv_web/live/post_live/composer.ex:3392
 #, elixir-autogen, elixir-format
 msgid "Caption (optional)"
 msgstr "Bildunterschrift (optional)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1874
-#: lib/vutuv_web/live/post_live/composer.ex:1937
-#: lib/vutuv_web/live/post_live/composer.ex:1995
+#: lib/vutuv_web/live/post_live/composer.ex:1903
+#: lib/vutuv_web/live/post_live/composer.ex:1966
+#: lib/vutuv_web/live/post_live/composer.ex:2024
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr "Entwurf verwerfen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1867
+#: lib/vutuv_web/live/post_live/composer.ex:1896
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr "Weiter, wo Sie aufgehört haben."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3265
+#: lib/vutuv_web/live/post_live/composer.ex:3326
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr "Eine Datei, deren Format sich nicht säubern lässt, wird exakt so weitergegeben, wie sie hochgeladen wurde."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2563
+#: lib/vutuv_web/live/post_live/composer.ex:2624
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr "Pro Foto verschieden"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2562
+#: lib/vutuv_web/live/post_live/composer.ex:2623
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr "Original, exakt wie hochgeladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2561
+#: lib/vutuv_web/live/post_live/composer.ex:2622
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr "Original, ohne Metadaten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2566
+#: lib/vutuv_web/live/post_live/composer.ex:2627
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr "Nur Web-Versionen (%{format})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3235
+#: lib/vutuv_web/live/post_live/composer.ex:3296
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr "Was Besucher speichern können"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3254
+#: lib/vutuv_web/live/post_live/composer.ex:3315
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -17033,13 +17023,13 @@ msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exak
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1357
-#: lib/vutuv_web/components/post_components.ex:7147
+#: lib/vutuv_web/components/post_components.ex:7154
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1355
-#: lib/vutuv_web/components/post_components.ex:7144
+#: lib/vutuv_web/components/post_components.ex:7151
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17049,7 +17039,7 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:7031
+#: lib/vutuv_web/components/post_components.ex:7038
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
@@ -17145,8 +17135,8 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr "Rücknahme"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2131
-#: lib/vutuv_web/live/post_live/composer.ex:3099
+#: lib/vutuv_web/live/post_live/composer.ex:2160
+#: lib/vutuv_web/live/post_live/composer.ex:3160
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr "Fotodetails"
@@ -17176,7 +17166,7 @@ msgstr "Ein Konto in einem anderen Netzwerk"
 msgid "Cancel request"
 msgstr "Anfrage zurückziehen"
 
-#: lib/vutuv_web/components/ui.ex:5638
+#: lib/vutuv_web/components/ui.ex:5641
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr "Konten auf Mastodon folgen, und von dort gefolgt werden"
@@ -17380,7 +17370,7 @@ msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, desh
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr "Ihr Konto ist derzeit gesperrt, deshalb geht nichts von Ihnen an andere Netzwerke und Sie können dort niemandem folgen. Das endet von selbst, sobald die Sperre abläuft."
 
-#: lib/vutuv_web/components/ui.ex:5640
+#: lib/vutuv_web/components/ui.ex:5643
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr "mastodon activitypub foederation federation follower folgen folge umzug migration entferntes konto"
@@ -17898,104 +17888,104 @@ msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, desh
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr "Einen nachgeschlagenen Beitrag bewahrt vutuv genauso sechs Monate lang auf wie jeden anderen Beitrag aus einem anderen Netzwerk. Der Server der verfassenden Person wird sonst nichts gefragt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2048
+#: lib/vutuv_web/live/post_live/composer.ex:2077
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr "Zuschnitt übernehmen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3005
+#: lib/vutuv_web/live/post_live/composer.ex:3066
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr "Großes Foto links"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3006
+#: lib/vutuv_web/live/post_live/composer.ex:3067
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr "Großes Foto rechts"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3011
+#: lib/vutuv_web/live/post_live/composer.ex:3072
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr "Spalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3008
+#: lib/vutuv_web/live/post_live/composer.ex:3069
 #, elixir-autogen, elixir-format
 msgid "Cover left"
 msgstr "Titelbild links"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3009
+#: lib/vutuv_web/live/post_live/composer.ex:3070
 #, elixir-autogen, elixir-format
 msgid "Cover on top"
 msgstr "Titelbild oben"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3010
+#: lib/vutuv_web/live/post_live/composer.ex:3071
 #, elixir-autogen, elixir-format
 msgid "Cover right"
 msgstr "Titelbild rechts"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2044
-#: lib/vutuv_web/live/post_live/composer.ex:2976
-#: lib/vutuv_web/live/post_live/composer.ex:2977
+#: lib/vutuv_web/live/post_live/composer.ex:2073
+#: lib/vutuv_web/live/post_live/composer.ex:3037
+#: lib/vutuv_web/live/post_live/composer.ex:3038
 #, elixir-autogen, elixir-format
 msgid "Crop photo"
 msgstr "Foto zuschneiden"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2935
+#: lib/vutuv_web/live/post_live/composer.ex:2996
 #, elixir-autogen, elixir-format
 msgid "Cropped"
 msgstr "Zugeschnitten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1966
+#: lib/vutuv_web/live/post_live/composer.ex:1995
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr "Fotos hier ablegen, um sie hinzuzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3012
+#: lib/vutuv_web/live/post_live/composer.ex:3073
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr "Raster"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3013
+#: lib/vutuv_web/live/post_live/composer.ex:3074
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr "Mosaik"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2046
+#: lib/vutuv_web/live/post_live/composer.ex:2075
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr "Wählen Sie ein Format, dann verschieben und zoomen Sie. Der gerahmte Ausschnitt ist das, was der Beitrag zeigt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3004
+#: lib/vutuv_web/live/post_live/composer.ex:3065
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr "Nebeneinander"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3007
+#: lib/vutuv_web/live/post_live/composer.ex:3068
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr "Übereinander"
 
-#: lib/vutuv_web/live/post_live/composer.ex:611
+#: lib/vutuv_web/live/post_live/composer.ex:630
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr "Das Foto konnte nicht zugeschnitten werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3453
+#: lib/vutuv_web/live/post_live/composer.ex:3514
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr "Dieses Foto ist zugeschnitten: Downloads geben das zugeschnittene Bild heraus, die unveränderte Originaldatei bleibt privat."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2050
+#: lib/vutuv_web/live/post_live/composer.ex:2079
 #, elixir-autogen, elixir-format
 msgid "Whole photo"
 msgstr "Ganzes Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3202
+#: lib/vutuv_web/live/post_live/composer.ex:3263
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr "Kacheln füllen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3186
+#: lib/vutuv_web/live/post_live/composer.ex:3247
 #, elixir-autogen, elixir-format
 msgid "Whole photos"
 msgstr "Ganze Fotos"
@@ -18233,22 +18223,22 @@ msgid_plural "%{formatted} posts"
 msgstr[0] "%{formatted} Beitrag"
 msgstr[1] "%{formatted} Beiträge"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:450
+#: lib/vutuv_web/live/tag_live/timeline.ex:454
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr "Meiste Likes"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:481
+#: lib/vutuv_web/live/tag_live/timeline.ex:485
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr "Zu diesem Tag gibt es noch keine Beiträge."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:479
+#: lib/vutuv_web/live/tag_live/timeline.ex:483
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr "Aus anderen Netzwerken gibt es zu diesem Tag noch keine Beiträge."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:476
+#: lib/vutuv_web/live/tag_live/timeline.ex:480
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr "Auf vutuv gibt es zu diesem Tag noch keine Beiträge."
@@ -18320,7 +18310,7 @@ msgstr "Quellcode"
 msgid "At most %{max} tags. Remove one to add another."
 msgstr "Höchstens %{max} Tags. Entfernen Sie eines, um ein anderes hinzuzufügen."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:93
+#: lib/vutuv_web/templates/settings/privacy.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr "Auf der Seite eines Beitrags stehen direkt unter der Zahl die Mitglieder, denen er gefällt. Hier legen Sie fest, ob Sie zu diesen Gesichtern gehören."
@@ -18330,24 +18320,24 @@ msgstr "Auf der Seite eines Beitrags stehen direkt unter der Zahl die Mitglieder
 msgid "Liked by"
 msgstr "Gefällt diesen Mitgliedern"
 
-#: lib/vutuv_web/components/post_components.ex:6130
+#: lib/vutuv_web/components/post_components.ex:6137
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Gefällt %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:6132
+#: lib/vutuv_web/components/post_components.ex:6139
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Gefällt %{name} und %{formatted} weiteren"
 msgstr[1] "Gefällt %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/components/post_components.ex:6143
+#: lib/vutuv_web/components/post_components.ex:6150
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr "Nur Sie sehen hier alle: Einige dieser Mitglieder werden anderen Lesern nicht genannt."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:111
+#: lib/vutuv_web/templates/settings/privacy.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "Reset to the site default"
 msgstr "Auf den Standardwert der Website zurücksetzen"
@@ -19242,17 +19232,17 @@ msgstr ""
 "Kommt keine PIN an? Ist die E-Mail-Adresse {email} korrekt? Haben Sie einmal "
 "in Ihren Spam-Ordner geschaut?"
 
-#: lib/vutuv/accounts/user.ex:1454
+#: lib/vutuv/accounts/user.ex:1461
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/vutuv/accounts/user.ex:1452
+#: lib/vutuv/accounts/user.ex:1459
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr "Weiblich"
 
-#: lib/vutuv/accounts/user.ex:1453
+#: lib/vutuv/accounts/user.ex:1460
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Männlich"
@@ -19361,7 +19351,7 @@ msgstr "Ebenfalls löschen"
 msgid "Always keep"
 msgstr "Immer behalten"
 
-#: lib/vutuv_web/components/ui.ex:5631
+#: lib/vutuv_web/components/ui.ex:5634
 #: lib/vutuv_web/controllers/settings_controller.ex:256
 #: lib/vutuv_web/controllers/settings_controller.ex:335
 #: lib/vutuv_web/controllers/settings_controller.ex:347
@@ -19458,7 +19448,7 @@ msgstr "Fotobeiträge behalten"
 msgid "Keep posts that did well"
 msgstr "Beiträge behalten, die gut liefen"
 
-#: lib/vutuv_web/components/ui.ex:5633
+#: lib/vutuv_web/components/ui.ex:5636
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr "Ihre Beiträge nach einer selbst gewählten Zeit auslaufen lassen"
@@ -19567,7 +19557,7 @@ msgstr "Sie können vorher alles herunterladen, was Sie hier haben:"
 msgid "Your rule"
 msgstr "Ihre Regel"
 
-#: lib/vutuv_web/components/ui.ex:5635
+#: lib/vutuv_web/components/ui.ex:5638
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr "löschen entfernen beiträge alter alt ablaufen verfallen automatisch aufräumen aufbewahrung"
@@ -20001,17 +19991,17 @@ msgstr "Der Besitzer vergibt die Rollen der anderen Mitglieder auf der Seite und
 msgid "Nothing published yet."
 msgstr "Noch nichts veröffentlicht."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2377
+#: lib/vutuv_web/live/post_live/composer.ex:2438
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
 msgstr "Als %{name} veröffentlichen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1530
+#: lib/vutuv_web/live/post_live/composer.ex:1559
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr "Sie dürfen nicht mehr im Namen dieser Organisation schreiben."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2354
+#: lib/vutuv_web/live/post_live/composer.ex:2415
 #, elixir-autogen, elixir-format
 msgid "A post in an organization's name is always public."
 msgstr "Ein Beitrag im Namen einer Organisation ist immer öffentlich."
@@ -20811,44 +20801,44 @@ msgstr "Sie haben %{used} von %{max} Tags."
 msgid "{n} of {max} free slots selected."
 msgstr "{n} von {max} freien Plätzen ausgewählt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2336
+#: lib/vutuv_web/live/post_live/composer.ex:2397
 #, elixir-autogen, elixir-format
 msgid "More languages"
 msgstr "Weitere Sprachen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2327
+#: lib/vutuv_web/live/post_live/composer.ex:2388
 #, elixir-autogen, elixir-format
 msgctxt "post composer"
 msgid "Language"
 msgstr "Sprache"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2323
-#: lib/vutuv_web/live/post_live/composer.ex:2324
+#: lib/vutuv_web/live/post_live/composer.ex:2384
+#: lib/vutuv_web/live/post_live/composer.ex:2385
 #, elixir-autogen, elixir-format
 msgid "The language this post is written in"
 msgstr "Die Sprache, in der dieser Beitrag geschrieben ist"
 
-#: lib/vutuv_web/components/post_components.ex:6024
+#: lib/vutuv_web/components/post_components.ex:6031
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Original anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:6060
+#: lib/vutuv_web/components/post_components.ex:6067
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Übersetzen"
 
-#: lib/vutuv_web/components/post_components.ex:6069
+#: lib/vutuv_web/components/post_components.ex:6076
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Übersetzt"
 
-#: lib/vutuv_web/components/post_components.ex:6072
+#: lib/vutuv_web/components/post_components.ex:6079
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Übersetzt aus %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:6049
+#: lib/vutuv_web/components/post_components.ex:6056
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Wird übersetzt …"
@@ -20858,7 +20848,7 @@ msgstr "Wird übersetzt …"
 msgid "Feed language settings reset to the site defaults."
 msgstr "Feed-Spracheinstellungen auf die Website-Vorgaben zurückgesetzt."
 
-#: lib/vutuv_web/components/post_components.ex:6039
+#: lib/vutuv_web/components/post_components.ex:6046
 #: lib/vutuv_web/components/ui.ex:5549
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -20867,27 +20857,27 @@ msgstr "Feed-Spracheinstellungen auf die Website-Vorgaben zurückgesetzt."
 msgid "Feed languages"
 msgstr "Feed-Sprachen"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:83
+#: lib/vutuv_web/gettext_extraction_anchors.ex:88
 #, elixir-autogen, elixir-format
 msgid "Hide them"
 msgstr "Ausblenden"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:81
+#: lib/vutuv_web/gettext_extraction_anchors.ex:86
 #, elixir-autogen, elixir-format
 msgid "Posts in other languages"
 msgstr "Beiträge in anderen Sprachen"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:82
+#: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #, elixir-autogen, elixir-format
 msgid "Translate into my language"
 msgstr "In meine Sprache übersetzen"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:84
+#: lib/vutuv_web/gettext_extraction_anchors.ex:89
 #, elixir-autogen, elixir-format
 msgid "What your feed does with posts outside your chosen languages: show them as they are, translate them for you, or hide them. Posts that declare no language always show."
 msgstr "Was Ihr Feed mit Beiträgen außerhalb Ihrer gewählten Sprachen macht: im Original zeigen, für Sie übersetzen oder ausblenden. Beiträge ohne Sprachangabe werden immer gezeigt."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:120
+#: lib/vutuv_web/gettext_extraction_anchors.ex:125
 #, elixir-autogen, elixir-format
 msgid "Date & time"
 msgstr "Datum & Uhrzeit"
@@ -20897,12 +20887,12 @@ msgstr "Datum & Uhrzeit"
 msgid "Date and time settings reset to the site defaults."
 msgstr "Datum und Uhrzeit folgen wieder den Voreinstellungen der Website."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:118
+#: lib/vutuv_web/gettext_extraction_anchors.ex:123
 #, elixir-autogen, elixir-format
 msgid "Date format"
 msgstr "Datumsformat"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:128
+#: lib/vutuv_web/gettext_extraction_anchors.ex:133
 #, elixir-autogen, elixir-format
 msgid "Germany, Austria, Switzerland"
 msgstr "Deutschland, Österreich, Schweiz"
@@ -20912,27 +20902,27 @@ msgstr "Deutschland, Österreich, Schweiz"
 msgid "Language and region saved."
 msgstr "Sprache und Region gespeichert."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:124
+#: lib/vutuv_web/gettext_extraction_anchors.ex:129
 #, elixir-autogen, elixir-format
 msgid "Posts, messages and notifications are stamped in this zone. New accounts take it from the browser."
 msgstr "Beiträge, Nachrichten und Benachrichtigungen tragen die Uhrzeit dieser Zeitzone. Neue Konten übernehmen sie vom Browser."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:121
+#: lib/vutuv_web/gettext_extraction_anchors.ex:126
 #, elixir-autogen, elixir-format
 msgid "The order and punctuation of every date you read here, and whether times run on a 12- or 24-hour clock."
 msgstr "Reihenfolge und Trennzeichen aller Datumsangaben, die Sie hier lesen, und ob Uhrzeiten im 12- oder 24-Stunden-Format stehen."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:119
+#: lib/vutuv_web/gettext_extraction_anchors.ex:124
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr "Zeitzone"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:129
+#: lib/vutuv_web/gettext_extraction_anchors.ex:134
 #, elixir-autogen, elixir-format
 msgid "United Kingdom, France, Brazil"
 msgstr "Vereinigtes Königreich, Frankreich, Brasilien"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:130
+#: lib/vutuv_web/gettext_extraction_anchors.ex:135
 #, elixir-autogen, elixir-format
 msgid "United States"
 msgstr "Vereinigte Staaten"
@@ -20942,7 +20932,7 @@ msgstr "Vereinigte Staaten"
 msgid "Your browser says: {zone}"
 msgstr "Ihr Browser meldet: {zone}"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:131
+#: lib/vutuv_web/gettext_extraction_anchors.ex:136
 #, elixir-autogen, elixir-format
 msgid "ISO 8601 (Sweden, Japan, China)"
 msgstr "ISO 8601 (Schweden, Japan, China)"
@@ -20987,20 +20977,20 @@ msgstr "Wir haben den Link in Ihrem Profil noch nicht gefunden. Bitte versuchen 
 msgid "Your username, or paste the address of your profile page."
 msgstr "Ihr Benutzername – oder fügen Sie die Adresse Ihrer Profilseite ein."
 
-#: lib/vutuv_web/components/post_components.ex:5802
+#: lib/vutuv_web/components/post_components.ex:5809
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] "Unsere KI prüft es gerade. Sobald die Prüfung durch ist, erscheint das Foto von selbst."
 msgstr[1] "Unsere KI prüft sie gerade, %{done} von %{total} sind durch. Sobald die letzte durch ist, erscheinen die Fotos von selbst."
 
-#: lib/vutuv_web/components/post_components.ex:5799
+#: lib/vutuv_web/components/post_components.ex:5806
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Ihr Beitrag ist veröffentlicht, das Foto noch nicht."
 
 #: lib/vutuv_web/components/post_components.ex:2912
-#: lib/vutuv_web/components/post_components.ex:4868
+#: lib/vutuv_web/components/post_components.ex:4875
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -21070,7 +21060,7 @@ msgstr "Damit können Sie sich von einer Mastodon-kompatiblen App aus bei diesem
 msgid "Mastodon app access changed"
 msgstr "Mastodon-App-Zugriff geändert"
 
-#: lib/vutuv_web/components/ui.ex:5669
+#: lib/vutuv_web/components/ui.ex:5672
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr "Mastodon-Apps, verbundene Apps und Zugriffstoken"
@@ -21116,7 +21106,7 @@ msgstr "Wer etwas geschrieben hat, wird weiter festgehalten, das Team kann also 
 msgid "Your account is then %{handle}."
 msgstr "Dein Konto heißt dann %{handle}."
 
-#: lib/vutuv_web/components/ui.ex:5671
+#: lib/vutuv_web/components/ui.ex:5674
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr "api token oauth entwickler verbunden drittanbieter schnittstelle mastodon app handy telefon client ivory tusky ice cubes anmelden"
@@ -21702,7 +21692,7 @@ msgstr ""
 msgid "Example"
 msgstr "Beispiel"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:95
+#: lib/vutuv_web/gettext_extraction_anchors.ex:100
 #, elixir-autogen, elixir-format
 msgid "Feed tabs"
 msgstr "Feed-Reiter"
@@ -21717,22 +21707,22 @@ msgstr "Neue Version geflasht, der Bootvorgang liegt jetzt unter zwei Sekunden"
 msgid "Play the example"
 msgstr "Beispiel abspielen"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:109
+#: lib/vutuv_web/gettext_extraction_anchors.ex:114
 #, elixir-autogen, elixir-format
 msgid "Between 4 and 20 seconds."
 msgstr "Zwischen 4 und 20 Sekunden."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:97
+#: lib/vutuv_web/gettext_extraction_anchors.ex:102
 #, elixir-autogen, elixir-format
 msgid "How long the quote stands"
 msgstr "Wie lange der Anriss steht"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:96
+#: lib/vutuv_web/gettext_extraction_anchors.ex:101
 #, elixir-autogen, elixir-format
 msgid "Quote what arrives on the other tab"
 msgstr "Neues auf dem anderen Reiter anreißen"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:98
+#: lib/vutuv_web/gettext_extraction_anchors.ex:103
 #, elixir-autogen, elixir-format
 msgid "When off, a tab holding something new wears its dot and says nothing more."
 msgstr "Ausgeschaltet trägt ein Reiter mit Neuem nur seinen Punkt und sagt sonst nichts."
@@ -21875,7 +21865,7 @@ msgid_plural "+%{formatted} more posts"
 msgstr[0] "+%{formatted} weiterer Beitrag"
 msgstr[1] "+%{formatted} weitere Beiträge"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:100
+#: lib/vutuv_web/gettext_extraction_anchors.ex:105
 #: lib/vutuv_web/templates/settings/preferences.html.heex:210
 #, elixir-autogen, elixir-format
 msgid "Browser tab"
@@ -21891,12 +21881,12 @@ msgstr "Einstellungen für den Browser-Tab auf die Website-Vorgaben zurückgeset
 msgid "Browser tab settings saved."
 msgstr "Einstellungen für den Browser-Tab gespeichert."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:102
+#: lib/vutuv_web/gettext_extraction_anchors.ex:107
 #, elixir-autogen, elixir-format
 msgid "Only while you are looking at another tab, and only for a few seconds. The tab title also shows up in screenshots, in your window switcher and in a screen share."
 msgstr "Nur solange Sie einen anderen Tab ansehen, und nur für ein paar Sekunden. Der Titel eines Tabs erscheint auch in Screenshots, in Ihrer Fensterauswahl und bei einer Bildschirmfreigabe."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:101
+#: lib/vutuv_web/gettext_extraction_anchors.ex:106
 #, elixir-autogen, elixir-format
 msgid "Tease new posts in the browser tab"
 msgstr "Neue Beiträge im Browser-Tab anreißen"
@@ -22537,7 +22527,7 @@ msgstr "Nur diese Accounts (leer = alle) …"
 msgid "only %{account}"
 msgstr "nur %{account}"
 
-#: lib/vutuv_web/components/post_components.ex:7492
+#: lib/vutuv_web/components/post_components.ex:7499
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -22552,7 +22542,7 @@ msgid_plural "%{formatted} shares"
 msgstr[0] "%{formatted} Mal geteilt"
 msgstr[1] "%{formatted} Mal geteilt"
 
-#: lib/vutuv_web/controllers/post_calendar_controller.ex:136
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:141
 #: lib/vutuv_web/live/notification_live/index.ex:821
 #, elixir-autogen, elixir-format
 msgid "Post without text"
@@ -22600,18 +22590,18 @@ msgid "Nothing matches."
 msgstr "Nichts gefunden."
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:336
-#: lib/vutuv_web/live/post_live/composer.ex:2130
-#: lib/vutuv_web/live/post_live/composer.ex:3132
+#: lib/vutuv_web/live/post_live/composer.ex:2159
+#: lib/vutuv_web/live/post_live/composer.ex:3193
 #, elixir-autogen, elixir-format
 msgid "Automatic"
 msgstr "Automatisch"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2135
+#: lib/vutuv_web/live/post_live/composer.ex:2164
 #, elixir-autogen, elixir-format
 msgid "Drag one photo onto another to swap them."
 msgstr "Ein Foto auf ein anderes ziehen, um sie zu tauschen."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2082
+#: lib/vutuv_web/live/post_live/composer.ex:2111
 #, elixir-autogen, elixir-format
 msgid "Not shown in the gallery — drag one into it to swap."
 msgstr "Nicht in der Galerie zu sehen — eines hineinziehen, um zu tauschen."
@@ -22668,17 +22658,17 @@ msgstr "Anfrage wirklich zurückziehen?"
 msgid "Unmute %{host}"
 msgstr "%{host} wieder einschalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1890
+#: lib/vutuv_web/live/post_live/composer.ex:1919
 #, elixir-autogen, elixir-format
 msgid "Draft discarded."
 msgstr "Entwurf gelöscht."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1929
+#: lib/vutuv_web/live/post_live/composer.ex:1958
 #, elixir-autogen, elixir-format
 msgid "Keep it"
 msgstr "Behalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1920
+#: lib/vutuv_web/live/post_live/composer.ex:1949
 #, elixir-autogen, elixir-format
 msgid "Keep this draft for later?"
 msgstr "Diesen Entwurf für später behalten?"
@@ -22710,7 +22700,7 @@ msgstr "Einstellungen zur Bandbreite gespeichert."
 msgid "If you are on a slow or metered connection, vutuv can leave out the parts of the page that cost the most to download."
 msgstr "Wenn Ihre Verbindung langsam ist oder Ihr Datenvolumen begrenzt, kann vutuv die Teile der Seite weglassen, die beim Laden am meisten kosten."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:107
+#: lib/vutuv_web/gettext_extraction_anchors.ex:112
 #, elixir-autogen, elixir-format
 msgid "Low-bandwidth mode"
 msgstr "Datensparmodus"
@@ -22791,7 +22781,7 @@ msgstr "Regeln, die den Text der Beiträge eines Kontos umschreiben, bevor Sie i
 
 #: lib/vutuv_web/components/post_components.ex:1456
 #: lib/vutuv_web/components/post_components.ex:3406
-#: lib/vutuv_web/components/post_components.ex:4658
+#: lib/vutuv_web/components/post_components.ex:4665
 #: lib/vutuv_web/components/ui.ex:5541
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
@@ -22878,7 +22868,7 @@ msgstr "Darstellung"
 msgid "About %{minutes} min of video"
 msgstr "Etwa %{minutes} Min. Video"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2634
+#: lib/vutuv_web/live/post_live/composer.ex:2695
 #, elixir-autogen, elixir-format
 msgid "Add video"
 msgstr "Video hinzufügen"
@@ -22915,37 +22905,37 @@ msgstr[1] "Unsere KI prüft es gerade, %{done} von %{total} Bildern sind durch."
 msgid "Reading the frames"
 msgstr "Standbilder werden gelesen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2670
+#: lib/vutuv_web/live/post_live/composer.ex:2731
 #, elixir-autogen, elixir-format
 msgid "Remove it to post the text without it, or pick another file."
 msgstr "Entfernen Sie es, um den Text ohne Video zu veröffentlichen, oder wählen Sie eine andere Datei."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1195
+#: lib/vutuv_web/live/post_live/composer.ex:1224
 #, elixir-autogen, elixir-format
 msgid "Remove the refused video to post the text without it."
 msgstr "Entfernen Sie das abgelehnte Video, um den Text ohne Video zu veröffentlichen."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2699
+#: lib/vutuv_web/live/post_live/composer.ex:2760
 #, elixir-autogen, elixir-format
 msgid "Remove video"
 msgstr "Video entfernen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2709
+#: lib/vutuv_web/live/post_live/composer.ex:2770
 #, elixir-autogen, elixir-format
 msgid "Tap a frame to make it the cover."
 msgstr "Tippen Sie auf ein Bild, um es zum Titelbild zu machen."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1062
+#: lib/vutuv_web/live/post_live/composer.ex:1081
 #, elixir-autogen, elixir-format
 msgid "That frame could not be used."
 msgstr "Dieses Bild konnte nicht verwendet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1520
+#: lib/vutuv_web/live/post_live/composer.ex:1549
 #, elixir-autogen, elixir-format
 msgid "The video could not be attached."
 msgstr "Das Video konnte nicht angehängt werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1607
+#: lib/vutuv_web/live/post_live/composer.ex:1636
 #, elixir-autogen, elixir-format
 msgid "The video is longer than %{seconds} seconds."
 msgstr "Das Video ist länger als %{seconds} Sekunden."
@@ -22966,17 +22956,17 @@ msgstr "Dieses Video konnte nicht umgewandelt werden."
 #: lib/vutuv_web/agent_docs/text.ex:919
 #: lib/vutuv_web/components/post_components.ex:2981
 #: lib/vutuv_web/components/video_components.ex:126
-#: lib/vutuv_web/live/post_live/composer.ex:2633
+#: lib/vutuv_web/live/post_live/composer.ex:2694
 #, elixir-autogen, elixir-format
 msgid "Video"
 msgstr "Video"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2677
+#: lib/vutuv_web/live/post_live/composer.ex:2738
 #, elixir-autogen, elixir-format
 msgid "Video description"
 msgstr "Videobeschreibung"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1614
+#: lib/vutuv_web/live/post_live/composer.ex:1643
 #, elixir-autogen, elixir-format
 msgid "Videos cannot be uploaded here."
 msgstr "Hier können keine Videos hochgeladen werden."
@@ -22986,12 +22976,12 @@ msgstr "Hier können keine Videos hochgeladen werden."
 msgid "Waiting in line"
 msgstr "Wartet in der Warteschlange"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2684
+#: lib/vutuv_web/live/post_live/composer.ex:2745
 #, elixir-autogen, elixir-format
 msgid "What is in the video, for people who cannot watch it"
 msgstr "Was im Video zu sehen ist, für Menschen, die es nicht ansehen können"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2673
+#: lib/vutuv_web/live/post_live/composer.ex:2734
 #, elixir-autogen, elixir-format
 msgid "You can post now — the post appears as soon as the video is ready."
 msgstr "Sie können jetzt veröffentlichen: Der Beitrag erscheint, sobald das Video fertig ist."
@@ -23022,7 +23012,7 @@ msgstr[1] "%{formatted} neue Follower"
 msgid "Last 30 days: %{parts}"
 msgstr "Letzte 30 Tage: %{parts}"
 
-#: lib/vutuv_web/components/post_components.ex:5220
+#: lib/vutuv_web/components/post_components.ex:5227
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Less"
@@ -23118,7 +23108,7 @@ msgstr[1] "%{formatted} neue Beiträge in Ihrem Feed"
 msgid "Can be changed at any time."
 msgstr "Können jederzeit geändert werden."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:108
+#: lib/vutuv_web/gettext_extraction_anchors.ex:113
 #, elixir-autogen, elixir-format
 msgid "For members on a slow connection."
 msgstr "Für Mitglieder mit langsamer Internetanbindung."
@@ -23337,7 +23327,7 @@ msgid "Hidden. What they pass on stays out of your feed; their own posts do not.
 msgstr "Ausgeblendet. Was dieses Konto weiterreicht, erscheint nicht mehr in Ihrem Feed, die eigenen Beiträge schon."
 
 #: lib/vutuv_web/components/post_components.ex:3378
-#: lib/vutuv_web/components/post_components.ex:4652
+#: lib/vutuv_web/components/post_components.ex:4659
 #, elixir-autogen, elixir-format
 msgid "Hide reposts"
 msgstr "Reposts ausblenden"
@@ -23451,7 +23441,8 @@ msgstr[1] "%{formatted} Beiträge"
 msgid "Post calendar"
 msgstr "Beitragskalender"
 
-#: lib/vutuv_web/controllers/post_calendar_controller.ex:126
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:131
+#: lib/vutuv_web/post_teaser.ex:187
 #, elixir-autogen, elixir-format
 msgid "Post not open to search engines"
 msgstr "Beitrag ohne Freigabe für Suchmaschinen"
@@ -23481,7 +23472,7 @@ msgstr "Die Beiträge dieses Tages."
 msgid "The posts written that month, by day."
 msgstr "Die Beiträge dieses Monats, nach Tagen."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:89
+#: lib/vutuv_web/gettext_extraction_anchors.ex:94
 #, elixir-autogen, elixir-format
 msgid "Feed length"
 msgstr "Länge des Feeds"
@@ -23501,7 +23492,7 @@ msgstr "Feed-Einstellungen gespeichert."
 msgid "How many load at once, and how many “Load more” adds"
 msgstr "Wie viele auf einmal geladen werden und wie viele „Mehr laden“ ergänzt"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:91
+#: lib/vutuv_web/gettext_extraction_anchors.ex:96
 #, elixir-autogen, elixir-format
 msgid "How many posts your feed shows before the “Load more” button, and how many that button adds. More posts mean a longer wait for the page."
 msgstr "Wie viele Beiträge Ihr Feed vor dem Knopf „Mehr laden“ zeigt und wie viele dieser Knopf ergänzt. Mehr Beiträge bedeuten eine längere Wartezeit auf die Seite."
@@ -23513,7 +23504,7 @@ msgstr "Wie viele Beiträge Ihr Feed vor dem Knopf „Mehr laden“ zeigt und wi
 msgid "Posts in your feed"
 msgstr "Beiträge in Ihrem Feed"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:90
+#: lib/vutuv_web/gettext_extraction_anchors.ex:95
 #, elixir-autogen, elixir-format
 msgid "Posts loaded at once"
 msgstr "Beiträge auf einmal"
@@ -23534,13 +23525,13 @@ msgstr "Sie können das auch direkt im Feed ändern, gleich unter „Mehr laden�
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr "feed länge seitengröße beiträge anzahl menge mehr laden scrollen blättern seite umfang page size posts number load more"
 
-#: lib/vutuv_web/components/post_components.ex:7483
-#: lib/vutuv_web/components/post_components.ex:7484
+#: lib/vutuv_web/components/post_components.ex:7490
+#: lib/vutuv_web/components/post_components.ex:7491
 #, elixir-autogen, elixir-format
 msgid "A word or phrase …"
 msgstr "Ein Wort oder eine Wortgruppe …"
 
-#: lib/vutuv_web/components/post_components.ex:7511
+#: lib/vutuv_web/components/post_components.ex:7518
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr "Für wen %{thing} ausgeblendet wird"
@@ -23557,7 +23548,7 @@ msgstr "Ausgeblendet"
 msgid "Hide something from your feed"
 msgstr "Etwas aus dem Feed ausblenden"
 
-#: lib/vutuv_web/components/post_components.ex:7429
+#: lib/vutuv_web/components/post_components.ex:7436
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr "Nicht mehr zeigen"
@@ -23572,22 +23563,22 @@ msgstr "Was hiervon getroffen wird, klappt im Feed auf eine Zeile zu."
 msgid "Words & tags"
 msgstr "Wörter & Tags"
 
-#: lib/vutuv_web/components/post_components.ex:7515
+#: lib/vutuv_web/components/post_components.ex:7522
 #, elixir-autogen, elixir-format
 msgid "everyone"
 msgstr "bei allen"
 
-#: lib/vutuv_web/components/post_components.ex:7518
+#: lib/vutuv_web/components/post_components.ex:7525
 #, elixir-autogen, elixir-format
 msgid "only %{handle}"
 msgstr "nur %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:7487
+#: lib/vutuv_web/components/post_components.ex:7494
 #, elixir-autogen, elixir-format
 msgid "this word"
 msgstr "dieses Wort"
 
-#: lib/vutuv_web/components/post_components.ex:7528
+#: lib/vutuv_web/components/post_components.ex:7535
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr "nur %{server}"
@@ -23639,7 +23630,7 @@ msgstr "Diese Website ist gerade offline."
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr "Die Website läuft, nur diese Adresse gibt es hier nicht. Wahrscheinlich ist der Link alt oder enthält einen Tippfehler."
 
-#: lib/vutuv_web/components/post_components.ex:6833
+#: lib/vutuv_web/components/post_components.ex:6840
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr "Screenshot vergrößern"
@@ -23730,7 +23721,7 @@ msgid "Hidden. What other people pass on of them stays out of your feed; their o
 msgstr "Ausgeblendet. Was andere von diesem Konto weiterreichen, erscheint nicht mehr in Ihrem Feed, die eigenen Beiträge schon."
 
 #: lib/vutuv_web/components/post_components.ex:3364
-#: lib/vutuv_web/components/post_components.ex:4640
+#: lib/vutuv_web/components/post_components.ex:4647
 #, elixir-autogen, elixir-format
 msgid "Hide when others repost them"
 msgstr "Ausblenden, wenn andere reposten"
@@ -23938,12 +23929,12 @@ msgstr ""
 "Anmeldung und später mit einem Schalter in den Einstellungen. Wir sind da "
 "nicht dogmatisch: jeder, wie er will."
 
-#: lib/vutuv_web/live/shell_live.ex:1824
+#: lib/vutuv_web/live/shell_live.ex:1825
 #, elixir-autogen, elixir-format
 msgid "All notifications"
 msgstr "Alle Mitteilungen"
 
-#: lib/vutuv_web/live/shell_live.ex:1777
+#: lib/vutuv_web/live/shell_live.ex:1778
 #, elixir-autogen, elixir-format
 msgid "New notifications"
 msgstr "Neue Mitteilungen"
@@ -24493,13 +24484,13 @@ msgstr "das Meldeformular"
 msgid "“%{note}”"
 msgstr "„%{note}“"
 
-#: lib/vutuv_web/components/post_components.ex:5398
-#: lib/vutuv_web/components/press_kit_components.ex:211
+#: lib/vutuv_web/components/post_components.ex:5405
+#: lib/vutuv_web/components/press_kit_components.ex:216
 #, elixir-autogen, elixir-format
 msgid "Show these photos larger"
 msgstr "Fotos vergrößern"
 
-#: lib/vutuv_web/components/post_components.ex:5584
+#: lib/vutuv_web/components/post_components.ex:5591
 #, elixir-autogen, elixir-format
 msgid "Show this photo larger"
 msgstr "Foto vergrößern"
@@ -24589,7 +24580,7 @@ msgstr "Ich habe die Rechte an dieser Datei und gebe sie zur redaktionellen Nutz
 msgid "Light"
 msgstr "Hell"
 
-#: lib/vutuv/press_kit.ex:251
+#: lib/vutuv/press_kit.ex:321
 #, elixir-autogen, elixir-format
 msgid "Logo variant"
 msgstr "Logo-Variante"
@@ -24638,7 +24629,7 @@ msgstr "Bild entfernt."
 msgid "Please confirm the rights first, then choose the file."
 msgstr "Bitte bestätigen Sie zuerst die Rechte und wählen Sie dann die Datei."
 
-#: lib/vutuv/press_kit.ex:251
+#: lib/vutuv/press_kit.ex:321
 #, elixir-autogen, elixir-format
 msgid "Press photo"
 msgstr "Pressefoto"
@@ -24724,18 +24715,18 @@ msgstr[1] "%{count} Bytes"
 msgid "Credit: %{credit}"
 msgstr "Bildnachweis: %{credit}"
 
-#: lib/vutuv_web/components/press_kit_components.ex:375
-#: lib/vutuv_web/components/press_kit_components.ex:378
+#: lib/vutuv_web/components/press_kit_components.ex:380
+#: lib/vutuv_web/components/press_kit_components.ex:383
 #, elixir-autogen, elixir-format
 msgid "Download %{format}"
 msgstr "%{format} herunterladen"
 
-#: lib/vutuv_web/components/press_kit_components.ex:331
+#: lib/vutuv_web/components/press_kit_components.ex:336
 #, elixir-autogen, elixir-format
 msgid "Download photo"
 msgstr "Foto herunterladen"
 
-#: lib/vutuv/press_kit.ex:715
+#: lib/vutuv/press_kit.ex:785
 #, elixir-autogen, elixir-format
 msgid "Free for editorial use with credit."
 msgstr "Zur freien redaktionellen Verwendung mit Bildnachweis."
@@ -24745,7 +24736,7 @@ msgstr "Zur freien redaktionellen Verwendung mit Bildnachweis."
 msgid "PNG version"
 msgstr "PNG-Fassung"
 
-#: lib/vutuv_web/agent_docs/press_kit_doc.ex:55
+#: lib/vutuv_web/agent_docs/press_kit_doc.ex:58
 #, elixir-autogen, elixir-format
 msgid "Press pictures %{name} offers for download, free for editorial use with credit."
 msgstr "Pressebilder, die %{name} zum Herunterladen anbietet, zur freien redaktionellen Verwendung mit Bildnachweis."
@@ -24780,7 +24771,7 @@ msgstr "Logo dieser Seite verwenden"
 msgid "What a journalist writing about this page may download: photos in print quality and its logo as a file. Everything here is public and free for editorial use as long as the credit is shown."
 msgstr "Was eine Redaktion, die über diese Seite schreibt, herunterladen darf: Fotos in Druckqualität und das Logo als Datei. Alles hier ist öffentlich und zur redaktionellen Nutzung frei, solange der Bildnachweis genannt wird."
 
-#: lib/vutuv_web/components/press_kit_components.ex:565
+#: lib/vutuv_web/components/press_kit_components.ex:570
 #: lib/vutuv_web/components/ui.ex:3281
 #, elixir-autogen, elixir-format
 msgid "Report this picture"
@@ -24882,7 +24873,7 @@ msgid "nobody"
 msgstr "niemand"
 
 #: lib/vutuv_web/components/press_kit_components.ex:120
-#: lib/vutuv_web/components/press_kit_components.ex:176
+#: lib/vutuv_web/components/press_kit_components.ex:181
 #, elixir-autogen, elixir-format
 msgid "All Media Kit files"
 msgstr "Das ganze Media Kit"
@@ -24902,7 +24893,7 @@ msgstr "Das ganze Media Kit"
 msgid "Media Kit"
 msgstr "Media Kit"
 
-#: lib/vutuv_web/agent_docs/press_kit_doc.ex:53
+#: lib/vutuv_web/agent_docs/press_kit_doc.ex:56
 #: lib/vutuv_web/views/press_kit_html.ex:32
 #, elixir-autogen, elixir-format
 msgid "Media Kit of %{name}"
@@ -24933,8 +24924,8 @@ msgstr "Sie können diesem Media Kit kein Bild hinzufügen."
 msgid "press kit media journalist photographer download original print logo svg credit copyright presse pressefotos pressemappe medienkit mediakit fotos logo herunterladen bildnachweis"
 msgstr "media kit medienkit mediakit pressemappe presse medien redaktion journalist fotograf download original druck logo svg bildnachweis urheberrecht pressefotos herunterladen press kit"
 
-#: lib/vutuv_web/components/post_components.ex:4556
-#: lib/vutuv_web/components/post_components.ex:4606
+#: lib/vutuv_web/components/post_components.ex:4563
+#: lib/vutuv_web/components/post_components.ex:4613
 #, elixir-autogen, elixir-format
 msgid "Copy link to post"
 msgstr "Link zum Beitrag kopieren"
@@ -24944,14 +24935,14 @@ msgstr "Link zum Beitrag kopieren"
 msgid "Link copied"
 msgstr "Link kopiert"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2820
+#: lib/vutuv_web/live/post_live/composer.ex:2881
 #, elixir-autogen, elixir-format
 msgid "%{left} of today's %{limit} left (%{percent} %)."
 msgstr "Noch %{left} von %{limit} für heute frei (%{percent} %)."
 
 #: lib/vutuv_web/live/message_live/index.ex:1291
 #: lib/vutuv_web/live/message_live/index.ex:1295
-#: lib/vutuv_web/live/post_live/composer.ex:2753
+#: lib/vutuv_web/live/post_live/composer.ex:2814
 #, elixir-autogen, elixir-format
 msgid "Add files"
 msgstr "Dateien hinzufügen"
@@ -24961,12 +24952,12 @@ msgstr "Dateien hinzufügen"
 msgid "File check"
 msgstr "Dateiprüfung"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3517
+#: lib/vutuv_web/live/post_live/composer.ex:3578
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{size}."
 msgstr "Die Datei ist größer als %{size}."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2752
+#: lib/vutuv_web/live/post_live/composer.ex:2813
 #, elixir-autogen, elixir-format
 msgid "Files"
 msgstr "Dateien"
@@ -24976,7 +24967,7 @@ msgstr "Dateien"
 msgid "Files may be up to %{size}."
 msgstr "Dateien dürfen bis zu %{size} groß sein."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3527
+#: lib/vutuv_web/live/post_live/composer.ex:3588
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} files per post."
 msgstr "Höchstens %{max} Dateien pro Beitrag."
@@ -24993,7 +24984,7 @@ msgstr "PDFs können auf dieser Website nicht geprüft werden, Text- und Markdow
 
 #: lib/vutuv_web/live/message_live/index.ex:1270
 #: lib/vutuv_web/live/message_live/index.ex:1271
-#: lib/vutuv_web/live/post_live/composer.ex:2799
+#: lib/vutuv_web/live/post_live/composer.ex:2860
 #, elixir-autogen, elixir-format
 msgid "Remove %{name}"
 msgstr "%{name} entfernen"
@@ -25018,7 +25009,7 @@ msgstr "Ihr Upload-Kontingent für diesen Monat ist aufgebraucht."
 msgid "You have used up today's upload allowance. It frees up again over the day."
 msgstr "Ihr Upload-Kontingent für heute ist aufgebraucht. Es wird im Lauf des Tages wieder frei."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2818
+#: lib/vutuv_web/live/post_live/composer.ex:2879
 #, elixir-autogen, elixir-format
 msgid "Your uploads are not limited."
 msgstr "Ihre Uploads sind nicht begrenzt."
@@ -25037,7 +25028,7 @@ msgstr "Ein Absatz, mit dem ein Artikel enden kann."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:121
 #: lib/vutuv_web/agent_docs/text.ex:412
-#: lib/vutuv_web/components/press_kit_components.ex:269
+#: lib/vutuv_web/components/press_kit_components.ex:274
 #, elixir-autogen, elixir-format
 msgid "About %{name}"
 msgstr "Über %{name}"
@@ -25062,12 +25053,12 @@ msgstr "Ein @handle verlinkt auf das Profil und benachrichtigt niemanden."
 msgid "As long as you like. The whole portrait."
 msgstr "So lang, wie Sie mögen. Das ganze Porträt."
 
-#: lib/vutuv/press_kit.ex:460
+#: lib/vutuv/press_kit.ex:530
 #, elixir-autogen, elixir-format
 msgid "Long version"
 msgstr "Lange Fassung"
 
-#: lib/vutuv/press_kit.ex:459
+#: lib/vutuv/press_kit.ex:529
 #, elixir-autogen, elixir-format
 msgid "Medium version"
 msgstr "Mittlere Fassung"
@@ -25077,12 +25068,12 @@ msgstr "Mittlere Fassung"
 msgid "Nothing written yet."
 msgstr "Noch nichts geschrieben."
 
-#: lib/vutuv/press_kit.ex:458
+#: lib/vutuv/press_kit.ex:528
 #, elixir-autogen, elixir-format
 msgid "Short version"
 msgstr "Kurze Fassung"
 
-#: lib/vutuv_web/components/press_kit_components.ex:272
+#: lib/vutuv_web/components/press_kit_components.ex:277
 #, elixir-autogen, elixir-format
 msgid "Take whichever length fits the space you have. Each one stands on its own."
 msgstr "Nehmen Sie die Fassung, die in Ihren Platz passt. Jede steht für sich."
@@ -25111,13 +25102,6 @@ msgstr "Schreiben"
 #, elixir-autogen, elixir-format
 msgid "File preview pages"
 msgstr "Dateivorschau"
-
-#: lib/vutuv_web/live/shell_live.ex:1742
-#, elixir-autogen, elixir-format
-msgid "%{count} post is being prepared"
-msgid_plural "%{count} posts are being prepared"
-msgstr[0] "%{count} Beitrag wird vorbereitet"
-msgstr[1] "%{count} Beiträge werden vorbereitet"
 
 #: lib/vutuv_web/live/uploads_live.ex:173
 #, elixir-autogen, elixir-format
@@ -25500,3 +25484,50 @@ msgstr "Dieses Bild konnte nicht gelesen werden."
 #, elixir-autogen, elixir-format
 msgid "You can only send files to members you are connected with."
 msgstr "Dateien können Sie nur an Mitglieder senden, mit denen Sie vernetzt sind."
+
+#: lib/vutuv_web/live/shell_live.ex:1743
+#, elixir-autogen, elixir-format
+msgid "%{formatted} post is being prepared"
+msgid_plural "%{formatted} posts are being prepared"
+msgstr[0] "%{formatted} Beitrag wird vorbereitet"
+msgstr[1] "%{formatted} Beiträge werden vorbereitet"
+
+#: lib/vutuv_web/live/post_live/composer.ex:2312
+#, elixir-autogen, elixir-format
+msgid "Remove the metadata from the files"
+msgstr "Metadaten aus den Dateien entfernen"
+
+#: lib/vutuv_web/components/ui.ex:5622
+#, elixir-autogen, elixir-format
+msgid "Search engines and AI, your posts, online status"
+msgstr "Suchmaschinen und KI, Ihre Beiträge, Online-Status"
+
+#: lib/vutuv_web/templates/settings/privacy.html.heex:93
+#, elixir-autogen, elixir-format
+msgid "Whether search engines and AI may read what you post. Each post keeps the answer it was published with, so changing this leaves everything you have already written exactly as it is."
+msgstr "Ob Suchmaschinen und KI lesen dürfen, was Sie veröffentlichen. Jeder Beitrag behält die Antwort, mit der er veröffentlicht wurde. Wenn Sie das hier ändern, bleibt alles bereits Geschriebene genau so, wie es ist."
+
+#: lib/vutuv_web/live/post_live/composer.ex:2314
+#, elixir-autogen, elixir-format
+msgid "Your name, the software you used and the dates come out of a PDF."
+msgstr "Ihr Name, die verwendete Software und die Daten kommen aus einer PDF-Datei heraus."
+
+#: lib/vutuv_web/templates/settings/privacy.html.heex:91
+#, elixir-autogen, elixir-format
+msgid "Your posts"
+msgstr "Ihre Beiträge"
+
+#: lib/vutuv_web/components/ui.ex:5624
+#, elixir-autogen, elixir-format
+msgid "privacy google search engine ai llm crawler noindex online dot public posts beiträge indexieren fediverse mastodon suchmaschine"
+msgstr "privatsphäre datenschutz google suchmaschine ki ai llm crawler noindex online punkt öffentlich sichtbar beiträge posts indexieren fediverse mastodon"
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:81
+#, elixir-autogen, elixir-format
+msgid "Covers the words, the pictures, the files and the machine formats of every post you write from now on. When off, your new posts also stay out of other networks completely: a server elsewhere keeps its copy for good and no instruction of ours reaches it. Posts you have already published keep the answer they went out with."
+msgstr "Gilt für den Text, die Bilder, die Dateien und die Maschinenformate jedes Beitrags, den Sie ab jetzt schreiben. Ausgeschaltet gehen Ihre neuen Beiträge außerdem gar nicht mehr in andere Netzwerke: Ein Server anderswo behält seine Kopie für immer, und keine Anweisung von uns erreicht ihn. Bereits veröffentlichte Beiträge behalten die Antwort, mit der sie hinausgegangen sind."
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:80
+#, elixir-autogen, elixir-format
+msgid "Search engines and AI may read my posts"
+msgstr "Suchmaschinen und KI dürfen meine Beiträge lesen"

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -6499,7 +6499,7 @@ msgstr ""
 msgid "Endorsed"
 msgstr "Empfohlen am"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:141
+#: lib/vutuv_web/agent_docs/list_docs.ex:143
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "Members who endorsed %{name} for %{tag}"
@@ -8832,7 +8832,7 @@ msgstr "Ungültig"
 msgid "Invalid address (skipped)"
 msgstr "Ungültige Adresse (übersprungen)"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:180
+#: lib/vutuv_web/agent_docs/list_docs.ex:182
 #: lib/vutuv_web/controllers/directory_controller.ex:54
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
@@ -8848,7 +8848,7 @@ msgstr "Mitgliederverzeichnis"
 msgid "Members by initial"
 msgstr "Mitglieder nach Anfangsbuchstaben"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:203
+#: lib/vutuv_web/agent_docs/list_docs.ex:205
 #: lib/vutuv_web/controllers/directory_controller.ex:86
 #: lib/vutuv_web/templates/directory/show.html.heex:2
 #, elixir-autogen, elixir-format
@@ -8867,7 +8867,7 @@ msgid_plural "%{formatted} members"
 msgstr[0] "Ein Mitglied"
 msgstr[1] "%{formatted} Mitglieder"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:209
+#: lib/vutuv_web/agent_docs/list_docs.ex:211
 #, elixir-autogen, elixir-format
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
@@ -22052,7 +22052,7 @@ msgstr "Welche Namen durchsucht werden"
 msgid "All vutuv members, filed alphabetically by last name."
 msgstr "Alle vutuv Mitglieder, alphabetisch nach Nachname sortiert."
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:195
+#: lib/vutuv_web/agent_docs/list_docs.ex:197
 #, elixir-autogen, elixir-format
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr "Alle vutuv Mitglieder, gruppiert nach dem Anfangsbuchstaben des Nachnamens."
@@ -23429,8 +23429,8 @@ msgid_plural "%{formatted} posts"
 msgstr[0] "Ein Beitrag"
 msgstr[1] "%{formatted} Beiträge"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:253
-#: lib/vutuv_web/agent_docs/list_docs.ex:285
+#: lib/vutuv_web/agent_docs/list_docs.ex:255
+#: lib/vutuv_web/agent_docs/list_docs.ex:287
 #: lib/vutuv_web/controllers/post_calendar_controller.ex:36
 #: lib/vutuv_web/templates/layout/app.html.heex:79
 #: lib/vutuv_web/templates/post_calendar/day.html.heex:5
@@ -23442,7 +23442,7 @@ msgid "Post calendar"
 msgstr "Beitragskalender"
 
 #: lib/vutuv_web/controllers/post_calendar_controller.ex:131
-#: lib/vutuv_web/post_teaser.ex:187
+#: lib/vutuv_web/post_teaser.ex:211
 #, elixir-autogen, elixir-format
 msgid "Post not open to search engines"
 msgstr "Beitrag ohne Freigabe für Suchmaschinen"
@@ -23462,12 +23462,12 @@ msgstr "Beiträge aus %{year}"
 msgid "Posts on %{date}"
 msgstr "Beiträge vom %{date}"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:286
+#: lib/vutuv_web/agent_docs/list_docs.ex:288
 #, elixir-autogen, elixir-format
 msgid "The posts written that day."
 msgstr "Die Beiträge dieses Tages."
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:254
+#: lib/vutuv_web/agent_docs/list_docs.ex:256
 #, elixir-autogen, elixir-format
 msgid "The posts written that month, by day."
 msgstr "Die Beiträge dieses Monats, nach Tagen."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -6258,7 +6258,7 @@ msgstr ""
 msgid "Endorsed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:141
+#: lib/vutuv_web/agent_docs/list_docs.ex:143
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "Members who endorsed %{name} for %{tag}"
@@ -8440,7 +8440,7 @@ msgstr ""
 msgid "Invalid address (skipped)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:180
+#: lib/vutuv_web/agent_docs/list_docs.ex:182
 #: lib/vutuv_web/controllers/directory_controller.ex:54
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
@@ -8456,7 +8456,7 @@ msgstr ""
 msgid "Members by initial"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:203
+#: lib/vutuv_web/agent_docs/list_docs.ex:205
 #: lib/vutuv_web/controllers/directory_controller.ex:86
 #: lib/vutuv_web/templates/directory/show.html.heex:2
 #, elixir-autogen, elixir-format
@@ -8475,7 +8475,7 @@ msgid_plural "%{formatted} members"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:209
+#: lib/vutuv_web/agent_docs/list_docs.ex:211
 #, elixir-autogen, elixir-format
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
@@ -21271,7 +21271,7 @@ msgstr ""
 msgid "All vutuv members, filed alphabetically by last name."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:195
+#: lib/vutuv_web/agent_docs/list_docs.ex:197
 #, elixir-autogen, elixir-format
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr ""
@@ -22644,8 +22644,8 @@ msgid_plural "%{formatted} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:253
-#: lib/vutuv_web/agent_docs/list_docs.ex:285
+#: lib/vutuv_web/agent_docs/list_docs.ex:255
+#: lib/vutuv_web/agent_docs/list_docs.ex:287
 #: lib/vutuv_web/controllers/post_calendar_controller.ex:36
 #: lib/vutuv_web/templates/layout/app.html.heex:79
 #: lib/vutuv_web/templates/post_calendar/day.html.heex:5
@@ -22657,7 +22657,7 @@ msgid "Post calendar"
 msgstr ""
 
 #: lib/vutuv_web/controllers/post_calendar_controller.ex:131
-#: lib/vutuv_web/post_teaser.ex:187
+#: lib/vutuv_web/post_teaser.ex:211
 #, elixir-autogen, elixir-format
 msgid "Post not open to search engines"
 msgstr ""
@@ -22677,12 +22677,12 @@ msgstr ""
 msgid "Posts on %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:286
+#: lib/vutuv_web/agent_docs/list_docs.ex:288
 #, elixir-autogen, elixir-format
 msgid "The posts written that day."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:254
+#: lib/vutuv_web/agent_docs/list_docs.ex:256
 #, elixir-autogen, elixir-format
 msgid "The posts written that month, by day."
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -120,7 +120,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_posting_live/form.ex:857
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
-#: lib/vutuv_web/live/post_live/composer.ex:2049
+#: lib/vutuv_web/live/post_live/composer.ex:2078
 #: lib/vutuv_web/live/press_kit_live.ex:729
 #: lib/vutuv_web/live/press_kit_live.ex:1139
 #: lib/vutuv_web/templates/ad/new.html.heex:136
@@ -165,7 +165,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4593
+#: lib/vutuv_web/components/post_components.ex:4600
 #: lib/vutuv_web/components/ui.ex:5042
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
@@ -206,14 +206,14 @@ msgid "Disable"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:446
-#: lib/vutuv_web/live/post_live/composer.ex:3228
+#: lib/vutuv_web/live/post_live/composer.ex:3289
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/views/qualification_html.ex:354
 #, elixir-autogen
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4558
+#: lib/vutuv_web/components/post_components.ex:4565
 #: lib/vutuv_web/components/ui.ex:5033
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
@@ -609,7 +609,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2361
+#: lib/vutuv_web/live/post_live/composer.ex:2422
 #: lib/vutuv_web/live/section_reorder_live.ex:272
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -621,7 +621,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4934
 #: lib/vutuv_web/live/organization_live/edit.ex:376
-#: lib/vutuv_web/live/post_live/composer.ex:2376
+#: lib/vutuv_web/live/post_live/composer.ex:2437
 #: lib/vutuv_web/live/press_kit_live.ex:727
 #: lib/vutuv_web/live/press_kit_live.ex:1138
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -1189,7 +1189,7 @@ msgstr ""
 msgid "All tag urls"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5211
+#: lib/vutuv_web/components/post_components.ex:5218
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:643
@@ -1610,11 +1610,11 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:321
 #: lib/vutuv_web/live/admin/job_live.ex:477
 #: lib/vutuv_web/live/admin/organization_live.ex:296
-#: lib/vutuv_web/live/post_live/composer.ex:1905
-#: lib/vutuv_web/live/post_live/composer.ex:2007
-#: lib/vutuv_web/live/post_live/composer.ex:2008
-#: lib/vutuv_web/live/post_live/composer.ex:3105
-#: lib/vutuv_web/live/post_live/composer.ex:3371
+#: lib/vutuv_web/live/post_live/composer.ex:1934
+#: lib/vutuv_web/live/post_live/composer.ex:2036
+#: lib/vutuv_web/live/post_live/composer.ex:2037
+#: lib/vutuv_web/live/post_live/composer.ex:3166
+#: lib/vutuv_web/live/post_live/composer.ex:3432
 #: lib/vutuv_web/templates/layout/app.html.heex:200
 #: lib/vutuv_web/templates/layout/app.html.heex:206
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:28
@@ -2067,7 +2067,7 @@ msgstr ""
 msgid "Add images"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2490
+#: lib/vutuv_web/live/post_live/composer.ex:2551
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2078,9 +2078,9 @@ msgstr ""
 msgid "Back to the post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2147
-#: lib/vutuv_web/live/post_live/composer.ex:2170
-#: lib/vutuv_web/live/post_live/composer.ex:2196
+#: lib/vutuv_web/live/post_live/composer.ex:2176
+#: lib/vutuv_web/live/post_live/composer.ex:2199
+#: lib/vutuv_web/live/post_live/composer.ex:2225
 #: lib/vutuv_web/live/press_kit_live.ex:1307
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
@@ -2091,7 +2091,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4590
+#: lib/vutuv_web/components/post_components.ex:4597
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2104,7 +2104,7 @@ msgid "Edit post"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:274
-#: lib/vutuv_web/gettext_extraction_anchors.ex:87
+#: lib/vutuv_web/gettext_extraction_anchors.ex:92
 #: lib/vutuv_web/live/organization_live/feed.ex:203
 #: lib/vutuv_web/live/post_live/feed.ex:365
 #: lib/vutuv_web/live/post_live/feed.ex:3536
@@ -2126,29 +2126,29 @@ msgstr ""
 msgid "Hidden from:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2466
+#: lib/vutuv_web/live/post_live/composer.ex:2527
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2394
+#: lib/vutuv_web/live/post_live/composer.ex:2455
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4536
-#: lib/vutuv_web/components/post_components.ex:4538
+#: lib/vutuv_web/components/post_components.ex:4543
+#: lib/vutuv_web/components/post_components.ex:4545
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2436
+#: lib/vutuv_web/live/post_live/composer.ex:2497
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1554
-#: lib/vutuv_web/live/post_live/composer.ex:1694
+#: lib/vutuv_web/live/post_live/composer.ex:1583
+#: lib/vutuv_web/live/post_live/composer.ex:1723
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr ""
@@ -2158,23 +2158,23 @@ msgstr ""
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1517
+#: lib/vutuv_web/live/post_live/composer.ex:1546
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2426
+#: lib/vutuv_web/live/post_live/composer.ex:2487
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2416
+#: lib/vutuv_web/live/post_live/composer.ex:2477
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:441
-#: lib/vutuv_web/live/post_live/composer.ex:2378
+#: lib/vutuv_web/live/post_live/composer.ex:2439
 #, elixir-autogen, elixir-format
 msgid "Post"
 msgstr ""
@@ -2184,11 +2184,11 @@ msgstr ""
 msgid "Post deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:243
+#: lib/vutuv_web/agent_docs/post_doc.ex:264
 #: lib/vutuv_web/controllers/post_controller.ex:69
 #: lib/vutuv_web/controllers/post_controller.ex:90
 #: lib/vutuv_web/controllers/user_controller.ex:77
-#: lib/vutuv_web/gettext_extraction_anchors.ex:113
+#: lib/vutuv_web/gettext_extraction_anchors.ex:118
 #: lib/vutuv_web/live/admin/dashboard_live.ex:270
 #: lib/vutuv_web/live/fediverse_account_live.ex:446
 #: lib/vutuv_web/live/organization_live/show.ex:733
@@ -2202,13 +2202,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5084
-#: lib/vutuv_web/components/post_components.ex:5088
+#: lib/vutuv_web/components/post_components.ex:5091
+#: lib/vutuv_web/components/post_components.ex:5095
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5085
+#: lib/vutuv_web/components/post_components.ex:5092
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2225,7 +2225,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:265
 #: lib/vutuv_web/live/organization_live/edit.ex:404
 #: lib/vutuv_web/live/organization_live/roles.ex:257
-#: lib/vutuv_web/live/post_live/composer.ex:2452
+#: lib/vutuv_web/live/post_live/composer.ex:2513
 #: lib/vutuv_web/live/post_live/filter_band.ex:456
 #: lib/vutuv_web/live/post_live/saved.ex:666
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2242,7 +2242,7 @@ msgstr ""
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2368
+#: lib/vutuv_web/live/post_live/composer.ex:2429
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr ""
@@ -2260,14 +2260,14 @@ msgid "Sorry, that page could not be found."
 msgstr ""
 
 #: lib/vutuv_web/attachment_text.ex:73
-#: lib/vutuv_web/live/post_live/composer.ex:1615
-#: lib/vutuv_web/live/post_live/composer.ex:1720
+#: lib/vutuv_web/live/post_live/composer.ex:1644
+#: lib/vutuv_web/live/post_live/composer.ex:1749
 #: lib/vutuv_web/live/press_kit_live.ex:541
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1499
+#: lib/vutuv_web/live/post_live/composer.ex:1528
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr ""
@@ -2277,17 +2277,17 @@ msgstr ""
 msgid "This post is for followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3546
+#: lib/vutuv_web/live/post_live/composer.ex:3607
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3547
+#: lib/vutuv_web/live/post_live/composer.ex:3608
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5865
+#: lib/vutuv_web/components/ui.ex:5868
 #: lib/vutuv_web/live/shell_live.ex:1588
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2296,37 +2296,37 @@ msgstr ""
 msgid "View profile"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2584
+#: lib/vutuv_web/live/post_live/composer.ex:2645
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2585
+#: lib/vutuv_web/live/post_live/composer.ex:2646
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4533
+#: lib/vutuv_web/components/post_components.ex:4540
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6851
+#: lib/vutuv_web/components/post_components.ex:6858
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6855
+#: lib/vutuv_web/components/post_components.ex:6862
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6853
+#: lib/vutuv_web/components/post_components.ex:6860
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6854
+#: lib/vutuv_web/components/post_components.ex:6861
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2338,21 +2338,21 @@ msgstr ""
 msgid "unknown"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2246
+#: lib/vutuv_web/live/post_live/composer.ex:2275
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1612
-#: lib/vutuv_web/live/post_live/composer.ex:3513
-#: lib/vutuv_web/live/post_live/composer.ex:3531
+#: lib/vutuv_web/live/post_live/composer.ex:1641
+#: lib/vutuv_web/live/post_live/composer.ex:3574
+#: lib/vutuv_web/live/post_live/composer.ex:3592
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3521
-#: lib/vutuv_web/live/post_live/composer.ex:3535
-#: lib/vutuv_web/live/post_live/composer.ex:3541
+#: lib/vutuv_web/live/post_live/composer.ex:3582
+#: lib/vutuv_web/live/post_live/composer.ex:3596
+#: lib/vutuv_web/live/post_live/composer.ex:3602
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr ""
@@ -2373,7 +2373,7 @@ msgid "All posts"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2185
-#: lib/vutuv_web/components/post_components.ex:6954
+#: lib/vutuv_web/components/post_components.ex:6961
 #: lib/vutuv_web/components/ui.ex:4476
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2392,7 +2392,7 @@ msgid "Bookmarks"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2129
-#: lib/vutuv_web/components/post_components.ex:7195
+#: lib/vutuv_web/components/post_components.ex:7202
 #: lib/vutuv_web/components/ui.ex:4462
 #: lib/vutuv_web/notification_line.ex:317
 #: lib/vutuv_web/views/user_html.ex:486
@@ -2401,12 +2401,12 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1301
-#: lib/vutuv_web/components/post_components.ex:7205
+#: lib/vutuv_web/components/post_components.ex:7212
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
 #: lib/vutuv_web/live/shell_live.ex:1596
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
-#: lib/vutuv_web/templates/settings/privacy.html.heex:91
+#: lib/vutuv_web/templates/settings/privacy.html.heex:118
 #: lib/vutuv_web/views/admin/report_html.ex:37
 #, elixir-autogen, elixir-format
 msgid "Likes"
@@ -2422,13 +2422,13 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6942
+#: lib/vutuv_web/components/post_components.ex:6949
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2184
-#: lib/vutuv_web/components/post_components.ex:6953
+#: lib/vutuv_web/components/post_components.ex:6960
 #: lib/vutuv_web/live/post_live/saved.ex:822
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2436,26 +2436,26 @@ msgid "Remove bookmark"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2165
-#: lib/vutuv_web/components/post_components.ex:6938
+#: lib/vutuv_web/components/post_components.ex:6945
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2758
-#: lib/vutuv_web/components/post_components.ex:5957
+#: lib/vutuv_web/components/post_components.ex:5964
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2164
-#: lib/vutuv_web/components/post_components.ex:6937
+#: lib/vutuv_web/components/post_components.ex:6944
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2128
-#: lib/vutuv_web/components/post_components.ex:7194
+#: lib/vutuv_web/components/post_components.ex:7201
 #: lib/vutuv_web/live/post_live/saved.ex:821
 #: lib/vutuv_web/views/user_html.ex:486
 #, elixir-autogen, elixir-format
@@ -2483,7 +2483,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7249
+#: lib/vutuv_web/components/post_components.ex:7256
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2495,8 +2495,8 @@ msgid "Replies"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2374
-#: lib/vutuv_web/components/post_components.ex:7232
-#: lib/vutuv_web/components/post_components.ex:7233
+#: lib/vutuv_web/components/post_components.ex:7239
+#: lib/vutuv_web/components/post_components.ex:7240
 #: lib/vutuv_web/live/notification_live/index.ex:993
 #: lib/vutuv_web/live/post_live/reply.ex:49
 #: lib/vutuv_web/notification_line.ex:314
@@ -2504,18 +2504,18 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4492
+#: lib/vutuv_web/components/post_components.ex:4499
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1502
-#: lib/vutuv_web/live/post_live/composer.ex:2356
+#: lib/vutuv_web/live/post_live/composer.ex:1531
+#: lib/vutuv_web/live/post_live/composer.ex:2417
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2497
+#: lib/vutuv_web/live/post_live/composer.ex:2558
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2533,14 +2533,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4464
+#: lib/vutuv_web/components/post_components.ex:4471
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4455
-#: lib/vutuv_web/components/post_components.ex:4484
-#: lib/vutuv_web/components/post_components.ex:4487
+#: lib/vutuv_web/components/post_components.ex:4462
+#: lib/vutuv_web/components/post_components.ex:4491
+#: lib/vutuv_web/components/post_components.ex:4494
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2756,7 +2756,7 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:109
 #: lib/vutuv_web/templates/settings/preferences.html.heex:195
-#: lib/vutuv_web/templates/settings/privacy.html.heex:179
+#: lib/vutuv_web/templates/settings/privacy.html.heex:206
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:216
 #: lib/vutuv_web/templates/user/show.html.heex:643
@@ -2817,7 +2817,7 @@ msgstr ""
 msgid "Other formats"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2406
+#: lib/vutuv_web/live/post_live/composer.ex:2467
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr ""
@@ -2840,7 +2840,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6852
+#: lib/vutuv_web/components/post_components.ex:6859
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4431
+#: lib/vutuv_web/components/post_components.ex:4438
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3153,7 +3153,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1466
 #: lib/vutuv_web/components/post_components.ex:3418
 #: lib/vutuv_web/components/post_components.ex:3605
-#: lib/vutuv_web/components/post_components.ex:4661
+#: lib/vutuv_web/components/post_components.ex:4668
 #: lib/vutuv_web/live/organization_live/show.ex:684
 #: lib/vutuv_web/templates/user/show.html.heex:252
 #, elixir-autogen, elixir-format
@@ -3863,7 +3863,7 @@ msgstr ""
 msgid "People %{name} follows"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:244
+#: lib/vutuv_web/agent_docs/post_doc.ex:265
 #, elixir-autogen, elixir-format
 msgid "Post archive of %{name}"
 msgstr ""
@@ -4452,11 +4452,11 @@ msgstr ""
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5625
+#: lib/vutuv_web/components/ui.ex:5628
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
-#: lib/vutuv_web/templates/settings/privacy.html.heex:176
+#: lib/vutuv_web/templates/settings/privacy.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Blocked members"
 msgstr ""
@@ -5219,7 +5219,7 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5675
+#: lib/vutuv_web/components/ui.ex:5678
 #: lib/vutuv_web/controllers/settings_controller.ex:161
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:552
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5255,12 +5255,12 @@ msgstr ""
 msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1523
+#: lib/vutuv_web/live/post_live/composer.ex:1552
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:182
+#: lib/vutuv_web/templates/settings/privacy.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "Content under review"
 msgstr ""
@@ -5298,10 +5298,10 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5772
-#: lib/vutuv_web/components/ui.ex:5777
-#: lib/vutuv_web/components/ui.ex:5856
-#: lib/vutuv_web/components/ui.ex:5920
+#: lib/vutuv_web/components/ui.ex:5775
+#: lib/vutuv_web/components/ui.ex:5780
+#: lib/vutuv_web/components/ui.ex:5859
+#: lib/vutuv_web/components/ui.ex:5923
 #: lib/vutuv_web/controllers/settings_controller.ex:68
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5371,9 +5371,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4741
-#: lib/vutuv_web/components/post_components.ex:5350
-#: lib/vutuv_web/components/post_components.ex:5688
+#: lib/vutuv_web/components/post_components.ex:4748
+#: lib/vutuv_web/components/post_components.ex:5357
+#: lib/vutuv_web/components/post_components.ex:5695
 #: lib/vutuv_web/live/notification_live/index.ex:1069
 #: lib/vutuv_web/views/user_html.ex:133
 #, elixir-autogen, elixir-format
@@ -5420,7 +5420,7 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5645
+#: lib/vutuv_web/components/ui.ex:5648
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:262
@@ -5460,7 +5460,7 @@ msgstr ""
 msgid "Notification settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:177
+#: lib/vutuv_web/templates/settings/privacy.html.heex:204
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you."
 msgstr ""
@@ -5470,14 +5470,14 @@ msgstr ""
 msgid "Personal tokens for the vutuv API."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2841
+#: lib/vutuv_web/live/post_live/composer.ex:2902
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5619
-#: lib/vutuv_web/gettext_extraction_anchors.ex:79
+#: lib/vutuv_web/gettext_extraction_anchors.ex:84
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr ""
@@ -5492,7 +5492,7 @@ msgstr ""
 msgid "Third-party apps you authorized."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:185
+#: lib/vutuv_web/templates/settings/privacy.html.heex:212
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr ""
@@ -5508,7 +5508,7 @@ msgstr ""
 msgid "Your post"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:183
+#: lib/vutuv_web/templates/settings/privacy.html.heex:210
 #, elixir-autogen, elixir-format
 msgid "Your posts or profile a moderator is looking at."
 msgstr ""
@@ -5589,7 +5589,7 @@ msgstr ""
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5668
+#: lib/vutuv_web/components/ui.ex:5671
 #: lib/vutuv_web/controllers/settings_controller.ex:185
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -5633,7 +5633,7 @@ msgstr ""
 msgid "Replies to and likes on your posts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:173
+#: lib/vutuv_web/templates/settings/privacy.html.heex:200
 #, elixir-autogen, elixir-format
 msgid "Safety"
 msgstr ""
@@ -5739,7 +5739,7 @@ msgid "Name (A-Z)"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:507
-#: lib/vutuv_web/live/tag_live/timeline.ex:448
+#: lib/vutuv_web/live/tag_live/timeline.ex:452
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr ""
@@ -5765,7 +5765,7 @@ msgid "Nothing here yet. People you like show up here."
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:508
-#: lib/vutuv_web/live/tag_live/timeline.ex:449
+#: lib/vutuv_web/live/tag_live/timeline.ex:453
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr ""
@@ -5879,23 +5879,23 @@ msgstr ""
 msgid "just now"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:125
+#: lib/vutuv_web/templates/settings/privacy.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "A green dot on your avatar tells other members you are online right now."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:124
+#: lib/vutuv_web/templates/settings/privacy.html.heex:151
 #: lib/vutuv_web/views/account_event_text.ex:233
 #, elixir-autogen, elixir-format
 msgid "Online status"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:126
+#: lib/vutuv_web/templates/settings/privacy.html.heex:153
 #, elixir-autogen, elixir-format
 msgid "Show when I'm online"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:127
+#: lib/vutuv_web/templates/settings/privacy.html.heex:154
 #, elixir-autogen, elixir-format
 msgid "When off, no one sees the green dot on your avatar, and you never show as online."
 msgstr ""
@@ -6077,7 +6077,7 @@ msgstr ""
 msgid "Use photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2051
+#: lib/vutuv_web/live/post_live/composer.ex:2080
 #: lib/vutuv_web/templates/user/edit.html.heex:66
 #: lib/vutuv_web/templates/user/edit.html.heex:151
 #, elixir-autogen, elixir-format
@@ -6229,7 +6229,7 @@ msgstr ""
 msgid "Map services to show"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:114
+#: lib/vutuv_web/gettext_extraction_anchors.ex:119
 #: lib/vutuv_web/templates/settings/preferences.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "Maps"
@@ -6242,7 +6242,7 @@ msgstr ""
 msgid "Open in %{name}"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:112
+#: lib/vutuv_web/gettext_extraction_anchors.ex:117
 #: lib/vutuv_web/templates/settings/preferences.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Opens first, as the main button. The others appear as alternatives."
@@ -6565,8 +6565,8 @@ msgid "Turn a switch off and the matching opt-out rides along on the pages and r
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3345
-#: lib/vutuv_web/components/post_components.ex:4614
-#: lib/vutuv_web/components/post_components.ex:4628
+#: lib/vutuv_web/components/post_components.ex:4621
+#: lib/vutuv_web/components/post_components.ex:4635
 #: lib/vutuv_web/components/ui.ex:3226
 #: lib/vutuv_web/live/fediverse_account_live.ex:437
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6594,7 +6594,7 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4614
+#: lib/vutuv_web/components/post_components.ex:4621
 #: lib/vutuv_web/components/ui.ex:3225
 #: lib/vutuv_web/live/fediverse_account_live.ex:435
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -7240,7 +7240,7 @@ msgid "Removed:"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:974
-#: lib/vutuv_web/live/post_live/composer.ex:1899
+#: lib/vutuv_web/live/post_live/composer.ex:1928
 #: lib/vutuv_web/live/post_live/filter_band.ex:533
 #, elixir-autogen, elixir-format
 msgid "Undo"
@@ -7287,9 +7287,9 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:7105
+#: lib/vutuv_web/components/post_components.ex:7112
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
-#: lib/vutuv_web/live/shell_live.ex:1830
+#: lib/vutuv_web/live/shell_live.ex:1831
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
 msgstr ""
@@ -8145,7 +8145,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5656
+#: lib/vutuv_web/components/ui.ex:5659
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8281,7 +8281,7 @@ msgstr ""
 msgid "Loading posts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:140
+#: lib/vutuv_web/templates/settings/privacy.html.heex:167
 #: lib/vutuv_web/templates/user/show.html.heex:1432
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
@@ -8361,7 +8361,7 @@ msgstr ""
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5647
+#: lib/vutuv_web/components/ui.ex:5650
 #: lib/vutuv_web/controllers/settings_controller.ex:112
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8371,7 +8371,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5660
+#: lib/vutuv_web/components/ui.ex:5663
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8393,17 +8393,17 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:142
+#: lib/vutuv_web/templates/settings/privacy.html.heex:169
 #, elixir-autogen, elixir-format
 msgid "If you list a Mastodon or Bluesky account, your profile can show your latest public posts from it."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:146
+#: lib/vutuv_web/templates/settings/privacy.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "Show my latest social media posts on my profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:147
+#: lib/vutuv_web/templates/settings/privacy.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "When off, the Social Media card lists your accounts without any posts."
 msgstr ""
@@ -8578,7 +8578,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:671
 #: lib/vutuv_web/components/organization_components.ex:285
 #: lib/vutuv_web/components/ui.ex:1825
-#: lib/vutuv_web/components/ui.ex:5637
+#: lib/vutuv_web/components/ui.ex:5640
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:366
 #: lib/vutuv_web/controllers/settings_controller.ex:433
@@ -8733,7 +8733,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5960
+#: lib/vutuv_web/components/post_components.ex:5967
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9396,7 +9396,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1295
+#: lib/vutuv/accounts/user.ex:1302
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9407,7 +9407,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1292
+#: lib/vutuv/accounts/user.ex:1299
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10149,13 +10149,13 @@ msgstr[1] ""
 msgid "Code"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:159
+#: lib/vutuv_web/templates/settings/privacy.html.heex:186
 #: lib/vutuv_web/views/account_event_text.ex:236
 #, elixir-autogen, elixir-format
 msgid "Code statistics"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:161
+#: lib/vutuv_web/templates/settings/privacy.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "If you list a GitHub, GitLab or Codeberg account, your profile can show its public statistics: stars, repositories, followers, languages and recent activity."
 msgstr ""
@@ -10165,12 +10165,12 @@ msgstr ""
 msgid "Last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:165
+#: lib/vutuv_web/templates/settings/privacy.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Show code statistics on my profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:166
+#: lib/vutuv_web/templates/settings/privacy.html.heex:193
 #, elixir-autogen, elixir-format
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
@@ -10563,17 +10563,17 @@ msgstr ""
 msgid "What every member gets until they choose for themselves on their settings pages, and what logged-out visitors see. Changes apply immediately; members who set their own value are not affected."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:110
+#: lib/vutuv_web/gettext_extraction_anchors.ex:115
 #, elixir-autogen, elixir-format
 msgid "0 means posts are never shortened."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:116
+#: lib/vutuv_web/gettext_extraction_anchors.ex:121
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:115
+#: lib/vutuv_web/gettext_extraction_anchors.ex:120
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr ""
@@ -10625,8 +10625,8 @@ msgid "Failed"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:198
-#: lib/vutuv_web/live/post_live/composer.ex:2130
-#: lib/vutuv_web/live/post_live/composer.ex:3099
+#: lib/vutuv_web/live/post_live/composer.ex:2159
+#: lib/vutuv_web/live/post_live/composer.ex:3160
 #, elixir-autogen, elixir-format
 msgid "Gallery"
 msgstr ""
@@ -10725,19 +10725,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1333
+#: lib/vutuv/accounts/user.ex:1340
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1338
+#: lib/vutuv/accounts/user.ex:1345
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1336
+#: lib/vutuv/accounts/user.ex:1343
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:823
 #, elixir-autogen, elixir-format
@@ -10975,7 +10975,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
 
-#: lib/vutuv_web/controllers/organization_controller.ex:305
+#: lib/vutuv_web/controllers/organization_controller.ex:322
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:31
 #, elixir-autogen, elixir-format
 msgid "Please log in first."
@@ -11707,7 +11707,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:531
 #: lib/vutuv_web/agent_docs/organization_doc.ex:138
 #: lib/vutuv_web/agent_docs/text.ex:481
-#: lib/vutuv_web/components/ui.ex:5664
+#: lib/vutuv_web/components/ui.ex:5667
 #: lib/vutuv_web/controllers/settings_controller.ex:222
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
@@ -12017,7 +12017,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1307
+#: lib/vutuv/accounts/user.ex:1314
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12136,7 +12136,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1306
+#: lib/vutuv/accounts/user.ex:1313
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12218,7 +12218,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1308
+#: lib/vutuv/accounts/user.ex:1315
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:590
 #: lib/vutuv_web/agent_docs/markdown.ex:570
@@ -13230,7 +13230,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1351
+#: lib/vutuv/accounts/user.ex:1358
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13241,19 +13241,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1354
+#: lib/vutuv/accounts/user.ex:1361
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1357
+#: lib/vutuv/accounts/user.ex:1364
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1348
+#: lib/vutuv/accounts/user.ex:1355
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13318,7 +13318,7 @@ msgstr ""
 msgid "Insert image"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3490
+#: lib/vutuv_web/live/post_live/composer.ex:3551
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr ""
@@ -13535,34 +13535,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6648
+#: lib/vutuv_web/components/post_components.ex:6655
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6605
+#: lib/vutuv_web/components/post_components.ex:6612
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6649
+#: lib/vutuv_web/components/post_components.ex:6656
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6651
+#: lib/vutuv_web/components/post_components.ex:6658
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6647
+#: lib/vutuv_web/components/post_components.ex:6654
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6604
+#: lib/vutuv_web/components/post_components.ex:6611
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13573,12 +13573,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6646
+#: lib/vutuv_web/components/post_components.ex:6653
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6650
+#: lib/vutuv_web/components/post_components.ex:6657
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13598,7 +13598,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6687
+#: lib/vutuv_web/components/post_components.ex:6694
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13606,30 +13606,30 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6717
+#: lib/vutuv_web/components/post_components.ex:6724
 #: lib/vutuv_web/components/ui.ex:3884
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6718
+#: lib/vutuv_web/components/post_components.ex:6725
 #: lib/vutuv_web/components/ui.ex:3885
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6716
+#: lib/vutuv_web/components/post_components.ex:6723
 #: lib/vutuv_web/components/ui.ex:3877
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6676
+#: lib/vutuv_web/components/post_components.ex:6683
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6723
+#: lib/vutuv_web/components/post_components.ex:6730
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13659,7 +13659,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6490
+#: lib/vutuv_web/components/post_components.ex:6497
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13702,7 +13702,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6481
+#: lib/vutuv_web/components/post_components.ex:6488
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -13847,7 +13847,7 @@ msgstr ""
 msgid "Lines in notifications"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:111
+#: lib/vutuv_web/gettext_extraction_anchors.ex:116
 #, elixir-autogen, elixir-format
 msgid "How much of a post a notification quotes before it is cut off."
 msgstr ""
@@ -13954,13 +13954,13 @@ msgstr ""
 msgid "mentioned you in a post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1507
+#: lib/vutuv_web/live/post_live/composer.ex:1536
 #: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1510
+#: lib/vutuv_web/live/post_live/composer.ex:1539
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -14083,7 +14083,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7204
+#: lib/vutuv_web/components/post_components.ex:7211
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14940,12 +14940,12 @@ msgstr ""
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5665
+#: lib/vutuv_web/components/ui.ex:5668
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5666
+#: lib/vutuv_web/components/ui.ex:5669
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr ""
@@ -15065,62 +15065,52 @@ msgstr ""
 msgid "job alert search agent watchlist"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5622
-#, elixir-autogen, elixir-format
-msgid "Search engines, AI, online status"
-msgstr ""
-
-#: lib/vutuv_web/components/ui.ex:5623
-#, elixir-autogen, elixir-format
-msgid "privacy google search engine ai llm crawler noindex online dot public"
-msgstr ""
-
-#: lib/vutuv_web/components/ui.ex:5626
+#: lib/vutuv_web/components/ui.ex:5629
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5627
+#: lib/vutuv_web/components/ui.ex:5630
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5648
+#: lib/vutuv_web/components/ui.ex:5651
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5649
+#: lib/vutuv_web/components/ui.ex:5652
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5657
+#: lib/vutuv_web/components/ui.ex:5660
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5658
+#: lib/vutuv_web/components/ui.ex:5661
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5661
+#: lib/vutuv_web/components/ui.ex:5664
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5662
+#: lib/vutuv_web/components/ui.ex:5665
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5676
+#: lib/vutuv_web/components/ui.ex:5679
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5677
+#: lib/vutuv_web/components/ui.ex:5680
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr ""
@@ -15228,7 +15218,7 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7150
+#: lib/vutuv_web/components/post_components.ex:7157
 #: lib/vutuv_web/live/notification_live/index.ex:1592
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -15236,7 +15226,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:7154
+#: lib/vutuv_web/components/post_components.ex:7161
 #: lib/vutuv_web/live/notification_live/index.ex:1586
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15244,7 +15234,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:7158
+#: lib/vutuv_web/components/post_components.ex:7165
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15252,7 +15242,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1339
-#: lib/vutuv_web/components/post_components.ex:7109
+#: lib/vutuv_web/components/post_components.ex:7116
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15580,7 +15570,7 @@ msgstr ""
 msgid "Access token revoked"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5651
+#: lib/vutuv_web/components/ui.ex:5654
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -15794,7 +15784,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/admin/media_live.ex:155
 #: lib/vutuv_web/live/fediverse_following_live.ex:351
-#: lib/vutuv_web/live/tag_live/timeline.ex:473
+#: lib/vutuv_web/live/tag_live/timeline.ex:477
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr ""
@@ -15926,7 +15916,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5652
+#: lib/vutuv_web/components/ui.ex:5655
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr ""
@@ -15962,7 +15952,7 @@ msgstr ""
 msgid "from a signed-in session"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5654
+#: lib/vutuv_web/components/ui.ex:5657
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -16014,22 +16004,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4443
+#: lib/vutuv_web/components/post_components.ex:4450
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4577
+#: lib/vutuv_web/components/post_components.ex:4584
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4585
+#: lib/vutuv_web/components/post_components.ex:4592
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4571
+#: lib/vutuv_web/components/post_components.ex:4578
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16073,7 +16063,7 @@ msgstr ""
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3503
+#: lib/vutuv_web/live/post_live/composer.ex:3564
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr ""
@@ -16105,12 +16095,12 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1456
 #: lib/vutuv_web/agent_docs/text.ex:921
-#: lib/vutuv_web/live/post_live/composer.ex:2927
+#: lib/vutuv_web/live/post_live/composer.ex:2988
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3341
+#: lib/vutuv_web/live/post_live/composer.ex:3402
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr ""
@@ -16122,22 +16112,22 @@ msgstr ""
 msgid "Download the original"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3440
+#: lib/vutuv_web/live/post_live/composer.ex:3501
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3396
+#: lib/vutuv_web/live/post_live/composer.ex:3457
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3398
+#: lib/vutuv_web/live/post_live/composer.ex:3459
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3417
+#: lib/vutuv_web/live/post_live/composer.ex:3478
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr ""
@@ -16147,7 +16137,7 @@ msgstr ""
 msgid "Next photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2946
+#: lib/vutuv_web/live/post_live/composer.ex:3007
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr ""
@@ -16157,27 +16147,27 @@ msgstr ""
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5526
-#: lib/vutuv_web/components/press_kit_components.ex:521
+#: lib/vutuv_web/components/post_components.ex:5533
+#: lib/vutuv_web/components/press_kit_components.ex:526
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5754
-#: lib/vutuv_web/components/press_kit_components.ex:618
+#: lib/vutuv_web/components/post_components.ex:5761
+#: lib/vutuv_web/components/press_kit_components.ex:623
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2899
-#: lib/vutuv_web/live/post_live/composer.ex:2900
+#: lib/vutuv_web/live/post_live/composer.ex:2960
+#: lib/vutuv_web/live/post_live/composer.ex:2961
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1500
 #: lib/vutuv_web/agent_docs/text.ex:909
-#: lib/vutuv_web/components/post_components.ex:5836
+#: lib/vutuv_web/components/post_components.ex:5843
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr ""
@@ -16187,18 +16177,18 @@ msgstr ""
 msgid "Previous photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2959
-#: lib/vutuv_web/live/post_live/composer.ex:2960
+#: lib/vutuv_web/live/post_live/composer.ex:3020
+#: lib/vutuv_web/live/post_live/composer.ex:3021
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3419
+#: lib/vutuv_web/live/post_live/composer.ex:3480
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3360
+#: lib/vutuv_web/live/post_live/composer.ex:3421
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr ""
@@ -16208,17 +16198,17 @@ msgstr ""
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3438
+#: lib/vutuv_web/live/post_live/composer.ex:3499
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3474
+#: lib/vutuv_web/live/post_live/composer.ex:3535
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3466
+#: lib/vutuv_web/live/post_live/composer.ex:3527
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
@@ -16243,12 +16233,12 @@ msgstr ""
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3217
+#: lib/vutuv_web/live/post_live/composer.ex:3278
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1537
+#: lib/vutuv_web/live/post_live/composer.ex:1566
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
@@ -16258,7 +16248,7 @@ msgstr ""
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1551
+#: lib/vutuv_web/live/post_live/composer.ex:1580
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
@@ -16273,64 +16263,64 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2842
+#: lib/vutuv_web/live/post_live/composer.ex:2903
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3212
+#: lib/vutuv_web/live/post_live/composer.ex:3273
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3331
+#: lib/vutuv_web/live/post_live/composer.ex:3392
 #, elixir-autogen, elixir-format
 msgid "Caption (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1874
-#: lib/vutuv_web/live/post_live/composer.ex:1937
-#: lib/vutuv_web/live/post_live/composer.ex:1995
+#: lib/vutuv_web/live/post_live/composer.ex:1903
+#: lib/vutuv_web/live/post_live/composer.ex:1966
+#: lib/vutuv_web/live/post_live/composer.ex:2024
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1867
+#: lib/vutuv_web/live/post_live/composer.ex:1896
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3265
+#: lib/vutuv_web/live/post_live/composer.ex:3326
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2563
+#: lib/vutuv_web/live/post_live/composer.ex:2624
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2562
+#: lib/vutuv_web/live/post_live/composer.ex:2623
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2561
+#: lib/vutuv_web/live/post_live/composer.ex:2622
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2566
+#: lib/vutuv_web/live/post_live/composer.ex:2627
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3235
+#: lib/vutuv_web/live/post_live/composer.ex:3296
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3254
+#: lib/vutuv_web/live/post_live/composer.ex:3315
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -16338,13 +16328,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1357
-#: lib/vutuv_web/components/post_components.ex:7147
+#: lib/vutuv_web/components/post_components.ex:7154
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1355
-#: lib/vutuv_web/components/post_components.ex:7144
+#: lib/vutuv_web/components/post_components.ex:7151
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16354,7 +16344,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7031
+#: lib/vutuv_web/components/post_components.ex:7038
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
@@ -16441,8 +16431,8 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2131
-#: lib/vutuv_web/live/post_live/composer.ex:3099
+#: lib/vutuv_web/live/post_live/composer.ex:2160
+#: lib/vutuv_web/live/post_live/composer.ex:3160
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr ""
@@ -16472,7 +16462,7 @@ msgstr ""
 msgid "Cancel request"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5638
+#: lib/vutuv_web/components/ui.ex:5641
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
@@ -16676,7 +16666,7 @@ msgstr ""
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5640
+#: lib/vutuv_web/components/ui.ex:5643
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
@@ -17181,104 +17171,104 @@ msgstr ""
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2048
+#: lib/vutuv_web/live/post_live/composer.ex:2077
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3005
+#: lib/vutuv_web/live/post_live/composer.ex:3066
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3006
+#: lib/vutuv_web/live/post_live/composer.ex:3067
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3011
+#: lib/vutuv_web/live/post_live/composer.ex:3072
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3008
+#: lib/vutuv_web/live/post_live/composer.ex:3069
 #, elixir-autogen, elixir-format
 msgid "Cover left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3009
+#: lib/vutuv_web/live/post_live/composer.ex:3070
 #, elixir-autogen, elixir-format
 msgid "Cover on top"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3010
+#: lib/vutuv_web/live/post_live/composer.ex:3071
 #, elixir-autogen, elixir-format
 msgid "Cover right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2044
-#: lib/vutuv_web/live/post_live/composer.ex:2976
-#: lib/vutuv_web/live/post_live/composer.ex:2977
+#: lib/vutuv_web/live/post_live/composer.ex:2073
+#: lib/vutuv_web/live/post_live/composer.ex:3037
+#: lib/vutuv_web/live/post_live/composer.ex:3038
 #, elixir-autogen, elixir-format
 msgid "Crop photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2935
+#: lib/vutuv_web/live/post_live/composer.ex:2996
 #, elixir-autogen, elixir-format
 msgid "Cropped"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1966
+#: lib/vutuv_web/live/post_live/composer.ex:1995
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3012
+#: lib/vutuv_web/live/post_live/composer.ex:3073
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3013
+#: lib/vutuv_web/live/post_live/composer.ex:3074
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2046
+#: lib/vutuv_web/live/post_live/composer.ex:2075
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3004
+#: lib/vutuv_web/live/post_live/composer.ex:3065
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3007
+#: lib/vutuv_web/live/post_live/composer.ex:3068
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:611
+#: lib/vutuv_web/live/post_live/composer.ex:630
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3453
+#: lib/vutuv_web/live/post_live/composer.ex:3514
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2050
+#: lib/vutuv_web/live/post_live/composer.ex:2079
 #, elixir-autogen, elixir-format
 msgid "Whole photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3202
+#: lib/vutuv_web/live/post_live/composer.ex:3263
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3186
+#: lib/vutuv_web/live/post_live/composer.ex:3247
 #, elixir-autogen, elixir-format
 msgid "Whole photos"
 msgstr ""
@@ -17513,22 +17503,22 @@ msgid_plural "%{formatted} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:450
+#: lib/vutuv_web/live/tag_live/timeline.ex:454
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:481
+#: lib/vutuv_web/live/tag_live/timeline.ex:485
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:479
+#: lib/vutuv_web/live/tag_live/timeline.ex:483
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:476
+#: lib/vutuv_web/live/tag_live/timeline.ex:480
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr ""
@@ -17600,7 +17590,7 @@ msgstr ""
 msgid "At most %{max} tags. Remove one to add another."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:93
+#: lib/vutuv_web/templates/settings/privacy.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr ""
@@ -17610,24 +17600,24 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6130
+#: lib/vutuv_web/components/post_components.ex:6137
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6132
+#: lib/vutuv_web/components/post_components.ex:6139
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6143
+#: lib/vutuv_web/components/post_components.ex:6150
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:111
+#: lib/vutuv_web/templates/settings/privacy.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "Reset to the site default"
 msgstr ""
@@ -18508,17 +18498,17 @@ msgstr ""
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1454
+#: lib/vutuv/accounts/user.ex:1461
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1452
+#: lib/vutuv/accounts/user.ex:1459
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1453
+#: lib/vutuv/accounts/user.ex:1460
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -18625,7 +18615,7 @@ msgstr ""
 msgid "Always keep"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5631
+#: lib/vutuv_web/components/ui.ex:5634
 #: lib/vutuv_web/controllers/settings_controller.ex:256
 #: lib/vutuv_web/controllers/settings_controller.ex:335
 #: lib/vutuv_web/controllers/settings_controller.ex:347
@@ -18722,7 +18712,7 @@ msgstr ""
 msgid "Keep posts that did well"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5633
+#: lib/vutuv_web/components/ui.ex:5636
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr ""
@@ -18831,7 +18821,7 @@ msgstr ""
 msgid "Your rule"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5635
+#: lib/vutuv_web/components/ui.ex:5638
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
@@ -19265,17 +19255,17 @@ msgstr ""
 msgid "Nothing published yet."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2377
+#: lib/vutuv_web/live/post_live/composer.ex:2438
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1530
+#: lib/vutuv_web/live/post_live/composer.ex:1559
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2354
+#: lib/vutuv_web/live/post_live/composer.ex:2415
 #, elixir-autogen, elixir-format
 msgid "A post in an organization's name is always public."
 msgstr ""
@@ -20056,44 +20046,44 @@ msgstr ""
 msgid "{n} of {max} free slots selected."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2336
+#: lib/vutuv_web/live/post_live/composer.ex:2397
 #, elixir-autogen, elixir-format
 msgid "More languages"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2327
+#: lib/vutuv_web/live/post_live/composer.ex:2388
 #, elixir-autogen, elixir-format
 msgctxt "post composer"
 msgid "Language"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2323
-#: lib/vutuv_web/live/post_live/composer.ex:2324
+#: lib/vutuv_web/live/post_live/composer.ex:2384
+#: lib/vutuv_web/live/post_live/composer.ex:2385
 #, elixir-autogen, elixir-format
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6024
+#: lib/vutuv_web/components/post_components.ex:6031
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6060
+#: lib/vutuv_web/components/post_components.ex:6067
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6069
+#: lib/vutuv_web/components/post_components.ex:6076
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6072
+#: lib/vutuv_web/components/post_components.ex:6079
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6049
+#: lib/vutuv_web/components/post_components.ex:6056
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
@@ -20103,7 +20093,7 @@ msgstr ""
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6039
+#: lib/vutuv_web/components/post_components.ex:6046
 #: lib/vutuv_web/components/ui.ex:5549
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -20112,27 +20102,27 @@ msgstr ""
 msgid "Feed languages"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:83
+#: lib/vutuv_web/gettext_extraction_anchors.ex:88
 #, elixir-autogen, elixir-format
 msgid "Hide them"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:81
+#: lib/vutuv_web/gettext_extraction_anchors.ex:86
 #, elixir-autogen, elixir-format
 msgid "Posts in other languages"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:82
+#: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #, elixir-autogen, elixir-format
 msgid "Translate into my language"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:84
+#: lib/vutuv_web/gettext_extraction_anchors.ex:89
 #, elixir-autogen, elixir-format
 msgid "What your feed does with posts outside your chosen languages: show them as they are, translate them for you, or hide them. Posts that declare no language always show."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:120
+#: lib/vutuv_web/gettext_extraction_anchors.ex:125
 #, elixir-autogen, elixir-format
 msgid "Date & time"
 msgstr ""
@@ -20142,12 +20132,12 @@ msgstr ""
 msgid "Date and time settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:118
+#: lib/vutuv_web/gettext_extraction_anchors.ex:123
 #, elixir-autogen, elixir-format
 msgid "Date format"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:128
+#: lib/vutuv_web/gettext_extraction_anchors.ex:133
 #, elixir-autogen, elixir-format
 msgid "Germany, Austria, Switzerland"
 msgstr ""
@@ -20157,27 +20147,27 @@ msgstr ""
 msgid "Language and region saved."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:124
+#: lib/vutuv_web/gettext_extraction_anchors.ex:129
 #, elixir-autogen, elixir-format
 msgid "Posts, messages and notifications are stamped in this zone. New accounts take it from the browser."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:121
+#: lib/vutuv_web/gettext_extraction_anchors.ex:126
 #, elixir-autogen, elixir-format
 msgid "The order and punctuation of every date you read here, and whether times run on a 12- or 24-hour clock."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:119
+#: lib/vutuv_web/gettext_extraction_anchors.ex:124
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:129
+#: lib/vutuv_web/gettext_extraction_anchors.ex:134
 #, elixir-autogen, elixir-format
 msgid "United Kingdom, France, Brazil"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:130
+#: lib/vutuv_web/gettext_extraction_anchors.ex:135
 #, elixir-autogen, elixir-format
 msgid "United States"
 msgstr ""
@@ -20187,7 +20177,7 @@ msgstr ""
 msgid "Your browser says: {zone}"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:131
+#: lib/vutuv_web/gettext_extraction_anchors.ex:136
 #, elixir-autogen, elixir-format
 msgid "ISO 8601 (Sweden, Japan, China)"
 msgstr ""
@@ -20232,20 +20222,20 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5802
+#: lib/vutuv_web/components/post_components.ex:5809
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5799
+#: lib/vutuv_web/components/post_components.ex:5806
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2912
-#: lib/vutuv_web/components/post_components.ex:4868
+#: lib/vutuv_web/components/post_components.ex:4875
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -20315,7 +20305,7 @@ msgstr ""
 msgid "Mastodon app access changed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5669
+#: lib/vutuv_web/components/ui.ex:5672
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr ""
@@ -20361,7 +20351,7 @@ msgstr ""
 msgid "Your account is then %{handle}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5671
+#: lib/vutuv_web/components/ui.ex:5674
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr ""
@@ -20944,7 +20934,7 @@ msgstr ""
 msgid "Example"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:95
+#: lib/vutuv_web/gettext_extraction_anchors.ex:100
 #, elixir-autogen, elixir-format
 msgid "Feed tabs"
 msgstr ""
@@ -20959,22 +20949,22 @@ msgstr ""
 msgid "Play the example"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:109
+#: lib/vutuv_web/gettext_extraction_anchors.ex:114
 #, elixir-autogen, elixir-format
 msgid "Between 4 and 20 seconds."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:97
+#: lib/vutuv_web/gettext_extraction_anchors.ex:102
 #, elixir-autogen, elixir-format
 msgid "How long the quote stands"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:96
+#: lib/vutuv_web/gettext_extraction_anchors.ex:101
 #, elixir-autogen, elixir-format
 msgid "Quote what arrives on the other tab"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:98
+#: lib/vutuv_web/gettext_extraction_anchors.ex:103
 #, elixir-autogen, elixir-format
 msgid "When off, a tab holding something new wears its dot and says nothing more."
 msgstr ""
@@ -21101,7 +21091,7 @@ msgid_plural "+%{formatted} more posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:100
+#: lib/vutuv_web/gettext_extraction_anchors.ex:105
 #: lib/vutuv_web/templates/settings/preferences.html.heex:210
 #, elixir-autogen, elixir-format
 msgid "Browser tab"
@@ -21117,12 +21107,12 @@ msgstr ""
 msgid "Browser tab settings saved."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:102
+#: lib/vutuv_web/gettext_extraction_anchors.ex:107
 #, elixir-autogen, elixir-format
 msgid "Only while you are looking at another tab, and only for a few seconds. The tab title also shows up in screenshots, in your window switcher and in a screen share."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:101
+#: lib/vutuv_web/gettext_extraction_anchors.ex:106
 #, elixir-autogen, elixir-format
 msgid "Tease new posts in the browser tab"
 msgstr ""
@@ -21752,7 +21742,7 @@ msgstr ""
 msgid "only %{account}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7492
+#: lib/vutuv_web/components/post_components.ex:7499
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -21767,7 +21757,7 @@ msgid_plural "%{formatted} shares"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/post_calendar_controller.ex:136
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:141
 #: lib/vutuv_web/live/notification_live/index.ex:821
 #, elixir-autogen, elixir-format
 msgid "Post without text"
@@ -21815,18 +21805,18 @@ msgid "Nothing matches."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:336
-#: lib/vutuv_web/live/post_live/composer.ex:2130
-#: lib/vutuv_web/live/post_live/composer.ex:3132
+#: lib/vutuv_web/live/post_live/composer.ex:2159
+#: lib/vutuv_web/live/post_live/composer.ex:3193
 #, elixir-autogen, elixir-format
 msgid "Automatic"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2135
+#: lib/vutuv_web/live/post_live/composer.ex:2164
 #, elixir-autogen, elixir-format
 msgid "Drag one photo onto another to swap them."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2082
+#: lib/vutuv_web/live/post_live/composer.ex:2111
 #, elixir-autogen, elixir-format
 msgid "Not shown in the gallery — drag one into it to swap."
 msgstr ""
@@ -21883,17 +21873,17 @@ msgstr ""
 msgid "Unmute %{host}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1890
+#: lib/vutuv_web/live/post_live/composer.ex:1919
 #, elixir-autogen, elixir-format
 msgid "Draft discarded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1929
+#: lib/vutuv_web/live/post_live/composer.ex:1958
 #, elixir-autogen, elixir-format
 msgid "Keep it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1920
+#: lib/vutuv_web/live/post_live/composer.ex:1949
 #, elixir-autogen, elixir-format
 msgid "Keep this draft for later?"
 msgstr ""
@@ -21925,7 +21915,7 @@ msgstr ""
 msgid "If you are on a slow or metered connection, vutuv can leave out the parts of the page that cost the most to download."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:107
+#: lib/vutuv_web/gettext_extraction_anchors.ex:112
 #, elixir-autogen, elixir-format
 msgid "Low-bandwidth mode"
 msgstr ""
@@ -22006,7 +21996,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1456
 #: lib/vutuv_web/components/post_components.ex:3406
-#: lib/vutuv_web/components/post_components.ex:4658
+#: lib/vutuv_web/components/post_components.ex:4665
 #: lib/vutuv_web/components/ui.ex:5541
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
@@ -22093,7 +22083,7 @@ msgstr ""
 msgid "About %{minutes} min of video"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2634
+#: lib/vutuv_web/live/post_live/composer.ex:2695
 #, elixir-autogen, elixir-format
 msgid "Add video"
 msgstr ""
@@ -22130,37 +22120,37 @@ msgstr[1] ""
 msgid "Reading the frames"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2670
+#: lib/vutuv_web/live/post_live/composer.ex:2731
 #, elixir-autogen, elixir-format
 msgid "Remove it to post the text without it, or pick another file."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1195
+#: lib/vutuv_web/live/post_live/composer.ex:1224
 #, elixir-autogen, elixir-format
 msgid "Remove the refused video to post the text without it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2699
+#: lib/vutuv_web/live/post_live/composer.ex:2760
 #, elixir-autogen, elixir-format
 msgid "Remove video"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2709
+#: lib/vutuv_web/live/post_live/composer.ex:2770
 #, elixir-autogen, elixir-format
 msgid "Tap a frame to make it the cover."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1062
+#: lib/vutuv_web/live/post_live/composer.ex:1081
 #, elixir-autogen, elixir-format
 msgid "That frame could not be used."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1520
+#: lib/vutuv_web/live/post_live/composer.ex:1549
 #, elixir-autogen, elixir-format
 msgid "The video could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1607
+#: lib/vutuv_web/live/post_live/composer.ex:1636
 #, elixir-autogen, elixir-format
 msgid "The video is longer than %{seconds} seconds."
 msgstr ""
@@ -22181,17 +22171,17 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:919
 #: lib/vutuv_web/components/post_components.ex:2981
 #: lib/vutuv_web/components/video_components.ex:126
-#: lib/vutuv_web/live/post_live/composer.ex:2633
+#: lib/vutuv_web/live/post_live/composer.ex:2694
 #, elixir-autogen, elixir-format
 msgid "Video"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2677
+#: lib/vutuv_web/live/post_live/composer.ex:2738
 #, elixir-autogen, elixir-format
 msgid "Video description"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1614
+#: lib/vutuv_web/live/post_live/composer.ex:1643
 #, elixir-autogen, elixir-format
 msgid "Videos cannot be uploaded here."
 msgstr ""
@@ -22201,12 +22191,12 @@ msgstr ""
 msgid "Waiting in line"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2684
+#: lib/vutuv_web/live/post_live/composer.ex:2745
 #, elixir-autogen, elixir-format
 msgid "What is in the video, for people who cannot watch it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2673
+#: lib/vutuv_web/live/post_live/composer.ex:2734
 #, elixir-autogen, elixir-format
 msgid "You can post now — the post appears as soon as the video is ready."
 msgstr ""
@@ -22237,7 +22227,7 @@ msgstr[1] ""
 msgid "Last 30 days: %{parts}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5220
+#: lib/vutuv_web/components/post_components.ex:5227
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Less"
@@ -22333,7 +22323,7 @@ msgstr[1] ""
 msgid "Can be changed at any time."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:108
+#: lib/vutuv_web/gettext_extraction_anchors.ex:113
 #, elixir-autogen, elixir-format
 msgid "For members on a slow connection."
 msgstr ""
@@ -22552,7 +22542,7 @@ msgid "Hidden. What they pass on stays out of your feed; their own posts do not.
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3378
-#: lib/vutuv_web/components/post_components.ex:4652
+#: lib/vutuv_web/components/post_components.ex:4659
 #, elixir-autogen, elixir-format
 msgid "Hide reposts"
 msgstr ""
@@ -22666,7 +22656,8 @@ msgstr[1] ""
 msgid "Post calendar"
 msgstr ""
 
-#: lib/vutuv_web/controllers/post_calendar_controller.ex:126
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:131
+#: lib/vutuv_web/post_teaser.ex:187
 #, elixir-autogen, elixir-format
 msgid "Post not open to search engines"
 msgstr ""
@@ -22696,7 +22687,7 @@ msgstr ""
 msgid "The posts written that month, by day."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:89
+#: lib/vutuv_web/gettext_extraction_anchors.ex:94
 #, elixir-autogen, elixir-format
 msgid "Feed length"
 msgstr ""
@@ -22716,7 +22707,7 @@ msgstr ""
 msgid "How many load at once, and how many “Load more” adds"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:91
+#: lib/vutuv_web/gettext_extraction_anchors.ex:96
 #, elixir-autogen, elixir-format
 msgid "How many posts your feed shows before the “Load more” button, and how many that button adds. More posts mean a longer wait for the page."
 msgstr ""
@@ -22728,7 +22719,7 @@ msgstr ""
 msgid "Posts in your feed"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:90
+#: lib/vutuv_web/gettext_extraction_anchors.ex:95
 #, elixir-autogen, elixir-format
 msgid "Posts loaded at once"
 msgstr ""
@@ -22749,13 +22740,13 @@ msgstr ""
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7483
-#: lib/vutuv_web/components/post_components.ex:7484
+#: lib/vutuv_web/components/post_components.ex:7490
+#: lib/vutuv_web/components/post_components.ex:7491
 #, elixir-autogen, elixir-format
 msgid "A word or phrase …"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7511
+#: lib/vutuv_web/components/post_components.ex:7518
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr ""
@@ -22772,7 +22763,7 @@ msgstr ""
 msgid "Hide something from your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7429
+#: lib/vutuv_web/components/post_components.ex:7436
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr ""
@@ -22787,22 +22778,22 @@ msgstr ""
 msgid "Words & tags"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7515
+#: lib/vutuv_web/components/post_components.ex:7522
 #, elixir-autogen, elixir-format
 msgid "everyone"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7518
+#: lib/vutuv_web/components/post_components.ex:7525
 #, elixir-autogen, elixir-format
 msgid "only %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7487
+#: lib/vutuv_web/components/post_components.ex:7494
 #, elixir-autogen, elixir-format
 msgid "this word"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7528
+#: lib/vutuv_web/components/post_components.ex:7535
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr ""
@@ -22854,7 +22845,7 @@ msgstr ""
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6833
+#: lib/vutuv_web/components/post_components.ex:6840
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr ""
@@ -22945,7 +22936,7 @@ msgid "Hidden. What other people pass on of them stays out of your feed; their o
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3364
-#: lib/vutuv_web/components/post_components.ex:4640
+#: lib/vutuv_web/components/post_components.ex:4647
 #, elixir-autogen, elixir-format
 msgid "Hide when others repost them"
 msgstr ""
@@ -23115,12 +23106,12 @@ msgstr ""
 msgid "vutuv is part of the Fediverse, the union of independent networks that Mastodon belongs to as well. Whether your posts take part is your choice at sign-up, and one switch in the settings later. We are not religious about it: each to their own."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1824
+#: lib/vutuv_web/live/shell_live.ex:1825
 #, elixir-autogen, elixir-format
 msgid "All notifications"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1777
+#: lib/vutuv_web/live/shell_live.ex:1778
 #, elixir-autogen, elixir-format
 msgid "New notifications"
 msgstr ""
@@ -23660,13 +23651,13 @@ msgstr ""
 msgid "“%{note}”"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5398
-#: lib/vutuv_web/components/press_kit_components.ex:211
+#: lib/vutuv_web/components/post_components.ex:5405
+#: lib/vutuv_web/components/press_kit_components.ex:216
 #, elixir-autogen, elixir-format
 msgid "Show these photos larger"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5584
+#: lib/vutuv_web/components/post_components.ex:5591
 #, elixir-autogen, elixir-format
 msgid "Show this photo larger"
 msgstr ""
@@ -23756,7 +23747,7 @@ msgstr ""
 msgid "Light"
 msgstr ""
 
-#: lib/vutuv/press_kit.ex:251
+#: lib/vutuv/press_kit.ex:321
 #, elixir-autogen, elixir-format
 msgid "Logo variant"
 msgstr ""
@@ -23805,7 +23796,7 @@ msgstr ""
 msgid "Please confirm the rights first, then choose the file."
 msgstr ""
 
-#: lib/vutuv/press_kit.ex:251
+#: lib/vutuv/press_kit.ex:321
 #, elixir-autogen, elixir-format
 msgid "Press photo"
 msgstr ""
@@ -23891,18 +23882,18 @@ msgstr[1] ""
 msgid "Credit: %{credit}"
 msgstr ""
 
-#: lib/vutuv_web/components/press_kit_components.ex:375
-#: lib/vutuv_web/components/press_kit_components.ex:378
+#: lib/vutuv_web/components/press_kit_components.ex:380
+#: lib/vutuv_web/components/press_kit_components.ex:383
 #, elixir-autogen, elixir-format
 msgid "Download %{format}"
 msgstr ""
 
-#: lib/vutuv_web/components/press_kit_components.ex:331
+#: lib/vutuv_web/components/press_kit_components.ex:336
 #, elixir-autogen, elixir-format
 msgid "Download photo"
 msgstr ""
 
-#: lib/vutuv/press_kit.ex:715
+#: lib/vutuv/press_kit.ex:785
 #, elixir-autogen, elixir-format
 msgid "Free for editorial use with credit."
 msgstr ""
@@ -23912,7 +23903,7 @@ msgstr ""
 msgid "PNG version"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/press_kit_doc.ex:55
+#: lib/vutuv_web/agent_docs/press_kit_doc.ex:58
 #, elixir-autogen, elixir-format
 msgid "Press pictures %{name} offers for download, free for editorial use with credit."
 msgstr ""
@@ -23947,7 +23938,7 @@ msgstr ""
 msgid "What a journalist writing about this page may download: photos in print quality and its logo as a file. Everything here is public and free for editorial use as long as the credit is shown."
 msgstr ""
 
-#: lib/vutuv_web/components/press_kit_components.ex:565
+#: lib/vutuv_web/components/press_kit_components.ex:570
 #: lib/vutuv_web/components/ui.ex:3281
 #, elixir-autogen, elixir-format
 msgid "Report this picture"
@@ -24049,7 +24040,7 @@ msgid "nobody"
 msgstr ""
 
 #: lib/vutuv_web/components/press_kit_components.ex:120
-#: lib/vutuv_web/components/press_kit_components.ex:176
+#: lib/vutuv_web/components/press_kit_components.ex:181
 #, elixir-autogen, elixir-format
 msgid "All Media Kit files"
 msgstr ""
@@ -24069,7 +24060,7 @@ msgstr ""
 msgid "Media Kit"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/press_kit_doc.ex:53
+#: lib/vutuv_web/agent_docs/press_kit_doc.ex:56
 #: lib/vutuv_web/views/press_kit_html.ex:32
 #, elixir-autogen, elixir-format
 msgid "Media Kit of %{name}"
@@ -24100,8 +24091,8 @@ msgstr ""
 msgid "press kit media journalist photographer download original print logo svg credit copyright presse pressefotos pressemappe medienkit mediakit fotos logo herunterladen bildnachweis"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4556
-#: lib/vutuv_web/components/post_components.ex:4606
+#: lib/vutuv_web/components/post_components.ex:4563
+#: lib/vutuv_web/components/post_components.ex:4613
 #, elixir-autogen, elixir-format
 msgid "Copy link to post"
 msgstr ""
@@ -24111,14 +24102,14 @@ msgstr ""
 msgid "Link copied"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2820
+#: lib/vutuv_web/live/post_live/composer.ex:2881
 #, elixir-autogen, elixir-format
 msgid "%{left} of today's %{limit} left (%{percent} %)."
 msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:1291
 #: lib/vutuv_web/live/message_live/index.ex:1295
-#: lib/vutuv_web/live/post_live/composer.ex:2753
+#: lib/vutuv_web/live/post_live/composer.ex:2814
 #, elixir-autogen, elixir-format
 msgid "Add files"
 msgstr ""
@@ -24128,12 +24119,12 @@ msgstr ""
 msgid "File check"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3517
+#: lib/vutuv_web/live/post_live/composer.ex:3578
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{size}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2752
+#: lib/vutuv_web/live/post_live/composer.ex:2813
 #, elixir-autogen, elixir-format
 msgid "Files"
 msgstr ""
@@ -24143,7 +24134,7 @@ msgstr ""
 msgid "Files may be up to %{size}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3527
+#: lib/vutuv_web/live/post_live/composer.ex:3588
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} files per post."
 msgstr ""
@@ -24160,7 +24151,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:1270
 #: lib/vutuv_web/live/message_live/index.ex:1271
-#: lib/vutuv_web/live/post_live/composer.ex:2799
+#: lib/vutuv_web/live/post_live/composer.ex:2860
 #, elixir-autogen, elixir-format
 msgid "Remove %{name}"
 msgstr ""
@@ -24185,7 +24176,7 @@ msgstr ""
 msgid "You have used up today's upload allowance. It frees up again over the day."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2818
+#: lib/vutuv_web/live/post_live/composer.ex:2879
 #, elixir-autogen, elixir-format
 msgid "Your uploads are not limited."
 msgstr ""
@@ -24204,7 +24195,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:121
 #: lib/vutuv_web/agent_docs/text.ex:412
-#: lib/vutuv_web/components/press_kit_components.ex:269
+#: lib/vutuv_web/components/press_kit_components.ex:274
 #, elixir-autogen, elixir-format
 msgid "About %{name}"
 msgstr ""
@@ -24229,12 +24220,12 @@ msgstr ""
 msgid "As long as you like. The whole portrait."
 msgstr ""
 
-#: lib/vutuv/press_kit.ex:460
+#: lib/vutuv/press_kit.ex:530
 #, elixir-autogen, elixir-format
 msgid "Long version"
 msgstr ""
 
-#: lib/vutuv/press_kit.ex:459
+#: lib/vutuv/press_kit.ex:529
 #, elixir-autogen, elixir-format
 msgid "Medium version"
 msgstr ""
@@ -24244,12 +24235,12 @@ msgstr ""
 msgid "Nothing written yet."
 msgstr ""
 
-#: lib/vutuv/press_kit.ex:458
+#: lib/vutuv/press_kit.ex:528
 #, elixir-autogen, elixir-format
 msgid "Short version"
 msgstr ""
 
-#: lib/vutuv_web/components/press_kit_components.ex:272
+#: lib/vutuv_web/components/press_kit_components.ex:277
 #, elixir-autogen, elixir-format
 msgid "Take whichever length fits the space you have. Each one stands on its own."
 msgstr ""
@@ -24278,13 +24269,6 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "File preview pages"
 msgstr ""
-
-#: lib/vutuv_web/live/shell_live.ex:1742
-#, elixir-autogen, elixir-format
-msgid "%{count} post is being prepared"
-msgid_plural "%{count} posts are being prepared"
-msgstr[0] ""
-msgstr[1] ""
 
 #: lib/vutuv_web/live/uploads_live.ex:173
 #, elixir-autogen, elixir-format
@@ -24666,4 +24650,51 @@ msgstr ""
 #: lib/vutuv_web/live/message_live/index.ex:627
 #, elixir-autogen, elixir-format
 msgid "You can only send files to members you are connected with."
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:1743
+#, elixir-autogen, elixir-format
+msgid "%{formatted} post is being prepared"
+msgid_plural "%{formatted} posts are being prepared"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:2312
+#, elixir-autogen, elixir-format
+msgid "Remove the metadata from the files"
+msgstr ""
+
+#: lib/vutuv_web/components/ui.ex:5622
+#, elixir-autogen, elixir-format
+msgid "Search engines and AI, your posts, online status"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/privacy.html.heex:93
+#, elixir-autogen, elixir-format
+msgid "Whether search engines and AI may read what you post. Each post keeps the answer it was published with, so changing this leaves everything you have already written exactly as it is."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:2314
+#, elixir-autogen, elixir-format
+msgid "Your name, the software you used and the dates come out of a PDF."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/privacy.html.heex:91
+#, elixir-autogen, elixir-format
+msgid "Your posts"
+msgstr ""
+
+#: lib/vutuv_web/components/ui.ex:5624
+#, elixir-autogen, elixir-format
+msgid "privacy google search engine ai llm crawler noindex online dot public posts beiträge indexieren fediverse mastodon suchmaschine"
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:81
+#, elixir-autogen, elixir-format
+msgid "Covers the words, the pictures, the files and the machine formats of every post you write from now on. When off, your new posts also stay out of other networks completely: a server elsewhere keeps its copy for good and no instruction of ours reaches it. Posts you have already published keep the answer they went out with."
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:80
+#, elixir-autogen, elixir-format
+msgid "Search engines and AI may read my posts"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -6256,7 +6256,7 @@ msgstr ""
 msgid "Endorsed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:141
+#: lib/vutuv_web/agent_docs/list_docs.ex:143
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "Members who endorsed %{name} for %{tag}"
@@ -8438,7 +8438,7 @@ msgstr ""
 msgid "Invalid address (skipped)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:180
+#: lib/vutuv_web/agent_docs/list_docs.ex:182
 #: lib/vutuv_web/controllers/directory_controller.ex:54
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
@@ -8454,7 +8454,7 @@ msgstr ""
 msgid "Members by initial"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:203
+#: lib/vutuv_web/agent_docs/list_docs.ex:205
 #: lib/vutuv_web/controllers/directory_controller.ex:86
 #: lib/vutuv_web/templates/directory/show.html.heex:2
 #, elixir-autogen, elixir-format
@@ -8473,7 +8473,7 @@ msgid_plural "%{formatted} members"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:209
+#: lib/vutuv_web/agent_docs/list_docs.ex:211
 #, elixir-autogen, elixir-format
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
@@ -21269,7 +21269,7 @@ msgstr ""
 msgid "All vutuv members, filed alphabetically by last name."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:195
+#: lib/vutuv_web/agent_docs/list_docs.ex:197
 #, elixir-autogen, elixir-format
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr ""
@@ -22642,8 +22642,8 @@ msgid_plural "%{formatted} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:253
-#: lib/vutuv_web/agent_docs/list_docs.ex:285
+#: lib/vutuv_web/agent_docs/list_docs.ex:255
+#: lib/vutuv_web/agent_docs/list_docs.ex:287
 #: lib/vutuv_web/controllers/post_calendar_controller.ex:36
 #: lib/vutuv_web/templates/layout/app.html.heex:79
 #: lib/vutuv_web/templates/post_calendar/day.html.heex:5
@@ -22655,7 +22655,7 @@ msgid "Post calendar"
 msgstr ""
 
 #: lib/vutuv_web/controllers/post_calendar_controller.ex:131
-#: lib/vutuv_web/post_teaser.ex:187
+#: lib/vutuv_web/post_teaser.ex:211
 #, elixir-autogen, elixir-format
 msgid "Post not open to search engines"
 msgstr ""
@@ -22675,12 +22675,12 @@ msgstr ""
 msgid "Posts on %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:286
+#: lib/vutuv_web/agent_docs/list_docs.ex:288
 #, elixir-autogen, elixir-format
 msgid "The posts written that day."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:254
+#: lib/vutuv_web/agent_docs/list_docs.ex:256
 #, elixir-autogen, elixir-format
 msgid "The posts written that month, by day."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -118,7 +118,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_posting_live/form.ex:857
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
-#: lib/vutuv_web/live/post_live/composer.ex:2049
+#: lib/vutuv_web/live/post_live/composer.ex:2078
 #: lib/vutuv_web/live/press_kit_live.ex:729
 #: lib/vutuv_web/live/press_kit_live.ex:1139
 #: lib/vutuv_web/templates/ad/new.html.heex:136
@@ -163,7 +163,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4593
+#: lib/vutuv_web/components/post_components.ex:4600
 #: lib/vutuv_web/components/ui.ex:5042
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
@@ -204,14 +204,14 @@ msgid "Disable"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:446
-#: lib/vutuv_web/live/post_live/composer.ex:3228
+#: lib/vutuv_web/live/post_live/composer.ex:3289
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/views/qualification_html.ex:354
 #, elixir-autogen
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4558
+#: lib/vutuv_web/components/post_components.ex:4565
 #: lib/vutuv_web/components/ui.ex:5033
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
@@ -607,7 +607,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2361
+#: lib/vutuv_web/live/post_live/composer.ex:2422
 #: lib/vutuv_web/live/section_reorder_live.ex:272
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -619,7 +619,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4934
 #: lib/vutuv_web/live/organization_live/edit.ex:376
-#: lib/vutuv_web/live/post_live/composer.ex:2376
+#: lib/vutuv_web/live/post_live/composer.ex:2437
 #: lib/vutuv_web/live/press_kit_live.ex:727
 #: lib/vutuv_web/live/press_kit_live.ex:1138
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -1187,7 +1187,7 @@ msgstr ""
 msgid "All tag urls"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5211
+#: lib/vutuv_web/components/post_components.ex:5218
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:643
@@ -1608,11 +1608,11 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:321
 #: lib/vutuv_web/live/admin/job_live.ex:477
 #: lib/vutuv_web/live/admin/organization_live.ex:296
-#: lib/vutuv_web/live/post_live/composer.ex:1905
-#: lib/vutuv_web/live/post_live/composer.ex:2007
-#: lib/vutuv_web/live/post_live/composer.ex:2008
-#: lib/vutuv_web/live/post_live/composer.ex:3105
-#: lib/vutuv_web/live/post_live/composer.ex:3371
+#: lib/vutuv_web/live/post_live/composer.ex:1934
+#: lib/vutuv_web/live/post_live/composer.ex:2036
+#: lib/vutuv_web/live/post_live/composer.ex:2037
+#: lib/vutuv_web/live/post_live/composer.ex:3166
+#: lib/vutuv_web/live/post_live/composer.ex:3432
 #: lib/vutuv_web/templates/layout/app.html.heex:200
 #: lib/vutuv_web/templates/layout/app.html.heex:206
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:28
@@ -2065,7 +2065,7 @@ msgstr ""
 msgid "Add images"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2490
+#: lib/vutuv_web/live/post_live/composer.ex:2551
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2076,9 +2076,9 @@ msgstr ""
 msgid "Back to the post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2147
-#: lib/vutuv_web/live/post_live/composer.ex:2170
-#: lib/vutuv_web/live/post_live/composer.ex:2196
+#: lib/vutuv_web/live/post_live/composer.ex:2176
+#: lib/vutuv_web/live/post_live/composer.ex:2199
+#: lib/vutuv_web/live/post_live/composer.ex:2225
 #: lib/vutuv_web/live/press_kit_live.ex:1307
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
@@ -2089,7 +2089,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4590
+#: lib/vutuv_web/components/post_components.ex:4597
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2102,7 +2102,7 @@ msgid "Edit post"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:274
-#: lib/vutuv_web/gettext_extraction_anchors.ex:87
+#: lib/vutuv_web/gettext_extraction_anchors.ex:92
 #: lib/vutuv_web/live/organization_live/feed.ex:203
 #: lib/vutuv_web/live/post_live/feed.ex:365
 #: lib/vutuv_web/live/post_live/feed.ex:3536
@@ -2124,29 +2124,29 @@ msgstr ""
 msgid "Hidden from:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2466
+#: lib/vutuv_web/live/post_live/composer.ex:2527
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2394
+#: lib/vutuv_web/live/post_live/composer.ex:2455
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4536
-#: lib/vutuv_web/components/post_components.ex:4538
+#: lib/vutuv_web/components/post_components.ex:4543
+#: lib/vutuv_web/components/post_components.ex:4545
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2436
+#: lib/vutuv_web/live/post_live/composer.ex:2497
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1554
-#: lib/vutuv_web/live/post_live/composer.ex:1694
+#: lib/vutuv_web/live/post_live/composer.ex:1583
+#: lib/vutuv_web/live/post_live/composer.ex:1723
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr ""
@@ -2156,23 +2156,23 @@ msgstr ""
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1517
+#: lib/vutuv_web/live/post_live/composer.ex:1546
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2426
+#: lib/vutuv_web/live/post_live/composer.ex:2487
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2416
+#: lib/vutuv_web/live/post_live/composer.ex:2477
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:441
-#: lib/vutuv_web/live/post_live/composer.ex:2378
+#: lib/vutuv_web/live/post_live/composer.ex:2439
 #, elixir-autogen, elixir-format
 msgid "Post"
 msgstr ""
@@ -2182,11 +2182,11 @@ msgstr ""
 msgid "Post deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:243
+#: lib/vutuv_web/agent_docs/post_doc.ex:264
 #: lib/vutuv_web/controllers/post_controller.ex:69
 #: lib/vutuv_web/controllers/post_controller.ex:90
 #: lib/vutuv_web/controllers/user_controller.ex:77
-#: lib/vutuv_web/gettext_extraction_anchors.ex:113
+#: lib/vutuv_web/gettext_extraction_anchors.ex:118
 #: lib/vutuv_web/live/admin/dashboard_live.ex:270
 #: lib/vutuv_web/live/fediverse_account_live.ex:446
 #: lib/vutuv_web/live/organization_live/show.ex:733
@@ -2200,13 +2200,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5084
-#: lib/vutuv_web/components/post_components.ex:5088
+#: lib/vutuv_web/components/post_components.ex:5091
+#: lib/vutuv_web/components/post_components.ex:5095
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5085
+#: lib/vutuv_web/components/post_components.ex:5092
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2223,7 +2223,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:265
 #: lib/vutuv_web/live/organization_live/edit.ex:404
 #: lib/vutuv_web/live/organization_live/roles.ex:257
-#: lib/vutuv_web/live/post_live/composer.ex:2452
+#: lib/vutuv_web/live/post_live/composer.ex:2513
 #: lib/vutuv_web/live/post_live/filter_band.ex:456
 #: lib/vutuv_web/live/post_live/saved.ex:666
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2240,7 +2240,7 @@ msgstr ""
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2368
+#: lib/vutuv_web/live/post_live/composer.ex:2429
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr ""
@@ -2258,14 +2258,14 @@ msgid "Sorry, that page could not be found."
 msgstr ""
 
 #: lib/vutuv_web/attachment_text.ex:73
-#: lib/vutuv_web/live/post_live/composer.ex:1615
-#: lib/vutuv_web/live/post_live/composer.ex:1720
+#: lib/vutuv_web/live/post_live/composer.ex:1644
+#: lib/vutuv_web/live/post_live/composer.ex:1749
 #: lib/vutuv_web/live/press_kit_live.ex:541
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1499
+#: lib/vutuv_web/live/post_live/composer.ex:1528
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr ""
@@ -2275,17 +2275,17 @@ msgstr ""
 msgid "This post is for followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3546
+#: lib/vutuv_web/live/post_live/composer.ex:3607
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3547
+#: lib/vutuv_web/live/post_live/composer.ex:3608
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5865
+#: lib/vutuv_web/components/ui.ex:5868
 #: lib/vutuv_web/live/shell_live.ex:1588
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2294,37 +2294,37 @@ msgstr ""
 msgid "View profile"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2584
+#: lib/vutuv_web/live/post_live/composer.ex:2645
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2585
+#: lib/vutuv_web/live/post_live/composer.ex:2646
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4533
+#: lib/vutuv_web/components/post_components.ex:4540
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6851
+#: lib/vutuv_web/components/post_components.ex:6858
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6855
+#: lib/vutuv_web/components/post_components.ex:6862
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6853
+#: lib/vutuv_web/components/post_components.ex:6860
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6854
+#: lib/vutuv_web/components/post_components.ex:6861
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2336,21 +2336,21 @@ msgstr ""
 msgid "unknown"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2246
+#: lib/vutuv_web/live/post_live/composer.ex:2275
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1612
-#: lib/vutuv_web/live/post_live/composer.ex:3513
-#: lib/vutuv_web/live/post_live/composer.ex:3531
+#: lib/vutuv_web/live/post_live/composer.ex:1641
+#: lib/vutuv_web/live/post_live/composer.ex:3574
+#: lib/vutuv_web/live/post_live/composer.ex:3592
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3521
-#: lib/vutuv_web/live/post_live/composer.ex:3535
-#: lib/vutuv_web/live/post_live/composer.ex:3541
+#: lib/vutuv_web/live/post_live/composer.ex:3582
+#: lib/vutuv_web/live/post_live/composer.ex:3596
+#: lib/vutuv_web/live/post_live/composer.ex:3602
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr ""
@@ -2371,7 +2371,7 @@ msgid "All posts"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2185
-#: lib/vutuv_web/components/post_components.ex:6954
+#: lib/vutuv_web/components/post_components.ex:6961
 #: lib/vutuv_web/components/ui.ex:4476
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2390,7 +2390,7 @@ msgid "Bookmarks"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2129
-#: lib/vutuv_web/components/post_components.ex:7195
+#: lib/vutuv_web/components/post_components.ex:7202
 #: lib/vutuv_web/components/ui.ex:4462
 #: lib/vutuv_web/notification_line.ex:317
 #: lib/vutuv_web/views/user_html.ex:486
@@ -2399,12 +2399,12 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1301
-#: lib/vutuv_web/components/post_components.ex:7205
+#: lib/vutuv_web/components/post_components.ex:7212
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
 #: lib/vutuv_web/live/shell_live.ex:1596
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
-#: lib/vutuv_web/templates/settings/privacy.html.heex:91
+#: lib/vutuv_web/templates/settings/privacy.html.heex:118
 #: lib/vutuv_web/views/admin/report_html.ex:37
 #, elixir-autogen, elixir-format
 msgid "Likes"
@@ -2420,13 +2420,13 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6942
+#: lib/vutuv_web/components/post_components.ex:6949
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2184
-#: lib/vutuv_web/components/post_components.ex:6953
+#: lib/vutuv_web/components/post_components.ex:6960
 #: lib/vutuv_web/live/post_live/saved.ex:822
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2434,26 +2434,26 @@ msgid "Remove bookmark"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2165
-#: lib/vutuv_web/components/post_components.ex:6938
+#: lib/vutuv_web/components/post_components.ex:6945
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2758
-#: lib/vutuv_web/components/post_components.ex:5957
+#: lib/vutuv_web/components/post_components.ex:5964
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2164
-#: lib/vutuv_web/components/post_components.ex:6937
+#: lib/vutuv_web/components/post_components.ex:6944
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2128
-#: lib/vutuv_web/components/post_components.ex:7194
+#: lib/vutuv_web/components/post_components.ex:7201
 #: lib/vutuv_web/live/post_live/saved.ex:821
 #: lib/vutuv_web/views/user_html.ex:486
 #, elixir-autogen, elixir-format
@@ -2481,7 +2481,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7249
+#: lib/vutuv_web/components/post_components.ex:7256
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2493,8 +2493,8 @@ msgid "Replies"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2374
-#: lib/vutuv_web/components/post_components.ex:7232
-#: lib/vutuv_web/components/post_components.ex:7233
+#: lib/vutuv_web/components/post_components.ex:7239
+#: lib/vutuv_web/components/post_components.ex:7240
 #: lib/vutuv_web/live/notification_live/index.ex:993
 #: lib/vutuv_web/live/post_live/reply.ex:49
 #: lib/vutuv_web/notification_line.ex:314
@@ -2502,18 +2502,18 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4492
+#: lib/vutuv_web/components/post_components.ex:4499
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1502
-#: lib/vutuv_web/live/post_live/composer.ex:2356
+#: lib/vutuv_web/live/post_live/composer.ex:1531
+#: lib/vutuv_web/live/post_live/composer.ex:2417
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2497
+#: lib/vutuv_web/live/post_live/composer.ex:2558
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2531,14 +2531,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4464
+#: lib/vutuv_web/components/post_components.ex:4471
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4455
-#: lib/vutuv_web/components/post_components.ex:4484
-#: lib/vutuv_web/components/post_components.ex:4487
+#: lib/vutuv_web/components/post_components.ex:4462
+#: lib/vutuv_web/components/post_components.ex:4491
+#: lib/vutuv_web/components/post_components.ex:4494
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2754,7 +2754,7 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:109
 #: lib/vutuv_web/templates/settings/preferences.html.heex:195
-#: lib/vutuv_web/templates/settings/privacy.html.heex:179
+#: lib/vutuv_web/templates/settings/privacy.html.heex:206
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:216
 #: lib/vutuv_web/templates/user/show.html.heex:643
@@ -2815,7 +2815,7 @@ msgstr ""
 msgid "Other formats"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2406
+#: lib/vutuv_web/live/post_live/composer.ex:2467
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr ""
@@ -2838,7 +2838,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6852
+#: lib/vutuv_web/components/post_components.ex:6859
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3090,7 +3090,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4431
+#: lib/vutuv_web/components/post_components.ex:4438
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3151,7 +3151,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1466
 #: lib/vutuv_web/components/post_components.ex:3418
 #: lib/vutuv_web/components/post_components.ex:3605
-#: lib/vutuv_web/components/post_components.ex:4661
+#: lib/vutuv_web/components/post_components.ex:4668
 #: lib/vutuv_web/live/organization_live/show.ex:684
 #: lib/vutuv_web/templates/user/show.html.heex:252
 #, elixir-autogen, elixir-format
@@ -3861,7 +3861,7 @@ msgstr ""
 msgid "People %{name} follows"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:244
+#: lib/vutuv_web/agent_docs/post_doc.ex:265
 #, elixir-autogen, elixir-format
 msgid "Post archive of %{name}"
 msgstr ""
@@ -4450,11 +4450,11 @@ msgstr ""
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5625
+#: lib/vutuv_web/components/ui.ex:5628
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
-#: lib/vutuv_web/templates/settings/privacy.html.heex:176
+#: lib/vutuv_web/templates/settings/privacy.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Blocked members"
 msgstr ""
@@ -5217,7 +5217,7 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5675
+#: lib/vutuv_web/components/ui.ex:5678
 #: lib/vutuv_web/controllers/settings_controller.ex:161
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:552
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5253,12 +5253,12 @@ msgstr ""
 msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1523
+#: lib/vutuv_web/live/post_live/composer.ex:1552
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:182
+#: lib/vutuv_web/templates/settings/privacy.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "Content under review"
 msgstr ""
@@ -5296,10 +5296,10 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5772
-#: lib/vutuv_web/components/ui.ex:5777
-#: lib/vutuv_web/components/ui.ex:5856
-#: lib/vutuv_web/components/ui.ex:5920
+#: lib/vutuv_web/components/ui.ex:5775
+#: lib/vutuv_web/components/ui.ex:5780
+#: lib/vutuv_web/components/ui.ex:5859
+#: lib/vutuv_web/components/ui.ex:5923
 #: lib/vutuv_web/controllers/settings_controller.ex:68
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5369,9 +5369,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4741
-#: lib/vutuv_web/components/post_components.ex:5350
-#: lib/vutuv_web/components/post_components.ex:5688
+#: lib/vutuv_web/components/post_components.ex:4748
+#: lib/vutuv_web/components/post_components.ex:5357
+#: lib/vutuv_web/components/post_components.ex:5695
 #: lib/vutuv_web/live/notification_live/index.ex:1069
 #: lib/vutuv_web/views/user_html.ex:133
 #, elixir-autogen, elixir-format
@@ -5418,7 +5418,7 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5645
+#: lib/vutuv_web/components/ui.ex:5648
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:262
@@ -5458,7 +5458,7 @@ msgstr ""
 msgid "Notification settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:177
+#: lib/vutuv_web/templates/settings/privacy.html.heex:204
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you."
 msgstr ""
@@ -5468,14 +5468,14 @@ msgstr ""
 msgid "Personal tokens for the vutuv API."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2841
+#: lib/vutuv_web/live/post_live/composer.ex:2902
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5619
-#: lib/vutuv_web/gettext_extraction_anchors.ex:79
+#: lib/vutuv_web/gettext_extraction_anchors.ex:84
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr ""
@@ -5490,7 +5490,7 @@ msgstr ""
 msgid "Third-party apps you authorized."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:185
+#: lib/vutuv_web/templates/settings/privacy.html.heex:212
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr ""
@@ -5506,7 +5506,7 @@ msgstr ""
 msgid "Your post"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:183
+#: lib/vutuv_web/templates/settings/privacy.html.heex:210
 #, elixir-autogen, elixir-format
 msgid "Your posts or profile a moderator is looking at."
 msgstr ""
@@ -5587,7 +5587,7 @@ msgstr ""
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5668
+#: lib/vutuv_web/components/ui.ex:5671
 #: lib/vutuv_web/controllers/settings_controller.ex:185
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -5631,7 +5631,7 @@ msgstr ""
 msgid "Replies to and likes on your posts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:173
+#: lib/vutuv_web/templates/settings/privacy.html.heex:200
 #, elixir-autogen, elixir-format
 msgid "Safety"
 msgstr ""
@@ -5737,7 +5737,7 @@ msgid "Name (A-Z)"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:507
-#: lib/vutuv_web/live/tag_live/timeline.ex:448
+#: lib/vutuv_web/live/tag_live/timeline.ex:452
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr ""
@@ -5763,7 +5763,7 @@ msgid "Nothing here yet. People you like show up here."
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:508
-#: lib/vutuv_web/live/tag_live/timeline.ex:449
+#: lib/vutuv_web/live/tag_live/timeline.ex:453
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr ""
@@ -5877,23 +5877,23 @@ msgstr ""
 msgid "just now"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:125
+#: lib/vutuv_web/templates/settings/privacy.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "A green dot on your avatar tells other members you are online right now."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:124
+#: lib/vutuv_web/templates/settings/privacy.html.heex:151
 #: lib/vutuv_web/views/account_event_text.ex:233
 #, elixir-autogen, elixir-format
 msgid "Online status"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:126
+#: lib/vutuv_web/templates/settings/privacy.html.heex:153
 #, elixir-autogen, elixir-format
 msgid "Show when I'm online"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:127
+#: lib/vutuv_web/templates/settings/privacy.html.heex:154
 #, elixir-autogen, elixir-format
 msgid "When off, no one sees the green dot on your avatar, and you never show as online."
 msgstr ""
@@ -6075,7 +6075,7 @@ msgstr ""
 msgid "Use photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2051
+#: lib/vutuv_web/live/post_live/composer.ex:2080
 #: lib/vutuv_web/templates/user/edit.html.heex:66
 #: lib/vutuv_web/templates/user/edit.html.heex:151
 #, elixir-autogen, elixir-format
@@ -6227,7 +6227,7 @@ msgstr ""
 msgid "Map services to show"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:114
+#: lib/vutuv_web/gettext_extraction_anchors.ex:119
 #: lib/vutuv_web/templates/settings/preferences.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "Maps"
@@ -6240,7 +6240,7 @@ msgstr ""
 msgid "Open in %{name}"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:112
+#: lib/vutuv_web/gettext_extraction_anchors.ex:117
 #: lib/vutuv_web/templates/settings/preferences.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Opens first, as the main button. The others appear as alternatives."
@@ -6563,8 +6563,8 @@ msgid "Turn a switch off and the matching opt-out rides along on the pages and r
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3345
-#: lib/vutuv_web/components/post_components.ex:4614
-#: lib/vutuv_web/components/post_components.ex:4628
+#: lib/vutuv_web/components/post_components.ex:4621
+#: lib/vutuv_web/components/post_components.ex:4635
 #: lib/vutuv_web/components/ui.ex:3226
 #: lib/vutuv_web/live/fediverse_account_live.ex:437
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6592,7 +6592,7 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4614
+#: lib/vutuv_web/components/post_components.ex:4621
 #: lib/vutuv_web/components/ui.ex:3225
 #: lib/vutuv_web/live/fediverse_account_live.ex:435
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -7238,7 +7238,7 @@ msgid "Removed:"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:974
-#: lib/vutuv_web/live/post_live/composer.ex:1899
+#: lib/vutuv_web/live/post_live/composer.ex:1928
 #: lib/vutuv_web/live/post_live/filter_band.ex:533
 #, elixir-autogen, elixir-format
 msgid "Undo"
@@ -7285,9 +7285,9 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:7105
+#: lib/vutuv_web/components/post_components.ex:7112
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
-#: lib/vutuv_web/live/shell_live.ex:1830
+#: lib/vutuv_web/live/shell_live.ex:1831
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
 msgstr ""
@@ -8143,7 +8143,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5656
+#: lib/vutuv_web/components/ui.ex:5659
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8279,7 +8279,7 @@ msgstr ""
 msgid "Loading posts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:140
+#: lib/vutuv_web/templates/settings/privacy.html.heex:167
 #: lib/vutuv_web/templates/user/show.html.heex:1432
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
@@ -8359,7 +8359,7 @@ msgstr ""
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5647
+#: lib/vutuv_web/components/ui.ex:5650
 #: lib/vutuv_web/controllers/settings_controller.ex:112
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8369,7 +8369,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5660
+#: lib/vutuv_web/components/ui.ex:5663
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8391,17 +8391,17 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:142
+#: lib/vutuv_web/templates/settings/privacy.html.heex:169
 #, elixir-autogen, elixir-format
 msgid "If you list a Mastodon or Bluesky account, your profile can show your latest public posts from it."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:146
+#: lib/vutuv_web/templates/settings/privacy.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "Show my latest social media posts on my profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:147
+#: lib/vutuv_web/templates/settings/privacy.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "When off, the Social Media card lists your accounts without any posts."
 msgstr ""
@@ -8576,7 +8576,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:671
 #: lib/vutuv_web/components/organization_components.ex:285
 #: lib/vutuv_web/components/ui.ex:1825
-#: lib/vutuv_web/components/ui.ex:5637
+#: lib/vutuv_web/components/ui.ex:5640
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:366
 #: lib/vutuv_web/controllers/settings_controller.ex:433
@@ -8731,7 +8731,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5960
+#: lib/vutuv_web/components/post_components.ex:5967
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9394,7 +9394,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1295
+#: lib/vutuv/accounts/user.ex:1302
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9405,7 +9405,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1292
+#: lib/vutuv/accounts/user.ex:1299
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10147,13 +10147,13 @@ msgstr[1] ""
 msgid "Code"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:159
+#: lib/vutuv_web/templates/settings/privacy.html.heex:186
 #: lib/vutuv_web/views/account_event_text.ex:236
 #, elixir-autogen, elixir-format
 msgid "Code statistics"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:161
+#: lib/vutuv_web/templates/settings/privacy.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "If you list a GitHub, GitLab or Codeberg account, your profile can show its public statistics: stars, repositories, followers, languages and recent activity."
 msgstr ""
@@ -10163,12 +10163,12 @@ msgstr ""
 msgid "Last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:165
+#: lib/vutuv_web/templates/settings/privacy.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Show code statistics on my profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:166
+#: lib/vutuv_web/templates/settings/privacy.html.heex:193
 #, elixir-autogen, elixir-format
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
@@ -10561,17 +10561,17 @@ msgstr ""
 msgid "What every member gets until they choose for themselves on their settings pages, and what logged-out visitors see. Changes apply immediately; members who set their own value are not affected."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:110
+#: lib/vutuv_web/gettext_extraction_anchors.ex:115
 #, elixir-autogen, elixir-format
 msgid "0 means posts are never shortened."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:116
+#: lib/vutuv_web/gettext_extraction_anchors.ex:121
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:115
+#: lib/vutuv_web/gettext_extraction_anchors.ex:120
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr ""
@@ -10623,8 +10623,8 @@ msgid "Failed"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:198
-#: lib/vutuv_web/live/post_live/composer.ex:2130
-#: lib/vutuv_web/live/post_live/composer.ex:3099
+#: lib/vutuv_web/live/post_live/composer.ex:2159
+#: lib/vutuv_web/live/post_live/composer.ex:3160
 #, elixir-autogen, elixir-format
 msgid "Gallery"
 msgstr ""
@@ -10723,19 +10723,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1333
+#: lib/vutuv/accounts/user.ex:1340
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1338
+#: lib/vutuv/accounts/user.ex:1345
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1336
+#: lib/vutuv/accounts/user.ex:1343
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:823
 #, elixir-autogen, elixir-format
@@ -10973,7 +10973,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
 
-#: lib/vutuv_web/controllers/organization_controller.ex:305
+#: lib/vutuv_web/controllers/organization_controller.ex:322
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:31
 #, elixir-autogen, elixir-format
 msgid "Please log in first."
@@ -11705,7 +11705,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:531
 #: lib/vutuv_web/agent_docs/organization_doc.ex:138
 #: lib/vutuv_web/agent_docs/text.ex:481
-#: lib/vutuv_web/components/ui.ex:5664
+#: lib/vutuv_web/components/ui.ex:5667
 #: lib/vutuv_web/controllers/settings_controller.ex:222
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
@@ -12015,7 +12015,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1307
+#: lib/vutuv/accounts/user.ex:1314
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12134,7 +12134,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1306
+#: lib/vutuv/accounts/user.ex:1313
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12216,7 +12216,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1308
+#: lib/vutuv/accounts/user.ex:1315
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:590
 #: lib/vutuv_web/agent_docs/markdown.ex:570
@@ -13228,7 +13228,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1351
+#: lib/vutuv/accounts/user.ex:1358
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13239,19 +13239,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1354
+#: lib/vutuv/accounts/user.ex:1361
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1357
+#: lib/vutuv/accounts/user.ex:1364
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1348
+#: lib/vutuv/accounts/user.ex:1355
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13316,7 +13316,7 @@ msgstr ""
 msgid "Insert image"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3490
+#: lib/vutuv_web/live/post_live/composer.ex:3551
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr ""
@@ -13533,34 +13533,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6648
+#: lib/vutuv_web/components/post_components.ex:6655
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6605
+#: lib/vutuv_web/components/post_components.ex:6612
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6649
+#: lib/vutuv_web/components/post_components.ex:6656
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6651
+#: lib/vutuv_web/components/post_components.ex:6658
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6647
+#: lib/vutuv_web/components/post_components.ex:6654
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6604
+#: lib/vutuv_web/components/post_components.ex:6611
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13571,12 +13571,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6646
+#: lib/vutuv_web/components/post_components.ex:6653
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6650
+#: lib/vutuv_web/components/post_components.ex:6657
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13596,7 +13596,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6687
+#: lib/vutuv_web/components/post_components.ex:6694
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13604,30 +13604,30 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6717
+#: lib/vutuv_web/components/post_components.ex:6724
 #: lib/vutuv_web/components/ui.ex:3884
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6718
+#: lib/vutuv_web/components/post_components.ex:6725
 #: lib/vutuv_web/components/ui.ex:3885
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6716
+#: lib/vutuv_web/components/post_components.ex:6723
 #: lib/vutuv_web/components/ui.ex:3877
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6676
+#: lib/vutuv_web/components/post_components.ex:6683
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6723
+#: lib/vutuv_web/components/post_components.ex:6730
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13657,7 +13657,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6490
+#: lib/vutuv_web/components/post_components.ex:6497
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13700,7 +13700,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6481
+#: lib/vutuv_web/components/post_components.ex:6488
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -13845,7 +13845,7 @@ msgstr ""
 msgid "Lines in notifications"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:111
+#: lib/vutuv_web/gettext_extraction_anchors.ex:116
 #, elixir-autogen, elixir-format
 msgid "How much of a post a notification quotes before it is cut off."
 msgstr ""
@@ -13952,13 +13952,13 @@ msgstr ""
 msgid "mentioned you in a post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1507
+#: lib/vutuv_web/live/post_live/composer.ex:1536
 #: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1510
+#: lib/vutuv_web/live/post_live/composer.ex:1539
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -14081,7 +14081,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7204
+#: lib/vutuv_web/components/post_components.ex:7211
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14938,12 +14938,12 @@ msgstr ""
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5665
+#: lib/vutuv_web/components/ui.ex:5668
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5666
+#: lib/vutuv_web/components/ui.ex:5669
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr ""
@@ -15063,62 +15063,52 @@ msgstr ""
 msgid "job alert search agent watchlist"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5622
-#, elixir-autogen, elixir-format
-msgid "Search engines, AI, online status"
-msgstr ""
-
-#: lib/vutuv_web/components/ui.ex:5623
-#, elixir-autogen, elixir-format
-msgid "privacy google search engine ai llm crawler noindex online dot public"
-msgstr ""
-
-#: lib/vutuv_web/components/ui.ex:5626
+#: lib/vutuv_web/components/ui.ex:5629
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5627
+#: lib/vutuv_web/components/ui.ex:5630
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5648
+#: lib/vutuv_web/components/ui.ex:5651
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5649
+#: lib/vutuv_web/components/ui.ex:5652
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5657
+#: lib/vutuv_web/components/ui.ex:5660
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5658
+#: lib/vutuv_web/components/ui.ex:5661
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5661
+#: lib/vutuv_web/components/ui.ex:5664
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5662
+#: lib/vutuv_web/components/ui.ex:5665
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5676
+#: lib/vutuv_web/components/ui.ex:5679
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5677
+#: lib/vutuv_web/components/ui.ex:5680
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr ""
@@ -15226,7 +15216,7 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7150
+#: lib/vutuv_web/components/post_components.ex:7157
 #: lib/vutuv_web/live/notification_live/index.ex:1592
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
@@ -15234,7 +15224,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:7154
+#: lib/vutuv_web/components/post_components.ex:7161
 #: lib/vutuv_web/live/notification_live/index.ex:1586
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15242,7 +15232,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:7158
+#: lib/vutuv_web/components/post_components.ex:7165
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15250,7 +15240,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1339
-#: lib/vutuv_web/components/post_components.ex:7109
+#: lib/vutuv_web/components/post_components.ex:7116
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15578,7 +15568,7 @@ msgstr ""
 msgid "Access token revoked"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5651
+#: lib/vutuv_web/components/ui.ex:5654
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -15792,7 +15782,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/admin/media_live.ex:155
 #: lib/vutuv_web/live/fediverse_following_live.ex:351
-#: lib/vutuv_web/live/tag_live/timeline.ex:473
+#: lib/vutuv_web/live/tag_live/timeline.ex:477
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr ""
@@ -15924,7 +15914,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5652
+#: lib/vutuv_web/components/ui.ex:5655
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr ""
@@ -15960,7 +15950,7 @@ msgstr ""
 msgid "from a signed-in session"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5654
+#: lib/vutuv_web/components/ui.ex:5657
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -16012,22 +16002,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4443
+#: lib/vutuv_web/components/post_components.ex:4450
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4577
+#: lib/vutuv_web/components/post_components.ex:4584
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4585
+#: lib/vutuv_web/components/post_components.ex:4592
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4571
+#: lib/vutuv_web/components/post_components.ex:4578
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16071,7 +16061,7 @@ msgstr ""
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3503
+#: lib/vutuv_web/live/post_live/composer.ex:3564
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr ""
@@ -16103,12 +16093,12 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1456
 #: lib/vutuv_web/agent_docs/text.ex:921
-#: lib/vutuv_web/live/post_live/composer.ex:2927
+#: lib/vutuv_web/live/post_live/composer.ex:2988
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3341
+#: lib/vutuv_web/live/post_live/composer.ex:3402
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr ""
@@ -16120,22 +16110,22 @@ msgstr ""
 msgid "Download the original"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3440
+#: lib/vutuv_web/live/post_live/composer.ex:3501
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3396
+#: lib/vutuv_web/live/post_live/composer.ex:3457
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3398
+#: lib/vutuv_web/live/post_live/composer.ex:3459
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3417
+#: lib/vutuv_web/live/post_live/composer.ex:3478
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr ""
@@ -16145,7 +16135,7 @@ msgstr ""
 msgid "Next photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2946
+#: lib/vutuv_web/live/post_live/composer.ex:3007
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr ""
@@ -16155,27 +16145,27 @@ msgstr ""
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5526
-#: lib/vutuv_web/components/press_kit_components.ex:521
+#: lib/vutuv_web/components/post_components.ex:5533
+#: lib/vutuv_web/components/press_kit_components.ex:526
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5754
-#: lib/vutuv_web/components/press_kit_components.ex:618
+#: lib/vutuv_web/components/post_components.ex:5761
+#: lib/vutuv_web/components/press_kit_components.ex:623
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2899
-#: lib/vutuv_web/live/post_live/composer.ex:2900
+#: lib/vutuv_web/live/post_live/composer.ex:2960
+#: lib/vutuv_web/live/post_live/composer.ex:2961
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1500
 #: lib/vutuv_web/agent_docs/text.ex:909
-#: lib/vutuv_web/components/post_components.ex:5836
+#: lib/vutuv_web/components/post_components.ex:5843
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
 msgstr ""
@@ -16185,18 +16175,18 @@ msgstr ""
 msgid "Previous photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2959
-#: lib/vutuv_web/live/post_live/composer.ex:2960
+#: lib/vutuv_web/live/post_live/composer.ex:3020
+#: lib/vutuv_web/live/post_live/composer.ex:3021
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3419
+#: lib/vutuv_web/live/post_live/composer.ex:3480
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3360
+#: lib/vutuv_web/live/post_live/composer.ex:3421
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Show camera settings"
 msgstr ""
@@ -16206,17 +16196,17 @@ msgstr ""
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3438
+#: lib/vutuv_web/live/post_live/composer.ex:3499
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3474
+#: lib/vutuv_web/live/post_live/composer.ex:3535
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3466
+#: lib/vutuv_web/live/post_live/composer.ex:3527
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
@@ -16241,12 +16231,12 @@ msgstr ""
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3217
+#: lib/vutuv_web/live/post_live/composer.ex:3278
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1537
+#: lib/vutuv_web/live/post_live/composer.ex:1566
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
@@ -16256,7 +16246,7 @@ msgstr ""
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1551
+#: lib/vutuv_web/live/post_live/composer.ex:1580
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
@@ -16271,64 +16261,64 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2842
+#: lib/vutuv_web/live/post_live/composer.ex:2903
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3212
+#: lib/vutuv_web/live/post_live/composer.ex:3273
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3331
+#: lib/vutuv_web/live/post_live/composer.ex:3392
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Caption (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1874
-#: lib/vutuv_web/live/post_live/composer.ex:1937
-#: lib/vutuv_web/live/post_live/composer.ex:1995
+#: lib/vutuv_web/live/post_live/composer.ex:1903
+#: lib/vutuv_web/live/post_live/composer.ex:1966
+#: lib/vutuv_web/live/post_live/composer.ex:2024
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1867
+#: lib/vutuv_web/live/post_live/composer.ex:1896
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3265
+#: lib/vutuv_web/live/post_live/composer.ex:3326
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2563
+#: lib/vutuv_web/live/post_live/composer.ex:2624
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2562
+#: lib/vutuv_web/live/post_live/composer.ex:2623
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2561
+#: lib/vutuv_web/live/post_live/composer.ex:2622
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2566
+#: lib/vutuv_web/live/post_live/composer.ex:2627
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3235
+#: lib/vutuv_web/live/post_live/composer.ex:3296
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3254
+#: lib/vutuv_web/live/post_live/composer.ex:3315
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -16336,13 +16326,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1357
-#: lib/vutuv_web/components/post_components.ex:7147
+#: lib/vutuv_web/components/post_components.ex:7154
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1355
-#: lib/vutuv_web/components/post_components.ex:7144
+#: lib/vutuv_web/components/post_components.ex:7151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16352,7 +16342,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7031
+#: lib/vutuv_web/components/post_components.ex:7038
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
@@ -16439,8 +16429,8 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2131
-#: lib/vutuv_web/live/post_live/composer.ex:3099
+#: lib/vutuv_web/live/post_live/composer.ex:2160
+#: lib/vutuv_web/live/post_live/composer.ex:3160
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr ""
@@ -16470,7 +16460,7 @@ msgstr ""
 msgid "Cancel request"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5638
+#: lib/vutuv_web/components/ui.ex:5641
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
@@ -16674,7 +16664,7 @@ msgstr ""
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5640
+#: lib/vutuv_web/components/ui.ex:5643
 #, elixir-autogen, elixir-format, fuzzy
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
@@ -17179,104 +17169,104 @@ msgstr ""
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2048
+#: lib/vutuv_web/live/post_live/composer.ex:2077
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3005
+#: lib/vutuv_web/live/post_live/composer.ex:3066
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3006
+#: lib/vutuv_web/live/post_live/composer.ex:3067
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3011
+#: lib/vutuv_web/live/post_live/composer.ex:3072
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3008
+#: lib/vutuv_web/live/post_live/composer.ex:3069
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3009
+#: lib/vutuv_web/live/post_live/composer.ex:3070
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover on top"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3010
+#: lib/vutuv_web/live/post_live/composer.ex:3071
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2044
-#: lib/vutuv_web/live/post_live/composer.ex:2976
-#: lib/vutuv_web/live/post_live/composer.ex:2977
+#: lib/vutuv_web/live/post_live/composer.ex:2073
+#: lib/vutuv_web/live/post_live/composer.ex:3037
+#: lib/vutuv_web/live/post_live/composer.ex:3038
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Crop photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2935
+#: lib/vutuv_web/live/post_live/composer.ex:2996
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cropped"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1966
+#: lib/vutuv_web/live/post_live/composer.ex:1995
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3012
+#: lib/vutuv_web/live/post_live/composer.ex:3073
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3013
+#: lib/vutuv_web/live/post_live/composer.ex:3074
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2046
+#: lib/vutuv_web/live/post_live/composer.ex:2075
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3004
+#: lib/vutuv_web/live/post_live/composer.ex:3065
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3007
+#: lib/vutuv_web/live/post_live/composer.ex:3068
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:611
+#: lib/vutuv_web/live/post_live/composer.ex:630
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3453
+#: lib/vutuv_web/live/post_live/composer.ex:3514
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2050
+#: lib/vutuv_web/live/post_live/composer.ex:2079
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Whole photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3202
+#: lib/vutuv_web/live/post_live/composer.ex:3263
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3186
+#: lib/vutuv_web/live/post_live/composer.ex:3247
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Whole photos"
 msgstr ""
@@ -17511,22 +17501,22 @@ msgid_plural "%{formatted} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:450
+#: lib/vutuv_web/live/tag_live/timeline.ex:454
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:481
+#: lib/vutuv_web/live/tag_live/timeline.ex:485
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:479
+#: lib/vutuv_web/live/tag_live/timeline.ex:483
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:476
+#: lib/vutuv_web/live/tag_live/timeline.ex:480
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr ""
@@ -17598,7 +17588,7 @@ msgstr ""
 msgid "At most %{max} tags. Remove one to add another."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:93
+#: lib/vutuv_web/templates/settings/privacy.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr ""
@@ -17608,24 +17598,24 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6130
+#: lib/vutuv_web/components/post_components.ex:6137
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6132
+#: lib/vutuv_web/components/post_components.ex:6139
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6143
+#: lib/vutuv_web/components/post_components.ex:6150
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:111
+#: lib/vutuv_web/templates/settings/privacy.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "Reset to the site default"
 msgstr ""
@@ -18506,17 +18496,17 @@ msgstr ""
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1454
+#: lib/vutuv/accounts/user.ex:1461
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1452
+#: lib/vutuv/accounts/user.ex:1459
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1453
+#: lib/vutuv/accounts/user.ex:1460
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -18623,7 +18613,7 @@ msgstr ""
 msgid "Always keep"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5631
+#: lib/vutuv_web/components/ui.ex:5634
 #: lib/vutuv_web/controllers/settings_controller.ex:256
 #: lib/vutuv_web/controllers/settings_controller.ex:335
 #: lib/vutuv_web/controllers/settings_controller.ex:347
@@ -18720,7 +18710,7 @@ msgstr ""
 msgid "Keep posts that did well"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5633
+#: lib/vutuv_web/components/ui.ex:5636
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr ""
@@ -18829,7 +18819,7 @@ msgstr ""
 msgid "Your rule"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5635
+#: lib/vutuv_web/components/ui.ex:5638
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
@@ -19263,17 +19253,17 @@ msgstr ""
 msgid "Nothing published yet."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2377
+#: lib/vutuv_web/live/post_live/composer.ex:2438
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1530
+#: lib/vutuv_web/live/post_live/composer.ex:1559
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2354
+#: lib/vutuv_web/live/post_live/composer.ex:2415
 #, elixir-autogen, elixir-format
 msgid "A post in an organization's name is always public."
 msgstr ""
@@ -20054,44 +20044,44 @@ msgstr ""
 msgid "{n} of {max} free slots selected."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2336
+#: lib/vutuv_web/live/post_live/composer.ex:2397
 #, elixir-autogen, elixir-format
 msgid "More languages"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2327
+#: lib/vutuv_web/live/post_live/composer.ex:2388
 #, elixir-autogen, elixir-format
 msgctxt "post composer"
 msgid "Language"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2323
-#: lib/vutuv_web/live/post_live/composer.ex:2324
+#: lib/vutuv_web/live/post_live/composer.ex:2384
+#: lib/vutuv_web/live/post_live/composer.ex:2385
 #, elixir-autogen, elixir-format
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6024
+#: lib/vutuv_web/components/post_components.ex:6031
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6060
+#: lib/vutuv_web/components/post_components.ex:6067
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6069
+#: lib/vutuv_web/components/post_components.ex:6076
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6072
+#: lib/vutuv_web/components/post_components.ex:6079
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6049
+#: lib/vutuv_web/components/post_components.ex:6056
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
@@ -20101,7 +20091,7 @@ msgstr ""
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6039
+#: lib/vutuv_web/components/post_components.ex:6046
 #: lib/vutuv_web/components/ui.ex:5549
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -20110,27 +20100,27 @@ msgstr ""
 msgid "Feed languages"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:83
+#: lib/vutuv_web/gettext_extraction_anchors.ex:88
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Hide them"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:81
+#: lib/vutuv_web/gettext_extraction_anchors.ex:86
 #, elixir-autogen, elixir-format
 msgid "Posts in other languages"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:82
+#: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Translate into my language"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:84
+#: lib/vutuv_web/gettext_extraction_anchors.ex:89
 #, elixir-autogen, elixir-format
 msgid "What your feed does with posts outside your chosen languages: show them as they are, translate them for you, or hide them. Posts that declare no language always show."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:120
+#: lib/vutuv_web/gettext_extraction_anchors.ex:125
 #, elixir-autogen, elixir-format
 msgid "Date & time"
 msgstr ""
@@ -20140,12 +20130,12 @@ msgstr ""
 msgid "Date and time settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:118
+#: lib/vutuv_web/gettext_extraction_anchors.ex:123
 #, elixir-autogen, elixir-format
 msgid "Date format"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:128
+#: lib/vutuv_web/gettext_extraction_anchors.ex:133
 #, elixir-autogen, elixir-format
 msgid "Germany, Austria, Switzerland"
 msgstr ""
@@ -20155,27 +20145,27 @@ msgstr ""
 msgid "Language and region saved."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:124
+#: lib/vutuv_web/gettext_extraction_anchors.ex:129
 #, elixir-autogen, elixir-format
 msgid "Posts, messages and notifications are stamped in this zone. New accounts take it from the browser."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:121
+#: lib/vutuv_web/gettext_extraction_anchors.ex:126
 #, elixir-autogen, elixir-format
 msgid "The order and punctuation of every date you read here, and whether times run on a 12- or 24-hour clock."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:119
+#: lib/vutuv_web/gettext_extraction_anchors.ex:124
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:129
+#: lib/vutuv_web/gettext_extraction_anchors.ex:134
 #, elixir-autogen, elixir-format
 msgid "United Kingdom, France, Brazil"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:130
+#: lib/vutuv_web/gettext_extraction_anchors.ex:135
 #, elixir-autogen, elixir-format
 msgid "United States"
 msgstr ""
@@ -20185,7 +20175,7 @@ msgstr ""
 msgid "Your browser says: {zone}"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:131
+#: lib/vutuv_web/gettext_extraction_anchors.ex:136
 #, elixir-autogen, elixir-format, fuzzy
 msgid "ISO 8601 (Sweden, Japan, China)"
 msgstr ""
@@ -20230,20 +20220,20 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5802
+#: lib/vutuv_web/components/post_components.ex:5809
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5799
+#: lib/vutuv_web/components/post_components.ex:5806
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2912
-#: lib/vutuv_web/components/post_components.ex:4868
+#: lib/vutuv_web/components/post_components.ex:4875
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -20313,7 +20303,7 @@ msgstr ""
 msgid "Mastodon app access changed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5669
+#: lib/vutuv_web/components/ui.ex:5672
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr ""
@@ -20359,7 +20349,7 @@ msgstr ""
 msgid "Your account is then %{handle}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5671
+#: lib/vutuv_web/components/ui.ex:5674
 #, elixir-autogen, elixir-format, fuzzy
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr ""
@@ -20942,7 +20932,7 @@ msgstr ""
 msgid "Example"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:95
+#: lib/vutuv_web/gettext_extraction_anchors.ex:100
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Feed tabs"
 msgstr ""
@@ -20957,22 +20947,22 @@ msgstr ""
 msgid "Play the example"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:109
+#: lib/vutuv_web/gettext_extraction_anchors.ex:114
 #, elixir-autogen, elixir-format
 msgid "Between 4 and 20 seconds."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:97
+#: lib/vutuv_web/gettext_extraction_anchors.ex:102
 #, elixir-autogen, elixir-format
 msgid "How long the quote stands"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:96
+#: lib/vutuv_web/gettext_extraction_anchors.ex:101
 #, elixir-autogen, elixir-format
 msgid "Quote what arrives on the other tab"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:98
+#: lib/vutuv_web/gettext_extraction_anchors.ex:103
 #, elixir-autogen, elixir-format
 msgid "When off, a tab holding something new wears its dot and says nothing more."
 msgstr ""
@@ -21099,7 +21089,7 @@ msgid_plural "+%{formatted} more posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:100
+#: lib/vutuv_web/gettext_extraction_anchors.ex:105
 #: lib/vutuv_web/templates/settings/preferences.html.heex:210
 #, elixir-autogen, elixir-format
 msgid "Browser tab"
@@ -21115,12 +21105,12 @@ msgstr ""
 msgid "Browser tab settings saved."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:102
+#: lib/vutuv_web/gettext_extraction_anchors.ex:107
 #, elixir-autogen, elixir-format
 msgid "Only while you are looking at another tab, and only for a few seconds. The tab title also shows up in screenshots, in your window switcher and in a screen share."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:101
+#: lib/vutuv_web/gettext_extraction_anchors.ex:106
 #, elixir-autogen, elixir-format
 msgid "Tease new posts in the browser tab"
 msgstr ""
@@ -21750,7 +21740,7 @@ msgstr ""
 msgid "only %{account}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7492
+#: lib/vutuv_web/components/post_components.ex:7499
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -21765,7 +21755,7 @@ msgid_plural "%{formatted} shares"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/post_calendar_controller.ex:136
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:141
 #: lib/vutuv_web/live/notification_live/index.ex:821
 #, elixir-autogen, elixir-format
 msgid "Post without text"
@@ -21813,18 +21803,18 @@ msgid "Nothing matches."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:336
-#: lib/vutuv_web/live/post_live/composer.ex:2130
-#: lib/vutuv_web/live/post_live/composer.ex:3132
+#: lib/vutuv_web/live/post_live/composer.ex:2159
+#: lib/vutuv_web/live/post_live/composer.ex:3193
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Automatic"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2135
+#: lib/vutuv_web/live/post_live/composer.ex:2164
 #, elixir-autogen, elixir-format
 msgid "Drag one photo onto another to swap them."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2082
+#: lib/vutuv_web/live/post_live/composer.ex:2111
 #, elixir-autogen, elixir-format
 msgid "Not shown in the gallery — drag one into it to swap."
 msgstr ""
@@ -21881,17 +21871,17 @@ msgstr ""
 msgid "Unmute %{host}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1890
+#: lib/vutuv_web/live/post_live/composer.ex:1919
 #, elixir-autogen, elixir-format
 msgid "Draft discarded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1929
+#: lib/vutuv_web/live/post_live/composer.ex:1958
 #, elixir-autogen, elixir-format
 msgid "Keep it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1920
+#: lib/vutuv_web/live/post_live/composer.ex:1949
 #, elixir-autogen, elixir-format
 msgid "Keep this draft for later?"
 msgstr ""
@@ -21923,7 +21913,7 @@ msgstr ""
 msgid "If you are on a slow or metered connection, vutuv can leave out the parts of the page that cost the most to download."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:107
+#: lib/vutuv_web/gettext_extraction_anchors.ex:112
 #, elixir-autogen, elixir-format
 msgid "Low-bandwidth mode"
 msgstr ""
@@ -22004,7 +21994,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1456
 #: lib/vutuv_web/components/post_components.ex:3406
-#: lib/vutuv_web/components/post_components.ex:4658
+#: lib/vutuv_web/components/post_components.ex:4665
 #: lib/vutuv_web/components/ui.ex:5541
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
@@ -22091,7 +22081,7 @@ msgstr ""
 msgid "About %{minutes} min of video"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2634
+#: lib/vutuv_web/live/post_live/composer.ex:2695
 #, elixir-autogen, elixir-format
 msgid "Add video"
 msgstr ""
@@ -22128,37 +22118,37 @@ msgstr[1] ""
 msgid "Reading the frames"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2670
+#: lib/vutuv_web/live/post_live/composer.ex:2731
 #, elixir-autogen, elixir-format
 msgid "Remove it to post the text without it, or pick another file."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1195
+#: lib/vutuv_web/live/post_live/composer.ex:1224
 #, elixir-autogen, elixir-format
 msgid "Remove the refused video to post the text without it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2699
+#: lib/vutuv_web/live/post_live/composer.ex:2760
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove video"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2709
+#: lib/vutuv_web/live/post_live/composer.ex:2770
 #, elixir-autogen, elixir-format
 msgid "Tap a frame to make it the cover."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1062
+#: lib/vutuv_web/live/post_live/composer.ex:1081
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That frame could not be used."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1520
+#: lib/vutuv_web/live/post_live/composer.ex:1549
 #, elixir-autogen, elixir-format, fuzzy
 msgid "The video could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1607
+#: lib/vutuv_web/live/post_live/composer.ex:1636
 #, elixir-autogen, elixir-format
 msgid "The video is longer than %{seconds} seconds."
 msgstr ""
@@ -22179,17 +22169,17 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:919
 #: lib/vutuv_web/components/post_components.ex:2981
 #: lib/vutuv_web/components/video_components.ex:126
-#: lib/vutuv_web/live/post_live/composer.ex:2633
+#: lib/vutuv_web/live/post_live/composer.ex:2694
 #, elixir-autogen, elixir-format
 msgid "Video"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2677
+#: lib/vutuv_web/live/post_live/composer.ex:2738
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Video description"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1614
+#: lib/vutuv_web/live/post_live/composer.ex:1643
 #, elixir-autogen, elixir-format
 msgid "Videos cannot be uploaded here."
 msgstr ""
@@ -22199,12 +22189,12 @@ msgstr ""
 msgid "Waiting in line"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2684
+#: lib/vutuv_web/live/post_live/composer.ex:2745
 #, elixir-autogen, elixir-format
 msgid "What is in the video, for people who cannot watch it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2673
+#: lib/vutuv_web/live/post_live/composer.ex:2734
 #, elixir-autogen, elixir-format
 msgid "You can post now — the post appears as soon as the video is ready."
 msgstr ""
@@ -22235,7 +22225,7 @@ msgstr[1] ""
 msgid "Last 30 days: %{parts}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5220
+#: lib/vutuv_web/components/post_components.ex:5227
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Less"
@@ -22331,7 +22321,7 @@ msgstr[1] ""
 msgid "Can be changed at any time."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:108
+#: lib/vutuv_web/gettext_extraction_anchors.ex:113
 #, elixir-autogen, elixir-format
 msgid "For members on a slow connection."
 msgstr ""
@@ -22550,7 +22540,7 @@ msgid "Hidden. What they pass on stays out of your feed; their own posts do not.
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3378
-#: lib/vutuv_web/components/post_components.ex:4652
+#: lib/vutuv_web/components/post_components.ex:4659
 #, elixir-autogen, elixir-format
 msgid "Hide reposts"
 msgstr ""
@@ -22664,7 +22654,8 @@ msgstr[1] ""
 msgid "Post calendar"
 msgstr ""
 
-#: lib/vutuv_web/controllers/post_calendar_controller.ex:126
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:131
+#: lib/vutuv_web/post_teaser.ex:187
 #, elixir-autogen, elixir-format
 msgid "Post not open to search engines"
 msgstr ""
@@ -22694,7 +22685,7 @@ msgstr ""
 msgid "The posts written that month, by day."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:89
+#: lib/vutuv_web/gettext_extraction_anchors.ex:94
 #, elixir-autogen, elixir-format
 msgid "Feed length"
 msgstr ""
@@ -22714,7 +22705,7 @@ msgstr ""
 msgid "How many load at once, and how many “Load more” adds"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:91
+#: lib/vutuv_web/gettext_extraction_anchors.ex:96
 #, elixir-autogen, elixir-format
 msgid "How many posts your feed shows before the “Load more” button, and how many that button adds. More posts mean a longer wait for the page."
 msgstr ""
@@ -22726,7 +22717,7 @@ msgstr ""
 msgid "Posts in your feed"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:90
+#: lib/vutuv_web/gettext_extraction_anchors.ex:95
 #, elixir-autogen, elixir-format
 msgid "Posts loaded at once"
 msgstr ""
@@ -22747,13 +22738,13 @@ msgstr ""
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7483
-#: lib/vutuv_web/components/post_components.ex:7484
+#: lib/vutuv_web/components/post_components.ex:7490
+#: lib/vutuv_web/components/post_components.ex:7491
 #, elixir-autogen, elixir-format, fuzzy
 msgid "A word or phrase …"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7511
+#: lib/vutuv_web/components/post_components.ex:7518
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr ""
@@ -22770,7 +22761,7 @@ msgstr ""
 msgid "Hide something from your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7429
+#: lib/vutuv_web/components/post_components.ex:7436
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr ""
@@ -22785,22 +22776,22 @@ msgstr ""
 msgid "Words & tags"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7515
+#: lib/vutuv_web/components/post_components.ex:7522
 #, elixir-autogen, elixir-format, fuzzy
 msgid "everyone"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7518
+#: lib/vutuv_web/components/post_components.ex:7525
 #, elixir-autogen, elixir-format, fuzzy
 msgid "only %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7487
+#: lib/vutuv_web/components/post_components.ex:7494
 #, elixir-autogen, elixir-format, fuzzy
 msgid "this word"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7528
+#: lib/vutuv_web/components/post_components.ex:7535
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr "only %{server}"
@@ -22852,7 +22843,7 @@ msgstr ""
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6833
+#: lib/vutuv_web/components/post_components.ex:6840
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr ""
@@ -22943,7 +22934,7 @@ msgid "Hidden. What other people pass on of them stays out of your feed; their o
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3364
-#: lib/vutuv_web/components/post_components.ex:4640
+#: lib/vutuv_web/components/post_components.ex:4647
 #, elixir-autogen, elixir-format
 msgid "Hide when others repost them"
 msgstr ""
@@ -23113,12 +23104,12 @@ msgstr ""
 msgid "vutuv is part of the Fediverse, the union of independent networks that Mastodon belongs to as well. Whether your posts take part is your choice at sign-up, and one switch in the settings later. We are not religious about it: each to their own."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1824
+#: lib/vutuv_web/live/shell_live.ex:1825
 #, elixir-autogen, elixir-format
 msgid "All notifications"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1777
+#: lib/vutuv_web/live/shell_live.ex:1778
 #, elixir-autogen, elixir-format
 msgid "New notifications"
 msgstr ""
@@ -23658,13 +23649,13 @@ msgstr ""
 msgid "“%{note}”"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5398
-#: lib/vutuv_web/components/press_kit_components.ex:211
+#: lib/vutuv_web/components/post_components.ex:5405
+#: lib/vutuv_web/components/press_kit_components.ex:216
 #, elixir-autogen, elixir-format
 msgid "Show these photos larger"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5584
+#: lib/vutuv_web/components/post_components.ex:5591
 #, elixir-autogen, elixir-format
 msgid "Show this photo larger"
 msgstr ""
@@ -23754,7 +23745,7 @@ msgstr ""
 msgid "Light"
 msgstr ""
 
-#: lib/vutuv/press_kit.ex:251
+#: lib/vutuv/press_kit.ex:321
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Logo variant"
 msgstr ""
@@ -23803,7 +23794,7 @@ msgstr ""
 msgid "Please confirm the rights first, then choose the file."
 msgstr ""
 
-#: lib/vutuv/press_kit.ex:251
+#: lib/vutuv/press_kit.ex:321
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Press photo"
 msgstr ""
@@ -23889,18 +23880,18 @@ msgstr[1] "%{count} bytes"
 msgid "Credit: %{credit}"
 msgstr "Credit: %{credit}"
 
-#: lib/vutuv_web/components/press_kit_components.ex:375
-#: lib/vutuv_web/components/press_kit_components.ex:378
+#: lib/vutuv_web/components/press_kit_components.ex:380
+#: lib/vutuv_web/components/press_kit_components.ex:383
 #, elixir-autogen, elixir-format
 msgid "Download %{format}"
 msgstr "Download %{format}"
 
-#: lib/vutuv_web/components/press_kit_components.ex:331
+#: lib/vutuv_web/components/press_kit_components.ex:336
 #, elixir-autogen, elixir-format
 msgid "Download photo"
 msgstr "Download photo"
 
-#: lib/vutuv/press_kit.ex:715
+#: lib/vutuv/press_kit.ex:785
 #, elixir-autogen, elixir-format
 msgid "Free for editorial use with credit."
 msgstr "Free for editorial use with credit."
@@ -23910,7 +23901,7 @@ msgstr "Free for editorial use with credit."
 msgid "PNG version"
 msgstr "PNG version"
 
-#: lib/vutuv_web/agent_docs/press_kit_doc.ex:55
+#: lib/vutuv_web/agent_docs/press_kit_doc.ex:58
 #, elixir-autogen, elixir-format
 msgid "Press pictures %{name} offers for download, free for editorial use with credit."
 msgstr "Press pictures %{name} offers for download, free for editorial use with credit."
@@ -23945,7 +23936,7 @@ msgstr ""
 msgid "What a journalist writing about this page may download: photos in print quality and its logo as a file. Everything here is public and free for editorial use as long as the credit is shown."
 msgstr ""
 
-#: lib/vutuv_web/components/press_kit_components.ex:565
+#: lib/vutuv_web/components/press_kit_components.ex:570
 #: lib/vutuv_web/components/ui.ex:3281
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report this picture"
@@ -24047,7 +24038,7 @@ msgid "nobody"
 msgstr ""
 
 #: lib/vutuv_web/components/press_kit_components.ex:120
-#: lib/vutuv_web/components/press_kit_components.ex:176
+#: lib/vutuv_web/components/press_kit_components.ex:181
 #, elixir-autogen, elixir-format
 msgid "All Media Kit files"
 msgstr ""
@@ -24067,7 +24058,7 @@ msgstr ""
 msgid "Media Kit"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/press_kit_doc.ex:53
+#: lib/vutuv_web/agent_docs/press_kit_doc.ex:56
 #: lib/vutuv_web/views/press_kit_html.ex:32
 #, elixir-autogen, elixir-format
 msgid "Media Kit of %{name}"
@@ -24098,8 +24089,8 @@ msgstr ""
 msgid "press kit media journalist photographer download original print logo svg credit copyright presse pressefotos pressemappe medienkit mediakit fotos logo herunterladen bildnachweis"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4556
-#: lib/vutuv_web/components/post_components.ex:4606
+#: lib/vutuv_web/components/post_components.ex:4563
+#: lib/vutuv_web/components/post_components.ex:4613
 #, elixir-autogen, elixir-format
 msgid "Copy link to post"
 msgstr ""
@@ -24109,14 +24100,14 @@ msgstr ""
 msgid "Link copied"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2820
+#: lib/vutuv_web/live/post_live/composer.ex:2881
 #, elixir-autogen, elixir-format
 msgid "%{left} of today's %{limit} left (%{percent} %)."
 msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:1291
 #: lib/vutuv_web/live/message_live/index.ex:1295
-#: lib/vutuv_web/live/post_live/composer.ex:2753
+#: lib/vutuv_web/live/post_live/composer.ex:2814
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add files"
 msgstr ""
@@ -24126,12 +24117,12 @@ msgstr ""
 msgid "File check"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3517
+#: lib/vutuv_web/live/post_live/composer.ex:3578
 #, elixir-autogen, elixir-format, fuzzy
 msgid "File is larger than %{size}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2752
+#: lib/vutuv_web/live/post_live/composer.ex:2813
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Files"
 msgstr ""
@@ -24141,7 +24132,7 @@ msgstr ""
 msgid "Files may be up to %{size}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3527
+#: lib/vutuv_web/live/post_live/composer.ex:3588
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No more than %{max} files per post."
 msgstr ""
@@ -24158,7 +24149,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:1270
 #: lib/vutuv_web/live/message_live/index.ex:1271
-#: lib/vutuv_web/live/post_live/composer.ex:2799
+#: lib/vutuv_web/live/post_live/composer.ex:2860
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove %{name}"
 msgstr "Remove %{name}"
@@ -24183,7 +24174,7 @@ msgstr ""
 msgid "You have used up today's upload allowance. It frees up again over the day."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2818
+#: lib/vutuv_web/live/post_live/composer.ex:2879
 #, elixir-autogen, elixir-format
 msgid "Your uploads are not limited."
 msgstr ""
@@ -24202,7 +24193,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:121
 #: lib/vutuv_web/agent_docs/text.ex:412
-#: lib/vutuv_web/components/press_kit_components.ex:269
+#: lib/vutuv_web/components/press_kit_components.ex:274
 #, elixir-autogen, elixir-format, fuzzy
 msgid "About %{name}"
 msgstr ""
@@ -24227,12 +24218,12 @@ msgstr ""
 msgid "As long as you like. The whole portrait."
 msgstr ""
 
-#: lib/vutuv/press_kit.ex:460
+#: lib/vutuv/press_kit.ex:530
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Long version"
 msgstr ""
 
-#: lib/vutuv/press_kit.ex:459
+#: lib/vutuv/press_kit.ex:529
 #, elixir-autogen, elixir-format
 msgid "Medium version"
 msgstr ""
@@ -24242,12 +24233,12 @@ msgstr ""
 msgid "Nothing written yet."
 msgstr ""
 
-#: lib/vutuv/press_kit.ex:458
+#: lib/vutuv/press_kit.ex:528
 #, elixir-autogen, elixir-format
 msgid "Short version"
 msgstr ""
 
-#: lib/vutuv_web/components/press_kit_components.ex:272
+#: lib/vutuv_web/components/press_kit_components.ex:277
 #, elixir-autogen, elixir-format
 msgid "Take whichever length fits the space you have. Each one stands on its own."
 msgstr ""
@@ -24276,13 +24267,6 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "File preview pages"
 msgstr ""
-
-#: lib/vutuv_web/live/shell_live.ex:1742
-#, elixir-autogen, elixir-format, fuzzy
-msgid "%{count} post is being prepared"
-msgid_plural "%{count} posts are being prepared"
-msgstr[0] ""
-msgstr[1] ""
 
 #: lib/vutuv_web/live/uploads_live.ex:173
 #, elixir-autogen, elixir-format
@@ -24664,4 +24648,51 @@ msgstr ""
 #: lib/vutuv_web/live/message_live/index.ex:627
 #, elixir-autogen, elixir-format
 msgid "You can only send files to members you are connected with."
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:1743
+#, elixir-autogen, elixir-format, fuzzy
+msgid "%{formatted} post is being prepared"
+msgid_plural "%{formatted} posts are being prepared"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:2312
+#, elixir-autogen, elixir-format
+msgid "Remove the metadata from the files"
+msgstr ""
+
+#: lib/vutuv_web/components/ui.ex:5622
+#, elixir-autogen, elixir-format
+msgid "Search engines and AI, your posts, online status"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/privacy.html.heex:93
+#, elixir-autogen, elixir-format
+msgid "Whether search engines and AI may read what you post. Each post keeps the answer it was published with, so changing this leaves everything you have already written exactly as it is."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:2314
+#, elixir-autogen, elixir-format
+msgid "Your name, the software you used and the dates come out of a PDF."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/privacy.html.heex:91
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Your posts"
+msgstr ""
+
+#: lib/vutuv_web/components/ui.ex:5624
+#, elixir-autogen, elixir-format, fuzzy
+msgid "privacy google search engine ai llm crawler noindex online dot public posts beiträge indexieren fediverse mastodon suchmaschine"
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:81
+#, elixir-autogen, elixir-format
+msgid "Covers the words, the pictures, the files and the machine formats of every post you write from now on. When off, your new posts also stay out of other networks completely: a server elsewhere keeps its copy for good and no instruction of ours reaches it. Posts you have already published keep the answer they went out with."
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:80
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Search engines and AI may read my posts"
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -120,7 +120,7 @@ msgstr "Compleanno"
 #: lib/vutuv_web/live/job_posting_live/form.ex:857
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
-#: lib/vutuv_web/live/post_live/composer.ex:2049
+#: lib/vutuv_web/live/post_live/composer.ex:2078
 #: lib/vutuv_web/live/press_kit_live.ex:729
 #: lib/vutuv_web/live/press_kit_live.ex:1139
 #: lib/vutuv_web/templates/ad/new.html.heex:136
@@ -165,7 +165,7 @@ msgstr "Contatto"
 msgid "Couldn't follow back to %{name}."
 msgstr "Non è stato possibile ricambiare il follow a %{name}."
 
-#: lib/vutuv_web/components/post_components.ex:4593
+#: lib/vutuv_web/components/post_components.ex:4600
 #: lib/vutuv_web/components/ui.ex:5042
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
@@ -206,14 +206,14 @@ msgid "Disable"
 msgstr "Disattiva"
 
 #: lib/vutuv_web/live/cv_live.ex:446
-#: lib/vutuv_web/live/post_live/composer.ex:3228
+#: lib/vutuv_web/live/post_live/composer.ex:3289
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/views/qualification_html.ex:354
 #, elixir-autogen
 msgid "Download"
 msgstr "Scarica"
 
-#: lib/vutuv_web/components/post_components.ex:4558
+#: lib/vutuv_web/components/post_components.ex:4565
 #: lib/vutuv_web/components/ui.ex:5033
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
@@ -611,7 +611,7 @@ msgstr "Profili di "
 msgid "Provider"
 msgstr "Piattaforma"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2361
+#: lib/vutuv_web/live/post_live/composer.ex:2422
 #: lib/vutuv_web/live/section_reorder_live.ex:272
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -623,7 +623,7 @@ msgstr "Pubblico"
 
 #: lib/vutuv_web/components/ui.ex:4934
 #: lib/vutuv_web/live/organization_live/edit.ex:376
-#: lib/vutuv_web/live/post_live/composer.ex:2376
+#: lib/vutuv_web/live/post_live/composer.ex:2437
 #: lib/vutuv_web/live/press_kit_live.ex:727
 #: lib/vutuv_web/live/press_kit_live.ex:1138
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -1210,7 +1210,7 @@ msgstr "Tutti i sinonimi dei tag"
 msgid "All tag urls"
 msgstr "Tutti gli URL dei tag"
 
-#: lib/vutuv_web/components/post_components.ex:5211
+#: lib/vutuv_web/components/post_components.ex:5218
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:643
@@ -1638,11 +1638,11 @@ msgstr "Controlli la Sua casella di posta"
 #: lib/vutuv_web/live/admin/job_live.ex:321
 #: lib/vutuv_web/live/admin/job_live.ex:477
 #: lib/vutuv_web/live/admin/organization_live.ex:296
-#: lib/vutuv_web/live/post_live/composer.ex:1905
-#: lib/vutuv_web/live/post_live/composer.ex:2007
-#: lib/vutuv_web/live/post_live/composer.ex:2008
-#: lib/vutuv_web/live/post_live/composer.ex:3105
-#: lib/vutuv_web/live/post_live/composer.ex:3371
+#: lib/vutuv_web/live/post_live/composer.ex:1934
+#: lib/vutuv_web/live/post_live/composer.ex:2036
+#: lib/vutuv_web/live/post_live/composer.ex:2037
+#: lib/vutuv_web/live/post_live/composer.ex:3166
+#: lib/vutuv_web/live/post_live/composer.ex:3432
 #: lib/vutuv_web/templates/layout/app.html.heex:200
 #: lib/vutuv_web/templates/layout/app.html.heex:206
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:28
@@ -2105,7 +2105,7 @@ msgstr "Markdown è supportato: grassetto, corsivo, link ed elenchi."
 msgid "Add images"
 msgstr "Aggiungi immagini"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2490
+#: lib/vutuv_web/live/post_live/composer.ex:2551
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2118,9 +2118,9 @@ msgstr ""
 msgid "Back to the post"
 msgstr "Torna al post"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2147
-#: lib/vutuv_web/live/post_live/composer.ex:2170
-#: lib/vutuv_web/live/post_live/composer.ex:2196
+#: lib/vutuv_web/live/post_live/composer.ex:2176
+#: lib/vutuv_web/live/post_live/composer.ex:2199
+#: lib/vutuv_web/live/post_live/composer.ex:2225
 #: lib/vutuv_web/live/press_kit_live.ex:1307
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
@@ -2131,7 +2131,7 @@ msgstr "Annulla il caricamento"
 msgid "Delete post"
 msgstr "Elimina il post"
 
-#: lib/vutuv_web/components/post_components.ex:4590
+#: lib/vutuv_web/components/post_components.ex:4597
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2144,7 +2144,7 @@ msgid "Edit post"
 msgstr "Modifica il post"
 
 #: lib/vutuv_web/components/organization_components.ex:274
-#: lib/vutuv_web/gettext_extraction_anchors.ex:87
+#: lib/vutuv_web/gettext_extraction_anchors.ex:92
 #: lib/vutuv_web/live/organization_live/feed.ex:203
 #: lib/vutuv_web/live/post_live/feed.ex:365
 #: lib/vutuv_web/live/post_live/feed.ex:3536
@@ -2166,29 +2166,29 @@ msgstr "Segua %{name} per leggerlo."
 msgid "Hidden from:"
 msgstr "Nascosto a:"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2466
+#: lib/vutuv_web/live/post_live/composer.ex:2527
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr "Nascondi a una persona specifica…"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2394
+#: lib/vutuv_web/live/post_live/composer.ex:2455
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr "Nascondi questo post a…"
 
-#: lib/vutuv_web/components/post_components.ex:4536
-#: lib/vutuv_web/components/post_components.ex:4538
+#: lib/vutuv_web/components/post_components.ex:4543
+#: lib/vutuv_web/components/post_components.ex:4545
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Pubblico limitato"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2436
+#: lib/vutuv_web/live/post_live/composer.ex:2497
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr "Visitatori non connessi"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1554
-#: lib/vutuv_web/live/post_live/composer.ex:1694
+#: lib/vutuv_web/live/post_live/composer.ex:1583
+#: lib/vutuv_web/live/post_live/composer.ex:1723
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr "Non più di %{max} immagini per post."
@@ -2200,23 +2200,23 @@ msgstr ""
 "Qui non c'è ancora nulla. Segua altre persone per riempire il Suo feed, "
 "oppure scriva il Suo primo post."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1517
+#: lib/vutuv_web/live/post_live/composer.ex:1546
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr "Non è stato possibile allegare una delle immagini."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2426
+#: lib/vutuv_web/live/post_live/composer.ex:2487
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr "Persone che non seguo"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2416
+#: lib/vutuv_web/live/post_live/composer.ex:2477
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr "Persone che non mi seguono"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:441
-#: lib/vutuv_web/live/post_live/composer.ex:2378
+#: lib/vutuv_web/live/post_live/composer.ex:2439
 #, elixir-autogen, elixir-format
 msgid "Post"
 msgstr "Pubblica"
@@ -2226,11 +2226,11 @@ msgstr "Pubblica"
 msgid "Post deleted successfully."
 msgstr "Post eliminato."
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:243
+#: lib/vutuv_web/agent_docs/post_doc.ex:264
 #: lib/vutuv_web/controllers/post_controller.ex:69
 #: lib/vutuv_web/controllers/post_controller.ex:90
 #: lib/vutuv_web/controllers/user_controller.ex:77
-#: lib/vutuv_web/gettext_extraction_anchors.ex:113
+#: lib/vutuv_web/gettext_extraction_anchors.ex:118
 #: lib/vutuv_web/live/admin/dashboard_live.ex:270
 #: lib/vutuv_web/live/fediverse_account_live.ex:446
 #: lib/vutuv_web/live/organization_live/show.ex:733
@@ -2244,13 +2244,13 @@ msgstr "Post eliminato."
 msgid "Posts"
 msgstr "Post"
 
-#: lib/vutuv_web/components/post_components.ex:5084
-#: lib/vutuv_web/components/post_components.ex:5088
+#: lib/vutuv_web/components/post_components.ex:5091
+#: lib/vutuv_web/components/post_components.ex:5095
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Leggi tutto"
 
-#: lib/vutuv_web/components/post_components.ex:5085
+#: lib/vutuv_web/components/post_components.ex:5092
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2267,7 +2267,7 @@ msgstr "Mostra meno"
 #: lib/vutuv_web/live/organization_live/domains.ex:265
 #: lib/vutuv_web/live/organization_live/edit.ex:404
 #: lib/vutuv_web/live/organization_live/roles.ex:257
-#: lib/vutuv_web/live/post_live/composer.ex:2452
+#: lib/vutuv_web/live/post_live/composer.ex:2513
 #: lib/vutuv_web/live/post_live/filter_band.ex:456
 #: lib/vutuv_web/live/post_live/saved.ex:666
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2286,7 +2286,7 @@ msgstr ""
 "I post con pubblico limitato sono nascosti anche ai visitatori non connessi "
 "e ai motori di ricerca."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2368
+#: lib/vutuv_web/live/post_live/composer.ex:2429
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr "Salvataggio…"
@@ -2304,14 +2304,14 @@ msgid "Sorry, that page could not be found."
 msgstr "Spiacenti, la pagina non è stata trovata."
 
 #: lib/vutuv_web/attachment_text.ex:73
-#: lib/vutuv_web/live/post_live/composer.ex:1615
-#: lib/vutuv_web/live/post_live/composer.ex:1720
+#: lib/vutuv_web/live/post_live/composer.ex:1644
+#: lib/vutuv_web/live/post_live/composer.ex:1749
 #: lib/vutuv_web/live/press_kit_live.ex:541
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr "Non è stato possibile elaborare il file."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1499
+#: lib/vutuv_web/live/post_live/composer.ex:1528
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr "La selezione del pubblico non è valida."
@@ -2321,17 +2321,17 @@ msgstr "La selezione del pubblico non è valida."
 msgid "This post is for followers of %{name}"
 msgstr "Questo post è per i follower di %{name}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3546
+#: lib/vutuv_web/live/post_live/composer.ex:3607
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Troppi file."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3547
+#: lib/vutuv_web/live/post_live/composer.ex:3608
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr "Caricamento non riuscito."
 
-#: lib/vutuv_web/components/ui.ex:5865
+#: lib/vutuv_web/components/ui.ex:5868
 #: lib/vutuv_web/live/shell_live.ex:1588
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2340,37 +2340,37 @@ msgstr "Caricamento non riuscito."
 msgid "View profile"
 msgstr "Vedi il profilo"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2584
+#: lib/vutuv_web/live/post_live/composer.ex:2645
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr "Che c'è di nuovo?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2585
+#: lib/vutuv_web/live/post_live/composer.ex:2646
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr "Che c'è di nuovo? Markdown è supportato."
 
-#: lib/vutuv_web/components/post_components.ex:4533
+#: lib/vutuv_web/components/post_components.ex:4540
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "modificato"
 
-#: lib/vutuv_web/components/post_components.ex:6851
+#: lib/vutuv_web/components/post_components.ex:6858
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "tutti gli altri"
 
-#: lib/vutuv_web/components/post_components.ex:6855
+#: lib/vutuv_web/components/post_components.ex:6862
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "visitatori non connessi"
 
-#: lib/vutuv_web/components/post_components.ex:6853
+#: lib/vutuv_web/components/post_components.ex:6860
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "persone che non La seguono"
 
-#: lib/vutuv_web/components/post_components.ex:6854
+#: lib/vutuv_web/components/post_components.ex:6861
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "persone che non segue"
@@ -2382,21 +2382,21 @@ msgstr "persone che non segue"
 msgid "unknown"
 msgstr "sconosciuto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2246
+#: lib/vutuv_web/live/post_live/composer.ex:2275
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr "Tag separati da virgole (max. %{max})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1612
-#: lib/vutuv_web/live/post_live/composer.ex:3513
-#: lib/vutuv_web/live/post_live/composer.ex:3531
+#: lib/vutuv_web/live/post_live/composer.ex:1641
+#: lib/vutuv_web/live/post_live/composer.ex:3574
+#: lib/vutuv_web/live/post_live/composer.ex:3592
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr "Il file supera %{mb} MB."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3521
-#: lib/vutuv_web/live/post_live/composer.ex:3535
-#: lib/vutuv_web/live/post_live/composer.ex:3541
+#: lib/vutuv_web/live/post_live/composer.ex:3582
+#: lib/vutuv_web/live/post_live/composer.ex:3596
+#: lib/vutuv_web/live/post_live/composer.ex:3602
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr "Tipo di file non supportato (ammessi: %{types})."
@@ -2417,7 +2417,7 @@ msgid "All posts"
 msgstr "Tutti i post"
 
 #: lib/vutuv_web/components/post_components.ex:2185
-#: lib/vutuv_web/components/post_components.ex:6954
+#: lib/vutuv_web/components/post_components.ex:6961
 #: lib/vutuv_web/components/ui.ex:4476
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2436,7 +2436,7 @@ msgid "Bookmarks"
 msgstr "Salvati"
 
 #: lib/vutuv_web/components/post_components.ex:2129
-#: lib/vutuv_web/components/post_components.ex:7195
+#: lib/vutuv_web/components/post_components.ex:7202
 #: lib/vutuv_web/components/ui.ex:4462
 #: lib/vutuv_web/notification_line.ex:317
 #: lib/vutuv_web/views/user_html.ex:486
@@ -2445,12 +2445,12 @@ msgid "Like"
 msgstr "Mi piace"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1301
-#: lib/vutuv_web/components/post_components.ex:7205
+#: lib/vutuv_web/components/post_components.ex:7212
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
 #: lib/vutuv_web/live/shell_live.ex:1596
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
-#: lib/vutuv_web/templates/settings/privacy.html.heex:91
+#: lib/vutuv_web/templates/settings/privacy.html.heex:118
 #: lib/vutuv_web/views/admin/report_html.ex:37
 #, elixir-autogen, elixir-format
 msgid "Likes"
@@ -2466,13 +2466,13 @@ msgstr "Qui non c'è ancora nulla. I post che salva compaiono qui."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Qui non c'è ancora nulla. I post a cui mette Mi piace compaiono qui."
 
-#: lib/vutuv_web/components/post_components.ex:6942
+#: lib/vutuv_web/components/post_components.ex:6949
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Solo i post pubblici possono essere ripubblicati."
 
 #: lib/vutuv_web/components/post_components.ex:2184
-#: lib/vutuv_web/components/post_components.ex:6953
+#: lib/vutuv_web/components/post_components.ex:6960
 #: lib/vutuv_web/live/post_live/saved.ex:822
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2480,26 +2480,26 @@ msgid "Remove bookmark"
 msgstr "Rimuovi dai salvati"
 
 #: lib/vutuv_web/components/post_components.ex:2165
-#: lib/vutuv_web/components/post_components.ex:6938
+#: lib/vutuv_web/components/post_components.ex:6945
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Ripubblica"
 
 #: lib/vutuv_web/components/post_components.ex:2758
-#: lib/vutuv_web/components/post_components.ex:5957
+#: lib/vutuv_web/components/post_components.ex:5964
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Ripubblicato da %{name}"
 
 #: lib/vutuv_web/components/post_components.ex:2164
-#: lib/vutuv_web/components/post_components.ex:6937
+#: lib/vutuv_web/components/post_components.ex:6944
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Annulla la ripubblicazione"
 
 #: lib/vutuv_web/components/post_components.ex:2128
-#: lib/vutuv_web/components/post_components.ex:7194
+#: lib/vutuv_web/components/post_components.ex:7201
 #: lib/vutuv_web/live/post_live/saved.ex:821
 #: lib/vutuv_web/views/user_html.ex:486
 #, elixir-autogen, elixir-format
@@ -2527,7 +2527,7 @@ msgstr "Non seguire più"
 msgid "Welcome to vutuv!"
 msgstr "Benvenuto su vutuv."
 
-#: lib/vutuv_web/components/post_components.ex:7249
+#: lib/vutuv_web/components/post_components.ex:7256
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Solo ai post pubblici si può rispondere."
@@ -2539,8 +2539,8 @@ msgid "Replies"
 msgstr "Risposte"
 
 #: lib/vutuv_web/components/post_components.ex:2374
-#: lib/vutuv_web/components/post_components.ex:7232
-#: lib/vutuv_web/components/post_components.ex:7233
+#: lib/vutuv_web/components/post_components.ex:7239
+#: lib/vutuv_web/components/post_components.ex:7240
 #: lib/vutuv_web/live/notification_live/index.ex:993
 #: lib/vutuv_web/live/post_live/reply.ex:49
 #: lib/vutuv_web/notification_line.ex:314
@@ -2548,20 +2548,20 @@ msgstr "Risposte"
 msgid "Reply"
 msgstr "Rispondi"
 
-#: lib/vutuv_web/components/post_components.ex:4492
+#: lib/vutuv_web/components/post_components.ex:4499
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Risposta a un post eliminato"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1502
-#: lib/vutuv_web/live/post_live/composer.ex:2356
+#: lib/vutuv_web/live/post_live/composer.ex:1531
+#: lib/vutuv_web/live/post_live/composer.ex:2417
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 "Il pubblico non può essere limitato finché esistono ripubblicazioni o "
 "risposte."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2497
+#: lib/vutuv_web/live/post_live/composer.ex:2558
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2582,14 +2582,14 @@ msgstr "ha risposto al Suo post."
 msgid "Reply to %{handle}"
 msgstr "Rispondi a %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:4464
+#: lib/vutuv_web/components/post_components.ex:4471
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Risposta a un post di %{handle} ora eliminato"
 
-#: lib/vutuv_web/components/post_components.ex:4455
-#: lib/vutuv_web/components/post_components.ex:4484
-#: lib/vutuv_web/components/post_components.ex:4487
+#: lib/vutuv_web/components/post_components.ex:4462
+#: lib/vutuv_web/components/post_components.ex:4491
+#: lib/vutuv_web/components/post_components.ex:4494
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "In risposta a %{handle}"
@@ -2807,7 +2807,7 @@ msgstr "Scriva il Suo primo post"
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:109
 #: lib/vutuv_web/templates/settings/preferences.html.heex:195
-#: lib/vutuv_web/templates/settings/privacy.html.heex:179
+#: lib/vutuv_web/templates/settings/privacy.html.heex:206
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:216
 #: lib/vutuv_web/templates/user/show.html.heex:643
@@ -2868,7 +2868,7 @@ msgstr "Ancora nessun collegamento."
 msgid "Other formats"
 msgstr "Altri formati"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2406
+#: lib/vutuv_web/live/post_live/composer.ex:2467
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr "Persone che non sono miei collegamenti"
@@ -2891,7 +2891,7 @@ msgid_plural "connections"
 msgstr[0] "collegamento"
 msgstr[1] "collegamenti"
 
-#: lib/vutuv_web/components/post_components.ex:6852
+#: lib/vutuv_web/components/post_components.ex:6859
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "persone che non sono Suoi collegamenti"
@@ -3158,7 +3158,7 @@ msgstr "Nudità, violenza o altri contenuti che non hanno posto su vutuv."
 msgid "Only visible to you"
 msgstr "Visibile solo a Lei"
 
-#: lib/vutuv_web/components/post_components.ex:4431
+#: lib/vutuv_web/components/post_components.ex:4438
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solo Lei può vedere questo post finché la segnalazione è in corso."
@@ -3221,7 +3221,7 @@ msgstr "Lo rimuova. La segnalazione si chiude, senza altre domande."
 #: lib/vutuv_web/components/post_components.ex:1466
 #: lib/vutuv_web/components/post_components.ex:3418
 #: lib/vutuv_web/components/post_components.ex:3605
-#: lib/vutuv_web/components/post_components.ex:4661
+#: lib/vutuv_web/components/post_components.ex:4668
 #: lib/vutuv_web/live/organization_live/show.ex:684
 #: lib/vutuv_web/templates/user/show.html.heex:252
 #, elixir-autogen, elixir-format
@@ -3985,7 +3985,7 @@ msgstr "Membri più confermati"
 msgid "People %{name} follows"
 msgstr "Persone seguite da %{name}"
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:244
+#: lib/vutuv_web/agent_docs/post_doc.ex:265
 #, elixir-autogen, elixir-format
 msgid "Post archive of %{name}"
 msgstr "Archivio dei post di %{name}"
@@ -4613,11 +4613,11 @@ msgstr ""
 " la vostra conversazione e impedisce ogni interazione in entrambe le "
 "direzioni. Sbloccare non ripristina ciò che è stato rimosso."
 
-#: lib/vutuv_web/components/ui.ex:5625
+#: lib/vutuv_web/components/ui.ex:5628
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
-#: lib/vutuv_web/templates/settings/privacy.html.heex:176
+#: lib/vutuv_web/templates/settings/privacy.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Blocked members"
 msgstr "Membri bloccati"
@@ -5421,7 +5421,7 @@ msgstr "Token API (%{date})"
 msgid "API documentation"
 msgstr "Documentazione dell'API"
 
-#: lib/vutuv_web/components/ui.ex:5675
+#: lib/vutuv_web/components/ui.ex:5678
 #: lib/vutuv_web/controllers/settings_controller.ex:161
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:552
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5461,12 +5461,12 @@ msgstr ""
 "Questo elimina definitivamente il Suo profilo, i post, i messaggi e tutto il"
 " resto. Le inviamo un PIN per e-mail per confermare. Non si può annullare."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1523
+#: lib/vutuv_web/live/post_live/composer.ex:1552
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr "Non può più rispondere a questo post."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:182
+#: lib/vutuv_web/templates/settings/privacy.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "Content under review"
 msgstr "Contenuto in esame"
@@ -5504,10 +5504,10 @@ msgstr "Scorciatoie da tastiera"
 msgid "Navigation"
 msgstr "Navigazione"
 
-#: lib/vutuv_web/components/ui.ex:5772
-#: lib/vutuv_web/components/ui.ex:5777
-#: lib/vutuv_web/components/ui.ex:5856
-#: lib/vutuv_web/components/ui.ex:5920
+#: lib/vutuv_web/components/ui.ex:5775
+#: lib/vutuv_web/components/ui.ex:5780
+#: lib/vutuv_web/components/ui.ex:5859
+#: lib/vutuv_web/components/ui.ex:5923
 #: lib/vutuv_web/controllers/settings_controller.ex:68
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5577,9 +5577,9 @@ msgstr "Navigazione principale"
 msgid "Footer navigation"
 msgstr "Navigazione a piè di pagina"
 
-#: lib/vutuv_web/components/post_components.ex:4741
-#: lib/vutuv_web/components/post_components.ex:5350
-#: lib/vutuv_web/components/post_components.ex:5688
+#: lib/vutuv_web/components/post_components.ex:4748
+#: lib/vutuv_web/components/post_components.ex:5357
+#: lib/vutuv_web/components/post_components.ex:5695
 #: lib/vutuv_web/live/notification_live/index.ex:1069
 #: lib/vutuv_web/views/user_html.ex:133
 #, elixir-autogen, elixir-format
@@ -5626,7 +5626,7 @@ msgstr "Tipo di indirizzo e-mail"
 msgid "About you"
 msgstr "Su di Lei"
 
-#: lib/vutuv_web/components/ui.ex:5645
+#: lib/vutuv_web/components/ui.ex:5648
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:262
@@ -5666,7 +5666,7 @@ msgstr "Indirizzi e-mail"
 msgid "Notification settings saved."
 msgstr "Impostazioni delle notifiche salvate."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:177
+#: lib/vutuv_web/templates/settings/privacy.html.heex:204
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you."
 msgstr "Persone che non possono interagire con Lei."
@@ -5676,14 +5676,14 @@ msgstr "Persone che non possono interagire con Lei."
 msgid "Personal tokens for the vutuv API."
 msgstr "Token personali per l'API di vutuv."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2841
+#: lib/vutuv_web/live/post_live/composer.ex:2902
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
 msgstr "Foto"
 
 #: lib/vutuv_web/components/ui.ex:5619
-#: lib/vutuv_web/gettext_extraction_anchors.ex:79
+#: lib/vutuv_web/gettext_extraction_anchors.ex:84
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr "Privacy"
@@ -5698,7 +5698,7 @@ msgstr "Impostazioni della privacy salvate."
 msgid "Third-party apps you authorized."
 msgstr "App di terze parti che ha autorizzato."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:185
+#: lib/vutuv_web/templates/settings/privacy.html.heex:212
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr "Vedi"
@@ -5714,7 +5714,7 @@ msgstr "Il Suo nome"
 msgid "Your post"
 msgstr "Il Suo post"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:183
+#: lib/vutuv_web/templates/settings/privacy.html.heex:210
 #, elixir-autogen, elixir-format
 msgid "Your posts or profile a moderator is looking at."
 msgstr "I Suoi post o il Suo profilo all'esame di un moderatore."
@@ -5797,7 +5797,7 @@ msgstr "@%{slug} ha iniziato a seguirla su vutuv"
 msgid "Apps"
 msgstr "App"
 
-#: lib/vutuv_web/components/ui.ex:5668
+#: lib/vutuv_web/components/ui.ex:5671
 #: lib/vutuv_web/controllers/settings_controller.ex:185
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -5841,7 +5841,7 @@ msgstr "Apri le Sue notifiche"
 msgid "Replies to and likes on your posts"
 msgstr "Risposte e Mi piace ai Suoi post"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:173
+#: lib/vutuv_web/templates/settings/privacy.html.heex:200
 #, elixir-autogen, elixir-format
 msgid "Safety"
 msgstr "Sicurezza"
@@ -5949,7 +5949,7 @@ msgid "Name (A-Z)"
 msgstr "Nome (A-Z)"
 
 #: lib/vutuv_web/live/post_live/saved.ex:507
-#: lib/vutuv_web/live/tag_live/timeline.ex:448
+#: lib/vutuv_web/live/tag_live/timeline.ex:452
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr "Prima i più recenti"
@@ -5976,7 +5976,7 @@ msgstr ""
 "Qui non c'è ancora nulla. Le persone a cui mette Mi piace compaiono qui."
 
 #: lib/vutuv_web/live/post_live/saved.ex:508
-#: lib/vutuv_web/live/tag_live/timeline.ex:449
+#: lib/vutuv_web/live/tag_live/timeline.ex:453
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr "Prima i meno recenti"
@@ -6090,25 +6090,25 @@ msgstr "È il primo accesso che vediamo da questo dispositivo o browser."
 msgid "just now"
 msgstr "adesso"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:125
+#: lib/vutuv_web/templates/settings/privacy.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "A green dot on your avatar tells other members you are online right now."
 msgstr ""
 "Un pallino verde sulla Sua immagine del profilo indica agli altri membri che"
 " è online in questo momento."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:124
+#: lib/vutuv_web/templates/settings/privacy.html.heex:151
 #: lib/vutuv_web/views/account_event_text.ex:233
 #, elixir-autogen, elixir-format
 msgid "Online status"
 msgstr "Stato online"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:126
+#: lib/vutuv_web/templates/settings/privacy.html.heex:153
 #, elixir-autogen, elixir-format
 msgid "Show when I'm online"
 msgstr "Mostrare quando sono online"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:127
+#: lib/vutuv_web/templates/settings/privacy.html.heex:154
 #, elixir-autogen, elixir-format
 msgid "When off, no one sees the green dot on your avatar, and you never show as online."
 msgstr ""
@@ -6297,7 +6297,7 @@ msgstr "Posizioni la Sua foto"
 msgid "Use photo"
 msgstr "Usa questa foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2051
+#: lib/vutuv_web/live/post_live/composer.ex:2080
 #: lib/vutuv_web/templates/user/edit.html.heex:66
 #: lib/vutuv_web/templates/user/edit.html.heex:151
 #, elixir-autogen, elixir-format
@@ -6453,7 +6453,7 @@ msgstr "Preferenze delle mappe salvate."
 msgid "Map services to show"
 msgstr "Servizi di mappe da mostrare"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:114
+#: lib/vutuv_web/gettext_extraction_anchors.ex:119
 #: lib/vutuv_web/templates/settings/preferences.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "Maps"
@@ -6466,7 +6466,7 @@ msgstr "Mappe"
 msgid "Open in %{name}"
 msgstr "Apri in %{name}"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:112
+#: lib/vutuv_web/gettext_extraction_anchors.ex:117
 #: lib/vutuv_web/templates/settings/preferences.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Opens first, as the main button. The others appear as alternatives."
@@ -6820,8 +6820,8 @@ msgstr ""
 "risposte che La riguardano. Con entrambe disattivate, ad esempio:"
 
 #: lib/vutuv_web/components/post_components.ex:3345
-#: lib/vutuv_web/components/post_components.ex:4614
-#: lib/vutuv_web/components/post_components.ex:4628
+#: lib/vutuv_web/components/post_components.ex:4621
+#: lib/vutuv_web/components/post_components.ex:4635
 #: lib/vutuv_web/components/ui.ex:3226
 #: lib/vutuv_web/live/fediverse_account_live.ex:437
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6849,7 +6849,7 @@ msgstr "Nuovi messaggi e nuovi collegamenti"
 msgid "Remove this connection? You will stop following them."
 msgstr "Rimuovere questo collegamento? Smetterà di seguire questa persona."
 
-#: lib/vutuv_web/components/post_components.ex:4614
+#: lib/vutuv_web/components/post_components.ex:4621
 #: lib/vutuv_web/components/ui.ex:3225
 #: lib/vutuv_web/live/fediverse_account_live.ex:435
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -7519,7 +7519,7 @@ msgid "Removed:"
 msgstr "Rimossi:"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:974
-#: lib/vutuv_web/live/post_live/composer.ex:1899
+#: lib/vutuv_web/live/post_live/composer.ex:1928
 #: lib/vutuv_web/live/post_live/filter_band.ex:533
 #, elixir-autogen, elixir-format
 msgid "Undo"
@@ -7566,9 +7566,9 @@ msgid "applies to the whole list, not just this page"
 msgstr "vale per l'intero elenco, non solo per questa pagina"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:7105
+#: lib/vutuv_web/components/post_components.ex:7112
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
-#: lib/vutuv_web/live/shell_live.ex:1830
+#: lib/vutuv_web/live/shell_live.ex:1831
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
 msgstr "+%{count} altri"
@@ -8488,7 +8488,7 @@ msgstr ""
 "Ecco cosa abbiamo trovato nella Sua esportazione. Tolga la spunta a ciò che "
 "non desidera. Le voci già presenti sul Suo profilo sono già senza spunta."
 
-#: lib/vutuv_web/components/ui.ex:5656
+#: lib/vutuv_web/components/ui.ex:5659
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importa"
@@ -8626,7 +8626,7 @@ msgstr "Controlli i campi contrassegnati in rosso."
 msgid "Loading posts"
 msgstr "Caricamento dei post"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:140
+#: lib/vutuv_web/templates/settings/privacy.html.heex:167
 #: lib/vutuv_web/templates/user/show.html.heex:1432
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
@@ -8721,7 +8721,7 @@ msgstr "Lingua e visualizzazione"
 msgid "More profile sections"
 msgstr "Altre sezioni del profilo"
 
-#: lib/vutuv_web/components/ui.ex:5647
+#: lib/vutuv_web/components/ui.ex:5650
 #: lib/vutuv_web/controllers/settings_controller.ex:112
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8731,7 +8731,7 @@ msgstr "Altre sezioni del profilo"
 msgid "Sign-in & security"
 msgstr "Accesso e sicurezza"
 
-#: lib/vutuv_web/components/ui.ex:5660
+#: lib/vutuv_web/components/ui.ex:5663
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8757,19 +8757,19 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr "Digiti il Suo nome utente per confermare:"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:142
+#: lib/vutuv_web/templates/settings/privacy.html.heex:169
 #, elixir-autogen, elixir-format
 msgid "If you list a Mastodon or Bluesky account, your profile can show your latest public posts from it."
 msgstr ""
 "Se indica un account Mastodon o Bluesky, il Suo profilo può mostrarne gli "
 "ultimi post pubblici."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:146
+#: lib/vutuv_web/templates/settings/privacy.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "Show my latest social media posts on my profile"
 msgstr "Mostrare sul mio profilo i miei ultimi post dai social media"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:147
+#: lib/vutuv_web/templates/settings/privacy.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "When off, the Social Media card lists your accounts without any posts."
 msgstr ""
@@ -8957,7 +8957,7 @@ msgstr "La scriva in Amministrazione › Pagine legali"
 #: lib/vutuv_web/agent_docs/text.ex:671
 #: lib/vutuv_web/components/organization_components.ex:285
 #: lib/vutuv_web/components/ui.ex:1825
-#: lib/vutuv_web/components/ui.ex:5637
+#: lib/vutuv_web/components/ui.ex:5640
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:366
 #: lib/vutuv_web/controllers/settings_controller.ex:433
@@ -9121,7 +9121,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Download del CV"
 
-#: lib/vutuv_web/components/post_components.ex:5960
+#: lib/vutuv_web/components/post_components.ex:5967
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9808,7 +9808,7 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Situazione lavorativa"
 
-#: lib/vutuv/accounts/user.ex:1295
+#: lib/vutuv/accounts/user.ex:1302
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9819,7 +9819,7 @@ msgstr "In cerca di lavoro"
 msgid "Not open to work"
 msgstr "Non in cerca di lavoro"
 
-#: lib/vutuv/accounts/user.ex:1292
+#: lib/vutuv/accounts/user.ex:1299
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10617,13 +10617,13 @@ msgstr[1] "%{formatted} stelle"
 msgid "Code"
 msgstr "Codice"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:159
+#: lib/vutuv_web/templates/settings/privacy.html.heex:186
 #: lib/vutuv_web/views/account_event_text.ex:236
 #, elixir-autogen, elixir-format
 msgid "Code statistics"
 msgstr "Statistiche del codice"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:161
+#: lib/vutuv_web/templates/settings/privacy.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "If you list a GitHub, GitLab or Codeberg account, your profile can show its public statistics: stars, repositories, followers, languages and recent activity."
 msgstr ""
@@ -10636,12 +10636,12 @@ msgstr ""
 msgid "Last active %{date}"
 msgstr "Ultima attività il %{date}"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:165
+#: lib/vutuv_web/templates/settings/privacy.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Show code statistics on my profile"
 msgstr "Mostrare le statistiche del codice sul mio profilo"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:166
+#: lib/vutuv_web/templates/settings/privacy.html.heex:193
 #, elixir-autogen, elixir-format
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
@@ -11076,17 +11076,17 @@ msgstr ""
 "valgono subito; i membri che hanno impostato un valore proprio non sono "
 "interessati."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:110
+#: lib/vutuv_web/gettext_extraction_anchors.ex:115
 #, elixir-autogen, elixir-format
 msgid "0 means posts are never shortened."
 msgstr "0 significa che i post non vengono mai accorciati."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:116
+#: lib/vutuv_web/gettext_extraction_anchors.ex:121
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr "Disattivato"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:115
+#: lib/vutuv_web/gettext_extraction_anchors.ex:120
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr "Attivato"
@@ -11148,8 +11148,8 @@ msgid "Failed"
 msgstr "Non riuscito"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:198
-#: lib/vutuv_web/live/post_live/composer.ex:2130
-#: lib/vutuv_web/live/post_live/composer.ex:3099
+#: lib/vutuv_web/live/post_live/composer.ex:2159
+#: lib/vutuv_web/live/post_live/composer.ex:3160
 #, elixir-autogen, elixir-format
 msgid "Gallery"
 msgstr "Galleria"
@@ -11254,19 +11254,19 @@ msgstr ""
 "Sua disponibilità ma non può garantirla, perché chiunque può creare un "
 "account. Scelga \"Nessuno\" per conservare lo stato senza mostrarlo."
 
-#: lib/vutuv/accounts/user.ex:1333
+#: lib/vutuv/accounts/user.ex:1340
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Tutti, compresi i visitatori non connessi"
 
-#: lib/vutuv/accounts/user.ex:1338
+#: lib/vutuv/accounts/user.ex:1345
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Nessuno"
 
-#: lib/vutuv/accounts/user.ex:1336
+#: lib/vutuv/accounts/user.ex:1343
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:823
 #, elixir-autogen, elixir-format
@@ -11524,7 +11524,7 @@ msgstr ""
 "Offri i formati leggibili dalle macchine (.md/.txt/.json/.xml) ed elencali "
 "per gli agenti IA."
 
-#: lib/vutuv_web/controllers/organization_controller.ex:305
+#: lib/vutuv_web/controllers/organization_controller.ex:322
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:31
 #, elixir-autogen, elixir-format
 msgid "Please log in first."
@@ -12307,7 +12307,7 @@ msgstr "Organizzazione sbloccata."
 #: lib/vutuv_web/agent_docs/markdown.ex:531
 #: lib/vutuv_web/agent_docs/organization_doc.ex:138
 #: lib/vutuv_web/agent_docs/text.ex:481
-#: lib/vutuv_web/components/ui.ex:5664
+#: lib/vutuv_web/components/ui.ex:5667
 #: lib/vutuv_web/controllers/settings_controller.ex:222
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
@@ -12633,7 +12633,7 @@ msgstr "I tag evidenziati corrispondono al Suo profilo."
 msgid "How to apply"
 msgstr "Come candidarsi"
 
-#: lib/vutuv/accounts/user.ex:1307
+#: lib/vutuv/accounts/user.ex:1314
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12755,7 +12755,7 @@ msgstr ""
 "Offri i formati leggibili dalle macchine (.md/.txt/.json/.xml) agli agenti "
 "IA."
 
-#: lib/vutuv/accounts/user.ex:1306
+#: lib/vutuv/accounts/user.ex:1313
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12839,7 +12839,7 @@ msgstr "Annuncio non trovato."
 msgid "Publish"
 msgstr "Pubblica"
 
-#: lib/vutuv/accounts/user.ex:1308
+#: lib/vutuv/accounts/user.ex:1315
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:590
 #: lib/vutuv_web/agent_docs/markdown.ex:570
@@ -13936,7 +13936,7 @@ msgstr ""
 "Se è venuto male (ad esempio con un avviso sui cookie che copre la pagina), "
 "può rimuoverlo."
 
-#: lib/vutuv/accounts/user.ex:1351
+#: lib/vutuv/accounts/user.ex:1358
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13950,19 +13950,19 @@ msgstr ""
 "la data esatta, \"Giorno e mese\" nasconde l'anno (e la Sua età) e \"Non "
 "mostrare\" lo conserva ma lo tiene fuori dal profilo."
 
-#: lib/vutuv/accounts/user.ex:1354
+#: lib/vutuv/accounts/user.ex:1361
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Giorno e mese, senza l'anno"
 
-#: lib/vutuv/accounts/user.ex:1357
+#: lib/vutuv/accounts/user.ex:1364
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Non mostrare il mio compleanno"
 
-#: lib/vutuv/accounts/user.ex:1348
+#: lib/vutuv/accounts/user.ex:1355
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -14038,7 +14038,7 @@ msgstr "A tutta larghezza"
 msgid "Insert image"
 msgstr "Inserisci un'immagine"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3490
+#: lib/vutuv_web/live/post_live/composer.ex:3551
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr "Inserisci nel testo"
@@ -14270,34 +14270,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr "ha aggiunto %{count} nuove voci al proprio CV:"
 
-#: lib/vutuv_web/components/post_components.ex:6648
+#: lib/vutuv_web/components/post_components.ex:6655
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Audiolibro"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6605
+#: lib/vutuv_web/components/post_components.ex:6612
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Recensione di un libro"
 
-#: lib/vutuv_web/components/post_components.ex:6649
+#: lib/vutuv_web/components/post_components.ex:6656
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Cinema"
 
-#: lib/vutuv_web/components/post_components.ex:6651
+#: lib/vutuv_web/components/post_components.ex:6658
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:6647
+#: lib/vutuv_web/components/post_components.ex:6654
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6604
+#: lib/vutuv_web/components/post_components.ex:6611
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Recensione di un film"
@@ -14308,12 +14308,12 @@ msgstr "Recensione di un film"
 msgid "Look up"
 msgstr "Cerca"
 
-#: lib/vutuv_web/components/post_components.ex:6646
+#: lib/vutuv_web/components/post_components.ex:6653
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Libro cartaceo"
 
-#: lib/vutuv_web/components/post_components.ex:6650
+#: lib/vutuv_web/components/post_components.ex:6657
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14333,7 +14333,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Anno"
 
-#: lib/vutuv_web/components/post_components.ex:6687
+#: lib/vutuv_web/components/post_components.ex:6694
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14341,30 +14341,30 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} pagina"
 msgstr[1] "%{formatted} pagine"
 
-#: lib/vutuv_web/components/post_components.ex:6717
+#: lib/vutuv_web/components/post_components.ex:6724
 #: lib/vutuv_web/components/ui.ex:3884
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} h"
 
-#: lib/vutuv_web/components/post_components.ex:6718
+#: lib/vutuv_web/components/post_components.ex:6725
 #: lib/vutuv_web/components/ui.ex:3885
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} h %{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:6716
+#: lib/vutuv_web/components/post_components.ex:6723
 #: lib/vutuv_web/components/ui.ex:3877
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:6676
+#: lib/vutuv_web/components/post_components.ex:6683
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(edizione cartacea)"
 
-#: lib/vutuv_web/components/post_components.ex:6723
+#: lib/vutuv_web/components/post_components.ex:6730
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "circa %{duration}"
@@ -14396,7 +14396,7 @@ msgstr "Con certificazione:"
 msgid "With qualification: %{name}"
 msgstr "Con certificazione: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:6490
+#: lib/vutuv_web/components/post_components.ex:6497
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Editore:"
@@ -14439,7 +14439,7 @@ msgstr "ora La seguono."
 msgid "endorsed you for %{tags}."
 msgstr "L'ha confermata per %{tags}."
 
-#: lib/vutuv_web/components/post_components.ex:6481
+#: lib/vutuv_web/components/post_components.ex:6488
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "di:"
@@ -14588,7 +14588,7 @@ msgstr "documento di prova"
 msgid "Lines in notifications"
 msgstr "Righe nelle notifiche"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:111
+#: lib/vutuv_web/gettext_extraction_anchors.ex:116
 #, elixir-autogen, elixir-format
 msgid "How much of a post a notification quotes before it is cut off."
 msgstr ""
@@ -14703,7 +14703,7 @@ msgstr "Menzione"
 msgid "mentioned you in a post."
 msgstr "L'ha menzionata in un post."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1507
+#: lib/vutuv_web/live/post_live/composer.ex:1536
 #: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
@@ -14711,7 +14711,7 @@ msgstr ""
 "Questo post non può più essere modificato: qualcuno gli ha messo Mi piace, "
 "lo ha ripubblicato o gli ha risposto."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1510
+#: lib/vutuv_web/live/post_live/composer.ex:1539
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -14852,7 +14852,7 @@ msgstr ""
 "Digiti un nome, un @handle o un indirizzo e-mail per trovare un account da "
 "bloccare."
 
-#: lib/vutuv_web/components/post_components.ex:7204
+#: lib/vutuv_web/components/post_components.ex:7211
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Non può mettere Mi piace al Suo stesso post."
@@ -15802,12 +15802,12 @@ msgstr "Gli argomenti per cui è conosciuto"
 msgid "skill topic keyword expertise endorsement"
 msgstr "competenza argomento parola chiave esperienza conferma"
 
-#: lib/vutuv_web/components/ui.ex:5665
+#: lib/vutuv_web/components/ui.ex:5668
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr "Pagine aziendali che gestisce"
 
-#: lib/vutuv_web/components/ui.ex:5666
+#: lib/vutuv_web/components/ui.ex:5669
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr "azienda datore di lavoro impresa attività organizzazione pagina"
@@ -15930,65 +15930,53 @@ msgstr ""
 msgid "job alert search agent watchlist"
 msgstr "lavoro avviso ricerca agente osservati"
 
-#: lib/vutuv_web/components/ui.ex:5622
-#, elixir-autogen, elixir-format
-msgid "Search engines, AI, online status"
-msgstr "Motori di ricerca, IA, stato online"
-
-#: lib/vutuv_web/components/ui.ex:5623
-#, elixir-autogen, elixir-format
-msgid "privacy google search engine ai llm crawler noindex online dot public"
-msgstr ""
-"privacy google motore di ricerca ia llm crawler noindex online pallino "
-"pubblico"
-
-#: lib/vutuv_web/components/ui.ex:5626
+#: lib/vutuv_web/components/ui.ex:5629
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr "Persone che non possono interagire con Lei"
 
-#: lib/vutuv_web/components/ui.ex:5627
+#: lib/vutuv_web/components/ui.ex:5630
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr "blocca bandisci silenzia segnala abuso molestie stalker"
 
-#: lib/vutuv_web/components/ui.ex:5648
+#: lib/vutuv_web/components/ui.ex:5651
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr "Passkey, dispositivi connessi, codici di accesso"
 
-#: lib/vutuv_web/components/ui.ex:5649
+#: lib/vutuv_web/components/ui.ex:5652
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 "password accesso entrare uscire sessione dispositivo passkey totp 2fa pin"
 
-#: lib/vutuv_web/components/ui.ex:5657
+#: lib/vutuv_web/components/ui.ex:5660
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr "Porti i Suoi dati da LinkedIn"
 
-#: lib/vutuv_web/components/ui.ex:5658
+#: lib/vutuv_web/components/ui.ex:5661
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr "linkedin caricamento zip migrazione trasferimento"
 
-#: lib/vutuv_web/components/ui.ex:5661
+#: lib/vutuv_web/components/ui.ex:5664
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr "Scarichi tutto ciò che conserviamo su di Lei"
 
-#: lib/vutuv_web/components/ui.ex:5662
+#: lib/vutuv_web/components/ui.ex:5665
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr "download gdpr rgpd dati backup json cv"
 
-#: lib/vutuv_web/components/ui.ex:5676
+#: lib/vutuv_web/components/ui.ex:5679
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr "Rimuova il Suo account e tutto ciò che contiene"
 
-#: lib/vutuv_web/components/ui.ex:5677
+#: lib/vutuv_web/components/ui.ex:5680
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr "elimina rimuovi chiudi esci cancella abbandona"
@@ -16118,7 +16106,7 @@ msgstr ""
 " vedere dove va a finire. Modificare o eliminare un post su vutuv è solo una"
 " richiesta rivolta a quei server, e non tutti la rispettano."
 
-#: lib/vutuv_web/components/post_components.ex:7150
+#: lib/vutuv_web/components/post_components.ex:7157
 #: lib/vutuv_web/live/notification_live/index.ex:1592
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -16126,7 +16114,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} risposta"
 msgstr[1] "%{formatted} risposte"
 
-#: lib/vutuv_web/components/post_components.ex:7154
+#: lib/vutuv_web/components/post_components.ex:7161
 #: lib/vutuv_web/live/notification_live/index.ex:1586
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -16134,7 +16122,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Mi piace"
 msgstr[1] "%{formatted} Mi piace"
 
-#: lib/vutuv_web/components/post_components.ex:7158
+#: lib/vutuv_web/components/post_components.ex:7165
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16142,7 +16130,7 @@ msgstr[0] "%{formatted} ripubblicazione"
 msgstr[1] "%{formatted} ripubblicazioni"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1339
-#: lib/vutuv_web/components/post_components.ex:7109
+#: lib/vutuv_web/components/post_components.ex:7116
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Già conteggiate nei numeri qui sopra."
@@ -16489,7 +16477,7 @@ msgstr "Token di accesso creato"
 msgid "Access token revoked"
 msgstr "Token di accesso revocato"
 
-#: lib/vutuv_web/components/ui.ex:5651
+#: lib/vutuv_web/components/ui.ex:5654
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -16710,7 +16698,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/admin/media_live.ex:155
 #: lib/vutuv_web/live/fediverse_following_live.ex:351
-#: lib/vutuv_web/live/tag_live/timeline.ex:473
+#: lib/vutuv_web/live/tag_live/timeline.ex:477
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr ""
@@ -16849,7 +16837,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr "Cosa è cambiato sul Suo account, ed esattamente quando."
 
-#: lib/vutuv_web/components/ui.ex:5652
+#: lib/vutuv_web/components/ui.ex:5655
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr "Cosa è cambiato sul Suo account, e quando"
@@ -16885,7 +16873,7 @@ msgstr "da chi gestisce il sito"
 msgid "from a signed-in session"
 msgstr "da una sessione connessa"
 
-#: lib/vutuv_web/components/ui.ex:5654
+#: lib/vutuv_web/components/ui.ex:5657
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -16942,22 +16930,22 @@ msgstr ""
 msgid "device or detail"
 msgstr "dispositivo o dettaglio"
 
-#: lib/vutuv_web/components/post_components.ex:4443
+#: lib/vutuv_web/components/post_components.ex:4450
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Post fissato"
 
-#: lib/vutuv_web/components/post_components.ex:4577
+#: lib/vutuv_web/components/post_components.ex:4584
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "Fissa sul profilo"
 
-#: lib/vutuv_web/components/post_components.ex:4585
+#: lib/vutuv_web/components/post_components.ex:4592
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Togli dal profilo"
 
-#: lib/vutuv_web/components/post_components.ex:4571
+#: lib/vutuv_web/components/post_components.ex:4578
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -17008,7 +16996,7 @@ msgstr ""
 "profilo, come si scrive una trascrizione, e le parentesi le aggiungiamo noi."
 " Se lo lascia vuoto non viene mostrato nulla."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3503
+#: lib/vutuv_web/live/post_live/composer.ex:3564
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr "Applica queste impostazioni a tutte le foto"
@@ -17040,12 +17028,12 @@ msgstr "CC0 1.0 (nessun diritto riservato)"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1456
 #: lib/vutuv_web/agent_docs/text.ex:921
-#: lib/vutuv_web/live/post_live/composer.ex:2927
+#: lib/vutuv_web/live/post_live/composer.ex:2988
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr "Copertina"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3341
+#: lib/vutuv_web/live/post_live/composer.ex:3402
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr "Descriva la foto per chi non può vederla"
@@ -17057,24 +17045,24 @@ msgstr "Descriva la foto per chi non può vederla"
 msgid "Download the original"
 msgstr "Scarica l'originale"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3440
+#: lib/vutuv_web/live/post_live/composer.ex:3501
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 "Tutti i campi di metadati conservati, compreso ciò che ha scritto la Sua "
 "fotocamera."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3396
+#: lib/vutuv_web/live/post_live/composer.ex:3457
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr "Chiunque può scaricare questa foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3398
+#: lib/vutuv_web/live/post_live/composer.ex:3459
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr "Risoluzione piena, direttamente dal post."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3417
+#: lib/vutuv_web/live/post_live/composer.ex:3478
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr "Solo l'immagine"
@@ -17084,7 +17072,7 @@ msgstr "Solo l'immagine"
 msgid "Next photo"
 msgstr "Foto successiva"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2946
+#: lib/vutuv_web/live/post_live/composer.ex:3007
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr "Ancora nessuna descrizione dell'immagine"
@@ -17094,27 +17082,27 @@ msgstr "Ancora nessuna descrizione dell'immagine"
 msgid "Open Fediverse settings"
 msgstr "Apri le impostazioni del Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:5526
-#: lib/vutuv_web/components/press_kit_components.ex:521
+#: lib/vutuv_web/components/post_components.ex:5533
+#: lib/vutuv_web/components/press_kit_components.ex:526
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} di %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:5754
-#: lib/vutuv_web/components/press_kit_components.ex:618
+#: lib/vutuv_web/components/post_components.ex:5761
+#: lib/vutuv_web/components/press_kit_components.ex:623
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "La foto è in fase di controllo"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2899
-#: lib/vutuv_web/live/post_live/composer.ex:2900
+#: lib/vutuv_web/live/post_live/composer.ex:2960
+#: lib/vutuv_web/live/post_live/composer.ex:2961
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr "Opzioni della foto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1500
 #: lib/vutuv_web/agent_docs/text.ex:909
-#: lib/vutuv_web/components/post_components.ex:5836
+#: lib/vutuv_web/components/post_components.ex:5843
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Foto:"
@@ -17124,20 +17112,20 @@ msgstr "Foto:"
 msgid "Previous photo"
 msgstr "Foto precedente"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2959
-#: lib/vutuv_web/live/post_live/composer.ex:2960
+#: lib/vutuv_web/live/post_live/composer.ex:3020
+#: lib/vutuv_web/live/post_live/composer.ex:3021
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr "Rimuovi la foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3419
+#: lib/vutuv_web/live/post_live/composer.ex:3480
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 "Gli stessi pixel e nient'altro: posizione e numeri di serie rimossi, qualità"
 " intatta."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3360
+#: lib/vutuv_web/live/post_live/composer.ex:3421
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr "Mostra le impostazioni della fotocamera"
@@ -17149,19 +17137,19 @@ msgstr ""
 "Quel server è bloccato su questo sito, quindi non gli si può inviare alcuna "
 "risposta."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3438
+#: lib/vutuv_web/live/post_live/composer.ex:3499
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr "Il file esattamente come l'ho caricato"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3474
+#: lib/vutuv_web/live/post_live/composer.ex:3535
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 "Questo formato di file può essere consegnato solo così com'è. Rimuova la "
 "foto se non è ciò che desidera."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3466
+#: lib/vutuv_web/live/post_live/composer.ex:3527
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
@@ -17193,12 +17181,12 @@ msgstr "Questo sito non partecipa al Fediverso."
 msgid "Turn on Fediverse participation to answer"
 msgstr "Attivi la partecipazione al Fediverso per rispondere"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3217
+#: lib/vutuv_web/live/post_live/composer.ex:3278
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr "Chi può riutilizzare queste foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1537
+#: lib/vutuv_web/live/post_live/composer.ex:1566
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
@@ -17211,7 +17199,7 @@ msgstr ""
 "Ha spostato il Suo account del Fediverso su un altro server, quindi da qui "
 "non vengono più inviate risposte."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1551
+#: lib/vutuv_web/live/post_live/composer.ex:1580
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
@@ -17230,66 +17218,66 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr "© Tutti i diritti riservati"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2842
+#: lib/vutuv_web/live/post_live/composer.ex:2903
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr "Aggiungi foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3212
+#: lib/vutuv_web/live/post_live/composer.ex:3273
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr "Licenza"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3331
+#: lib/vutuv_web/live/post_live/composer.ex:3392
 #, elixir-autogen, elixir-format
 msgid "Caption (optional)"
 msgstr "Didascalia (facoltativa)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1874
-#: lib/vutuv_web/live/post_live/composer.ex:1937
-#: lib/vutuv_web/live/post_live/composer.ex:1995
+#: lib/vutuv_web/live/post_live/composer.ex:1903
+#: lib/vutuv_web/live/post_live/composer.ex:1966
+#: lib/vutuv_web/live/post_live/composer.ex:2024
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr "Scarta la bozza"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1867
+#: lib/vutuv_web/live/post_live/composer.ex:1896
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr "Ripreso da dove aveva lasciato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3265
+#: lib/vutuv_web/live/post_live/composer.ex:3326
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 "Un file il cui formato non può essere ripulito viene consegnato esattamente "
 "come caricato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2563
+#: lib/vutuv_web/live/post_live/composer.ex:2624
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr "Diverso per ogni foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2562
+#: lib/vutuv_web/live/post_live/composer.ex:2623
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr "Originale, esattamente come caricato"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2561
+#: lib/vutuv_web/live/post_live/composer.ex:2622
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr "Originale, senza metadati"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2566
+#: lib/vutuv_web/live/post_live/composer.ex:2627
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr "Solo versioni per il web (%{format})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3235
+#: lib/vutuv_web/live/post_live/composer.ex:3296
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr "Cosa può salvare un visitatore"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3254
+#: lib/vutuv_web/live/post_live/composer.ex:3315
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -17301,13 +17289,13 @@ msgstr[1] ""
 "il file esatto lo rivela."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1357
-#: lib/vutuv_web/components/post_components.ex:7147
+#: lib/vutuv_web/components/post_components.ex:7154
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "A %{handle} è piaciuto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1355
-#: lib/vutuv_web/components/post_components.ex:7144
+#: lib/vutuv_web/components/post_components.ex:7151
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} lo ha condiviso"
@@ -17317,7 +17305,7 @@ msgstr "%{handle} lo ha condiviso"
 msgid "Fediverse reactions"
 msgstr "Reazioni dal Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:7031
+#: lib/vutuv_web/components/post_components.ex:7038
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Da altre reti"
@@ -17413,8 +17401,8 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr "Richiesta di ritiro"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2131
-#: lib/vutuv_web/live/post_live/composer.ex:3099
+#: lib/vutuv_web/live/post_live/composer.ex:2160
+#: lib/vutuv_web/live/post_live/composer.ex:3160
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr "Dettagli della foto"
@@ -17444,7 +17432,7 @@ msgstr "Un account su un'altra rete"
 msgid "Cancel request"
 msgstr "Annulla la richiesta"
 
-#: lib/vutuv_web/components/ui.ex:5638
+#: lib/vutuv_web/components/ui.ex:5641
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr "Segua account su Mastodon, e si faccia seguire da lì"
@@ -17681,7 +17669,7 @@ msgstr ""
 "reti e non può seguire nessuno lì. La sospensione decade da sé quando "
 "termina."
 
-#: lib/vutuv_web/components/ui.ex:5640
+#: lib/vutuv_web/components/ui.ex:5643
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
@@ -18254,108 +18242,108 @@ msgstr ""
 "previsti per ogni altro post da un'altra rete, e al server del suo autore "
 "non viene chiesto nient'altro."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2048
+#: lib/vutuv_web/live/post_live/composer.ex:2077
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr "Applica il ritaglio"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3005
+#: lib/vutuv_web/live/post_live/composer.ex:3066
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr "Foto grande a sinistra"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3006
+#: lib/vutuv_web/live/post_live/composer.ex:3067
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr "Foto grande a destra"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3011
+#: lib/vutuv_web/live/post_live/composer.ex:3072
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr "Colonne"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3008
+#: lib/vutuv_web/live/post_live/composer.ex:3069
 #, elixir-autogen, elixir-format
 msgid "Cover left"
 msgstr "Copertina a sinistra"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3009
+#: lib/vutuv_web/live/post_live/composer.ex:3070
 #, elixir-autogen, elixir-format
 msgid "Cover on top"
 msgstr "Copertina in alto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3010
+#: lib/vutuv_web/live/post_live/composer.ex:3071
 #, elixir-autogen, elixir-format
 msgid "Cover right"
 msgstr "Copertina a destra"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2044
-#: lib/vutuv_web/live/post_live/composer.ex:2976
-#: lib/vutuv_web/live/post_live/composer.ex:2977
+#: lib/vutuv_web/live/post_live/composer.ex:2073
+#: lib/vutuv_web/live/post_live/composer.ex:3037
+#: lib/vutuv_web/live/post_live/composer.ex:3038
 #, elixir-autogen, elixir-format
 msgid "Crop photo"
 msgstr "Ritaglia la foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2935
+#: lib/vutuv_web/live/post_live/composer.ex:2996
 #, elixir-autogen, elixir-format
 msgid "Cropped"
 msgstr "Ritagliata"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1966
+#: lib/vutuv_web/live/post_live/composer.ex:1995
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr "Trascini qui le foto per aggiungerle"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3012
+#: lib/vutuv_web/live/post_live/composer.ex:3073
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr "Griglia"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3013
+#: lib/vutuv_web/live/post_live/composer.ex:3074
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr "Mosaico"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2046
+#: lib/vutuv_web/live/post_live/composer.ex:2075
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr ""
 "Scelga una forma, poi trascini e ingrandisca. La parte nel riquadro è quella"
 " che il post mostra."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3004
+#: lib/vutuv_web/live/post_live/composer.ex:3065
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr "Affiancate"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3007
+#: lib/vutuv_web/live/post_live/composer.ex:3068
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr "Impilate"
 
-#: lib/vutuv_web/live/post_live/composer.ex:611
+#: lib/vutuv_web/live/post_live/composer.ex:630
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr "Non è stato possibile ritagliare la foto."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3453
+#: lib/vutuv_web/live/post_live/composer.ex:3514
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr ""
 "Questa foto è ritagliata: i download consegnano l'immagine ritagliata, e il "
 "caricamento intatto resta privato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2050
+#: lib/vutuv_web/live/post_live/composer.ex:2079
 #, elixir-autogen, elixir-format
 msgid "Whole photo"
 msgstr "Foto intera"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3202
+#: lib/vutuv_web/live/post_live/composer.ex:3263
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr "Riempi le caselle"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3186
+#: lib/vutuv_web/live/post_live/composer.ex:3247
 #, elixir-autogen, elixir-format
 msgid "Whole photos"
 msgstr "Foto intere"
@@ -18614,22 +18602,22 @@ msgid_plural "%{formatted} posts"
 msgstr[0] "%{formatted} post"
 msgstr[1] "%{formatted} post"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:450
+#: lib/vutuv_web/live/tag_live/timeline.ex:454
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr "Più apprezzati"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:481
+#: lib/vutuv_web/live/tag_live/timeline.ex:485
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr "Nessun post porta ancora questo tag."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:479
+#: lib/vutuv_web/live/tag_live/timeline.ex:483
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr "Nessun post da altre reti porta ancora questo tag."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:476
+#: lib/vutuv_web/live/tag_live/timeline.ex:480
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr "Nessun post su vutuv porta ancora questo tag."
@@ -18705,7 +18693,7 @@ msgstr "Codice sorgente"
 msgid "At most %{max} tags. Remove one to add another."
 msgstr "Al massimo %{max} tag. Ne rimuova uno per aggiungerne un altro."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:93
+#: lib/vutuv_web/templates/settings/privacy.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr ""
@@ -18717,26 +18705,26 @@ msgstr ""
 msgid "Liked by"
 msgstr "Piace a"
 
-#: lib/vutuv_web/components/post_components.ex:6130
+#: lib/vutuv_web/components/post_components.ex:6137
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Piace a %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:6132
+#: lib/vutuv_web/components/post_components.ex:6139
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Piace a %{name} e a %{formatted} altro"
 msgstr[1] "Piace a %{name} e ad altri %{formatted}"
 
-#: lib/vutuv_web/components/post_components.ex:6143
+#: lib/vutuv_web/components/post_components.ex:6150
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
 "Solo Lei li vede tutti qui: alcuni di questi membri non vengono nominati "
 "agli altri lettori."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:111
+#: lib/vutuv_web/templates/settings/privacy.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "Reset to the site default"
 msgstr "Riporta al valore predefinito del sito"
@@ -19690,17 +19678,17 @@ msgstr ""
 "Il PIN non arriva? L'indirizzo e-mail {email} è corretto? Ha controllato la "
 "cartella dello spam?"
 
-#: lib/vutuv/accounts/user.ex:1454
+#: lib/vutuv/accounts/user.ex:1461
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Non binario"
 
-#: lib/vutuv/accounts/user.ex:1452
+#: lib/vutuv/accounts/user.ex:1459
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr "Femminile"
 
-#: lib/vutuv/accounts/user.ex:1453
+#: lib/vutuv/accounts/user.ex:1460
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Maschile"
@@ -19815,7 +19803,7 @@ msgstr "Elimina anche"
 msgid "Always keep"
 msgstr "Conserva sempre"
 
-#: lib/vutuv_web/components/ui.ex:5631
+#: lib/vutuv_web/components/ui.ex:5634
 #: lib/vutuv_web/controllers/settings_controller.ex:256
 #: lib/vutuv_web/controllers/settings_controller.ex:335
 #: lib/vutuv_web/controllers/settings_controller.ex:347
@@ -19925,7 +19913,7 @@ msgstr "Conserva i post con foto"
 msgid "Keep posts that did well"
 msgstr "Conserva i post andati bene"
 
-#: lib/vutuv_web/components/ui.ex:5633
+#: lib/vutuv_web/components/ui.ex:5636
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr "Lasci scadere i Suoi post dopo un tempo che decide Lei"
@@ -20049,7 +20037,7 @@ msgstr "Prima può scaricare tutto ciò che ha qui:"
 msgid "Your rule"
 msgstr "La Sua regola"
 
-#: lib/vutuv_web/components/ui.ex:5635
+#: lib/vutuv_web/components/ui.ex:5638
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
@@ -20530,17 +20518,17 @@ msgstr ""
 msgid "Nothing published yet."
 msgstr "Ancora nulla di pubblicato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2377
+#: lib/vutuv_web/live/post_live/composer.ex:2438
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
 msgstr "Pubblica come %{name}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1530
+#: lib/vutuv_web/live/post_live/composer.ex:1559
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr "Non può più scrivere a nome di questa organizzazione."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2354
+#: lib/vutuv_web/live/post_live/composer.ex:2415
 #, elixir-autogen, elixir-format
 msgid "A post in an organization's name is always public."
 msgstr "Un post a nome di un'organizzazione è sempre pubblico."
@@ -21406,44 +21394,44 @@ msgstr "Ha %{used} tag su %{max}."
 msgid "{n} of {max} free slots selected."
 msgstr "Selezionati {n} posti liberi su {max}."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2336
+#: lib/vutuv_web/live/post_live/composer.ex:2397
 #, elixir-autogen, elixir-format
 msgid "More languages"
 msgstr "Altre lingue"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2327
+#: lib/vutuv_web/live/post_live/composer.ex:2388
 #, elixir-autogen, elixir-format
 msgctxt "post composer"
 msgid "Language"
 msgstr "Lingua"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2323
-#: lib/vutuv_web/live/post_live/composer.ex:2324
+#: lib/vutuv_web/live/post_live/composer.ex:2384
+#: lib/vutuv_web/live/post_live/composer.ex:2385
 #, elixir-autogen, elixir-format
 msgid "The language this post is written in"
 msgstr "La lingua in cui è scritto questo post"
 
-#: lib/vutuv_web/components/post_components.ex:6024
+#: lib/vutuv_web/components/post_components.ex:6031
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Mostra l'originale"
 
-#: lib/vutuv_web/components/post_components.ex:6060
+#: lib/vutuv_web/components/post_components.ex:6067
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Traduci"
 
-#: lib/vutuv_web/components/post_components.ex:6069
+#: lib/vutuv_web/components/post_components.ex:6076
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Tradotto"
 
-#: lib/vutuv_web/components/post_components.ex:6072
+#: lib/vutuv_web/components/post_components.ex:6079
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Tradotto da %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:6049
+#: lib/vutuv_web/components/post_components.ex:6056
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Traduzione in corso…"
@@ -21454,7 +21442,7 @@ msgid "Feed language settings reset to the site defaults."
 msgstr ""
 "Impostazioni delle lingue del feed riportate ai valori predefiniti del sito."
 
-#: lib/vutuv_web/components/post_components.ex:6039
+#: lib/vutuv_web/components/post_components.ex:6046
 #: lib/vutuv_web/components/ui.ex:5549
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -21463,22 +21451,22 @@ msgstr ""
 msgid "Feed languages"
 msgstr "Lingue del feed"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:83
+#: lib/vutuv_web/gettext_extraction_anchors.ex:88
 #, elixir-autogen, elixir-format
 msgid "Hide them"
 msgstr "Nascondili"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:81
+#: lib/vutuv_web/gettext_extraction_anchors.ex:86
 #, elixir-autogen, elixir-format
 msgid "Posts in other languages"
 msgstr "Post in altre lingue"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:82
+#: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #, elixir-autogen, elixir-format
 msgid "Translate into my language"
 msgstr "Traducili nella mia lingua"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:84
+#: lib/vutuv_web/gettext_extraction_anchors.ex:89
 #, elixir-autogen, elixir-format
 msgid "What your feed does with posts outside your chosen languages: show them as they are, translate them for you, or hide them. Posts that declare no language always show."
 msgstr ""
@@ -21486,7 +21474,7 @@ msgstr ""
 "così come sono, tradurglieli o nasconderli. I post che non dichiarano una "
 "lingua vengono sempre mostrati."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:120
+#: lib/vutuv_web/gettext_extraction_anchors.ex:125
 #, elixir-autogen, elixir-format
 msgid "Date & time"
 msgstr "Data e ora"
@@ -21496,12 +21484,12 @@ msgstr "Data e ora"
 msgid "Date and time settings reset to the site defaults."
 msgstr "Impostazioni di data e ora riportate ai valori predefiniti del sito."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:118
+#: lib/vutuv_web/gettext_extraction_anchors.ex:123
 #, elixir-autogen, elixir-format
 msgid "Date format"
 msgstr "Formato della data"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:128
+#: lib/vutuv_web/gettext_extraction_anchors.ex:133
 #, elixir-autogen, elixir-format
 msgid "Germany, Austria, Switzerland"
 msgstr "Germania, Austria, Svizzera"
@@ -21511,31 +21499,31 @@ msgstr "Germania, Austria, Svizzera"
 msgid "Language and region saved."
 msgstr "Lingua e regione salvate."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:124
+#: lib/vutuv_web/gettext_extraction_anchors.ex:129
 #, elixir-autogen, elixir-format
 msgid "Posts, messages and notifications are stamped in this zone. New accounts take it from the browser."
 msgstr ""
 "Post, messaggi e notifiche vengono datati in questo fuso. I nuovi account lo"
 " ricavano dal browser."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:121
+#: lib/vutuv_web/gettext_extraction_anchors.ex:126
 #, elixir-autogen, elixir-format
 msgid "The order and punctuation of every date you read here, and whether times run on a 12- or 24-hour clock."
 msgstr ""
 "L'ordine e la punteggiatura di ogni data che legge qui, e se gli orari usano"
 " il formato a 12 o a 24 ore."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:119
+#: lib/vutuv_web/gettext_extraction_anchors.ex:124
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr "Fuso orario"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:129
+#: lib/vutuv_web/gettext_extraction_anchors.ex:134
 #, elixir-autogen, elixir-format
 msgid "United Kingdom, France, Brazil"
 msgstr "Regno Unito, Francia, Brasile"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:130
+#: lib/vutuv_web/gettext_extraction_anchors.ex:135
 #, elixir-autogen, elixir-format
 msgid "United States"
 msgstr "Stati Uniti"
@@ -21545,7 +21533,7 @@ msgstr "Stati Uniti"
 msgid "Your browser says: {zone}"
 msgstr "Il Suo browser dice: {zone}"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:131
+#: lib/vutuv_web/gettext_extraction_anchors.ex:136
 #, elixir-autogen, elixir-format
 msgid "ISO 8601 (Sweden, Japan, China)"
 msgstr "ISO 8601 (Svezia, Giappone, Cina)"
@@ -21597,7 +21585,7 @@ msgid "Your username, or paste the address of your profile page."
 msgstr ""
 "Il Suo nome utente, oppure incolli l'indirizzo della Sua pagina di profilo."
 
-#: lib/vutuv_web/components/post_components.ex:5802
+#: lib/vutuv_web/components/post_components.ex:5809
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
@@ -21608,13 +21596,13 @@ msgstr[1] ""
 "La nostra IA le sta ancora controllando, %{done} su %{total} fatte. Appena "
 "avrà finito con l'ultima, le foto compariranno da sé."
 
-#: lib/vutuv_web/components/post_components.ex:5799
+#: lib/vutuv_web/components/post_components.ex:5806
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Il Suo post è pubblicato, la foto non c'è ancora."
 
 #: lib/vutuv_web/components/post_components.ex:2912
-#: lib/vutuv_web/components/post_components.ex:4868
+#: lib/vutuv_web/components/post_components.ex:4875
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -21697,7 +21685,7 @@ msgstr ""
 msgid "Mastodon app access changed"
 msgstr "Accesso delle app Mastodon modificato"
 
-#: lib/vutuv_web/components/ui.ex:5669
+#: lib/vutuv_web/components/ui.ex:5672
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr "App Mastodon, app collegate e token di accesso"
@@ -21753,7 +21741,7 @@ msgstr ""
 msgid "Your account is then %{handle}."
 msgstr "Il Suo account è allora %{handle}."
 
-#: lib/vutuv_web/components/ui.ex:5671
+#: lib/vutuv_web/components/ui.ex:5674
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr ""
@@ -22395,7 +22383,7 @@ msgstr "Alcuni fra i membri più recenti. Seguirli è un bel benvenuto."
 msgid "Example"
 msgstr "Esempio"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:95
+#: lib/vutuv_web/gettext_extraction_anchors.ex:100
 #, elixir-autogen, elixir-format
 msgid "Feed tabs"
 msgstr "Schede del feed"
@@ -22411,22 +22399,22 @@ msgstr ""
 msgid "Play the example"
 msgstr "Riproduci l'esempio"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:109
+#: lib/vutuv_web/gettext_extraction_anchors.ex:114
 #, elixir-autogen, elixir-format
 msgid "Between 4 and 20 seconds."
 msgstr "Fra 4 e 20 secondi."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:97
+#: lib/vutuv_web/gettext_extraction_anchors.ex:102
 #, elixir-autogen, elixir-format
 msgid "How long the quote stands"
 msgstr "Quanto resta la citazione"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:96
+#: lib/vutuv_web/gettext_extraction_anchors.ex:101
 #, elixir-autogen, elixir-format
 msgid "Quote what arrives on the other tab"
 msgstr "Cita ciò che arriva sull'altra scheda"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:98
+#: lib/vutuv_web/gettext_extraction_anchors.ex:103
 #, elixir-autogen, elixir-format
 msgid "When off, a tab holding something new wears its dot and says nothing more."
 msgstr ""
@@ -22555,7 +22543,7 @@ msgid_plural "+%{formatted} more posts"
 msgstr[0] "+%{formatted} altro post"
 msgstr[1] "+%{formatted} altri post"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:100
+#: lib/vutuv_web/gettext_extraction_anchors.ex:105
 #: lib/vutuv_web/templates/settings/preferences.html.heex:210
 #, elixir-autogen, elixir-format
 msgid "Browser tab"
@@ -22571,12 +22559,12 @@ msgstr "Impostazioni della scheda del browser ripristinate ai valori predefiniti
 msgid "Browser tab settings saved."
 msgstr "Impostazioni della scheda del browser salvate."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:102
+#: lib/vutuv_web/gettext_extraction_anchors.ex:107
 #, elixir-autogen, elixir-format
 msgid "Only while you are looking at another tab, and only for a few seconds. The tab title also shows up in screenshots, in your window switcher and in a screen share."
 msgstr "Solo mentre sta guardando un'altra scheda, e solo per qualche secondo. Il titolo della scheda compare anche negli screenshot, nel selettore di finestre e in una condivisione dello schermo."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:101
+#: lib/vutuv_web/gettext_extraction_anchors.ex:106
 #, elixir-autogen, elixir-format
 msgid "Tease new posts in the browser tab"
 msgstr "Anticipa i nuovi post nella scheda del browser"
@@ -23216,7 +23204,7 @@ msgstr "Solo questi account (vuoto = tutti) …"
 msgid "only %{account}"
 msgstr "solo %{account}"
 
-#: lib/vutuv_web/components/post_components.ex:7492
+#: lib/vutuv_web/components/post_components.ex:7499
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -23231,7 +23219,7 @@ msgid_plural "%{formatted} shares"
 msgstr[0] "%{formatted} condivisione"
 msgstr[1] "%{formatted} condivisioni"
 
-#: lib/vutuv_web/controllers/post_calendar_controller.ex:136
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:141
 #: lib/vutuv_web/live/notification_live/index.ex:821
 #, elixir-autogen, elixir-format
 msgid "Post without text"
@@ -23279,18 +23267,18 @@ msgid "Nothing matches."
 msgstr "Nessun risultato."
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:336
-#: lib/vutuv_web/live/post_live/composer.ex:2130
-#: lib/vutuv_web/live/post_live/composer.ex:3132
+#: lib/vutuv_web/live/post_live/composer.ex:2159
+#: lib/vutuv_web/live/post_live/composer.ex:3193
 #, elixir-autogen, elixir-format
 msgid "Automatic"
 msgstr "Automatico"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2135
+#: lib/vutuv_web/live/post_live/composer.ex:2164
 #, elixir-autogen, elixir-format
 msgid "Drag one photo onto another to swap them."
 msgstr "Trascina una foto su un'altra per scambiarle."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2082
+#: lib/vutuv_web/live/post_live/composer.ex:2111
 #, elixir-autogen, elixir-format
 msgid "Not shown in the gallery — drag one into it to swap."
 msgstr "Non nella galleria — trascinane una dentro per scambiarla."
@@ -23347,17 +23335,17 @@ msgstr "Ritirare davvero la richiesta?"
 msgid "Unmute %{host}"
 msgstr "Riattiva %{host}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1890
+#: lib/vutuv_web/live/post_live/composer.ex:1919
 #, elixir-autogen, elixir-format
 msgid "Draft discarded."
 msgstr "Bozza eliminata."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1929
+#: lib/vutuv_web/live/post_live/composer.ex:1958
 #, elixir-autogen, elixir-format
 msgid "Keep it"
 msgstr "Conserva"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1920
+#: lib/vutuv_web/live/post_live/composer.ex:1949
 #, elixir-autogen, elixir-format
 msgid "Keep this draft for later?"
 msgstr "Conservare questa bozza per dopo?"
@@ -23389,7 +23377,7 @@ msgstr "Impostazioni della larghezza di banda salvate."
 msgid "If you are on a slow or metered connection, vutuv can leave out the parts of the page that cost the most to download."
 msgstr "Se la Sua connessione è lenta o a consumo, vutuv può tralasciare le parti della pagina che pesano di più da scaricare."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:107
+#: lib/vutuv_web/gettext_extraction_anchors.ex:112
 #, elixir-autogen, elixir-format
 msgid "Low-bandwidth mode"
 msgstr "Modalità risparmio dati"
@@ -23470,7 +23458,7 @@ msgstr "Regole che riscrivono il testo dei post di un account prima che Lei li l
 
 #: lib/vutuv_web/components/post_components.ex:1456
 #: lib/vutuv_web/components/post_components.ex:3406
-#: lib/vutuv_web/components/post_components.ex:4658
+#: lib/vutuv_web/components/post_components.ex:4665
 #: lib/vutuv_web/components/ui.ex:5541
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
@@ -23557,7 +23545,7 @@ msgstr "Aspetto"
 msgid "About %{minutes} min of video"
 msgstr "Circa %{minutes} min di video"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2634
+#: lib/vutuv_web/live/post_live/composer.ex:2695
 #, elixir-autogen, elixir-format
 msgid "Add video"
 msgstr "Aggiungi video"
@@ -23594,37 +23582,37 @@ msgstr[1] "La nostra IA lo sta controllando, %{done} di %{total} fotogrammi veri
 msgid "Reading the frames"
 msgstr "Lettura dei fotogrammi"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2670
+#: lib/vutuv_web/live/post_live/composer.ex:2731
 #, elixir-autogen, elixir-format
 msgid "Remove it to post the text without it, or pick another file."
 msgstr "Lo rimuova per pubblicare il testo senza video, oppure scelga un altro file."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1195
+#: lib/vutuv_web/live/post_live/composer.ex:1224
 #, elixir-autogen, elixir-format
 msgid "Remove the refused video to post the text without it."
 msgstr "Rimuova il video rifiutato per pubblicare il testo senza di esso."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2699
+#: lib/vutuv_web/live/post_live/composer.ex:2760
 #, elixir-autogen, elixir-format
 msgid "Remove video"
 msgstr "Rimuovi video"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2709
+#: lib/vutuv_web/live/post_live/composer.ex:2770
 #, elixir-autogen, elixir-format
 msgid "Tap a frame to make it the cover."
 msgstr "Tocchi un fotogramma per usarlo come copertina."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1062
+#: lib/vutuv_web/live/post_live/composer.ex:1081
 #, elixir-autogen, elixir-format
 msgid "That frame could not be used."
 msgstr "Questo fotogramma non può essere usato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1520
+#: lib/vutuv_web/live/post_live/composer.ex:1549
 #, elixir-autogen, elixir-format
 msgid "The video could not be attached."
 msgstr "Il video non può essere allegato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1607
+#: lib/vutuv_web/live/post_live/composer.ex:1636
 #, elixir-autogen, elixir-format
 msgid "The video is longer than %{seconds} seconds."
 msgstr "Il video dura più di %{seconds} secondi."
@@ -23645,17 +23633,17 @@ msgstr "Questo video non può essere convertito."
 #: lib/vutuv_web/agent_docs/text.ex:919
 #: lib/vutuv_web/components/post_components.ex:2981
 #: lib/vutuv_web/components/video_components.ex:126
-#: lib/vutuv_web/live/post_live/composer.ex:2633
+#: lib/vutuv_web/live/post_live/composer.ex:2694
 #, elixir-autogen, elixir-format
 msgid "Video"
 msgstr "Video"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2677
+#: lib/vutuv_web/live/post_live/composer.ex:2738
 #, elixir-autogen, elixir-format
 msgid "Video description"
 msgstr "Descrizione del video"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1614
+#: lib/vutuv_web/live/post_live/composer.ex:1643
 #, elixir-autogen, elixir-format
 msgid "Videos cannot be uploaded here."
 msgstr "Qui non è possibile caricare video."
@@ -23665,12 +23653,12 @@ msgstr "Qui non è possibile caricare video."
 msgid "Waiting in line"
 msgstr "In attesa in coda"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2684
+#: lib/vutuv_web/live/post_live/composer.ex:2745
 #, elixir-autogen, elixir-format
 msgid "What is in the video, for people who cannot watch it"
 msgstr "Cosa mostra il video, per chi non può guardarlo"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2673
+#: lib/vutuv_web/live/post_live/composer.ex:2734
 #, elixir-autogen, elixir-format
 msgid "You can post now — the post appears as soon as the video is ready."
 msgstr "Può pubblicare subito: il post apparirà appena il video sarà pronto."
@@ -23701,7 +23689,7 @@ msgstr[1] "%{formatted} nuovi follower"
 msgid "Last 30 days: %{parts}"
 msgstr "Ultimi 30 giorni: %{parts}"
 
-#: lib/vutuv_web/components/post_components.ex:5220
+#: lib/vutuv_web/components/post_components.ex:5227
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Less"
@@ -23797,7 +23785,7 @@ msgstr[1] "%{formatted} nuovi post nel tuo feed"
 msgid "Can be changed at any time."
 msgstr "Si possono cambiare in qualsiasi momento."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:108
+#: lib/vutuv_web/gettext_extraction_anchors.ex:113
 #, elixir-autogen, elixir-format
 msgid "For members on a slow connection."
 msgstr "Per chi ha una connessione lenta."
@@ -24016,7 +24004,7 @@ msgid "Hidden. What they pass on stays out of your feed; their own posts do not.
 msgstr "Nascosto. Ciò che questo account ripubblica non compare più nel Suo feed, i suoi post sì."
 
 #: lib/vutuv_web/components/post_components.ex:3378
-#: lib/vutuv_web/components/post_components.ex:4652
+#: lib/vutuv_web/components/post_components.ex:4659
 #, elixir-autogen, elixir-format
 msgid "Hide reposts"
 msgstr "Nascondi le ripubblicazioni"
@@ -24130,7 +24118,8 @@ msgstr[1] ""
 msgid "Post calendar"
 msgstr ""
 
-#: lib/vutuv_web/controllers/post_calendar_controller.ex:126
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:131
+#: lib/vutuv_web/post_teaser.ex:187
 #, elixir-autogen, elixir-format
 msgid "Post not open to search engines"
 msgstr ""
@@ -24160,7 +24149,7 @@ msgstr ""
 msgid "The posts written that month, by day."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:89
+#: lib/vutuv_web/gettext_extraction_anchors.ex:94
 #, elixir-autogen, elixir-format
 msgid "Feed length"
 msgstr ""
@@ -24180,7 +24169,7 @@ msgstr "Impostazioni del feed salvate."
 msgid "How many load at once, and how many “Load more” adds"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:91
+#: lib/vutuv_web/gettext_extraction_anchors.ex:96
 #, elixir-autogen, elixir-format
 msgid "How many posts your feed shows before the “Load more” button, and how many that button adds. More posts mean a longer wait for the page."
 msgstr ""
@@ -24192,7 +24181,7 @@ msgstr ""
 msgid "Posts in your feed"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:90
+#: lib/vutuv_web/gettext_extraction_anchors.ex:95
 #, elixir-autogen, elixir-format
 msgid "Posts loaded at once"
 msgstr ""
@@ -24213,13 +24202,13 @@ msgstr ""
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7483
-#: lib/vutuv_web/components/post_components.ex:7484
+#: lib/vutuv_web/components/post_components.ex:7490
+#: lib/vutuv_web/components/post_components.ex:7491
 #, elixir-autogen, elixir-format
 msgid "A word or phrase …"
 msgstr "Una parola o un'espressione …"
 
-#: lib/vutuv_web/components/post_components.ex:7511
+#: lib/vutuv_web/components/post_components.ex:7518
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr "Per chi %{thing} viene nascosto"
@@ -24236,7 +24225,7 @@ msgstr "Nascosti"
 msgid "Hide something from your feed"
 msgstr "Nascondi qualcosa dal tuo feed"
 
-#: lib/vutuv_web/components/post_components.ex:7429
+#: lib/vutuv_web/components/post_components.ex:7436
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr "Non mostrare più"
@@ -24251,22 +24240,22 @@ msgstr "Ciò che corrisponde viene ridotto a una riga nel tuo feed."
 msgid "Words & tags"
 msgstr "Parole e tag"
 
-#: lib/vutuv_web/components/post_components.ex:7515
+#: lib/vutuv_web/components/post_components.ex:7522
 #, elixir-autogen, elixir-format
 msgid "everyone"
 msgstr "per tutti"
 
-#: lib/vutuv_web/components/post_components.ex:7518
+#: lib/vutuv_web/components/post_components.ex:7525
 #, elixir-autogen, elixir-format
 msgid "only %{handle}"
 msgstr "solo %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:7487
+#: lib/vutuv_web/components/post_components.ex:7494
 #, elixir-autogen, elixir-format
 msgid "this word"
 msgstr "questa parola"
 
-#: lib/vutuv_web/components/post_components.ex:7528
+#: lib/vutuv_web/components/post_components.ex:7535
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr "solo %{server}"
@@ -24318,7 +24307,7 @@ msgstr "Questo sito è offline in questo momento."
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr "Il sito funziona, è questo indirizzo a non essere uno dei nostri. Probabilmente il link è vecchio oppure contiene un errore di battitura."
 
-#: lib/vutuv_web/components/post_components.ex:6833
+#: lib/vutuv_web/components/post_components.ex:6840
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr "Ingrandisci lo screenshot"
@@ -24409,7 +24398,7 @@ msgid "Hidden. What other people pass on of them stays out of your feed; their o
 msgstr "Nascosto. Ciò che altri ripubblicano di questo account non compare più nel Suo feed, i suoi post sì."
 
 #: lib/vutuv_web/components/post_components.ex:3364
-#: lib/vutuv_web/components/post_components.ex:4640
+#: lib/vutuv_web/components/post_components.ex:4647
 #, elixir-autogen, elixir-format
 msgid "Hide when others repost them"
 msgstr "Nascondi quando altri lo ripubblicano"
@@ -24615,12 +24604,12 @@ msgstr ""
 " più tardi con un interruttore nelle impostazioni. Non ne facciamo una "
 "religione: ognuno come vuole."
 
-#: lib/vutuv_web/live/shell_live.ex:1824
+#: lib/vutuv_web/live/shell_live.ex:1825
 #, elixir-autogen, elixir-format
 msgid "All notifications"
 msgstr "Tutte le notifiche"
 
-#: lib/vutuv_web/live/shell_live.ex:1777
+#: lib/vutuv_web/live/shell_live.ex:1778
 #, elixir-autogen, elixir-format
 msgid "New notifications"
 msgstr "Nuove notifiche"
@@ -25171,13 +25160,13 @@ msgstr "il modulo di segnalazione"
 msgid "“%{note}”"
 msgstr "“%{note}”"
 
-#: lib/vutuv_web/components/post_components.ex:5398
-#: lib/vutuv_web/components/press_kit_components.ex:211
+#: lib/vutuv_web/components/post_components.ex:5405
+#: lib/vutuv_web/components/press_kit_components.ex:216
 #, elixir-autogen, elixir-format
 msgid "Show these photos larger"
 msgstr "Ingrandisci le foto"
 
-#: lib/vutuv_web/components/post_components.ex:5584
+#: lib/vutuv_web/components/post_components.ex:5591
 #, elixir-autogen, elixir-format
 msgid "Show this photo larger"
 msgstr "Ingrandisci la foto"
@@ -25267,7 +25256,7 @@ msgstr "Detengo i diritti su questo file e lo rilascio per uso editoriale, purch
 msgid "Light"
 msgstr "Chiaro"
 
-#: lib/vutuv/press_kit.ex:251
+#: lib/vutuv/press_kit.ex:321
 #, elixir-autogen, elixir-format
 msgid "Logo variant"
 msgstr "Variante del logo"
@@ -25316,7 +25305,7 @@ msgstr "Immagine rimossa."
 msgid "Please confirm the rights first, then choose the file."
 msgstr "Confermi prima i diritti e scelga poi il file."
 
-#: lib/vutuv/press_kit.ex:251
+#: lib/vutuv/press_kit.ex:321
 #, elixir-autogen, elixir-format
 msgid "Press photo"
 msgstr "Foto per la stampa"
@@ -25402,18 +25391,18 @@ msgstr[1] "%{count} byte"
 msgid "Credit: %{credit}"
 msgstr "Credito: %{credit}"
 
-#: lib/vutuv_web/components/press_kit_components.ex:375
-#: lib/vutuv_web/components/press_kit_components.ex:378
+#: lib/vutuv_web/components/press_kit_components.ex:380
+#: lib/vutuv_web/components/press_kit_components.ex:383
 #, elixir-autogen, elixir-format
 msgid "Download %{format}"
 msgstr "Scarica %{format}"
 
-#: lib/vutuv_web/components/press_kit_components.ex:331
+#: lib/vutuv_web/components/press_kit_components.ex:336
 #, elixir-autogen, elixir-format
 msgid "Download photo"
 msgstr "Scarica la foto"
 
-#: lib/vutuv/press_kit.ex:715
+#: lib/vutuv/press_kit.ex:785
 #, elixir-autogen, elixir-format
 msgid "Free for editorial use with credit."
 msgstr "Libera per uso editoriale, citando il credito."
@@ -25423,7 +25412,7 @@ msgstr "Libera per uso editoriale, citando il credito."
 msgid "PNG version"
 msgstr "Versione PNG"
 
-#: lib/vutuv_web/agent_docs/press_kit_doc.ex:55
+#: lib/vutuv_web/agent_docs/press_kit_doc.ex:58
 #, elixir-autogen, elixir-format
 msgid "Press pictures %{name} offers for download, free for editorial use with credit."
 msgstr "Immagini stampa che %{name} offre in download, libere per uso editoriale citando il credito."
@@ -25458,7 +25447,7 @@ msgstr "Usa il logo di questa pagina"
 msgid "What a journalist writing about this page may download: photos in print quality and its logo as a file. Everything here is public and free for editorial use as long as the credit is shown."
 msgstr "Ciò che una redazione che scrive di questa pagina può scaricare: foto in qualità di stampa e il suo logo come file. Tutto qui è pubblico e libero per uso editoriale, purché vengano indicati i crediti."
 
-#: lib/vutuv_web/components/press_kit_components.ex:565
+#: lib/vutuv_web/components/press_kit_components.ex:570
 #: lib/vutuv_web/components/ui.ex:3281
 #, elixir-autogen, elixir-format
 msgid "Report this picture"
@@ -25560,7 +25549,7 @@ msgid "nobody"
 msgstr "nessuno"
 
 #: lib/vutuv_web/components/press_kit_components.ex:120
-#: lib/vutuv_web/components/press_kit_components.ex:176
+#: lib/vutuv_web/components/press_kit_components.ex:181
 #, elixir-autogen, elixir-format
 msgid "All Media Kit files"
 msgstr "Tutto il Media Kit"
@@ -25580,7 +25569,7 @@ msgstr "Tutto il Media Kit"
 msgid "Media Kit"
 msgstr "Media Kit"
 
-#: lib/vutuv_web/agent_docs/press_kit_doc.ex:53
+#: lib/vutuv_web/agent_docs/press_kit_doc.ex:56
 #: lib/vutuv_web/views/press_kit_html.ex:32
 #, elixir-autogen, elixir-format
 msgid "Media Kit of %{name}"
@@ -25611,8 +25600,8 @@ msgstr "Non può aggiungere un'immagine a questo Media Kit."
 msgid "press kit media journalist photographer download original print logo svg credit copyright presse pressefotos pressemappe medienkit mediakit fotos logo herunterladen bildnachweis"
 msgstr "media kit mediakit kit stampa media redazione giornalista fotografo download originale stampa logo svg crediti copyright foto scaricare"
 
-#: lib/vutuv_web/components/post_components.ex:4556
-#: lib/vutuv_web/components/post_components.ex:4606
+#: lib/vutuv_web/components/post_components.ex:4563
+#: lib/vutuv_web/components/post_components.ex:4613
 #, elixir-autogen, elixir-format
 msgid "Copy link to post"
 msgstr "Copia il link al post"
@@ -25622,14 +25611,14 @@ msgstr "Copia il link al post"
 msgid "Link copied"
 msgstr "Link copiato"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2820
+#: lib/vutuv_web/live/post_live/composer.ex:2881
 #, elixir-autogen, elixir-format
 msgid "%{left} of today's %{limit} left (%{percent} %)."
 msgstr "Restano %{left} di %{limit} per oggi (%{percent} %)."
 
 #: lib/vutuv_web/live/message_live/index.ex:1291
 #: lib/vutuv_web/live/message_live/index.ex:1295
-#: lib/vutuv_web/live/post_live/composer.ex:2753
+#: lib/vutuv_web/live/post_live/composer.ex:2814
 #, elixir-autogen, elixir-format
 msgid "Add files"
 msgstr "Aggiungi file"
@@ -25639,12 +25628,12 @@ msgstr "Aggiungi file"
 msgid "File check"
 msgstr "Controllo file"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3517
+#: lib/vutuv_web/live/post_live/composer.ex:3578
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{size}."
 msgstr "Il file è più grande di %{size}."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2752
+#: lib/vutuv_web/live/post_live/composer.ex:2813
 #, elixir-autogen, elixir-format
 msgid "Files"
 msgstr "File"
@@ -25654,7 +25643,7 @@ msgstr "File"
 msgid "Files may be up to %{size}."
 msgstr "I file possono arrivare a %{size}."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3527
+#: lib/vutuv_web/live/post_live/composer.ex:3588
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} files per post."
 msgstr "Non più di %{max} file per post."
@@ -25671,7 +25660,7 @@ msgstr "Su questo sito i PDF non possono essere controllati, i file di testo e M
 
 #: lib/vutuv_web/live/message_live/index.ex:1270
 #: lib/vutuv_web/live/message_live/index.ex:1271
-#: lib/vutuv_web/live/post_live/composer.ex:2799
+#: lib/vutuv_web/live/post_live/composer.ex:2860
 #, elixir-autogen, elixir-format
 msgid "Remove %{name}"
 msgstr "Rimuovi %{name}"
@@ -25696,7 +25685,7 @@ msgstr "Ha esaurito il Suo limite di caricamento per questo mese."
 msgid "You have used up today's upload allowance. It frees up again over the day."
 msgstr "Ha esaurito il Suo limite di caricamento per oggi. Si libera di nuovo nel corso della giornata."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2818
+#: lib/vutuv_web/live/post_live/composer.ex:2879
 #, elixir-autogen, elixir-format
 msgid "Your uploads are not limited."
 msgstr "I Suoi caricamenti non hanno limiti."
@@ -25715,7 +25704,7 @@ msgstr "Un paragrafo con cui un articolo può chiudersi."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:121
 #: lib/vutuv_web/agent_docs/text.ex:412
-#: lib/vutuv_web/components/press_kit_components.ex:269
+#: lib/vutuv_web/components/press_kit_components.ex:274
 #, elixir-autogen, elixir-format
 msgid "About %{name}"
 msgstr "Su %{name}"
@@ -25740,12 +25729,12 @@ msgstr "Una @handle rimanda a quel profilo e non avvisa nessuno."
 msgid "As long as you like. The whole portrait."
 msgstr "Lunga quanto vuole. Il ritratto completo."
 
-#: lib/vutuv/press_kit.ex:460
+#: lib/vutuv/press_kit.ex:530
 #, elixir-autogen, elixir-format
 msgid "Long version"
 msgstr "Versione lunga"
 
-#: lib/vutuv/press_kit.ex:459
+#: lib/vutuv/press_kit.ex:529
 #, elixir-autogen, elixir-format
 msgid "Medium version"
 msgstr "Versione media"
@@ -25755,12 +25744,12 @@ msgstr "Versione media"
 msgid "Nothing written yet."
 msgstr "Non ha ancora scritto nulla."
 
-#: lib/vutuv/press_kit.ex:458
+#: lib/vutuv/press_kit.ex:528
 #, elixir-autogen, elixir-format
 msgid "Short version"
 msgstr "Versione breve"
 
-#: lib/vutuv_web/components/press_kit_components.ex:272
+#: lib/vutuv_web/components/press_kit_components.ex:277
 #, elixir-autogen, elixir-format
 msgid "Take whichever length fits the space you have. Each one stands on its own."
 msgstr "Prenda la lunghezza che entra nello spazio che ha. Ognuna sta in piedi da sola."
@@ -25789,13 +25778,6 @@ msgstr "Scrivi"
 #, elixir-autogen, elixir-format
 msgid "File preview pages"
 msgstr "Anteprima file"
-
-#: lib/vutuv_web/live/shell_live.ex:1742
-#, elixir-autogen, elixir-format
-msgid "%{count} post is being prepared"
-msgid_plural "%{count} posts are being prepared"
-msgstr[0] "%{count} post è in preparazione"
-msgstr[1] "%{count} post sono in preparazione"
 
 #: lib/vutuv_web/live/uploads_live.ex:173
 #, elixir-autogen, elixir-format
@@ -26178,3 +26160,52 @@ msgstr "Non è stato possibile leggere questa immagine."
 #, elixir-autogen, elixir-format
 msgid "You can only send files to members you are connected with."
 msgstr "Può inviare file solo ai membri con cui è in contatto."
+
+#: lib/vutuv_web/live/shell_live.ex:1743
+#, elixir-autogen, elixir-format
+msgid "%{formatted} post is being prepared"
+msgid_plural "%{formatted} posts are being prepared"
+msgstr[0] "%{formatted} post in preparazione"
+msgstr[1] "%{formatted} post in preparazione"
+
+#: lib/vutuv_web/live/post_live/composer.ex:2312
+#, elixir-autogen, elixir-format
+msgid "Remove the metadata from the files"
+msgstr "Rimuovi i metadati dai file"
+
+#: lib/vutuv_web/components/ui.ex:5622
+#, elixir-autogen, elixir-format
+msgid "Search engines and AI, your posts, online status"
+msgstr "Motori di ricerca e IA, i Suoi post, stato online"
+
+#: lib/vutuv_web/templates/settings/privacy.html.heex:93
+#, elixir-autogen, elixir-format
+msgid "Whether search engines and AI may read what you post. Each post keeps the answer it was published with, so changing this leaves everything you have already written exactly as it is."
+msgstr "Se i motori di ricerca e l'IA possono leggere ciò che pubblica. Ogni post conserva la risposta con cui è stato pubblicato, quindi cambiare qui non tocca nulla di quanto ha già scritto."
+
+#: lib/vutuv_web/live/post_live/composer.ex:2314
+#, elixir-autogen, elixir-format
+msgid "Your name, the software you used and the dates come out of a PDF."
+msgstr "Il Suo nome, il software che ha usato e le date escono dal PDF."
+
+#: lib/vutuv_web/templates/settings/privacy.html.heex:91
+#, elixir-autogen, elixir-format
+msgid "Your posts"
+msgstr "I Suoi post"
+
+#: lib/vutuv_web/components/ui.ex:5624
+#, elixir-autogen, elixir-format
+msgid "privacy google search engine ai llm crawler noindex online dot public posts beiträge indexieren fediverse mastodon suchmaschine"
+msgstr ""
+"privacy google motore di ricerca ia llm crawler noindex online pallino "
+"pubblico post indicizzare fediverse mastodon"
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:81
+#, elixir-autogen, elixir-format
+msgid "Covers the words, the pictures, the files and the machine formats of every post you write from now on. When off, your new posts also stay out of other networks completely: a server elsewhere keeps its copy for good and no instruction of ours reaches it. Posts you have already published keep the answer they went out with."
+msgstr "Vale per il testo, le immagini, i file e i formati per macchine di ogni post che scriverà da ora in poi. Disattivato, i Suoi nuovi post restano anche del tutto fuori dalle altre reti: un server altrove tiene la sua copia per sempre e nessuna nostra istruzione lo raggiunge. I post già pubblicati conservano la risposta con cui sono usciti."
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:80
+#, elixir-autogen, elixir-format
+msgid "Search engines and AI may read my posts"
+msgstr "I motori di ricerca e l'IA possono leggere i miei post"

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -6486,7 +6486,7 @@ msgstr ""
 msgid "Endorsed"
 msgstr "Confermato"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:141
+#: lib/vutuv_web/agent_docs/list_docs.ex:143
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "Members who endorsed %{name} for %{tag}"
@@ -8807,7 +8807,7 @@ msgstr "Non valido"
 msgid "Invalid address (skipped)"
 msgstr "Indirizzo non valido (saltato)"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:180
+#: lib/vutuv_web/agent_docs/list_docs.ex:182
 #: lib/vutuv_web/controllers/directory_controller.ex:54
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
@@ -8823,7 +8823,7 @@ msgstr "Elenco dei membri"
 msgid "Members by initial"
 msgstr "Membri per iniziale"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:203
+#: lib/vutuv_web/agent_docs/list_docs.ex:205
 #: lib/vutuv_web/controllers/directory_controller.ex:86
 #: lib/vutuv_web/templates/directory/show.html.heex:2
 #, elixir-autogen, elixir-format
@@ -8842,7 +8842,7 @@ msgid_plural "%{formatted} members"
 msgstr[0] "Un membro"
 msgstr[1] "%{formatted} membri"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:209
+#: lib/vutuv_web/agent_docs/list_docs.ex:211
 #, elixir-autogen, elixir-format
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr "La pagina %{letter} dell'elenco dei membri, ordinata per cognome."
@@ -22729,7 +22729,7 @@ msgstr "Quali nomi cercare"
 msgid "All vutuv members, filed alphabetically by last name."
 msgstr "Tutti i membri vutuv, in ordine alfabetico per cognome."
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:195
+#: lib/vutuv_web/agent_docs/list_docs.ex:197
 #, elixir-autogen, elixir-format
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr "Tutti i membri vutuv, raggruppati per la prima lettera del cognome."
@@ -24106,8 +24106,8 @@ msgid_plural "%{formatted} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:253
-#: lib/vutuv_web/agent_docs/list_docs.ex:285
+#: lib/vutuv_web/agent_docs/list_docs.ex:255
+#: lib/vutuv_web/agent_docs/list_docs.ex:287
 #: lib/vutuv_web/controllers/post_calendar_controller.ex:36
 #: lib/vutuv_web/templates/layout/app.html.heex:79
 #: lib/vutuv_web/templates/post_calendar/day.html.heex:5
@@ -24119,7 +24119,7 @@ msgid "Post calendar"
 msgstr ""
 
 #: lib/vutuv_web/controllers/post_calendar_controller.ex:131
-#: lib/vutuv_web/post_teaser.ex:187
+#: lib/vutuv_web/post_teaser.ex:211
 #, elixir-autogen, elixir-format
 msgid "Post not open to search engines"
 msgstr ""
@@ -24139,12 +24139,12 @@ msgstr ""
 msgid "Posts on %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:286
+#: lib/vutuv_web/agent_docs/list_docs.ex:288
 #, elixir-autogen, elixir-format
 msgid "The posts written that day."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:254
+#: lib/vutuv_web/agent_docs/list_docs.ex:256
 #, elixir-autogen, elixir-format
 msgid "The posts written that month, by day."
 msgstr ""

--- a/priv/repo/migrations/20260911052615_add_machine_reading_switches.exs
+++ b/priv/repo/migrations/20260911052615_add_machine_reading_switches.exs
@@ -1,0 +1,62 @@
+defmodule Vutuv.Repo.Migrations.AddMachineReadingSwitches do
+  use Ecto.Migration
+
+  # Issue #2107: one member-level decision about machines, stamped onto every
+  # post as it is published, plus the composer's file question.
+  #
+  # `users.posts_machines_allowed?` is a `Vutuv.Prefs` key, so it follows that
+  # layer's shape exactly: **nullable, no database default**. NULL means "never
+  # asked, inherit the installation default" and is what distinguishes it from
+  # a member who deliberately chose the shipped value — which is the whole
+  # reason an operator can move the default later without touching 6,000 rows.
+  #
+  # `posts.noindex_noai?` is the member's answer **frozen at publish time**,
+  # true meaning no machines. Not read back from the member afterwards: a post
+  # keeps what it went out with, so changing the setting leaves every older
+  # post exactly as it was. `false` is what every post written so far means —
+  # nobody was asked, and a backfill to "no" would have withdrawn six years of
+  # posts from search and from every server that already holds a copy.
+  #
+  # `posts.strip_metadata?` is the composer's own switch, the author's *answer*
+  # about their files rather than a record of what happened — that is
+  # `attachments.metadata_stripped_at`, written by the qpdf run itself. It
+  # defaults to `true` (the switch's own default) so a post inserted by the
+  # previous release during the blue/green overlap carries the answer the
+  # composer would have sent.
+  #
+  # All five columns are plain additions, so the deployed release keeps reading
+  # and writing these tables without naming any of them (N-1). The overlap
+  # window is not merely short, it is **empty**: nothing writes
+  # `users.posts_machines_allowed?` before this release, so no post the old slot
+  # inserts during the switch can carry a member's "no" that the column default
+  # would then contradict.
+  def change do
+    alter table(:users) do
+      add(:posts_machines_allowed?, :boolean)
+    end
+
+    alter table(:posts) do
+      add(:noindex_noai?, :boolean, default: false, null: false)
+      add(:strip_metadata?, :boolean, default: true, null: false)
+    end
+
+    # The file question travels through the draft, so a reload brings it back
+    # beside the words it was chosen with. Nullable, unlike the post's column:
+    # a draft written before this deploy has no answer, and the composer must
+    # fall back to its own default rather than to a stored `false` nobody
+    # chose. The machines question has no draft column on purpose — it is not
+    # asked in the composer any more.
+    alter table(:post_drafts) do
+      add(:strip_metadata?, :boolean)
+    end
+
+    # When this file's served copy was rewritten without its metadata. NULL
+    # means "still verbatim" — either qpdf is not on this box, the file is not
+    # a PDF, or the author asked for the metadata to stay. The column is the
+    # only thing that can tell "cleaned" from "never asked" once the bytes are
+    # on disk, which is what lets the answer be changed later without guessing.
+    alter table(:attachments) do
+      add(:metadata_stripped_at, :utc_datetime)
+    end
+  end
+end

--- a/test/support/attachment_fixtures.ex
+++ b/test/support/attachment_fixtures.ex
@@ -156,6 +156,21 @@ defmodule Vutuv.AttachmentFixtures do
     write(dir, "multi-#{count}.pdf", multi_page(count))
   end
 
+  @doc """
+  A PDF carrying its author's name, the software that wrote it and its dates
+  in **both** places a PDF keeps them (issue #2107): the trailer's `/Info`
+  dictionary and an XMP metadata packet on the catalog. Stripping only one of
+  the two leaves the name in the file, which is what makes a fixture with both
+  worth building.
+  """
+  def metadata_pdf(dir), do: write(dir, "metadata.pdf", pdf(:metadata))
+
+  @doc "The name that fixture puts in every metadata field."
+  def metadata_author, do: "Erika Mustermann"
+
+  @doc "The software that fixture claims wrote it."
+  def metadata_software, do: "SecretWriter 9.1"
+
   @doc "A plain text file."
   def text_file(dir, body \\ "Just some notes.\nOn two lines.\n"),
     do: write(dir, "notes.txt", body)
@@ -166,6 +181,22 @@ defmodule Vutuv.AttachmentFixtures do
   @doc "A file of `bytes` zero bytes under a `.txt` name."
   def sized_file(dir, bytes, name \\ "big.txt"),
     do: write(dir, name, :binary.copy("a", bytes))
+
+  @doc """
+  A throwaway uploads root for one test, pointed at by `:uploads_dir_prefix`
+  and removed on exit, plus the `files/` directory the fixtures are built in.
+  Answers `%{tmp:, files:}`, so a `setup` block merges it straight into the
+  context. Every attachment suite needs the same five lines; this is them.
+  """
+  def tmp_uploads_dir do
+    tmp = Path.join(System.tmp_dir!(), "vutuv_uploads_#{System.unique_integer([:positive])}")
+    files = Path.join(tmp, "files")
+    File.mkdir_p!(files)
+    Vutuv.WebPushHelpers.put_config(:uploads_dir_prefix, tmp)
+    ExUnit.Callbacks.on_exit(fn -> File.rm_rf(tmp) end)
+
+    %{tmp: tmp, files: files}
+  end
 
   @doc """
   Sets keys of `:attachments` for the rest of the test module (restored on
@@ -221,9 +252,14 @@ defmodule Vutuv.AttachmentFixtures do
         {4, "<< /Length #{byte_size(@content)} >>\nstream\n#{@content}\nendstream"},
         {5, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>"}
         | extra
-      ] ++ more
+      ] ++ more,
+      trailer_extra(kind)
     )
   end
+
+  # Only the metadata fixture needs anything past /Root in the trailer.
+  defp trailer_extra(:metadata), do: " /Info 7 0 R"
+  defp trailer_extra(_kind), do: ""
 
   # The page dictionary. `:page_action` hangs an additional action off it, which
   # is where a launch goes when there is no `/OpenAction` to put it in.
@@ -289,6 +325,33 @@ defmodule Vutuv.AttachmentFixtures do
 
   defp catalog(:page_action), do: {"<< /Type /Catalog /Pages 2 0 R >>", []}
 
+  # The author's name, the software and the dates, in both of the two places a
+  # PDF keeps them: the XMP packet hanging off the catalog (object 6) and the
+  # /Info dictionary the trailer points at (object 7).
+  defp catalog(:metadata) do
+    xmp = """
+    <?xpacket begin="" id="W5M0MpCehiHzreSzNTczkc9d"?>
+    <x:xmpmeta xmlns:x="adobe:ns:meta/"><rdf:RDF \
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/" \
+    xmlns:xmp="http://ns.adobe.com/xap/1.0/">
+    <dc:creator><rdf:Seq><rdf:li>#{metadata_author()}</rdf:li></rdf:Seq></dc:creator>
+    <xmp:CreatorTool>#{metadata_software()}</xmp:CreatorTool>
+    <xmp:CreateDate>2026-01-02T03:04:05Z</xmp:CreateDate>
+    </rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="w"?>
+    """
+
+    {"<< /Type /Catalog /Pages 2 0 R /Metadata 6 0 R >>",
+     [
+       {6,
+        "<< /Type /Metadata /Subtype /XML /Length #{byte_size(xmp)} >>\nstream\n#{xmp}\nendstream"},
+       {7,
+        "<< /Author (#{metadata_author()}) /Creator (#{metadata_software()}) " <>
+          "/Producer (#{metadata_software()}) /Title (Interne Preisliste) " <>
+          "/CreationDate (D:20260102030405Z) /ModDate (D:20260102030405Z) >>"}
+     ]}
+  end
+
   # 9 MB of filler in the catalog, so the object stream qpdf builds from it
   # inflates past `PdfGate`'s per-stream cut. The padding compresses to nothing,
   # which is what makes the finished file ~10 KB.
@@ -310,7 +373,7 @@ defmodule Vutuv.AttachmentFixtures do
   # Serialises numbered objects with a cross-reference table. Nothing clever:
   # the offsets have to be right or poppler will not read the file, which is
   # what makes these fixtures worth having.
-  defp build(objects) do
+  defp build(objects, trailer_extra \\ "") do
     objects = Enum.sort_by(objects, &elem(&1, 0))
 
     {body, offsets} =
@@ -332,6 +395,6 @@ defmodule Vutuv.AttachmentFixtures do
     body <>
       "xref\n0 #{size}\n0000000000 65535 f \n" <>
       entries <>
-      "trailer\n<< /Size #{size} /Root 1 0 R >>\nstartxref\n#{byte_size(body)}\n%%EOF\n"
+      "trailer\n<< /Size #{size} /Root 1 0 R#{trailer_extra} >>\nstartxref\n#{byte_size(body)}\n%%EOF\n"
   end
 end

--- a/test/vutuv/post_body_chokepoint_test.exs
+++ b/test/vutuv/post_body_chokepoint_test.exs
@@ -1,0 +1,195 @@
+defmodule Vutuv.PostBodyChokepointTest do
+  @moduledoc """
+  **The invariant: a post's body leaves the database toward a surface a machine
+  can read only through a query that asked `machines_allowed?`** (issue #2107).
+
+  Three review rounds found three more leaks, each one complete when it was
+  measured and each one missing the next: round 1 the archive, the tag pages and
+  the calendar; round 2 the conversation, the reply, the repost and the profile
+  document; round 3 the profile HTML's who-to-follow rail and its pinned card.
+  The sites cannot be enumerated by hand — there is no list, only a property —
+  and the last pair proved it twice over: `recent_posts_by_authors/3` selects
+  `body:` into **bare maps**, which no struct-taking helper could ever have
+  reached, and `pinned_post/2` fetches by id rather than through a timeline, so
+  no listing gate applied.
+
+  So the property is enforced here instead, the way `Vutuv.SchemaUuidChokepointTest`
+  and `Vutuv.Notifications.MailerChokepointTest` enforce theirs: read the source,
+  collect what breaks the rule, and fail the build with the offenders named.
+
+  **An exception is explicit and carries its reason.** A surface that shows the
+  text to a **person** on purpose is listed in `@deliberate` below with why; the
+  silent absence of a check is what this test exists to stop.
+  """
+  use ExUnit.Case, async: true
+
+  # The whole context layer, not just `posts.ex`: a query carrying a body could
+  # be written in any of these, and the census that drove this test found the
+  # one outside `posts.ex` (`Vutuv.Mentions`) only by looking at all of them.
+  @context "lib/vutuv/*.ex"
+  @agent_docs "lib/vutuv_web/agent_docs"
+
+  # A body-selecting query that is **not** a leak, each with its reason. Two
+  # shapes, and they are different reasons rather than one loose "allowed":
+  # a body nothing renders, and a body that is not a post's at all.
+  @exempt_queries %{
+    "mentions.ex" =>
+      "counts how many posts name a handle (Enum.count over the rows); the body " <>
+        "is never returned, never rendered and never reaches a template",
+    "chat.ex" =>
+      "a private message between two members, not a post: `Vutuv.Chat.Message` " <>
+        "carries no `noindex_noai?`, and no machine reads a direct message"
+  }
+
+  # The two spellings of the gate. `scope_machines_for/2` is the one to reach
+  # for (it keeps a member's own posts for them); `scope_machines_allowed/1` is
+  # its anonymous case, for a query with no viewer to make an exception for.
+  @gates ["scope_machines_for(", "scope_machines_allowed("]
+
+  # Documents whose **subject** post keeps its body, deliberately.
+  #
+  # A permalink document is one post's own document, and it carries that post's
+  # answer in its own headers: a withheld post's `.md`/`.txt`/`.json`/`.xml`
+  # sibling is served with `noindex, noai, noimageai` and an all-no
+  # `Content-Signal`, which is exactly the shape a member-level opt-out already
+  # has. What the switch is about is a **list** — an archive, a tag page, a
+  # profile, a conversation — which carries one all-yes signal for many rows and
+  # cannot signal per row. So the subject stays and the neighbours are redacted.
+  @deliberate %{
+    {"post_doc.ex", 95} => "the permalink doc's own subject post; its headers carry the answer",
+    {"post_doc.ex", 98} => "same document, the subject's body",
+    {"post_doc.ex", 103} => "link extraction from the subject's body, not text output",
+    {"post_doc.ex", 217} => "the organization permalink doc's own subject post",
+    {"post_doc.ex", 220} => "same document, the subject's body",
+    {"organization_doc.ex", 121} =>
+      "a page's post listing, already gated in the query by scope_machines_for_page/3"
+  }
+
+  test "every query that selects a post body pipes through the machines gate" do
+    offenders =
+      body_selecting_functions()
+      |> Enum.reject(fn {file, _name, body} ->
+        Map.has_key?(@exempt_queries, file) or Enum.any?(@gates, &String.contains?(body, &1))
+      end)
+      |> Enum.map(fn {file, name, _body} -> "#{file} #{name}/?" end)
+
+    assert offenders == [],
+           """
+           These functions under lib/vutuv/ select a post's `body` and do not pipe
+           the query through `Vutuv.Posts.scope_machines_for/2` (or its anonymous
+           case `scope_machines_allowed/1`):
+
+             #{Enum.join(offenders, "\n  ")}
+
+           A post whose author keeps search engines and AI out (issue #2107) must not
+           reach a page a crawler reads. `scope_visible/2` answers a different
+           question — may this VIEWER see it — and a withheld post is public, it is
+           simply not for machines. Pipe through the gate, or, if the surface shows
+           the text to a person on purpose, say so where the query is built.
+           """
+  end
+
+  # Calibration, the line `Vutuv.SchemaUuidChokepointTest` calls the most
+  # important one it has: if the scanner stops finding the queries it is meant
+  # to judge, the assertion above passes while testing nothing at all. The
+  # census behind this test counted **three** such functions across `lib/vutuv/`
+  # — `Posts.fetch_recent_posts/4`, `Mentions.count_post_mentions/1` and one in
+  # `Chat` — so the floor is the whole population, not a guess.
+  test "the scanner still finds the body-selecting queries it judges" do
+    found = body_selecting_functions()
+
+    assert length(found) >= 3,
+           "expected at least the three known body-selecting queries " <>
+             "(Posts.fetch_recent_posts/4, Mentions.count_post_mentions/1, Chat), found " <>
+             "#{length(found)}: #{inspect(Enum.map(found, fn {f, n, _} -> "#{f} #{n}" end))}. " <>
+             "The scanner has stopped measuring, so the guard above is vacuous."
+  end
+
+  test "no agent document quotes a local post's body without the machine gate" do
+    offenders =
+      Path.wildcard(Path.join(@agent_docs, "*.ex"))
+      |> Enum.flat_map(&body_reads/1)
+      |> Enum.reject(fn {file, line, _text} -> Map.has_key?(@deliberate, {file, line}) end)
+
+    assert offenders == [],
+           """
+           These lines under #{@agent_docs}/ read a local post's body or teaser
+           without going through `VutuvWeb.PostTeaser.machine_line/2` or
+           `machine_body/2`:
+
+             #{Enum.map_join(offenders, "\n  ", fn {f, l, t} -> "#{f}:#{l}  #{t}" end)}
+
+           An agent document IS the machine surface. Either route it through the
+           machine-audience half of `VutuvWeb.PostTeaser`, or add the line to
+           `@deliberate` in this file **with the reason it may show the words** —
+           a silent missing check is what this guard exists to catch.
+
+           Note the line numbers in `@deliberate` move when the file does; a
+           failure naming a line that looks right is usually that, and the fix is
+           to re-read the line rather than to widen the rule.
+           """
+  end
+
+  defp body_selecting_functions do
+    @context
+    |> Path.wildcard()
+    |> Enum.flat_map(fn path ->
+      file = Path.basename(path)
+
+      path
+      |> functions_of()
+      |> Enum.filter(fn {_name, body} -> selects_post_body?(body) end)
+      |> Enum.map(fn {name, body} -> {file, name, body} end)
+    end)
+  end
+
+  # A function is everything from one top-level `def`/`defp` to the next.
+  defp functions_of(path) do
+    path
+    |> File.read!()
+    |> String.split(~r/\n(?=  defp? [a-z_])/)
+    |> Enum.map(fn chunk ->
+      name =
+        case Regex.run(~r/\A\s*defp? ([a-z_][a-zA-Z0-9_?!]*)/, chunk) do
+          [_, name] -> name
+          nil -> "(module body)"
+        end
+
+      {name, chunk}
+    end)
+  end
+
+  # An Ecto select carrying a post body: `body: <binding>.body` inside a
+  # `select`. Deliberately narrow — it is the shape that has actually leaked
+  # twice, and a wide regex over `.body` would match every struct read in the
+  # module and drown the signal.
+  defp selects_post_body?(chunk) do
+    String.contains?(chunk, "select") and
+      (Regex.match?(~r/\n\s+body: [a-z]+\.body,?\n/, chunk) or
+         Regex.match?(~r/select: [a-z]+\.body\b/, chunk))
+  end
+
+  # A local post's words leaving an agent document. Remote records are out of
+  # scope by construction: a `%RemotePost{}`, a `%Note{}` and an
+  # `%ExternalPost{}` carry no `noindex_noai?` column, their authors never gave
+  # this installation an answer, and their bodies are somebody else's server's
+  # to publish.
+  @remote ~w(remote note subject external reference point)
+  defp body_reads(path) do
+    file = Path.basename(path)
+
+    path
+    |> File.read!()
+    |> String.split("\n")
+    |> Enum.with_index(1)
+    |> Enum.filter(fn {line, _n} ->
+      trimmed = String.trim(line)
+
+      not String.starts_with?(trimmed, "#") and
+        (Regex.match?(~r/PostTeaser\.(plain_)?line\(/, trimmed) or
+           Regex.match?(~r/[a-z_]+\.body\b/, trimmed)) and
+        not Enum.any?(@remote, &Regex.match?(~r/\b#{&1}(\.|\))/, trimmed))
+    end)
+    |> Enum.map(fn {line, n} -> {file, n, String.trim(line)} end)
+  end
+end

--- a/test/vutuv/post_publish_switches_test.exs
+++ b/test/vutuv/post_publish_switches_test.exs
@@ -1,0 +1,420 @@
+defmodule Vutuv.PostPublishSwitchesTest do
+  @moduledoc """
+  The two answers a post carries out of the composer (issue #2107).
+
+  The first — *may search engines and AI see this post* — is the sharp one:
+  a post that says no is not handed to the Fediverse **at all**, because a
+  remote server keeps its copy for ever and no `X-Robots-Tag` reaches it.
+  Every outbound path is asserted here, not only the Create, because a post
+  withheld from its author's followers and then announced by a topic actor
+  would have left anyway.
+
+  The second — *remove the metadata from the files* — is a `qpdf` run on the
+  **served** copy only. The private original is the promise that what the
+  member sent is kept exactly as they sent it, and the tests read both files.
+  """
+
+  use Vutuv.DataCase, async: false
+
+  alias Vutuv.AttachmentFixtures, as: Fixtures
+  alias Vutuv.Attachments
+  alias Vutuv.Attachments.Attachment
+  alias Vutuv.Attachments.Metadata
+  alias Vutuv.AttachmentStore
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Delivery
+  alias Vutuv.Posts
+  alias Vutuv.Posts.Pending
+  alias Vutuv.Posts.Post
+  alias Vutuv.Repo
+  alias Vutuv.Tags.Timeline
+  alias VutuvWeb.AgentDocs.PostDoc
+
+  # An admin (the milestone's `ATTACHMENT_UPLOADERS` default) with an uploads
+  # root of its own, shared by the two describes that put real bytes on disk.
+  defp uploading_admin(_context) do
+    %{files: files} = Fixtures.tmp_uploads_dir()
+    %{user: insert_activated_user(admin?: true), files: files}
+  end
+
+  defp federated_user(attrs \\ []) do
+    insert(:activated_user, Keyword.merge([fediverse_followers?: true], attrs))
+  end
+
+  defp with_follower(user) do
+    {:ok, _actor} = Fediverse.ensure_actor(user)
+
+    {:ok, _} =
+      Fediverse.add_follower(user, %{
+        actor_uri: "https://social.example/users/alice",
+        inbox_uri: "https://social.example/inbox"
+      })
+
+    user
+  end
+
+  describe "machines_allowed?/1" do
+    test "a post says yes unless its author turned the switch off" do
+      assert Posts.machines_allowed?(%Post{noindex_noai?: false})
+      refute Posts.machines_allowed?(%Post{noindex_noai?: true})
+    end
+
+    test "the column defaults to no-opt-out, so every post written so far still counts" do
+      assert %Post{noindex_noai?: false, strip_metadata?: true} = insert(:post)
+    end
+  end
+
+  describe "a post that says no search engines and no AI" do
+    test "is not delivered to the author's remote followers" do
+      user = with_follower(federated_user())
+
+      blocked = insert(:post, user: user, body: "Nur hier", noindex_noai?: true)
+
+      assert :skip == Fediverse.federate_new_post(blocked)
+      assert Repo.aggregate(Delivery, :count) == 0
+
+      # Calibration in the same test: the only thing different about the next
+      # post is the answer, and it goes out.
+      open = insert(:post, user: user, body: "Überall")
+      assert :ok == Fediverse.federate_new_post(open)
+      assert Repo.aggregate(Delivery, :count) == 1
+    end
+
+    test "is not announced by the topic actors either" do
+      user = federated_user()
+      tag = insert(:tag, name: "Elixir", slug: "elixir")
+
+      {:ok, _} =
+        Fediverse.add_tag_follower(tag, %{
+          actor_uri: "https://social.example/users/bob",
+          inbox_uri: "https://social.example/inbox-b"
+        })
+
+      # Driven through the real publish path, which announces by itself. The
+      # author has no followers of their own, so every delivery here is the
+      # topic actor's.
+      {:ok, _blocked} =
+        Posts.create_post(user, %{
+          body: "Neues von hier.",
+          tags: tag.name,
+          noindex_noai: "true"
+        })
+
+      assert Repo.aggregate(Delivery, :count) == 0
+
+      # Calibration in the same test: the same post without the switch is
+      # announced.
+      {:ok, _open} = Posts.create_post(user, %{body: "Und noch mehr.", tags: tag.name})
+
+      assert Repo.aggregate(Delivery, :count) == 1
+    end
+
+    test "is not reshared out either, however public the resharer is" do
+      author = with_follower(federated_user())
+      resharer = with_follower(federated_user())
+
+      post = insert(:post, user: author, noindex_noai?: true)
+
+      assert :skip == Fediverse.federate_repost(post, resharer)
+      assert Repo.aggregate(Delivery, :count) == 0
+    end
+
+    test "is not put into the featured collection when it is pinned" do
+      user = with_follower(federated_user())
+      post = insert(:post, user: user, noindex_noai?: true)
+
+      assert :skip == Fediverse.federate_pin(post, user)
+      assert Repo.aggregate(Delivery, :count) == 0
+      assert Fediverse.featured_posts(%{user | pinned_post_id: post.id}) == []
+    end
+
+    test "is left out of the site-wide feed, which cannot signal per item" do
+      author = insert(:activated_user, noindex?: false, noai?: false)
+
+      open = insert(:post, user: author)
+      _blocked = insert(:post, user: author, noindex_noai?: true)
+
+      ids = :all |> Posts.recent_public_posts() |> Enum.map(& &1.id)
+
+      assert ids == [open.id]
+    end
+
+    test "is quoted on no shared listing surface, in any format" do
+      # Measured on the un-fixed branch over HTTP: the 200-character excerpt
+      # went out on `/<slug>/posts.md|.txt|.json`, on every tag page's four
+      # formats, on `/system/posts/<y>/<m>/<d>` and on `/api/2.0/users/:slug/
+      # posts`, each under `Content-Signal: ai-train=yes, search=yes` and with
+      # no `X-Robots-Tag` at all. Those documents are the machine surface and
+      # cannot signal per row, so the words had to go rather than the signal.
+      author = insert(:activated_user, noindex?: false, noai?: false)
+      tag = insert(:tag, name: "Zurueckgehalten", slug: "zurueckgehalten")
+
+      {:ok, open} = Posts.create_post(author, %{body: "Ganz offen", tags: tag.name})
+
+      {:ok, blocked} =
+        Posts.create_post(author, %{
+          body: "Geheime Preisliste",
+          tags: tag.name,
+          noindex_noai: "true"
+        })
+
+      # The public archive drops it, so its `.md`/`.json`/`.xml` siblings and
+      # `/api/2.0/users/:slug/posts` never see it.
+      archive =
+        PostDoc.build_archive(author, "/#{author.username}/posts", entries(author), 1, nil)
+
+      assert Enum.map(archive.posts, & &1.id) == [open.id]
+
+      # And the shared row builder withholds the words anywhere a withheld post
+      # still reaches a list — the reader's own feed document, a conversation
+      # folded into a row — rather than relying on every caller to filter.
+      assert %{excerpt: "Post not open to search engines"} =
+               PostDoc.timeline_entry(%{post: Repo.reload!(blocked)})
+
+      # The tag page drops it outright — a public topic surface with no owner
+      # to make an exception for.
+      tag_ids =
+        tag |> Timeline.page() |> Map.fetch!(:entries) |> Enum.map(& &1.post.id)
+
+      assert tag_ids == [open.id]
+    end
+
+    test "is out of the author's public archive but stays in their own" do
+      author = insert(:activated_user)
+      {:ok, open} = Posts.create_post(author, %{body: "Offen"})
+      {:ok, blocked} = Posts.create_post(author, %{body: "Nur hier", noindex_noai: "true"})
+
+      anonymous = author |> Posts.author_posts_page(nil, %{}) |> ids()
+      own = author |> Posts.author_posts_page(author, %{}) |> ids()
+
+      assert anonymous == [open.id]
+      assert Enum.sort(own) == Enum.sort([open.id, blocked.id])
+    end
+
+    defp entries(author), do: author |> Posts.author_posts_page(nil, %{}) |> elem(0)
+
+    defp ids({entries, _total}), do: entries |> Enum.map(& &1.post.id) |> Enum.sort()
+
+    test "carries noindex and noai on its permalink and its agent formats" do
+      author = insert(:activated_user, noindex?: false, noai?: false)
+      post = insert(:post, user: author, noindex_noai?: true)
+
+      assert {true, true} = PostDoc.robots_axes(author, post, false)
+    end
+
+    test "is out of the outbox count too, not only out of the notes it counts" do
+      user = federated_user()
+      _open = insert(:post, user: user)
+      _blocked = insert(:post, user: user, noindex_noai?: true)
+
+      assert Fediverse.public_post_count(user) == 1
+    end
+
+    test "is called back when the switch is turned on after it went out" do
+      user = with_follower(federated_user())
+      post = insert(:post, user: user, body: "Erst öffentlich")
+
+      assert :ok == Fediverse.federate_new_post(post)
+      Repo.delete_all(Delivery)
+
+      {:ok, post} = Posts.update_post(post, %{body: post.body, noindex_noai: "true"})
+      assert %Post{noindex_noai?: true} = post
+
+      # A Delete, not silence: what already left has to be called back, and
+      # `:skip` would have left the remote copies standing while the row said
+      # the author had refused them.
+      assert [delivery] = Repo.all(Delivery)
+      assert delivery.activity_json =~ ~s("type":"Delete")
+    end
+  end
+
+  describe "removing the metadata from a file" do
+    setup :uploading_admin
+
+    test "the served copy loses the author, the software and the dates", %{
+      user: user,
+      files: files
+    } do
+      if Metadata.available?() do
+        source = Fixtures.metadata_pdf(files)
+        assert {:ok, attachment} = Attachments.create_pending(user, source, "preise.pdf")
+
+        served = File.read!(AttachmentStore.served_path(attachment.token))
+        refute served =~ "Erika Mustermann"
+        refute served =~ "SecretWriter"
+
+        # The private original is the promise that what the member sent is
+        # kept exactly as they sent it.
+        assert File.read!(AttachmentStore.original_path(attachment.token)) == File.read!(source)
+        assert attachment.metadata_stripped_at
+      end
+    end
+
+    test "a text file is left alone — there is nothing to strip", %{user: user, files: files} do
+      source = Path.join(files, "notiz.txt")
+      File.write!(source, "nur Worte\n")
+
+      assert {:ok, attachment} = Attachments.create_pending(user, source, "notiz.txt")
+      assert attachment.metadata_stripped_at == nil
+      assert File.read!(AttachmentStore.served_path(attachment.token)) == "nur Worte\n"
+    end
+
+    test "the author saying no puts the verbatim upload back on the served copy", %{
+      user: user,
+      files: files
+    } do
+      if Metadata.available?() do
+        source = Fixtures.metadata_pdf(files)
+        {:ok, attachment} = Attachments.create_pending(user, source, "preise.pdf")
+
+        {:ok, post} =
+          Posts.create_post(user, %{
+            body: "Mit Metadaten",
+            attachment_ids: [attachment.id],
+            strip_metadata: "false"
+          })
+
+        assert %Post{strip_metadata?: false} = post
+        assert File.read!(AttachmentStore.served_path(attachment.token)) == File.read!(source)
+        assert Repo.reload!(attachment).metadata_stripped_at == nil
+
+        # …and turning it back on cleans the file after all. Answering only the
+        # first direction left the row claiming the metadata was gone while the
+        # bytes still carried the author's name.
+        {:ok, _} = Posts.update_post(post, %{body: post.body, strip_metadata: "true"})
+
+        refute File.read!(AttachmentStore.served_path(attachment.token)) =~
+                 Fixtures.metadata_author()
+
+        assert Repo.reload!(attachment).metadata_stripped_at
+      end
+    end
+
+    test "an atom-keyed false is an answer, not an absent key", %{user: user, files: files} do
+      # `fetch/2` joined the two key shapes with `||`, which cannot carry a
+      # `false` — so the composer, which builds atom-keyed attrs, had its "keep
+      # my metadata" silently read as "the caller said nothing" and the post
+      # stored the default. It survived only on the parked path, where the
+      # attrs round-trip through JSONB into string keys.
+      {:ok, file} = Attachments.create_pending(user, Fixtures.plain_pdf(files), "a.pdf")
+
+      {:ok, post} =
+        Posts.create_post(user, %{
+          body: "Atomschlüssel",
+          attachment_ids: [file.id],
+          strip_metadata: false,
+          noindex_noai: false
+        })
+
+      assert %Post{strip_metadata?: false, noindex_noai?: false} = post
+    end
+
+    test "without qpdf on the box nothing is stripped and nothing fails", %{
+      user: user,
+      files: files
+    } do
+      Fixtures.put_config(qpdf: "vutuv-no-such-qpdf")
+      Metadata.forget_capability()
+      on_exit(&Metadata.forget_capability/0)
+
+      refute Metadata.available?()
+
+      source = Fixtures.metadata_pdf(files)
+      assert {:ok, attachment} = Attachments.create_pending(user, source, "preise.pdf")
+      assert attachment.metadata_stripped_at == nil
+      assert File.read!(AttachmentStore.served_path(attachment.token)) == File.read!(source)
+    end
+
+    test "a qpdf too old for the flags counts as no qpdf at all", %{user: user, files: files} do
+      # Debian 12 ships qpdf 11.3.0 and Ubuntu 24.04 ships 11.9.0; both have the
+      # binary and neither has `--remove-info`, which arrived in 11.10.0. A
+      # probe that only asked whether the file exists left the switch visible
+      # and inert on every one of those boxes — the run died with
+      # `unrecognized argument` and the file kept the author's name.
+      old = Path.join(files, "qpdf-11.9.0")
+
+      File.write!(old, """
+      #!/bin/sh
+      case "$1" in
+        --help=--remove-info|--help=--remove-metadata) echo "unknown option"; exit 2 ;;
+        *) exit 0 ;;
+      esac
+      """)
+
+      File.chmod!(old, 0o755)
+      Fixtures.put_config(qpdf: old)
+      Metadata.forget_capability()
+      on_exit(&Metadata.forget_capability/0)
+
+      refute Metadata.available?()
+
+      source = Fixtures.metadata_pdf(files)
+      assert {:ok, attachment} = Attachments.create_pending(user, source, "preise.pdf")
+      assert attachment.metadata_stripped_at == nil
+      assert File.read!(AttachmentStore.served_path(attachment.token)) == File.read!(source)
+    end
+
+    test "a qpdf that knows the flags is used", %{files: files} do
+      new = Path.join(files, "qpdf-12.2.0")
+      File.write!(new, "#!/bin/sh\nexit 0\n")
+      File.chmod!(new, 0o755)
+      Fixtures.put_config(qpdf: new)
+      Metadata.forget_capability()
+      on_exit(&Metadata.forget_capability/0)
+
+      assert Metadata.available?()
+    end
+  end
+
+  describe "the four corrections this PR folds in (blind review of #2106)" do
+    setup :uploading_admin
+
+    test "a refused file cannot be attached to a post", %{user: user, files: files} do
+      {:ok, refused} =
+        Attachments.create_pending(user, Fixtures.plain_pdf(files), "abgelehnt.pdf")
+
+      {1, _} =
+        Repo.update_all(
+          from(a in Attachment, where: a.id == ^refused.id),
+          set: [refused_at: DateTime.utc_now() |> DateTime.truncate(:second)]
+        )
+
+      assert {:error, :invalid_attachments} =
+               Posts.create_post(user, %{body: "Trotzdem", attachment_ids: [refused.id]})
+    end
+
+    test "publishing without the refused part is refused when nothing would be left", %{
+      user: user,
+      files: files
+    } do
+      {:ok, file} = Attachments.create_pending(user, Fixtures.plain_pdf(files), "allein.pdf")
+
+      # A post whose only content is the file, and the file was refused: there
+      # is nothing to publish, and the context has to say so rather than let
+      # the create path answer with an opaque failure.
+      {:ok, pending} =
+        Pending.create(user, "post", %{}, %{body: ""}, attachments: [file])
+
+      {1, _} =
+        Repo.update_all(
+          from(a in Attachment, where: a.id == ^file.id),
+          set: [refused_at: DateTime.utc_now() |> DateTime.truncate(:second), stage: "ready"]
+        )
+
+      assert {:error, :nothing_left} = Pending.publish_without_refused(pending)
+    end
+
+    test "a file that failed to render is still publishable", %{user: user, files: files} do
+      {:ok, failed} = Attachments.create_pending(user, Fixtures.plain_pdf(files), "kaputt.pdf")
+
+      {1, _} =
+        Repo.update_all(
+          from(a in Attachment, where: a.id == ^failed.id),
+          set: [stage: "failed"]
+        )
+
+      assert {:ok, %Post{}} =
+               Posts.create_post(user, %{body: "Geht doch", attachment_ids: [failed.id]})
+    end
+  end
+end

--- a/test/vutuv/post_publish_switches_test.exs
+++ b/test/vutuv/post_publish_switches_test.exs
@@ -169,7 +169,7 @@ defmodule Vutuv.PostPublishSwitchesTest do
       # still reaches a list — the reader's own feed document, a conversation
       # folded into a row — rather than relying on every caller to filter.
       assert %{excerpt: "Post not open to search engines"} =
-               PostDoc.timeline_entry(%{post: Repo.reload!(blocked)})
+               PostDoc.timeline_entry(%{post: Repo.reload!(blocked)}, nil)
 
       # The tag page drops it outright — a public topic surface with no owner
       # to make an exception for.

--- a/test/vutuv_web/account_event_hooks_test.exs
+++ b/test/vutuv_web/account_event_hooks_test.exs
@@ -193,7 +193,9 @@ defmodule VutuvWeb.AccountEventHooksTest do
       post(conn, ~p"/settings/privacy/reset")
 
       assert [event] = events(user, "privacy_changed")
-      assert event.details["fields"] == ["like_attribution?"]
+      # Every pref in the `:privacy` group, which is what the reset link on that
+      # page offers — one more of them since issue #2107.
+      assert event.details["fields"] == ["like_attribution?", "posts_machines_allowed?"]
       assert events(user, "preferences_changed") == []
     end
   end

--- a/test/vutuv_web/live/composer_publish_switches_test.exs
+++ b/test/vutuv_web/live/composer_publish_switches_test.exs
@@ -1,0 +1,84 @@
+defmodule VutuvWeb.ComposerPublishSwitchesTest do
+  @moduledoc """
+  What the composer asks before publishing (issue #2107), and — as much of this
+  file's point as the rest — what it deliberately does **not** ask.
+
+  It asks one thing: whether the files travelling with the post have their
+  metadata removed. That is a question about *these* files, so it belongs beside
+  them. Whether search engines and AI may read the post is a standing decision
+  the member takes once on `/settings/privacy` and the server stamps onto the
+  row as it publishes; asking it per post was one question too many, and a
+  composer that asks nothing about it is the assertion below.
+
+  The file half depends on `qpdf` being on the box, which is an installation
+  fact, so it lives in `Vutuv.PostPublishSwitchesTest`. What is asserted here is
+  what the author sees and what survives a reload.
+
+  `async: false` — the attachment config is application env, which is global.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Posts
+  alias Vutuv.Posts.Post
+  alias Vutuv.Repo
+
+  defp post_it(live, params) do
+    live |> form("#composer-form", %{"post" => params}) |> render_submit()
+  end
+
+  describe "the composer and the machines question" do
+    test "publishes at once for a member who said no, carrying their answer", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      user
+      |> Ecto.Changeset.change(posts_machines_allowed?: false)
+      |> Repo.update!()
+
+      {:ok, live, _html} = live(conn, ~p"/feed")
+      post_it(live, %{"body" => "Nur für Menschen"})
+
+      # One press, one post. Nothing held the submission behind a warning and
+      # nothing asked the question a second time: the answer was given on the
+      # settings page and the server applied it. That the composer no longer
+      # asks is what this asserts — a refute against the removed switch's own
+      # marker would pass whatever the composer did.
+      assert %Post{noindex_noai?: true} = Repo.get_by!(Post, user_id: user.id)
+    end
+
+    test "and for everybody else the post allows machines", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      {:ok, live, _html} = live(conn, ~p"/feed")
+      post_it(live, %{"body" => "Ganz normal"})
+
+      assert %Post{noindex_noai?: false, strip_metadata?: true} =
+               Repo.get_by!(Post, user_id: user.id)
+    end
+  end
+
+  describe "removing the metadata from the files" do
+    test "the switch is not offered while there is no file to clean", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+
+      {:ok, live, _html} = live(conn, ~p"/feed")
+
+      refute has_element?(live, "[data-strip-metadata-switch]")
+    end
+  end
+
+  describe "editing a published post" do
+    test "does not offer the metadata switch again", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      {:ok, post} = Posts.create_post(user, %{body: "Schon draußen"})
+
+      {:ok, live, _html} = live(conn, ~p"/posts/#{post.id}/edit")
+
+      # Rewriting a file already handed out is not an edit. Calibrated: the
+      # switch really does render on a new post carrying one
+      # (`Vutuv.PostPublishSwitchesTest` drives the file half).
+      refute has_element?(live, "[data-strip-metadata-switch]")
+    end
+  end
+end

--- a/test/vutuv_web/organization_post_note_web_test.exs
+++ b/test/vutuv_web/organization_post_note_web_test.exs
@@ -40,13 +40,16 @@ defmodule VutuvWeb.OrganizationPostNoteWebTest do
 
     {:ok, _} = Organizations.add_role(page, owner, "publisher", owner)
     {:ok, post} = Posts.create_organization_post(page, owner, %{body: body})
-    {page, post}
+    # The owner travels with them: a test that needs to publish a second post
+    # as the page's publisher should take it here rather than read the roles
+    # table back out with a schemaless query.
+    {page, post, owner}
   end
 
   defp ap(conn), do: put_req_header(conn, "accept", "application/activity+json")
 
   test "the page post permalink answers ActivityPub with its Note", %{conn: conn} do
-    {page, post} = federating_page_with_post()
+    {page, post, _owner} = federating_page_with_post()
 
     conn = conn |> ap() |> get(~p"/organizations/#{page.slug}/posts/#{post.id}")
 
@@ -66,7 +69,7 @@ defmodule VutuvWeb.OrganizationPostNoteWebTest do
   end
 
   test "a page that does not federate serves no Note", %{conn: conn} do
-    {page, post} = federating_page_with_post()
+    {page, post, _owner} = federating_page_with_post()
 
     page
     |> Ecto.Changeset.change(%{fediverse_followers?: false})
@@ -79,9 +82,66 @@ defmodule VutuvWeb.OrganizationPostNoteWebTest do
   end
 
   test "the HTML permalink is untouched", %{conn: conn} do
-    {page, post} = federating_page_with_post()
+    {page, post, _owner} = federating_page_with_post()
 
     assert conn |> get(~p"/organizations/#{page.slug}/posts/#{post.id}") |> html_response(200) =~
              "Von uns."
+  end
+
+  describe "a page post that refused machines (issue #2107)" do
+    # A page post carries the same switch a member's does — the composer offers
+    # it whoever is being published for — and all three of these surfaces
+    # answered as if it did not. Measured on the un-fixed branch: the AP request
+    # returned 200 with the whole Note, `.json` carried the body under
+    # `ai-train=yes`, and the HTML page stamped no `X-Robots-Tag` at all.
+    defp withheld_page_post(body \\ "Interne Preisliste.") do
+      {page, post, owner} = federating_page_with_post(body)
+      {:ok, post} = Posts.update_post(post, %{body: body, noindex_noai: "true"})
+      {page, post, owner}
+    end
+
+    test "is not handed over as a Note", %{conn: conn} do
+      {page, post, _owner} = withheld_page_post()
+
+      conn = conn |> ap() |> get(~p"/organizations/#{page.slug}/posts/#{post.id}")
+
+      refute conn.status == 200
+      refute conn.resp_body =~ "Preisliste"
+    end
+
+    test "says so in its agent document instead of inviting a crawler", %{conn: conn} do
+      {page, post, _owner} = withheld_page_post()
+
+      conn = get(conn, "/organizations/#{page.slug}/posts/#{post.id}.json")
+
+      # The headers are what a crawler acts on, so they are what is asserted.
+      assert json_response(conn, 200)["body_markdown"] =~ "Preisliste"
+      assert [signal] = get_resp_header(conn, "content-signal")
+      assert signal =~ "ai-train=no"
+      assert signal =~ "search=no"
+      assert signal =~ "ai-input=no"
+      assert get_resp_header(conn, "x-robots-tag") == ["noindex, noai, noimageai"]
+    end
+
+    test "stamps the HTML page with the robots header", %{conn: conn} do
+      {page, post, _owner} = withheld_page_post()
+
+      conn = get(conn, ~p"/organizations/#{page.slug}/posts/#{post.id}")
+
+      assert html_response(conn, 200) =~ "Preisliste"
+      assert get_resp_header(conn, "x-robots-tag") == ["noindex, noai, noimageai"]
+    end
+
+    test "leaves the page's public timeline, and with it the feed and the page document" do
+      {page, post, owner} = withheld_page_post()
+      {:ok, open} = Posts.create_organization_post(page, owner, %{body: "Offen."})
+
+      %{entries: public} = Posts.organization_posts_page(page, nil)
+      %{entries: theirs} = Posts.organization_posts_page(page, owner)
+
+      assert Enum.map(public, & &1.id) == [open.id]
+      # …and the team still sees their own withheld post on their own page.
+      assert post.id in Enum.map(theirs, & &1.id)
+    end
   end
 end

--- a/test/vutuv_web/settings_posts_machines_test.exs
+++ b/test/vutuv_web/settings_posts_machines_test.exs
@@ -1,0 +1,192 @@
+defmodule VutuvWeb.SettingsPostsMachinesTest do
+  @moduledoc """
+  The one decision a member takes about machines and their posts (issue #2107):
+  on `/settings/privacy`, once, and **stamped onto each post as it is
+  published** rather than read back when an old post is rendered.
+
+  That stamping is the whole design. A live read would mean flipping the switch
+  silently rewrote six years of posts — including withdrawing copies other
+  servers already hold, which nothing can do — so the column on the row is what
+  answers, and the setting is only ever its default for the next post.
+
+  The setting is a `Vutuv.Prefs` key rather than a plain `users` column, so a
+  member who was never asked (`nil`) inherits the installation default and an
+  operator can move it for everybody. Its two neighbours on that page,
+  `noindex?` and `noai?`, are the opposite shape — opt-**out** columns with hard
+  defaults — and this file asserts they stay independent of it.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  alias Vutuv.Organizations
+  alias Vutuv.OrganizationsHelpers
+  alias Vutuv.Posts
+  alias Vutuv.Posts.Post
+  alias Vutuv.Prefs
+  alias Vutuv.Repo
+
+  describe "the setting itself" do
+    test "ships allowing machines, so nothing changes for a member who never looked" do
+      assert Prefs.default(:posts_machines_allowed?) == true
+      assert Prefs.get(insert(:activated_user), :posts_machines_allowed?) == true
+    end
+
+    test "is on the Visibility page, and saving no is remembered", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      html = conn |> get(~p"/settings/privacy") |> html_response(200)
+      assert html =~ "Search engines and AI may read my posts"
+      assert html =~ "posts-machines-form"
+
+      conn =
+        conn
+        |> recycle()
+        |> put(~p"/settings/privacy", %{"user" => %{"posts_machines_allowed?" => "false"}})
+
+      assert redirected_to(conn) == ~p"/settings/privacy"
+      assert Repo.reload!(user).posts_machines_allowed? == false
+    end
+
+    test "says on that page what only it can say: the post never reaches other networks", %{
+      conn: conn
+    } do
+      {conn, _user} = create_and_login_user(conn)
+
+      html = conn |> get(~p"/settings/privacy") |> html_response(200)
+
+      # The composer used to carry this warning in a panel before publishing.
+      # The decision is made here now, so the sentence has to be here — it is
+      # the one consequence a member cannot discover by trying it, because a
+      # copy on somebody else's server cannot be called back.
+      assert html =~ "stay out of other networks completely"
+      assert html =~ "keeps its copy for good"
+      assert html =~ "keep the answer they went out with"
+    end
+
+    test "is findable by searching the settings hub for a word it does not print", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+
+      html = conn |> get(~p"/settings") |> html_response(200)
+
+      # `:terms` is never rendered as text; it rides `data-search`, which the
+      # filter box matches. Without it the new setting is on a page nobody can
+      # find by typing what they are looking for.
+      assert html =~ "beiträge"
+      assert html =~ "fediverse"
+    end
+  end
+
+  describe "the answer is stamped onto the post" do
+    test "a member who allows machines publishes posts that allow them" do
+      user = insert(:activated_user)
+
+      {:ok, post} = Posts.create_post(user, %{body: "Ganz normal"})
+
+      assert %Post{noindex_noai?: false} = post
+      assert Posts.machines_allowed?(post)
+    end
+
+    test "a member who said no publishes posts that say no" do
+      user = say_no(insert(:activated_user))
+
+      {:ok, post} = Posts.create_post(user, %{body: "Nur für Menschen"})
+
+      assert %Post{noindex_noai?: true} = post
+      refute Posts.machines_allowed?(post)
+    end
+
+    test "a reply carries the answer too — it is a post like any other" do
+      author = insert(:activated_user)
+      replier = say_no(insert(:activated_user))
+
+      {:ok, parent} = Posts.create_post(author, %{body: "Frage"})
+      {:ok, reply} = Posts.create_reply(replier, parent, %{body: "Antwort"})
+
+      assert %Post{noindex_noai?: true} = reply
+    end
+
+    test "changing the setting afterwards leaves the older post exactly as it was" do
+      user = insert(:activated_user)
+      {:ok, old} = Posts.create_post(user, %{body: "Vorher"})
+
+      user = say_no(user)
+      {:ok, new} = Posts.create_post(user, %{body: "Nachher"})
+
+      # This is the promise the whole design exists for: the old post answers
+      # from its own column, which nothing re-reads.
+      assert Repo.reload!(old).noindex_noai? == false
+      assert new.noindex_noai? == true
+    end
+
+    test "and editing an old post does not re-ask the setting" do
+      user = insert(:activated_user)
+      {:ok, post} = Posts.create_post(user, %{body: "Vorher"})
+
+      _user = say_no(user)
+      {:ok, edited} = Posts.update_post(post, %{body: "Vorher, korrigiert"})
+
+      assert edited.noindex_noai? == false
+    end
+
+    test "an explicit answer in the attrs still wins, which is what the API sends" do
+      user = insert(:activated_user)
+
+      {:ok, post} = Posts.create_post(user, %{body: "Ausnahme", noindex_noai: "true"})
+
+      assert post.noindex_noai? == true
+    end
+
+    test "a post published in an organization's name does not take the member's answer" do
+      # A page has its own `seo?`/`geo?`, and one publisher's private posture
+      # must not silently mute the brand they publish for.
+      Application.put_env(:vutuv, :verify_organization_domains, true)
+
+      on_exit(fn ->
+        Application.put_env(:vutuv, :verify_organization_domains, false)
+        Application.delete_env(:vutuv, :organizations_dns_resolver)
+      end)
+
+      owner = say_no(insert(:activated_user))
+      page = OrganizationsHelpers.active_organization_for(owner)
+      {:ok, _} = Organizations.add_role(page, owner, "publisher", owner)
+
+      {:ok, post} = Posts.create_organization_post(page, owner, %{body: "Von uns."})
+
+      assert post.noindex_noai? == false
+    end
+
+    test "the two profile opt-outs beside it decide nothing about posts" do
+      # `noai?`'s column default is `true` for every member who was never asked,
+      # so deriving a post's answer from that pair would have defaulted almost
+      # every post out of the Fediverse. They are a separate question about the
+      # profile and stay one.
+      user = insert(:activated_user, noindex?: true, noai?: true)
+
+      {:ok, post} = Posts.create_post(user, %{body: "Profil zu, Beitrag offen"})
+
+      assert post.noindex_noai? == false
+    end
+  end
+
+  describe "in German" do
+    test "the setting reads as German on the Visibility page", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+
+      html =
+        conn
+        |> recycle()
+        |> put_req_header("accept-language", "de-DE,de")
+        |> get(~p"/settings/privacy")
+        |> html_response(200)
+
+      assert html =~ "Suchmaschinen und KI dürfen meine Beiträge lesen"
+      assert html =~ "Ihre Beiträge"
+      assert html =~ "gar nicht mehr in andere Netzwerke"
+    end
+  end
+
+  defp say_no(user) do
+    user
+    |> Ecto.Changeset.change(posts_machines_allowed?: false)
+    |> Repo.update!()
+  end
+end

--- a/test/vutuv_web/withheld_post_profile_html_test.exs
+++ b/test/vutuv_web/withheld_post_profile_html_test.exs
@@ -1,0 +1,90 @@
+defmodule VutuvWeb.WithheldPostProfileHtmlTest do
+  @moduledoc """
+  `/:slug` is public, anonymous, in the sitemap and carries **no**
+  `X-Robots-Tag`, so a crawler reads whatever is in it. Two queries put a
+  withheld post's whole body there (issue #2107), both by reaching the page on
+  a path the listing gates never touched:
+
+    * the **who-to-follow rail** (`Vutuv.Posts.recent_posts_by_authors/3`),
+      which selects `body:` into **bare maps** — nothing struct-shaped, so no
+      per-entry redaction could ever have caught it; and
+    * the **pinned post card** (`Vutuv.Posts.pinned_post/2`), fetched by id
+      rather than through a timeline, so no listing scope applied.
+
+  The second is the sharper one: the same page's `profile.json` redacted it
+  correctly and the ActivityPub `featured` collection left it out correctly,
+  so the HTML was the one surface of three that handed it over.
+
+  Both are now gated by `scope_machines_for/2` — the same per-row predicate the
+  archive uses — which is why the author still sees their own on their own
+  profile. `test/vutuv/post_body_chokepoint_test.exs` is what stops a third
+  query appearing.
+  """
+  use VutuvWeb.ConnCase, async: true
+
+  alias Vutuv.Posts
+
+  @withheld "Interne Preisliste, nur für Menschen."
+
+  # The rail only teases a post that landed (`min_likes` 1 by default), so the
+  # fixtures are liked — otherwise the query answers empty and the test would
+  # pass without ever reaching the gate.
+  defp withheld_author do
+    author = insert(:activated_user, noindex?: false, noai?: false, emails: [build(:email)])
+    fan = insert(:activated_user)
+    {:ok, post} = Posts.create_post(author, %{body: @withheld, noindex_noai: "true"})
+    {:ok, open} = Posts.create_post(author, %{body: "Ganz offen"})
+    :ok = Posts.like_post(fan, post)
+    :ok = Posts.like_post(fan, open)
+    %{author: author, post: post, open: open}
+  end
+
+  describe "the pinned post card" do
+    test "is not handed to an anonymous visitor", %{conn: conn} do
+      %{author: author, post: post} = withheld_author()
+      {:ok, author} = Posts.pin_to_profile(author, post)
+
+      html = conn |> get("/#{author.username}") |> html_response(200)
+
+      refute html =~ "Preisliste"
+    end
+
+    test "but the author still sees it on their own profile", %{conn: conn} do
+      %{author: author, post: post} = withheld_author()
+      {:ok, author} = Posts.pin_to_profile(author, post)
+
+      html =
+        conn
+        |> login_via_pin(hd(author.emails).value)
+        |> get("/#{author.username}")
+        |> html_response(200)
+
+      # The switch is about machines. Hiding a member's own pinned post from
+      # their own profile would be a different feature, and the archive already
+      # makes exactly this exception.
+      assert html =~ "Preisliste"
+    end
+  end
+
+  describe "the who-to-follow rail's post teasers" do
+    test "quote an open post and never a withheld one" do
+      %{author: author, post: post, open: open} = withheld_author()
+
+      teasers = Posts.recent_posts_by_authors([author], nil, per_author: 5)
+      quoted = Map.get(teasers, author.id, [])
+
+      assert open.id in Enum.map(quoted, & &1.id)
+      refute post.id in Enum.map(quoted, & &1.id)
+      refute Enum.any?(quoted, &(&1.body =~ "Preisliste"))
+    end
+
+    test "keep the author's own when the author is the one reading" do
+      %{author: author, post: post} = withheld_author()
+
+      teasers = Posts.recent_posts_by_authors([author], author, per_author: 5)
+      quoted = Map.get(teasers, author.id, [])
+
+      assert post.id in Enum.map(quoted, & &1.id)
+    end
+  end
+end

--- a/test/vutuv_web/withheld_post_redaction_test.exs
+++ b/test/vutuv_web/withheld_post_redaction_test.exs
@@ -1,0 +1,172 @@
+defmodule VutuvWeb.WithheldPostRedactionTest do
+  @moduledoc """
+  A post whose author keeps machines away (issue #2107) is redacted wherever a
+  **machine** reads it — and the HTML conversation still shows it to people.
+
+  The switch protected the post's own documents from the start; what it did not
+  protect was the post as it appears **inside somebody else's**. Measured over
+  HTTP before the fix: a reply's permalink and all four of its agent formats
+  served the withheld parent's complete body under
+  `Content-Signal: ai-train=yes` with no `X-Robots-Tag` at all, because the
+  header axes of a document are computed from its **subject** post and a
+  conversation quotes other people's. The same hole ran through a repost onto
+  the reposter's public archive and through the profile document's pinned-post
+  excerpt.
+
+  Page and doc differ here **on purpose**: the promise is about machines, not
+  about readers, so the permalink's HTML thread keeps every word. The one place
+  they must agree is the archive listing, which is a crawl surface — its doc
+  already omitted the quoted parent while the page printed it in full.
+  """
+  use VutuvWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Posts
+  alias Vutuv.Repo
+
+  @withheld "Interne Preisliste, nur für Menschen."
+
+  # The parent is withheld, the reply is not: the reply's own document is
+  # wide open and quotes the parent, which is exactly the hole.
+  defp withheld_parent_with_reply do
+    author = insert(:activated_user, noindex?: false, noai?: false)
+    replier = insert(:activated_user, noindex?: false, noai?: false)
+
+    {:ok, parent} = Posts.create_post(author, %{body: @withheld, noindex_noai: "true"})
+    {:ok, reply} = Posts.create_reply(replier, parent, %{body: "Danke für die Zahlen!"})
+
+    %{author: author, replier: replier, parent: parent, reply: reply}
+  end
+
+  describe "a conversation a machine reads" do
+    test "the reply's agent formats quote the withheld parent by name, not by body", %{conn: conn} do
+      %{replier: replier, reply: reply, parent: parent} = withheld_parent_with_reply()
+
+      doc = conn |> get("/#{replier.username}/posts/#{reply.id}.json") |> json_response(200)
+
+      quoted = Enum.find(doc["thread"], &(&1["id"] == parent.id))
+
+      assert quoted, "the withheld parent keeps its place in the conversation"
+      refute quoted["body_markdown"] =~ "Preisliste"
+      assert quoted["body_markdown"] == "Post not open to search engines"
+
+      # The reply itself is untouched — one post's answer is not another's.
+      assert doc["body_markdown"] =~ "Danke für die Zahlen!"
+    end
+
+    test "the same is true of the Markdown sibling", %{conn: conn} do
+      %{replier: replier, reply: reply} = withheld_parent_with_reply()
+
+      body = conn |> get("/#{replier.username}/posts/#{reply.id}.md") |> response(200)
+
+      refute body =~ "Preisliste"
+      assert body =~ "Post not open to search engines"
+    end
+
+    test "a withheld reply under an open post gives up its words too", %{conn: conn} do
+      author = insert(:activated_user, noindex?: false, noai?: false)
+      replier = insert(:activated_user, noindex?: false, noai?: false)
+
+      {:ok, post} = Posts.create_post(author, %{body: "Ganz offen"})
+      {:ok, _reply} = Posts.create_reply(replier, post, %{body: @withheld, noindex_noai: "true"})
+
+      doc = conn |> get("/#{author.username}/posts/#{post.id}.json") |> json_response(200)
+
+      assert [entry] = doc["replies"]
+      refute entry["body_markdown"] =~ "Preisliste"
+      assert entry["body_markdown"] == "Post not open to search engines"
+    end
+
+    test "but the HTML conversation still shows it to a person", %{conn: conn} do
+      %{replier: replier, reply: reply} = withheld_parent_with_reply()
+
+      html = conn |> get("/#{replier.username}/posts/#{reply.id}") |> html_response(200)
+
+      # Page and doc differ on purpose. The thread is rendered by an embedded
+      # LiveView, so the dead render is what this asserts — which is the render
+      # a crawler would get, and it carries the reply's own robots axes rather
+      # than the parent's. That is the accepted trade: the promise is about the
+      # machine documents, and a human reading a conversation sees all of it.
+      assert html =~ "Danke für die Zahlen!"
+    end
+  end
+
+  describe "a repost of a withheld post" do
+    test "is off the reposter's public archive, page and document alike", %{conn: conn} do
+      author = insert(:activated_user, noindex?: false, noai?: false)
+      reposter = insert(:activated_user, noindex?: false, noai?: false)
+
+      {:ok, withheld} = Posts.create_post(author, %{body: @withheld, noindex_noai: "true"})
+      {:ok, open} = Posts.create_post(author, %{body: "Ganz offen"})
+      :ok = Posts.repost_post(reposter, withheld)
+      :ok = Posts.repost_post(reposter, open)
+
+      html = conn |> get("/#{reposter.username}/posts") |> html_response(200)
+      refute html =~ "Preisliste"
+      assert html =~ "Ganz offen"
+
+      doc = conn |> get("/#{reposter.username}/posts.json") |> json_response(200)
+      refute Jason.encode!(doc) =~ "Preisliste"
+    end
+
+    test "and off the reposter's profile document", %{conn: conn} do
+      author = insert(:activated_user, noindex?: false, noai?: false)
+      reposter = insert(:activated_user, noindex?: false, noai?: false)
+
+      {:ok, withheld} = Posts.create_post(author, %{body: @withheld, noindex_noai: "true"})
+      :ok = Posts.repost_post(reposter, withheld)
+
+      doc = conn |> get("/#{reposter.username}.json") |> json_response(200)
+
+      refute Jason.encode!(doc) =~ "Preisliste"
+    end
+  end
+
+  describe "a withheld post pinned to its own author's profile" do
+    test "keeps its place in the profile document and gives up its excerpt", %{conn: conn} do
+      author = insert(:activated_user, noindex?: false, noai?: false)
+      {:ok, post} = Posts.create_post(author, %{body: @withheld, noindex_noai: "true"})
+      {:ok, author} = Posts.pin_to_profile(author, post)
+
+      doc = conn |> get("/#{author.username}.json") |> json_response(200)
+
+      refute Jason.encode!(doc) =~ "Preisliste"
+    end
+  end
+
+  describe "a private page a machine never reads" do
+    test "keeps the quoted parent on the reader's own bookmarks", %{conn: conn} do
+      %{parent: parent, reply: reply} = withheld_parent_with_reply()
+      {conn, reader} = create_and_login_user(conn)
+      :ok = Posts.bookmark_post(reader, reply)
+
+      {:ok, _live, html} = live(conn, ~p"/bookmarks")
+
+      # `/likes` and `/bookmarks` are login-only, so no crawler reaches them and
+      # the policy has no business there. This is the calibration for keeping
+      # the gate in `Posts.public_ancestors/1` rather than in the shared card
+      # component, where it would have taken a member's own quoted parent away.
+      assert html =~ "Danke für die Zahlen!"
+      assert html =~ "Preisliste"
+      assert Repo.get!(Vutuv.Posts.Post, parent.id)
+    end
+  end
+
+  describe "the archive's quoted parent" do
+    test "is not printed on the public page either, which its own document omits", %{conn: conn} do
+      %{replier: replier, reply: reply} = withheld_parent_with_reply()
+
+      html = conn |> get("/#{replier.username}/posts") |> html_response(200)
+
+      # The archive is a crawl surface — this branch already drops a withheld
+      # post of the page owner's own from it — so the parent quoted above a
+      # reply card must go the same way. Its `.md`/`.json` siblings carry no
+      # thread for an archive entry at all, so this is also what stops the page
+      # and the document disagreeing.
+      refute html =~ "Preisliste"
+      assert html =~ "Danke für die Zahlen!"
+      assert Repo.get!(Vutuv.Posts.Post, reply.id)
+    end
+  end
+end

--- a/test/vutuv_web/withheld_post_redaction_test.exs
+++ b/test/vutuv_web/withheld_post_redaction_test.exs
@@ -24,6 +24,7 @@ defmodule VutuvWeb.WithheldPostRedactionTest do
 
   alias Vutuv.Posts
   alias Vutuv.Repo
+  alias VutuvWeb.AgentDocs.PostDoc
 
   @withheld "Interne Preisliste, nur für Menschen."
 
@@ -132,6 +133,62 @@ defmodule VutuvWeb.WithheldPostRedactionTest do
       doc = conn |> get("/#{author.username}.json") |> json_response(200)
 
       refute Jason.encode!(doc) =~ "Preisliste"
+    end
+  end
+
+  describe "a reader who is allowed to read it is not redacted at" do
+    # A redaction that hits somebody entitled to the text is as wrong as a
+    # missing one. Both of these are login-gated and per-viewer: the feed
+    # document declares `noindex: true, noai: true` over the whole response, and
+    # `/api/2.0` is a token read on a member's behalf. Either way that person
+    # opens the permalink and reads every word, so the sentence would take
+    # something away and tell them nothing.
+    test "the feed document", %{conn: _conn} do
+      %{parent: parent} = withheld_parent_with_reply()
+      reader = insert(:activated_user)
+
+      entry = PostDoc.timeline_entry(%{post: Posts.get_post(parent.id)}, reader)
+
+      assert entry.excerpt =~ "Preisliste"
+      refute entry.excerpt == "Post not open to search engines"
+    end
+
+    test "a permalink read through the API on a member's behalf" do
+      %{author: author, parent: parent, reply: reply} = withheld_parent_with_reply()
+      reader = insert(:activated_user)
+
+      loaded = Posts.get_post(reply.id)
+      doc = PostDoc.build(Posts.author(loaded), loaded, viewer: reader)
+      quoted = Enum.find(doc.thread, &(&1.id == parent.id))
+
+      assert quoted.body_markdown =~ "Preisliste"
+      # …and the anonymous build of the very same post still redacts it.
+      anonymous = PostDoc.build(Posts.author(loaded), loaded)
+
+      assert Enum.find(anonymous.thread, &(&1.id == parent.id)).body_markdown ==
+               "Post not open to search engines"
+
+      assert author
+    end
+  end
+
+  describe "an author reading their own archive" do
+    test "keeps the quoted parent above their own reply to their own withheld post", %{conn: conn} do
+      author = insert(:activated_user, noindex?: false, noai?: false, emails: [build(:email)])
+      {:ok, parent} = Posts.create_post(author, %{body: @withheld, noindex_noai: "true"})
+      {:ok, _reply} = Posts.create_reply(author, parent, %{body: "Nachtrag von mir."})
+
+      html =
+        conn
+        |> login_via_pin(hd(author.emails).value)
+        |> get("/#{author.username}/posts")
+        |> html_response(200)
+
+      # The archive already shows an author their own withheld posts, so
+      # dropping the quote one row down made a single page disagree with
+      # itself. `public_ancestors/2` takes the viewer for exactly this.
+      assert html =~ "Nachtrag von mir."
+      assert html =~ "Preisliste"
     end
   end
 


### PR DESCRIPTION
Nothing kept search engines and AI away from a member's posts, and a post that said no leaked its whole body wherever it sat inside somebody else's — most sharply on `/:slug`, which is public, anonymous, in the sitemap and carries no `X-Robots-Tag`.

`/settings/privacy` now holds one switch, *Search engines and AI may read my posts* (`Vutuv.Prefs`' `posts_machines_allowed?`, default on). `Vutuv.Posts` stamps the answer onto `posts.noindex_noai?` as a post is published, so flipping it later leaves older posts exactly as they went out.

Three review rounds each measured completely and each missed the next surface, so this is enforced as a property rather than a list: a post's body leaves the database toward a machine-readable surface only through `Posts.scope_machines_for/2`, and `test/vutuv/post_body_chokepoint_test.exs` fails the build when a new query selects a `body` past it. Exceptions carry their reason. A withheld post also leaves the Fediverse, the sitemap and every listing document entirely; the HTML conversation still shows it to people.

**To decide:** page and doc differ on purpose, and `/ModDate` survives the strip.

Closes #2107

https://claude.ai/code/session_013VnEsuePUe2CB2QvDcshcp
