### PR TITLE
Media Kit: photos keep the order they were picked in

### DIFF
--- a/docs/architecture/images.md
+++ b/docs/architecture/images.md
@@ -929,11 +929,43 @@ and format whitelist, `position` belongs to `PressKit.reorder/4`, and
 `rights_confirmed` would re-give a release that was already given — so
 `confirm_rights/1` keeps the original stamp on that path.
 
+A shelf holding a picture the AI gate has not released yet says **once, above
+the tiles**, that a visitor meets the pixelated stand-in meanwhile and that the
+mark clears itself: ten fresh pictures wear ten identical grey badges and
+nothing else, which reads as ten failed uploads (issue #2144). Nothing there
+estimates how long the check takes, because nothing measures it — `image_scans`
+records `scanned_at` and no start, so the only bounded numbers in the whole path
+are `ImageScanWorker`'s 15 s poll (a fresh row is nudged, so it does not wait
+for one), the Ollama call's 120 s timeout and the stand-in's own hour. A file a
+shelf refuses points at the other shelf underneath the refusal, but only where
+that shelf's whitelist really takes the format — a PDF is refused by both, and
+pointing at a second refusal is worse than pointing nowhere.
+
 `PressKit.reorder/4` and `move/5` number a shelf **0..n-1**, not 1..n like
 `Vutuv.Ordering`: a download is named from `position + 1`
 (`PressKit.download_name/2`), so the hero has to sit at 0. What the two do share
 — reading an untrusted drag payload, and swapping one row with its neighbour —
-is `Ordering.arrange/2` and `Ordering.swap/3`. A member's press kit is also a
+is `Ordering.arrange/2` and `Ordering.swap/3`. A **new** picture's position is
+the slot it was picked for rather than the shelf's row count when it lands
+(`create/5`'s `:position`, issue #2141): several files climb in parallel and
+finish in the order their sizes decide, so counting at completion time handed
+the hero a member deliberately picked first the *last* slot, under a line saying
+the first photo is the one shown first. `VutuvWeb.PressKitLive` writes each
+upload ref's rank down the first time it sees the entry list, which is the file
+picker's own order and stays that order until an entry is consumed. **That rank
+is a floor and not an answer**: it comes from one socket's snapshot of one
+moment, so two tabs of the same member both wish for slot 0, and a shelf whose
+row at 3 was just deleted has nine rows, a highest position of nine and
+therefore wishes for ten. Reading a wish as the answer gave the first case two
+downloads called `<handle>-press-1.jpg` and the second a refusal reading "no
+more than 10 press photos" under a counter reading "9 of 10". So `take_slot/3`
+takes the first slot **free** at or after the floor, falls back to the lowest
+free slot there is, and refuses only a shelf with no room at all — pick order
+kept, a delete's gap filled by the next upload, the second tab handed 1.
+Positions are still sparse while a batch is climbing (the hero holds 0 and lands
+last) and after a cancelled entry, so a shelf can skip a download number
+(`press-1`, `press-2`, `press-4`) until a reorder renumbers it. A member's
+press kit is also a
 section of `Vutuv.Export` (schema version 10), each entry carrying the address
 the file itself is at; the pictures they uploaded *for a page* are deliberately
 absent, since those belong to the page.

--- a/lib/vutuv/press_kit.ex
+++ b/lib/vutuv/press_kit.ex
@@ -762,8 +762,20 @@ defmodule Vutuv.PressKit do
   `{:error, :too_large}`, `{:error, :too_many}` or `{:error, :invalid_file}`
   for the three the form cannot see. The authorization is asked **first**, so a
   refused upload never so much as measures the file.
+
+  `opts` takes `:position`, **the slot this picture was picked for** — which is
+  not the same as the end of the shelf whenever several files are in flight at
+  once, because they finish in the order their sizes decide and the biggest one
+  finishes last (issue #2141). A caller that knows the pick order says so; one
+  that does not gets the front of the shelf and lands behind whatever is there.
+
+  It is a **floor and not an answer**: the picture takes the first slot free at
+  or after it, or the lowest free slot there is, and the only refusal is a shelf
+  with no room at all. A caller holds a snapshot of one moment and two of them
+  may hold the same one, so a slot it names may be taken or may be past a gap a
+  delete left; `take_slot/3` says why that has to be the shelf's decision.
   """
-  def create(owner, %User{} = uploader, {path, filename}, attrs) do
+  def create(owner, %User{} = uploader, {path, filename}, attrs, opts \\ []) do
     token = Uploads.gen_token()
 
     changeset =
@@ -776,7 +788,7 @@ defmodule Vutuv.PressKit do
     with :ok <- authorize(owner, uploader),
          :ok <- validate_form(changeset),
          :ok <- validate_size(path),
-         {:ok, position} <- take_slot(owner, logo?),
+         {:ok, position} <- take_slot(owner, logo?, opts[:position]),
          {:ok, meta} <- PressKitStore.store(path, filename, token, logo?) do
       insert(changeset, position, meta, token)
     end
@@ -1034,16 +1046,39 @@ defmodule Vutuv.PressKit do
     if File.stat!(path).size > max_filesize(), do: {:error, :too_large}, else: :ok
   end
 
-  # The room on the shelf and the position the new picture takes are the same
-  # count, so they are one query rather than two. Two uploads racing can land on
-  # the same position; #2085's editor is what reorders them, and the id
-  # tiebreaker in `shelf/2` keeps the order stable meanwhile.
-  defp take_slot(owner, logo?) do
-    used = count(owner, logo?)
+  # **A reserved slot is a floor, never an answer**, and the shelf itself
+  # decides. `wanted` comes from one socket's snapshot of one moment, so it is
+  # a wish about order and nothing more: two tabs of the same member both wish
+  # for 0, and a shelf whose row at 3 was just deleted has nine rows and a
+  # highest position of 9, which wishes for 10. Reading the wish as the answer
+  # gave the first case two pictures one slot (two files called
+  # `<handle>-press-1.jpg`) and the second a refusal saying "no more than 10
+  # press photos" under a counter reading "9 of 10" — a sentence the product
+  # could not honour, on the commonest edit a shelf gets.
+  #
+  # So the room is the only refusal (`used >= cap`), and the slot is the first
+  # one **free** at or after the floor, falling back to the lowest free slot
+  # there is. A batch keeps its order, because each picture's floor is its own
+  # pick position and the ones before it are either already there or still
+  # climbing towards slots below it; a delete's gap is filled by the next
+  # upload; and the second tab is handed 1 rather than a copy of 0. Since
+  # `used < cap` there is always a free slot under the cap for the fallback to
+  # find.
+  defp take_slot(owner, logo?, wanted) do
     cap = if logo?, do: max_logos(), else: max_photos()
+    positions = owner |> shelf(logo?) |> select([i], i.position) |> Repo.all()
 
-    if used < cap, do: {:ok, used}, else: {:error, :too_many}
+    if length(positions) >= cap,
+      do: {:error, :too_many},
+      else: {:ok, free_slot(MapSet.new(positions), wanted || 0, cap)}
   end
+
+  defp free_slot(taken, floor, cap) do
+    first_free(taken, floor, cap) || first_free(taken, 0, cap)
+  end
+
+  defp first_free(taken, from, cap),
+    do: Enum.find(from..(cap - 1)//1, &(&1 not in taken))
 
   defp insert(changeset, position, meta, token) do
     changeset

--- a/lib/vutuv_web/live/press_kit_live.ex
+++ b/lib/vutuv_web/live/press_kit_live.ex
@@ -81,6 +81,7 @@ defmodule VutuvWeb.PressKitLive do
   alias Vutuv.Organizations.Organization
   alias Vutuv.PressKit
   alias Vutuv.PressKitStore
+  alias Vutuv.Uploads
   alias VutuvWeb.ErrorHelpers
   alias VutuvWeb.Live.InitAssigns
   alias VutuvWeb.OrganizationLive.ManageGate
@@ -144,6 +145,10 @@ defmodule VutuvWeb.PressKitLive do
       # own moment. A reconnect is safe: the tick and the credit sit in a form
       # with a `phx-change`, which LiveView's form recovery replays on rejoin.
       |> assign(:armed, %{false => false, true => false})
+      # Which slot each picked file is on its way to, per shelf and by upload
+      # ref (issue #2141). Not rendered; see `note_slots/2` for why the pick
+      # order has to be written down the moment a file is seen.
+      |> assign(:slots, %{false => %{}, true => %{}})
       # Which ground the logo tiles stand on. A white wordmark is invisible on
       # white, so the shelf that holds one lets the owner look at it on the
       # background it was drawn for. A preview only — nothing about it is stored.
@@ -206,8 +211,7 @@ defmodule VutuvWeb.PressKitLive do
   end
 
   def handle_event("cancel-upload", %{"ref" => ref} = params, socket) do
-    name = if shelf_param(params), do: :logo, else: :photo
-    {:noreply, cancel_upload(socket, name, ref)}
+    {:noreply, cancel_upload(socket, params |> shelf_param() |> upload_name(), ref)}
   end
 
   def handle_event("open", %{"id" => id}, socket) do
@@ -417,10 +421,55 @@ defmodule VutuvWeb.PressKitLive do
 
   defp count_of(bio, length), do: PressKit.bio_word_count(Map.fetch!(bio, length))
 
-  # `auto_upload: true`, so this runs the moment the last chunk lands.
+  # `auto_upload: true`, so this runs on every chunk and stores on the last one.
   defp handle_progress(name, entry, socket) when name in [:photo, :logo] do
-    if entry.done?, do: store(socket, entry, name == :logo), else: {:noreply, socket}
+    logo? = name == :logo
+    socket = note_slots(socket, logo?)
+
+    if entry.done?, do: store(socket, entry, logo?), else: {:noreply, socket}
   end
+
+  # The order the member picked, written down the first time each file is seen
+  # (issue #2141).
+  #
+  # Ten photos go up **in parallel** and the position used to be taken when one
+  # landed, which is the order their sizes decide rather than the order they
+  # were picked: a pick of portrait, p2, p3, p4 with a 16 MB portrait came back
+  # p2, p4, p3, portrait, so the hero the member deliberately picked first got
+  # the last slot on a shelf whose own line says the first photo is the one
+  # shown first.
+  #
+  # `@uploads.<shelf>.entries` **is** the file picker's order, and it stays that
+  # order until an entry is consumed — which only `store/3` below does, and only
+  # after this has run. So the first sight of a ref is its rank. Refs that have
+  # left the list (stored, cancelled) are dropped here rather than in a cleanup
+  # of their own, and a second pick made while the first is still climbing takes
+  # the slots behind the ones already reserved.
+  defp note_slots(socket, logo?) do
+    refs = Enum.map(socket.assigns.uploads[upload_name(logo?)].entries, & &1.ref)
+    known = Map.take(socket.assigns.slots[logo?], refs)
+
+    # Past the last slot **taken**, which is not the same as past the last row:
+    # a shelf of one picture at position 5 has one row, and a floor of 1 lets a
+    # file picked later be handed a slot a file picked earlier is still climbing
+    # towards, since the first free slot at or after a low floor can overtake
+    # one at or after a high one. `PressKit.take_slot/3` is what keeps two
+    # pictures off one slot — a floor is a wish, and only the shelf knows what
+    # is free — so what is left here is purely the order.
+    taken = Enum.map(shelf_images(socket, logo?), &(&1.position || 0))
+    next = Enum.max([-1 | taken ++ Map.values(known)]) + 1
+
+    slots =
+      refs
+      |> Enum.reject(&Map.has_key?(known, &1))
+      |> Enum.with_index(next)
+      |> Enum.into(known)
+
+    put_in_shelf(socket, :slots, logo?, slots)
+  end
+
+  defp shelf_images(socket, true), do: socket.assigns.logos
+  defp shelf_images(socket, false), do: socket.assigns.photos
 
   defp store(socket, entry, logo?) do
     # The tick rides in as the changeset's own `rights_confirmed`, rather than
@@ -437,7 +486,8 @@ defmodule VutuvWeb.PressKitLive do
            socket.assigns.owner,
            socket.assigns.current_user,
            {path, entry.client_name},
-           attrs
+           attrs,
+           position: socket.assigns.slots[logo?][entry.ref]
          )}
       end)
 
@@ -829,6 +879,38 @@ defmodule VutuvWeb.PressKitLive do
           else: gettext("No press photo here yet.")}
       </p>
 
+      <%!-- Said once for the shelf rather than louder on each tile (#2144). Ten
+      fresh pictures wear ten identical grey badges and nothing else, which
+      reads as ten failed uploads — so the sentence the badge was missing is
+      what a stranger meets meanwhile, and that nobody has to do anything.
+      Amber, the hourglass and a `role="status"`, because this is the same wait
+      the post composer's author panel already describes
+      (`VutuvWeb.PostComponents.photo_check_progress/1`) and the app says
+      "we are looking at your picture" in one voice. **No estimate of how long**,
+      deliberately: `image_scans` stamps `scanned_at` and no start, so nothing
+      here measures a duration to promise — and no "N of M done" either, since
+      this page learns of a verdict only on its next event and a count that sat
+      still would read as stuck. --%>
+      <div
+        :if={Enum.any?(@images, &pending?/1)}
+        data-press-pending={PressKit.shelf_name(@logo?)}
+        class="mt-3 flex items-start gap-2 rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-800 ring-1 ring-amber-200 dark:bg-amber-900/30 dark:text-amber-200 dark:ring-amber-800"
+        role="status"
+        aria-live="polite"
+      >
+        <.hourglass class="mt-0.5 h-4 w-4" />
+        <span>
+          <span class="font-semibold">
+            {gettext("A picture still being checked is not public yet.")}
+          </span>
+          <span class="mt-0.5 block">
+            {gettext(
+              "A visitor sees a pixelated stand-in in its place and can download nothing. The mark goes by itself when the check is through."
+            )}
+          </span>
+        </span>
+      </div>
+
       <ul
         :if={@images != []}
         id={"press-order-#{PressKit.shelf_name(@logo?)}"}
@@ -1172,6 +1254,21 @@ defmodule VutuvWeb.PressKitLive do
 
       <.upload_problems upload={@upload} />
 
+      <%!-- "That file type is not allowed." is the whole answer a member gets
+      for dropping a photo on the logo shelf, or an SVG on the photo shelf, and
+      the shelf that would have taken it is on the same page (#2144). Offered
+      only where the other shelf really does take this format — a PDF is
+      refused by both, and pointing at a second refusal is worse than none. --%>
+      <p
+        :if={wrong_shelf?(@upload, @logo?)}
+        data-press-wrong-shelf={@shelf}
+        class="text-xs text-slate-600 dark:text-slate-400"
+      >
+        {if @logo?,
+          do: gettext("Press photos, further up this page, take this format."),
+          else: gettext("Logo variants, further down this page, take this format.")}
+      </p>
+
       <div
         :for={entry <- @upload.entries}
         class="flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400"
@@ -1251,12 +1348,36 @@ defmodule VutuvWeb.PressKitLive do
   defp shelf_max(true), do: PressKit.max_logos()
   defp shelf_max(false), do: PressKit.max_photos()
 
+  # A shelf's `allow_upload/3` name, beside `shelf_name/1` and `shelf_max/1`:
+  # three call sites ask it, and a hand-written `if` at each was already two.
+  defp upload_name(true), do: :logo
+  defp upload_name(false), do: :photo
+
   # A logo's `thumb` is scaled down whole; a photo's is a square crop, so its
   # tile takes `lite` — the cheap version, which is what this page's ten tiles
   # should cost on the phone they are uploaded from.
   defp tile_version(image), do: if(Image.logo?(image), do: "thumb", else: "lite")
 
   defp pending?(image), do: not ImageScans.released?(image.moderation)
+
+  # Whether a file this shelf refused is one the other shelf takes. Asked
+  # through `Uploads.valid_extension?/2`, which is the very predicate
+  # `PressKitStore.store/4` will run on the file once it is dropped where it
+  # belongs — a second spelling of "does this extension count" is how an offer
+  # comes to promise a format the other box then refuses.
+  # `upload.errors` first, because it is `[]` for every one of the ~100 progress
+  # ticks a climbing file costs and this is asked on each of them: a shelf with
+  # nothing refused answers without building the other one's whitelist.
+  defp wrong_shelf?(%{errors: []}, _logo?), do: false
+
+  defp wrong_shelf?(upload, logo?) do
+    elsewhere = PressKitStore.extension_whitelist(not logo?)
+
+    Enum.any?(upload.entries, fn entry ->
+      :not_accepted in upload_errors(upload, entry) and
+        Uploads.valid_extension?(entry.client_name, elsewhere)
+    end)
+  end
 
   defp tile_title(image), do: PressKit.title(image)
 end

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -119,8 +119,8 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
 #: lib/vutuv_web/live/post_live/composer.ex:2081
-#: lib/vutuv_web/live/press_kit_live.ex:679
-#: lib/vutuv_web/live/press_kit_live.ex:1057
+#: lib/vutuv_web/live/press_kit_live.ex:729
+#: lib/vutuv_web/live/press_kit_live.ex:1139
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -220,8 +220,8 @@ msgstr "Download"
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
 #: lib/vutuv_web/live/job_posting_live/show.ex:201
 #: lib/vutuv_web/live/organization_live/show.ex:159
-#: lib/vutuv_web/live/press_kit_live.ex:641
-#: lib/vutuv_web/live/press_kit_live.ex:974
+#: lib/vutuv_web/live/press_kit_live.ex:691
+#: lib/vutuv_web/live/press_kit_live.ex:1056
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:19
@@ -622,8 +622,8 @@ msgstr "Öffentlich"
 #: lib/vutuv_web/components/ui.ex:4934
 #: lib/vutuv_web/live/organization_live/edit.ex:376
 #: lib/vutuv_web/live/post_live/composer.ex:2408
-#: lib/vutuv_web/live/press_kit_live.ex:677
-#: lib/vutuv_web/live/press_kit_live.ex:1056
+#: lib/vutuv_web/live/press_kit_live.ex:727
+#: lib/vutuv_web/live/press_kit_live.ex:1138
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
@@ -943,8 +943,8 @@ msgid "You follow back %{name}."
 msgstr "Sie folgen %{name} jetzt zurück."
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:178
-#: lib/vutuv_web/live/press_kit_live.ex:109
+#: lib/vutuv_web/live/post_live/feed.ex:179
+#: lib/vutuv_web/live/press_kit_live.ex:110
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1711,7 +1711,7 @@ msgstr "Empfehlen"
 #: lib/vutuv_web/live/organization_live/following.ex:421
 #: lib/vutuv_web/live/organization_live/show.ex:602
 #: lib/vutuv_web/live/organization_live/show.ex:639
-#: lib/vutuv_web/live/post_live/feed.ex:1053
+#: lib/vutuv_web/live/post_live/feed.ex:1054
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
 #: lib/vutuv_web/templates/user/show.html.heex:1350
 #: lib/vutuv_web/views/user_html.ex:643
@@ -2119,7 +2119,7 @@ msgstr "Zurück zum Beitrag"
 #: lib/vutuv_web/live/post_live/composer.ex:2179
 #: lib/vutuv_web/live/post_live/composer.ex:2202
 #: lib/vutuv_web/live/post_live/composer.ex:2228
-#: lib/vutuv_web/live/press_kit_live.ex:1210
+#: lib/vutuv_web/live/press_kit_live.ex:1307
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr "Upload abbrechen"
@@ -2144,8 +2144,8 @@ msgstr "Beitrag bearbeiten"
 #: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:203
-#: lib/vutuv_web/live/post_live/feed.ex:364
-#: lib/vutuv_web/live/post_live/feed.ex:3530
+#: lib/vutuv_web/live/post_live/feed.ex:365
+#: lib/vutuv_web/live/post_live/feed.ex:3536
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1346
 #: lib/vutuv_web/live/shell_live.ex:1692
@@ -2191,7 +2191,7 @@ msgstr "Nicht eingeloggte Besucher"
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3870
+#: lib/vutuv_web/live/post_live/feed.ex:3876
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2270,7 +2270,7 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/live/post_live/saved.ex:666
 #: lib/vutuv_web/live/post_live/saved.ex:694
 #: lib/vutuv_web/live/post_rewrites_live.ex:376
-#: lib/vutuv_web/live/press_kit_live.ex:983
+#: lib/vutuv_web/live/press_kit_live.ex:1065
 #: lib/vutuv_web/templates/connection/index.html.heex:45
 #: lib/vutuv_web/views/settings_html.ex:386
 #, elixir-autogen, elixir-format
@@ -2289,7 +2289,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2706
+#: lib/vutuv_web/live/post_live/feed.ex:2712
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2304,7 +2304,7 @@ msgstr "Diese Seite konnte leider nicht gefunden werden."
 #: lib/vutuv_web/live/post_live/composer.ex:1614
 #: lib/vutuv_web/live/post_live/composer.ex:1652
 #: lib/vutuv_web/live/post_live/composer.ex:1752
-#: lib/vutuv_web/live/press_kit_live.ex:491
+#: lib/vutuv_web/live/press_kit_live.ex:541
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr "Diese Datei konnte nicht verarbeitet werden."
@@ -2512,7 +2512,7 @@ msgstr "Gefällt mir entfernen"
 #: lib/vutuv_web/live/organization_live/following.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:476
 #: lib/vutuv_web/live/organization_live/show.ex:644
-#: lib/vutuv_web/live/post_live/feed.ex:1040
+#: lib/vutuv_web/live/post_live/feed.ex:1041
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:42
 #: lib/vutuv_web/views/user_html.ex:633
@@ -2829,7 +2829,7 @@ msgstr[0] "1 Vernetzung"
 msgstr[1] "%{formatted} Vernetzungen"
 
 #: lib/vutuv_web/live/job_board_live.ex:458
-#: lib/vutuv_web/live/post_live/feed.ex:1184
+#: lib/vutuv_web/live/post_live/feed.ex:1185
 #: lib/vutuv_web/templates/user/card_list.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -4650,7 +4650,7 @@ msgstr "Sie haben niemanden blockiert."
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3875
+#: lib/vutuv_web/live/post_live/feed.ex:3881
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
@@ -5624,7 +5624,7 @@ msgstr "Art der E-Mail"
 msgid "Type of email address"
 msgstr "Art der E-Mail-Adresse"
 
-#: lib/vutuv_web/live/press_kit_live.ex:578
+#: lib/vutuv_web/live/press_kit_live.ex:628
 #: lib/vutuv_web/templates/user/edit.html.heex:256
 #, elixir-autogen, elixir-format
 msgid "About you"
@@ -6412,7 +6412,7 @@ msgid "View all phone numbers"
 msgstr "Alle Telefonnummern anzeigen"
 
 #: lib/vutuv_web/live/feed_languages_live.ex:235
-#: lib/vutuv_web/live/press_kit_live.ex:897
+#: lib/vutuv_web/live/press_kit_live.ex:979
 #: lib/vutuv_web/live/section_reorder_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder"
@@ -6427,7 +6427,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/feed_languages_live.ex:267
 #: lib/vutuv_web/live/post_rewrites_live.ex:364
-#: lib/vutuv_web/live/press_kit_live.ex:959
+#: lib/vutuv_web/live/press_kit_live.ex:1041
 #: lib/vutuv_web/live/section_reorder_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Move down"
@@ -6435,7 +6435,7 @@ msgstr "Nach unten"
 
 #: lib/vutuv_web/live/feed_languages_live.ex:256
 #: lib/vutuv_web/live/post_rewrites_live.ex:352
-#: lib/vutuv_web/live/press_kit_live.ex:948
+#: lib/vutuv_web/live/press_kit_live.ex:1030
 #: lib/vutuv_web/live/section_reorder_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -7689,9 +7689,9 @@ msgstr ""
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/media_live.ex:270
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:4169
+#: lib/vutuv_web/live/post_live/feed.ex:4175
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
-#: lib/vutuv_web/live/press_kit_live.ex:974
+#: lib/vutuv_web/live/press_kit_live.ex:1056
 #, elixir-autogen
 msgid "Done"
 msgstr "Fertig"
@@ -8168,7 +8168,7 @@ msgstr "Administratoren"
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
 #: lib/vutuv_web/live/job_board_live.ex:468
-#: lib/vutuv_web/live/post_live/feed.ex:1193
+#: lib/vutuv_web/live/post_live/feed.ex:1194
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr "Alle Mitglieder"
@@ -14026,7 +14026,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5556
 #: lib/vutuv_web/controllers/settings_controller.ex:643
-#: lib/vutuv_web/live/post_live/feed.ex:853
+#: lib/vutuv_web/live/post_live/feed.ex:854
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
@@ -14929,7 +14929,7 @@ msgstr ""
 "Wählen Sie unten einen Abschluss oder eine Schule, um ihn statt eines "
 "Jobtitels oben in Ihrem Profil anzuzeigen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1253
+#: lib/vutuv_web/live/post_live/feed.ex:1254
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr "Trotzdem anzeigen"
@@ -18514,7 +18514,7 @@ msgstr "Ausstellungsdatum"
 msgid "Label"
 msgstr "Bezeichnung"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3893
+#: lib/vutuv_web/live/post_live/feed.ex:3899
 #: lib/vutuv_web/live/reference_check_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -18932,7 +18932,7 @@ msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr "PDF, JPG, PNG oder WebP, bis %{limit}"
 
 #: lib/vutuv_web/components/ui.ex:4760
-#: lib/vutuv_web/live/press_kit_live.ex:478
+#: lib/vutuv_web/live/press_kit_live.ex:528
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "That file is larger than %{limit}. Please upload a smaller one."
@@ -21016,7 +21016,7 @@ msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Empfohlen: quadratisch, mindestens %{width} × %{height} Pixel."
 
 #: lib/vutuv_web/live/job_board_live.ex:431
-#: lib/vutuv_web/live/post_live/feed.ex:1130
+#: lib/vutuv_web/live/post_live/feed.ex:1131
 #: lib/vutuv_web/views/user_html.ex:355
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -21637,12 +21637,12 @@ msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public po
 msgstr ""
 "Folgen Sie #%{tag} von Mastodon oder einer anderen Fediverse-App aus, dann landen die öffentlichen Beiträge in Ihrer Timeline. Ein vutuv-Konto brauchen Sie dafür nicht."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4063
+#: lib/vutuv_web/live/post_live/feed.ex:4069
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Andere Mitglieder begrüßen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:854
+#: lib/vutuv_web/live/post_live/feed.ex:855
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr "Neu dabei"
@@ -21688,7 +21688,7 @@ msgstr "Der beste Weg: Folgen Sie %{name} hier. Neue Beiträge landen in Ihrem F
 msgid "With a vutuv account"
 msgstr "Mit einem vutuv-Konto"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1122
+#: lib/vutuv_web/live/post_live/feed.ex:1123
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
@@ -22065,7 +22065,7 @@ msgstr "Alle vutuv Mitglieder, alphabetisch nach Nachname sortiert."
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr "Alle vutuv Mitglieder, gruppiert nach dem Anfangsbuchstaben des Nachnamens."
 
-#: lib/vutuv_web/live/post_live/feed.ex:979
+#: lib/vutuv_web/live/post_live/feed.ex:980
 #: lib/vutuv_web/live/post_live/filter_band.ex:350
 #, elixir-autogen, elixir-format
 msgid "A photo"
@@ -22081,7 +22081,7 @@ msgstr "Auch in längeren Wörtern: %{word} trifft auch %{example}."
 msgid "A–Z"
 msgstr "A–Z"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1080
+#: lib/vutuv_web/live/post_live/feed.ex:1081
 #, elixir-autogen, elixir-format
 msgid "Browse the tags"
 msgstr "Alle Tags ansehen"
@@ -22096,7 +22096,7 @@ msgstr "Aktivste zuerst"
 msgid "Clear all"
 msgstr "Alle löschen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:891
+#: lib/vutuv_web/live/post_live/feed.ex:892
 #, elixir-autogen, elixir-format
 msgid "Drag, or use the arrow keys"
 msgstr "Ziehen, oder die Pfeiltasten benutzen"
@@ -22111,13 +22111,13 @@ msgstr "Auf- und zuklappen"
 msgid "Find an account or a server …"
 msgstr "Konto oder Server suchen …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:915
+#: lib/vutuv_web/live/post_live/feed.ex:916
 #, elixir-autogen, elixir-format
 msgid "Fold %{card}"
 msgstr "%{card} einklappen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1051
 #: lib/vutuv_web/live/post_live/feed.ex:1052
+#: lib/vutuv_web/live/post_live/feed.ex:1053
 #, elixir-autogen, elixir-format
 msgid "Follow a tag …"
 msgstr "Einem Tag folgen …"
@@ -22134,19 +22134,19 @@ msgstr "Tag ausblenden …"
 msgid "Hide a word or a whole phrase …"
 msgstr "Wort oder ganzen Satz ausblenden …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:852
-#: lib/vutuv_web/live/post_live/feed.ex:4226
+#: lib/vutuv_web/live/post_live/feed.ex:853
+#: lib/vutuv_web/live/post_live/feed.ex:4232
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Tags ausblenden"
 
-#: lib/vutuv_web/live/post_live/feed.ex:851
-#: lib/vutuv_web/live/post_live/feed.ex:4215
+#: lib/vutuv_web/live/post_live/feed.ex:852
+#: lib/vutuv_web/live/post_live/feed.ex:4221
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Wörter ausblenden"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1086
+#: lib/vutuv_web/live/post_live/feed.ex:1087
 #: lib/vutuv_web/live/post_live/filter_band.ex:394
 #, elixir-autogen, elixir-format
 msgid "In your feed right now:"
@@ -22162,7 +22162,7 @@ msgstr "Trifft gerade nichts in Ihrem Feed — für alles Neue gilt die Regel tr
 msgid "More of your %{formatted} accounts"
 msgstr "Mehr Ihrer %{formatted} Konten"
 
-#: lib/vutuv_web/live/post_live/feed.ex:890
+#: lib/vutuv_web/live/post_live/feed.ex:891
 #, elixir-autogen, elixir-format
 msgid "Move %{card}"
 msgstr "%{card} verschieben"
@@ -22173,12 +22173,12 @@ msgstr "%{card} verschieben"
 msgid "No account found."
 msgstr "Kein Konto gefunden."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1075
+#: lib/vutuv_web/live/post_live/feed.ex:1076
 #, elixir-autogen, elixir-format
 msgid "No tag called %{name} yet."
 msgstr "Noch kein Tag namens %{name}."
 
-#: lib/vutuv_web/live/post_live/feed.ex:844
+#: lib/vutuv_web/live/post_live/feed.ex:845
 #, elixir-autogen, elixir-format
 msgid "Not read yet"
 msgstr "Noch nicht gelesen"
@@ -22208,13 +22208,13 @@ msgstr "Beiträge mit einem dieser Tags werden genauso zugeklappt."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Beiträge mit einem dieser Wörter werden auf eine Zeile zugeklappt — nicht gelöscht, und mit einem Weg, sie doch zu lesen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4089
+#: lib/vutuv_web/live/post_live/feed.ex:4095
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Weggelegt:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:936
 #: lib/vutuv_web/live/post_live/feed.ex:937
+#: lib/vutuv_web/live/post_live/feed.ex:938
 #, elixir-autogen, elixir-format
 msgid "Remove %{card}"
 msgstr "%{card} entfernen"
@@ -22246,8 +22246,8 @@ msgstr "Nur %{source} anzeigen"
 msgid "Show posts by %{name}"
 msgstr "Beiträge von %{name} anzeigen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:850
-#: lib/vutuv_web/live/post_live/feed.ex:4181
+#: lib/vutuv_web/live/post_live/feed.ex:851
+#: lib/vutuv_web/live/post_live/feed.ex:4187
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr "Quellen"
@@ -22257,12 +22257,12 @@ msgstr "Quellen"
 msgid "Switching off means muting, not unfollowing. You stay a follower, the posts just stop reaching your feed: permanently and on every device, until you switch them back on here."
 msgstr "Ausschalten heißt stumm schalten, nicht entfolgen. Sie folgen weiter, die Beiträge bleiben nur aus Ihrem Feed: dauerhaft und auf allen Geräten, bis Sie hier wieder einschalten."
 
-#: lib/vutuv_web/live/post_live/feed.ex:914
+#: lib/vutuv_web/live/post_live/feed.ex:915
 #, elixir-autogen, elixir-format
 msgid "Unfold %{card}"
 msgstr "%{card} ausklappen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1041
+#: lib/vutuv_web/live/post_live/feed.ex:1042
 #, elixir-autogen, elixir-format
 msgid "Unfollow the tag %{tag}"
 msgstr "Dem Tag %{tag} nicht mehr folgen"
@@ -22286,20 +22286,20 @@ msgid_plural "and %{formatted} more"
 msgstr[0] "und 1 weiterer"
 msgstr[1] "und %{formatted} weitere"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3647
-#: lib/vutuv_web/live/post_live/feed.ex:3674
+#: lib/vutuv_web/live/post_live/feed.ex:3653
+#: lib/vutuv_web/live/post_live/feed.ex:3680
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
 msgstr "Filter"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1261
+#: lib/vutuv_web/live/post_live/feed.ex:1262
 #, elixir-autogen, elixir-format
 msgctxt "filtered post"
 msgid "Hidden:"
 msgstr "Ausgeblendet:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:989
+#: lib/vutuv_web/live/post_live/feed.ex:990
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} post in the feed"
 msgid_plural "Show %{formatted} posts in the feed"
@@ -22319,7 +22319,7 @@ msgstr ""
 "erscheint, sobald die Prüfung durch ist."
 
 #: lib/vutuv_web/live/organization_live/edit.ex:290
-#: lib/vutuv_web/live/press_kit_live.ex:1143
+#: lib/vutuv_web/live/press_kit_live.ex:1225
 #: lib/vutuv_web/templates/user/edit.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "%{formats}, up to %{limit}"
@@ -22353,7 +22353,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} Beitrag am %{day}"
 msgstr[1] "%{count} Beiträge am %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3850
+#: lib/vutuv_web/live/post_live/feed.ex:3856
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Zurück zu jetzt"
@@ -22363,7 +22363,7 @@ msgstr "Zurück zu jetzt"
 msgid "Busy month: the shading counts at least this much."
 msgstr "Voller Monat: die Färbung zählt mindestens so viel."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3896
+#: lib/vutuv_web/live/post_live/feed.ex:3902
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -22385,7 +22385,7 @@ msgstr "Nächster Monat"
 msgid "Next year"
 msgstr "Nächstes Jahr"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3846
+#: lib/vutuv_web/live/post_live/feed.ex:3852
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Am %{day} ist nichts in Ihrem Feed angekommen."
@@ -22472,7 +22472,7 @@ msgstr "Neue Version bereit."
 msgid "Page management"
 msgstr "Verwaltung"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2700
+#: lib/vutuv_web/live/post_live/feed.ex:2706
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
@@ -22504,7 +22504,7 @@ msgstr "Ein Konto erwähnen"
 msgid "{used} of {max} mentions"
 msgstr "{used} von {max} Erwähnungen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2812
+#: lib/vutuv_web/live/post_live/feed.ex:2818
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr "Bis hier neu"
@@ -22719,7 +22719,7 @@ msgctxt "phone tab bar"
 msgid "Write"
 msgstr "Schreiben"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3984
+#: lib/vutuv_web/live/post_live/feed.ex:3990
 #: lib/vutuv_web/live/post_rewrites_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "%{formatted} rule"
@@ -23516,8 +23516,8 @@ msgstr "Beiträge in Ihrem Feed"
 msgid "Posts loaded at once"
 msgstr "Beiträge auf einmal"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3920
-#: lib/vutuv_web/live/post_live/feed.ex:3924
+#: lib/vutuv_web/live/post_live/feed.ex:3926
+#: lib/vutuv_web/live/post_live/feed.ex:3930
 #, elixir-autogen, elixir-format
 msgid "Posts per page"
 msgstr "Beiträge pro Seite"
@@ -23543,14 +23543,14 @@ msgstr "Ein Wort oder eine Wortgruppe …"
 msgid "For whom %{thing} is hidden"
 msgstr "Für wen %{thing} ausgeblendet wird"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3981
-#: lib/vutuv_web/live/post_live/feed.ex:4145
-#: lib/vutuv_web/live/post_live/feed.ex:4154
+#: lib/vutuv_web/live/post_live/feed.ex:3987
+#: lib/vutuv_web/live/post_live/feed.ex:4151
+#: lib/vutuv_web/live/post_live/feed.ex:4160
 #, elixir-autogen, elixir-format
 msgid "Hidden"
 msgstr "Ausgeblendet"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4119
+#: lib/vutuv_web/live/post_live/feed.ex:4125
 #, elixir-autogen, elixir-format
 msgid "Hide something from your feed"
 msgstr "Etwas aus dem Feed ausblenden"
@@ -23560,12 +23560,12 @@ msgstr "Etwas aus dem Feed ausblenden"
 msgid "Stop showing"
 msgstr "Nicht mehr zeigen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4160
+#: lib/vutuv_web/live/post_live/feed.ex:4166
 #, elixir-autogen, elixir-format
 msgid "Whatever these match is folded to a single line in your feed."
 msgstr "Was hiervon getroffen wird, klappt im Feed auf eine Zeile zu."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4180
+#: lib/vutuv_web/live/post_live/feed.ex:4186
 #, elixir-autogen, elixir-format
 msgid "Words & tags"
 msgstr "Wörter & Tags"
@@ -24516,48 +24516,48 @@ msgid_plural "%{formatted} more entries (%{years})"
 msgstr[0] "Ein weiterer Eintrag (%{years})"
 msgstr[1] "%{formatted} weitere Einträge (%{years})"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1202
+#: lib/vutuv_web/live/press_kit_live.ex:1299
 #, elixir-autogen, elixir-format
 msgid "%{percent}%"
 msgstr "%{percent} %"
 
-#: lib/vutuv_web/live/press_kit_live.ex:797
+#: lib/vutuv_web/live/press_kit_live.ex:847
 #, elixir-autogen, elixir-format
 msgid "%{used} of %{max}"
 msgstr "%{used} von %{max}"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1051
+#: lib/vutuv_web/live/press_kit_live.ex:1133
 #, elixir-autogen, elixir-format
 msgid "A photographer's @handle links to their profile and notifies nobody."
 msgstr "Ein @handle verlinkt auf das Profil des Fotografen und benachrichtigt niemanden."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1136
+#: lib/vutuv_web/live/press_kit_live.ex:1218
 #, elixir-autogen, elixir-format
 msgid "Add a logo variant"
 msgstr "Logo-Variante hinzufügen"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1137
+#: lib/vutuv_web/live/press_kit_live.ex:1219
 #, elixir-autogen, elixir-format
 msgid "Add a press photo"
 msgstr "Pressefoto hinzufügen"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1013
+#: lib/vutuv_web/live/press_kit_live.ex:1095
 #, elixir-autogen, elixir-format
 msgid "At the desk in the Bonn office"
 msgstr "Am Schreibtisch im Bonner Büro"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1045
+#: lib/vutuv_web/live/press_kit_live.ex:1127
 #, elixir-autogen, elixir-format
 msgid "Caption"
 msgstr "Bildunterschrift"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1023
-#: lib/vutuv_web/live/press_kit_live.ex:1088
+#: lib/vutuv_web/live/press_kit_live.ex:1105
+#: lib/vutuv_web/live/press_kit_live.ex:1170
 #, elixir-autogen, elixir-format
 msgid "Credit"
 msgstr "Bildnachweis"
 
-#: lib/vutuv_web/live/press_kit_live.ex:814
+#: lib/vutuv_web/live/press_kit_live.ex:864
 #, elixir-autogen, elixir-format
 msgid "Dark"
 msgstr "Dunkel"
@@ -24567,22 +24567,22 @@ msgstr "Dunkel"
 msgid "Files a journalist may download and print"
 msgstr "Dateien, die eine Redaktion herunterladen und drucken darf"
 
-#: lib/vutuv_web/live/press_kit_live.ex:934
+#: lib/vutuv_web/live/press_kit_live.ex:1016
 #, elixir-autogen, elixir-format
 msgid "First: the main photo"
 msgstr "An erster Stelle: das Hauptfoto"
 
-#: lib/vutuv_web/live/press_kit_live.ex:933
+#: lib/vutuv_web/live/press_kit_live.ex:1015
 #, elixir-autogen, elixir-format
 msgid "First: the main variant"
 msgstr "An erster Stelle: die Hauptvariante"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1111
+#: lib/vutuv_web/live/press_kit_live.ex:1193
 #, elixir-autogen, elixir-format
 msgid "I hold the rights to this file and release it for editorial use, as long as the credit above is shown."
 msgstr "Ich habe die Rechte an dieser Datei und gebe sie zur redaktionellen Nutzung frei, solange der Bildnachweis oben genannt wird."
 
-#: lib/vutuv_web/live/press_kit_live.ex:814
+#: lib/vutuv_web/live/press_kit_live.ex:864
 #, elixir-autogen, elixir-format
 msgid "Light"
 msgstr "Hell"
@@ -24594,44 +24594,44 @@ msgstr "Logo-Variante"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:414
-#: lib/vutuv_web/live/press_kit_live.ex:788
+#: lib/vutuv_web/live/press_kit_live.ex:838
 #: lib/vutuv_web/templates/press_kit/index.html.heex:55
 #, elixir-autogen, elixir-format
 msgid "Logo variants"
 msgstr "Logo-Varianten"
 
-#: lib/vutuv_web/live/press_kit_live.ex:828
+#: lib/vutuv_web/live/press_kit_live.ex:878
 #, elixir-autogen, elixir-format
 msgid "No logo here yet."
 msgstr "Hier ist noch kein Logo."
 
-#: lib/vutuv_web/live/press_kit_live.ex:468
+#: lib/vutuv_web/live/press_kit_live.ex:518
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} logo variants."
 msgstr "Höchstens %{max} Logo-Varianten."
 
-#: lib/vutuv_web/live/press_kit_live.ex:471
+#: lib/vutuv_web/live/press_kit_live.ex:521
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} press photos."
 msgstr "Höchstens %{max} Pressefotos."
 
-#: lib/vutuv_web/live/press_kit_live.ex:829
+#: lib/vutuv_web/live/press_kit_live.ex:879
 #, elixir-autogen, elixir-format
 msgid "No press photo here yet."
 msgstr "Hier ist noch kein Pressefoto."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1032
-#: lib/vutuv_web/live/press_kit_live.ex:1098
+#: lib/vutuv_web/live/press_kit_live.ex:1114
+#: lib/vutuv_web/live/press_kit_live.ex:1180
 #, elixir-autogen, elixir-format
 msgid "Photo: Ada King"
 msgstr "Foto: Ada King"
 
-#: lib/vutuv_web/live/press_kit_live.ex:258
+#: lib/vutuv_web/live/press_kit_live.ex:262
 #, elixir-autogen, elixir-format
 msgid "Picture removed."
 msgstr "Bild entfernt."
 
-#: lib/vutuv_web/live/press_kit_live.ex:487
+#: lib/vutuv_web/live/press_kit_live.ex:537
 #, elixir-autogen, elixir-format
 msgid "Please confirm the rights first, then choose the file."
 msgstr "Bitte bestätigen Sie zuerst die Rechte und wählen Sie dann die Datei."
@@ -24643,63 +24643,63 @@ msgstr "Pressefoto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:122
 #: lib/vutuv_web/agent_docs/text.ex:413
-#: lib/vutuv_web/live/press_kit_live.ex:788
+#: lib/vutuv_web/live/press_kit_live.ex:838
 #: lib/vutuv_web/templates/press_kit/index.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "Press photos"
 msgstr "Pressefotos"
 
-#: lib/vutuv_web/live/press_kit_live.ex:812
+#: lib/vutuv_web/live/press_kit_live.ex:862
 #, elixir-autogen, elixir-format
 msgid "Show tiles on:"
 msgstr "Kacheln zeigen auf:"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1035
+#: lib/vutuv_web/live/press_kit_live.ex:1117
 #, elixir-autogen, elixir-format
 msgid "Shown beside the picture and asked for with every download."
 msgstr "Steht neben dem Bild und wird bei jedem Download genannt."
 
-#: lib/vutuv_web/live/press_kit_live.ex:500
+#: lib/vutuv_web/live/press_kit_live.ex:550
 #, elixir-autogen, elixir-format
 msgid "That could not be saved."
 msgstr "Das konnte nicht gespeichert werden."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1241
+#: lib/vutuv_web/live/press_kit_live.ex:1338
 #, elixir-autogen, elixir-format
 msgid "The first photo is the one shown first. Drag a tile, or use the arrows, to change the order."
 msgstr "Das erste Foto wird zuerst gezeigt. Ziehen Sie eine Kachel oder nutzen Sie die Pfeile, um die Reihenfolge zu ändern."
 
-#: lib/vutuv_web/live/press_kit_live.ex:865
+#: lib/vutuv_web/live/press_kit_live.ex:947
 #, elixir-autogen, elixir-format
 msgid "This shelf is full. Remove one picture to add another."
 msgstr "Hier ist kein Platz mehr. Entfernen Sie ein Bild, um ein weiteres hinzuzufügen."
 
-#: lib/vutuv_web/live/press_kit_live.ex:747
+#: lib/vutuv_web/live/press_kit_live.ex:797
 #, elixir-autogen, elixir-format
 msgid "What a journalist writing about you may download: photos in print quality and your logo as a file. Everything here is public and free for editorial use as long as your credit is shown."
 msgstr "Was eine Redaktion, die über Sie schreibt, herunterladen darf: Fotos in Druckqualität und Ihr Logo als Datei. Alles hier ist öffentlich und zur redaktionellen Nutzung frei, solange Ihr Bildnachweis genannt wird."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1001
+#: lib/vutuv_web/live/press_kit_live.ex:1083
 #, elixir-autogen, elixir-format
 msgid "What the picture shows"
 msgstr "Was das Bild zeigt"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1000
+#: lib/vutuv_web/live/press_kit_live.ex:1082
 #, elixir-autogen, elixir-format
 msgid "Which variant this is"
 msgstr "Um welche Variante es sich handelt"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1012
+#: lib/vutuv_web/live/press_kit_live.ex:1094
 #, elixir-autogen, elixir-format
 msgid "White on a dark background"
 msgstr "Weiß auf dunklem Grund"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1046
+#: lib/vutuv_web/live/press_kit_live.ex:1128
 #, elixir-autogen, elixir-format
 msgid "Who took it, where, and what may be cropped."
 msgstr "Wer es aufgenommen hat, wo, und was beschnitten werden darf."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1233
+#: lib/vutuv_web/live/press_kit_live.ex:1330
 #, elixir-autogen, elixir-format
 msgid "Your logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
 msgstr "Ihr Logo als Datei, eine Kachel je Variante. Eine Druckerei fragt nach einem Vektor (SVG), alle anderen können ein PNG öffnen."
@@ -24758,22 +24758,22 @@ msgstr "Diese Bilder stehen für die redaktionelle Verwendung bereit. Nutzen Sie
 msgid "Video is being checked"
 msgstr "Video wird geprüft"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1169
+#: lib/vutuv_web/live/press_kit_live.ex:1251
 #, elixir-autogen, elixir-format
 msgid "Copies the vector file this page's logo was uploaded as onto this shelf."
 msgstr "Kopiert die Vektordatei, als die das Logo dieser Seite hochgeladen wurde, hierher."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1227
+#: lib/vutuv_web/live/press_kit_live.ex:1324
 #, elixir-autogen, elixir-format
 msgid "The page's logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
 msgstr "Das Logo dieser Seite als Datei, eine Kachel je Variante. Eine Druckerei fragt nach einem Vektor (SVG), alle anderen können ein PNG öffnen."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1166
+#: lib/vutuv_web/live/press_kit_live.ex:1248
 #, elixir-autogen, elixir-format
 msgid "Use the page's own logo"
 msgstr "Logo dieser Seite verwenden"
 
-#: lib/vutuv_web/live/press_kit_live.ex:729
+#: lib/vutuv_web/live/press_kit_live.ex:779
 #, elixir-autogen, elixir-format
 msgid "What a journalist writing about this page may download: photos in print quality and its logo as a file. Everything here is public and free for editorial use as long as the credit is shown."
 msgstr "Was eine Redaktion, die über diese Seite schreibt, herunterladen darf: Fotos in Druckqualität und das Logo als Datei. Alles hier ist öffentlich und zur redaktionellen Nutzung frei, solange der Bildnachweis genannt wird."
@@ -24893,7 +24893,7 @@ msgstr "Das ganze Media Kit"
 #: lib/vutuv_web/components/press_kit_components.ex:100
 #: lib/vutuv_web/components/ui.ex:5455
 #: lib/vutuv_web/live/organization_live/show.ex:168
-#: lib/vutuv_web/live/press_kit_live.ex:135
+#: lib/vutuv_web/live/press_kit_live.ex:136
 #: lib/vutuv_web/views/press_kit_html.ex:28
 #: lib/vutuv_web/views/press_kit_html.ex:46
 #, elixir-autogen, elixir-format
@@ -24906,12 +24906,12 @@ msgstr "Media Kit"
 msgid "Media Kit of %{name}"
 msgstr "Media Kit von %{name}"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1247
+#: lib/vutuv_web/live/press_kit_live.ex:1344
 #, elixir-autogen, elixir-format
 msgid "Remove this picture from this page's Media Kit?"
 msgstr "Dieses Bild aus dem Media Kit dieser Seite entfernen?"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1249
+#: lib/vutuv_web/live/press_kit_live.ex:1346
 #, elixir-autogen, elixir-format
 msgid "Remove this picture from your Media Kit?"
 msgstr "Dieses Bild aus Ihrem Media Kit entfernen?"
@@ -24921,7 +24921,7 @@ msgstr "Dieses Bild aus Ihrem Media Kit entfernen?"
 msgid "Set up the Media Kit"
 msgstr "Media Kit einrichten"
 
-#: lib/vutuv_web/live/press_kit_live.ex:483
+#: lib/vutuv_web/live/press_kit_live.ex:533
 #, elixir-autogen, elixir-format
 msgid "You cannot add a picture to this Media Kit."
 msgstr "Sie können diesem Media Kit kein Bild hinzufügen."
@@ -25032,14 +25032,14 @@ msgstr "Ihr Upload-Kontingent für heute ist aufgebraucht. Es wird im Lauf des T
 msgid "Your uploads are not limited."
 msgstr "Ihre Uploads sind nicht begrenzt."
 
-#: lib/vutuv_web/live/press_kit_live.ex:622
+#: lib/vutuv_web/live/press_kit_live.ex:672
 #, elixir-autogen, elixir-format
 msgid "%{formatted} word"
 msgid_plural "%{formatted} words"
 msgstr[0] "%{formatted} Wort"
 msgstr[1] "%{formatted} Wörter"
 
-#: lib/vutuv_web/live/press_kit_live.ex:706
+#: lib/vutuv_web/live/press_kit_live.ex:756
 #, elixir-autogen, elixir-format
 msgid "A paragraph an article can end on."
 msgstr "Ein Absatz, mit dem ein Artikel enden kann."
@@ -25051,22 +25051,22 @@ msgstr "Ein Absatz, mit dem ein Artikel enden kann."
 msgid "About %{name}"
 msgstr "Über %{name}"
 
-#: lib/vutuv_web/live/press_kit_live.ex:699
+#: lib/vutuv_web/live/press_kit_live.ex:749
 #, elixir-autogen, elixir-format
 msgid "About %{words} words. A paragraph at the end of an article."
 msgstr "Etwa %{words} Wörter. Ein Absatz am Ende eines Artikels."
 
-#: lib/vutuv_web/live/press_kit_live.ex:693
+#: lib/vutuv_web/live/press_kit_live.ex:743
 #, elixir-autogen, elixir-format
 msgid "About %{words} words. The two sentences under a photo."
 msgstr "Etwa %{words} Wörter. Die zwei Sätze unter einem Foto."
 
-#: lib/vutuv_web/live/press_kit_live.ex:673
+#: lib/vutuv_web/live/press_kit_live.ex:723
 #, elixir-autogen, elixir-format
 msgid "An @handle links to that profile and notifies nobody."
 msgstr "Ein @handle verlinkt auf das Profil und benachrichtigt niemanden."
 
-#: lib/vutuv_web/live/press_kit_live.ex:703
+#: lib/vutuv_web/live/press_kit_live.ex:753
 #, elixir-autogen, elixir-format
 msgid "As long as you like. The whole portrait."
 msgstr "So lang, wie Sie mögen. Das ganze Porträt."
@@ -25081,7 +25081,7 @@ msgstr "Lange Fassung"
 msgid "Medium version"
 msgstr "Mittlere Fassung"
 
-#: lib/vutuv_web/live/press_kit_live.ex:631
+#: lib/vutuv_web/live/press_kit_live.ex:681
 #, elixir-autogen, elixir-format
 msgid "Nothing written yet."
 msgstr "Noch nichts geschrieben."
@@ -25096,22 +25096,22 @@ msgstr "Kurze Fassung"
 msgid "Take whichever length fits the space you have. Each one stands on its own."
 msgstr "Nehmen Sie die Fassung, die in Ihren Platz passt. Jede steht für sich."
 
-#: lib/vutuv_web/live/press_kit_live.ex:707
+#: lib/vutuv_web/live/press_kit_live.ex:757
 #, elixir-autogen, elixir-format
 msgid "The whole story, for as long as it needs."
 msgstr "Die ganze Geschichte, so lang sie sein muss."
 
-#: lib/vutuv_web/live/press_kit_live.ex:580
+#: lib/vutuv_web/live/press_kit_live.ex:630
 #, elixir-autogen, elixir-format
 msgid "Three bios in three lengths, so a journalist can take the one that fits. You write them; nothing is made out of your CV."
 msgstr "Drei Biografien in drei Längen, damit eine Redaktion die passende nehmen kann. Sie schreiben sie selbst; aus Ihrem Lebenslauf wird nichts gebaut."
 
-#: lib/vutuv_web/live/press_kit_live.ex:705
+#: lib/vutuv_web/live/press_kit_live.ex:755
 #, elixir-autogen, elixir-format
 msgid "Two sentences a caption can carry."
 msgstr "Zwei Sätze, die in eine Bildunterschrift passen."
 
-#: lib/vutuv_web/live/press_kit_live.ex:641
+#: lib/vutuv_web/live/press_kit_live.ex:691
 #, elixir-autogen, elixir-format
 msgid "Write"
 msgstr "Schreiben"
@@ -25419,3 +25419,23 @@ msgstr[1] "%{tag} folgen. Heute %{uses} Beiträge auf %{servers} Servern, an ein
 #, elixir-autogen, elixir-format
 msgid "Very busy on other servers right now:"
 msgstr "Gerade sehr aktiv auf anderen Servern:"
+
+#: lib/vutuv_web/live/press_kit_live.ex:904
+#, elixir-autogen, elixir-format
+msgid "A picture still being checked is not public yet."
+msgstr "Ein Bild, das noch geprüft wird, ist noch nicht öffentlich."
+
+#: lib/vutuv_web/live/press_kit_live.ex:907
+#, elixir-autogen, elixir-format
+msgid "A visitor sees a pixelated stand-in in its place and can download nothing. The mark goes by itself when the check is through."
+msgstr "Besucher sehen an seiner Stelle eine verpixelte Vorschau und können nichts herunterladen. Die Markierung verschwindet von selbst, sobald die Prüfung abgeschlossen ist."
+
+#: lib/vutuv_web/live/press_kit_live.ex:1269
+#, elixir-autogen, elixir-format
+msgid "Logo variants, further down this page, take this format."
+msgstr "Logo-Varianten, weiter unten auf dieser Seite, nehmen dieses Format."
+
+#: lib/vutuv_web/live/press_kit_live.ex:1268
+#, elixir-autogen, elixir-format
+msgid "Press photos, further up this page, take this format."
+msgstr "Pressefotos, weiter oben auf dieser Seite, nehmen dieses Format."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -121,8 +121,8 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
 #: lib/vutuv_web/live/post_live/composer.ex:2081
-#: lib/vutuv_web/live/press_kit_live.ex:679
-#: lib/vutuv_web/live/press_kit_live.ex:1057
+#: lib/vutuv_web/live/press_kit_live.ex:729
+#: lib/vutuv_web/live/press_kit_live.ex:1139
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -220,8 +220,8 @@ msgstr ""
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
 #: lib/vutuv_web/live/job_posting_live/show.ex:201
 #: lib/vutuv_web/live/organization_live/show.ex:159
-#: lib/vutuv_web/live/press_kit_live.ex:641
-#: lib/vutuv_web/live/press_kit_live.ex:974
+#: lib/vutuv_web/live/press_kit_live.ex:691
+#: lib/vutuv_web/live/press_kit_live.ex:1056
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:19
@@ -622,8 +622,8 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:4934
 #: lib/vutuv_web/live/organization_live/edit.ex:376
 #: lib/vutuv_web/live/post_live/composer.ex:2408
-#: lib/vutuv_web/live/press_kit_live.ex:677
-#: lib/vutuv_web/live/press_kit_live.ex:1056
+#: lib/vutuv_web/live/press_kit_live.ex:727
+#: lib/vutuv_web/live/press_kit_live.ex:1138
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
@@ -935,8 +935,8 @@ msgid "You follow back %{name}."
 msgstr ""
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:178
-#: lib/vutuv_web/live/press_kit_live.ex:109
+#: lib/vutuv_web/live/post_live/feed.ex:179
+#: lib/vutuv_web/live/press_kit_live.ex:110
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1684,7 +1684,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:421
 #: lib/vutuv_web/live/organization_live/show.ex:602
 #: lib/vutuv_web/live/organization_live/show.ex:639
-#: lib/vutuv_web/live/post_live/feed.ex:1053
+#: lib/vutuv_web/live/post_live/feed.ex:1054
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
 #: lib/vutuv_web/templates/user/show.html.heex:1350
 #: lib/vutuv_web/views/user_html.ex:643
@@ -2081,7 +2081,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/composer.ex:2179
 #: lib/vutuv_web/live/post_live/composer.ex:2202
 #: lib/vutuv_web/live/post_live/composer.ex:2228
-#: lib/vutuv_web/live/press_kit_live.ex:1210
+#: lib/vutuv_web/live/press_kit_live.ex:1307
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2106,8 +2106,8 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:203
-#: lib/vutuv_web/live/post_live/feed.ex:364
-#: lib/vutuv_web/live/post_live/feed.ex:3530
+#: lib/vutuv_web/live/post_live/feed.ex:365
+#: lib/vutuv_web/live/post_live/feed.ex:3536
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1346
 #: lib/vutuv_web/live/shell_live.ex:1692
@@ -2153,7 +2153,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3870
+#: lib/vutuv_web/live/post_live/feed.ex:3876
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2230,7 +2230,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:666
 #: lib/vutuv_web/live/post_live/saved.ex:694
 #: lib/vutuv_web/live/post_rewrites_live.ex:376
-#: lib/vutuv_web/live/press_kit_live.ex:983
+#: lib/vutuv_web/live/press_kit_live.ex:1065
 #: lib/vutuv_web/templates/connection/index.html.heex:45
 #: lib/vutuv_web/views/settings_html.ex:386
 #, elixir-autogen, elixir-format
@@ -2247,7 +2247,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2706
+#: lib/vutuv_web/live/post_live/feed.ex:2712
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2262,7 +2262,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/composer.ex:1614
 #: lib/vutuv_web/live/post_live/composer.ex:1652
 #: lib/vutuv_web/live/post_live/composer.ex:1752
-#: lib/vutuv_web/live/press_kit_live.ex:491
+#: lib/vutuv_web/live/press_kit_live.ex:541
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
@@ -2470,7 +2470,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:476
 #: lib/vutuv_web/live/organization_live/show.ex:644
-#: lib/vutuv_web/live/post_live/feed.ex:1040
+#: lib/vutuv_web/live/post_live/feed.ex:1041
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:42
 #: lib/vutuv_web/views/user_html.ex:633
@@ -2785,7 +2785,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/live/job_board_live.ex:458
-#: lib/vutuv_web/live/post_live/feed.ex:1184
+#: lib/vutuv_web/live/post_live/feed.ex:1185
 #: lib/vutuv_web/templates/user/card_list.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -4492,7 +4492,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3875
+#: lib/vutuv_web/live/post_live/feed.ex:3881
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -5412,7 +5412,7 @@ msgstr ""
 msgid "Type of email address"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:578
+#: lib/vutuv_web/live/press_kit_live.ex:628
 #: lib/vutuv_web/templates/user/edit.html.heex:256
 #, elixir-autogen, elixir-format
 msgid "About you"
@@ -6177,7 +6177,7 @@ msgid "View all phone numbers"
 msgstr ""
 
 #: lib/vutuv_web/live/feed_languages_live.ex:235
-#: lib/vutuv_web/live/press_kit_live.ex:897
+#: lib/vutuv_web/live/press_kit_live.ex:979
 #: lib/vutuv_web/live/section_reorder_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder"
@@ -6190,7 +6190,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/feed_languages_live.ex:267
 #: lib/vutuv_web/live/post_rewrites_live.ex:364
-#: lib/vutuv_web/live/press_kit_live.ex:959
+#: lib/vutuv_web/live/press_kit_live.ex:1041
 #: lib/vutuv_web/live/section_reorder_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Move down"
@@ -6198,7 +6198,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/feed_languages_live.ex:256
 #: lib/vutuv_web/live/post_rewrites_live.ex:352
-#: lib/vutuv_web/live/press_kit_live.ex:948
+#: lib/vutuv_web/live/press_kit_live.ex:1030
 #: lib/vutuv_web/live/section_reorder_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -7390,9 +7390,9 @@ msgstr ""
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/media_live.ex:270
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:4169
+#: lib/vutuv_web/live/post_live/feed.ex:4175
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
-#: lib/vutuv_web/live/press_kit_live.ex:974
+#: lib/vutuv_web/live/press_kit_live.ex:1056
 #, elixir-autogen
 msgid "Done"
 msgstr ""
@@ -7833,7 +7833,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
 #: lib/vutuv_web/live/job_board_live.ex:468
-#: lib/vutuv_web/live/post_live/feed.ex:1193
+#: lib/vutuv_web/live/post_live/feed.ex:1194
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr ""
@@ -13375,7 +13375,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5556
 #: lib/vutuv_web/controllers/settings_controller.ex:643
-#: lib/vutuv_web/live/post_live/feed.ex:853
+#: lib/vutuv_web/live/post_live/feed.ex:854
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
@@ -14258,7 +14258,7 @@ msgstr ""
 msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1253
+#: lib/vutuv_web/live/post_live/feed.ex:1254
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -17792,7 +17792,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3893
+#: lib/vutuv_web/live/post_live/feed.ex:3899
 #: lib/vutuv_web/live/reference_check_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -18210,7 +18210,7 @@ msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4760
-#: lib/vutuv_web/live/press_kit_live.ex:478
+#: lib/vutuv_web/live/press_kit_live.ex:528
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "That file is larger than %{limit}. Please upload a smaller one."
@@ -20261,7 +20261,7 @@ msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:431
-#: lib/vutuv_web/live/post_live/feed.ex:1130
+#: lib/vutuv_web/live/post_live/feed.ex:1131
 #: lib/vutuv_web/views/user_html.ex:355
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -20881,12 +20881,12 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4063
+#: lib/vutuv_web/live/post_live/feed.ex:4069
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:854
+#: lib/vutuv_web/live/post_live/feed.ex:855
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr ""
@@ -20932,7 +20932,7 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1122
+#: lib/vutuv_web/live/post_live/feed.ex:1123
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
@@ -21284,7 +21284,7 @@ msgstr ""
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:979
+#: lib/vutuv_web/live/post_live/feed.ex:980
 #: lib/vutuv_web/live/post_live/filter_band.ex:350
 #, elixir-autogen, elixir-format
 msgid "A photo"
@@ -21300,7 +21300,7 @@ msgstr ""
 msgid "A–Z"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1080
+#: lib/vutuv_web/live/post_live/feed.ex:1081
 #, elixir-autogen, elixir-format
 msgid "Browse the tags"
 msgstr ""
@@ -21315,7 +21315,7 @@ msgstr ""
 msgid "Clear all"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:891
+#: lib/vutuv_web/live/post_live/feed.ex:892
 #, elixir-autogen, elixir-format
 msgid "Drag, or use the arrow keys"
 msgstr ""
@@ -21330,13 +21330,13 @@ msgstr ""
 msgid "Find an account or a server …"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:915
+#: lib/vutuv_web/live/post_live/feed.ex:916
 #, elixir-autogen, elixir-format
 msgid "Fold %{card}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1051
 #: lib/vutuv_web/live/post_live/feed.ex:1052
+#: lib/vutuv_web/live/post_live/feed.ex:1053
 #, elixir-autogen, elixir-format
 msgid "Follow a tag …"
 msgstr ""
@@ -21353,19 +21353,19 @@ msgstr ""
 msgid "Hide a word or a whole phrase …"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:852
-#: lib/vutuv_web/live/post_live/feed.ex:4226
+#: lib/vutuv_web/live/post_live/feed.ex:853
+#: lib/vutuv_web/live/post_live/feed.ex:4232
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:851
-#: lib/vutuv_web/live/post_live/feed.ex:4215
+#: lib/vutuv_web/live/post_live/feed.ex:852
+#: lib/vutuv_web/live/post_live/feed.ex:4221
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1086
+#: lib/vutuv_web/live/post_live/feed.ex:1087
 #: lib/vutuv_web/live/post_live/filter_band.ex:394
 #, elixir-autogen, elixir-format
 msgid "In your feed right now:"
@@ -21381,7 +21381,7 @@ msgstr ""
 msgid "More of your %{formatted} accounts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:890
+#: lib/vutuv_web/live/post_live/feed.ex:891
 #, elixir-autogen, elixir-format
 msgid "Move %{card}"
 msgstr ""
@@ -21392,12 +21392,12 @@ msgstr ""
 msgid "No account found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1075
+#: lib/vutuv_web/live/post_live/feed.ex:1076
 #, elixir-autogen, elixir-format
 msgid "No tag called %{name} yet."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:844
+#: lib/vutuv_web/live/post_live/feed.ex:845
 #, elixir-autogen, elixir-format
 msgid "Not read yet"
 msgstr ""
@@ -21427,13 +21427,13 @@ msgstr ""
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4089
+#: lib/vutuv_web/live/post_live/feed.ex:4095
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:936
 #: lib/vutuv_web/live/post_live/feed.ex:937
+#: lib/vutuv_web/live/post_live/feed.ex:938
 #, elixir-autogen, elixir-format
 msgid "Remove %{card}"
 msgstr ""
@@ -21465,8 +21465,8 @@ msgstr ""
 msgid "Show posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:850
-#: lib/vutuv_web/live/post_live/feed.ex:4181
+#: lib/vutuv_web/live/post_live/feed.ex:851
+#: lib/vutuv_web/live/post_live/feed.ex:4187
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr ""
@@ -21476,12 +21476,12 @@ msgstr ""
 msgid "Switching off means muting, not unfollowing. You stay a follower, the posts just stop reaching your feed: permanently and on every device, until you switch them back on here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:914
+#: lib/vutuv_web/live/post_live/feed.ex:915
 #, elixir-autogen, elixir-format
 msgid "Unfold %{card}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1041
+#: lib/vutuv_web/live/post_live/feed.ex:1042
 #, elixir-autogen, elixir-format
 msgid "Unfollow the tag %{tag}"
 msgstr ""
@@ -21505,20 +21505,20 @@ msgid_plural "and %{formatted} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3647
-#: lib/vutuv_web/live/post_live/feed.ex:3674
+#: lib/vutuv_web/live/post_live/feed.ex:3653
+#: lib/vutuv_web/live/post_live/feed.ex:3680
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1261
+#: lib/vutuv_web/live/post_live/feed.ex:1262
 #, elixir-autogen, elixir-format
 msgctxt "filtered post"
 msgid "Hidden:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:989
+#: lib/vutuv_web/live/post_live/feed.ex:990
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} post in the feed"
 msgid_plural "Show %{formatted} posts in the feed"
@@ -21536,7 +21536,7 @@ msgid "Your organization page was updated. The new logo is being checked and app
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:290
-#: lib/vutuv_web/live/press_kit_live.ex:1143
+#: lib/vutuv_web/live/press_kit_live.ex:1225
 #: lib/vutuv_web/templates/user/edit.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "%{formats}, up to %{limit}"
@@ -21568,7 +21568,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3850
+#: lib/vutuv_web/live/post_live/feed.ex:3856
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr ""
@@ -21578,7 +21578,7 @@ msgstr ""
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3896
+#: lib/vutuv_web/live/post_live/feed.ex:3902
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -21600,7 +21600,7 @@ msgstr ""
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3846
+#: lib/vutuv_web/live/post_live/feed.ex:3852
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
@@ -21687,7 +21687,7 @@ msgstr ""
 msgid "Page management"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2700
+#: lib/vutuv_web/live/post_live/feed.ex:2706
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
@@ -21719,7 +21719,7 @@ msgstr ""
 msgid "{used} of {max} mentions"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2812
+#: lib/vutuv_web/live/post_live/feed.ex:2818
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr ""
@@ -21934,7 +21934,7 @@ msgctxt "phone tab bar"
 msgid "Write"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3984
+#: lib/vutuv_web/live/post_live/feed.ex:3990
 #: lib/vutuv_web/live/post_rewrites_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "%{formatted} rule"
@@ -22731,8 +22731,8 @@ msgstr ""
 msgid "Posts loaded at once"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3920
-#: lib/vutuv_web/live/post_live/feed.ex:3924
+#: lib/vutuv_web/live/post_live/feed.ex:3926
+#: lib/vutuv_web/live/post_live/feed.ex:3930
 #, elixir-autogen, elixir-format
 msgid "Posts per page"
 msgstr ""
@@ -22758,14 +22758,14 @@ msgstr ""
 msgid "For whom %{thing} is hidden"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3981
-#: lib/vutuv_web/live/post_live/feed.ex:4145
-#: lib/vutuv_web/live/post_live/feed.ex:4154
+#: lib/vutuv_web/live/post_live/feed.ex:3987
+#: lib/vutuv_web/live/post_live/feed.ex:4151
+#: lib/vutuv_web/live/post_live/feed.ex:4160
 #, elixir-autogen, elixir-format
 msgid "Hidden"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4119
+#: lib/vutuv_web/live/post_live/feed.ex:4125
 #, elixir-autogen, elixir-format
 msgid "Hide something from your feed"
 msgstr ""
@@ -22775,12 +22775,12 @@ msgstr ""
 msgid "Stop showing"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4160
+#: lib/vutuv_web/live/post_live/feed.ex:4166
 #, elixir-autogen, elixir-format
 msgid "Whatever these match is folded to a single line in your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4180
+#: lib/vutuv_web/live/post_live/feed.ex:4186
 #, elixir-autogen, elixir-format
 msgid "Words & tags"
 msgstr ""
@@ -23683,48 +23683,48 @@ msgid_plural "%{formatted} more entries (%{years})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1202
+#: lib/vutuv_web/live/press_kit_live.ex:1299
 #, elixir-autogen, elixir-format
 msgid "%{percent}%"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:797
+#: lib/vutuv_web/live/press_kit_live.ex:847
 #, elixir-autogen, elixir-format
 msgid "%{used} of %{max}"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1051
+#: lib/vutuv_web/live/press_kit_live.ex:1133
 #, elixir-autogen, elixir-format
 msgid "A photographer's @handle links to their profile and notifies nobody."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1136
+#: lib/vutuv_web/live/press_kit_live.ex:1218
 #, elixir-autogen, elixir-format
 msgid "Add a logo variant"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1137
+#: lib/vutuv_web/live/press_kit_live.ex:1219
 #, elixir-autogen, elixir-format
 msgid "Add a press photo"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1013
+#: lib/vutuv_web/live/press_kit_live.ex:1095
 #, elixir-autogen, elixir-format
 msgid "At the desk in the Bonn office"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1045
+#: lib/vutuv_web/live/press_kit_live.ex:1127
 #, elixir-autogen, elixir-format
 msgid "Caption"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1023
-#: lib/vutuv_web/live/press_kit_live.ex:1088
+#: lib/vutuv_web/live/press_kit_live.ex:1105
+#: lib/vutuv_web/live/press_kit_live.ex:1170
 #, elixir-autogen, elixir-format
 msgid "Credit"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:814
+#: lib/vutuv_web/live/press_kit_live.ex:864
 #, elixir-autogen, elixir-format
 msgid "Dark"
 msgstr ""
@@ -23734,22 +23734,22 @@ msgstr ""
 msgid "Files a journalist may download and print"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:934
+#: lib/vutuv_web/live/press_kit_live.ex:1016
 #, elixir-autogen, elixir-format
 msgid "First: the main photo"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:933
+#: lib/vutuv_web/live/press_kit_live.ex:1015
 #, elixir-autogen, elixir-format
 msgid "First: the main variant"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1111
+#: lib/vutuv_web/live/press_kit_live.ex:1193
 #, elixir-autogen, elixir-format
 msgid "I hold the rights to this file and release it for editorial use, as long as the credit above is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:814
+#: lib/vutuv_web/live/press_kit_live.ex:864
 #, elixir-autogen, elixir-format
 msgid "Light"
 msgstr ""
@@ -23761,44 +23761,44 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:414
-#: lib/vutuv_web/live/press_kit_live.ex:788
+#: lib/vutuv_web/live/press_kit_live.ex:838
 #: lib/vutuv_web/templates/press_kit/index.html.heex:55
 #, elixir-autogen, elixir-format
 msgid "Logo variants"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:828
+#: lib/vutuv_web/live/press_kit_live.ex:878
 #, elixir-autogen, elixir-format
 msgid "No logo here yet."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:468
+#: lib/vutuv_web/live/press_kit_live.ex:518
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} logo variants."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:471
+#: lib/vutuv_web/live/press_kit_live.ex:521
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} press photos."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:829
+#: lib/vutuv_web/live/press_kit_live.ex:879
 #, elixir-autogen, elixir-format
 msgid "No press photo here yet."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1032
-#: lib/vutuv_web/live/press_kit_live.ex:1098
+#: lib/vutuv_web/live/press_kit_live.ex:1114
+#: lib/vutuv_web/live/press_kit_live.ex:1180
 #, elixir-autogen, elixir-format
 msgid "Photo: Ada King"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:258
+#: lib/vutuv_web/live/press_kit_live.ex:262
 #, elixir-autogen, elixir-format
 msgid "Picture removed."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:487
+#: lib/vutuv_web/live/press_kit_live.ex:537
 #, elixir-autogen, elixir-format
 msgid "Please confirm the rights first, then choose the file."
 msgstr ""
@@ -23810,63 +23810,63 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:122
 #: lib/vutuv_web/agent_docs/text.ex:413
-#: lib/vutuv_web/live/press_kit_live.ex:788
+#: lib/vutuv_web/live/press_kit_live.ex:838
 #: lib/vutuv_web/templates/press_kit/index.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "Press photos"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:812
+#: lib/vutuv_web/live/press_kit_live.ex:862
 #, elixir-autogen, elixir-format
 msgid "Show tiles on:"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1035
+#: lib/vutuv_web/live/press_kit_live.ex:1117
 #, elixir-autogen, elixir-format
 msgid "Shown beside the picture and asked for with every download."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:500
+#: lib/vutuv_web/live/press_kit_live.ex:550
 #, elixir-autogen, elixir-format
 msgid "That could not be saved."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1241
+#: lib/vutuv_web/live/press_kit_live.ex:1338
 #, elixir-autogen, elixir-format
 msgid "The first photo is the one shown first. Drag a tile, or use the arrows, to change the order."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:865
+#: lib/vutuv_web/live/press_kit_live.ex:947
 #, elixir-autogen, elixir-format
 msgid "This shelf is full. Remove one picture to add another."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:747
+#: lib/vutuv_web/live/press_kit_live.ex:797
 #, elixir-autogen, elixir-format
 msgid "What a journalist writing about you may download: photos in print quality and your logo as a file. Everything here is public and free for editorial use as long as your credit is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1001
+#: lib/vutuv_web/live/press_kit_live.ex:1083
 #, elixir-autogen, elixir-format
 msgid "What the picture shows"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1000
+#: lib/vutuv_web/live/press_kit_live.ex:1082
 #, elixir-autogen, elixir-format
 msgid "Which variant this is"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1012
+#: lib/vutuv_web/live/press_kit_live.ex:1094
 #, elixir-autogen, elixir-format
 msgid "White on a dark background"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1046
+#: lib/vutuv_web/live/press_kit_live.ex:1128
 #, elixir-autogen, elixir-format
 msgid "Who took it, where, and what may be cropped."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1233
+#: lib/vutuv_web/live/press_kit_live.ex:1330
 #, elixir-autogen, elixir-format
 msgid "Your logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
 msgstr ""
@@ -23925,22 +23925,22 @@ msgstr ""
 msgid "Video is being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1169
+#: lib/vutuv_web/live/press_kit_live.ex:1251
 #, elixir-autogen, elixir-format
 msgid "Copies the vector file this page's logo was uploaded as onto this shelf."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1227
+#: lib/vutuv_web/live/press_kit_live.ex:1324
 #, elixir-autogen, elixir-format
 msgid "The page's logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1166
+#: lib/vutuv_web/live/press_kit_live.ex:1248
 #, elixir-autogen, elixir-format
 msgid "Use the page's own logo"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:729
+#: lib/vutuv_web/live/press_kit_live.ex:779
 #, elixir-autogen, elixir-format
 msgid "What a journalist writing about this page may download: photos in print quality and its logo as a file. Everything here is public and free for editorial use as long as the credit is shown."
 msgstr ""
@@ -24060,7 +24060,7 @@ msgstr ""
 #: lib/vutuv_web/components/press_kit_components.ex:100
 #: lib/vutuv_web/components/ui.ex:5455
 #: lib/vutuv_web/live/organization_live/show.ex:168
-#: lib/vutuv_web/live/press_kit_live.ex:135
+#: lib/vutuv_web/live/press_kit_live.ex:136
 #: lib/vutuv_web/views/press_kit_html.ex:28
 #: lib/vutuv_web/views/press_kit_html.ex:46
 #, elixir-autogen, elixir-format
@@ -24073,12 +24073,12 @@ msgstr ""
 msgid "Media Kit of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1247
+#: lib/vutuv_web/live/press_kit_live.ex:1344
 #, elixir-autogen, elixir-format
 msgid "Remove this picture from this page's Media Kit?"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1249
+#: lib/vutuv_web/live/press_kit_live.ex:1346
 #, elixir-autogen, elixir-format
 msgid "Remove this picture from your Media Kit?"
 msgstr ""
@@ -24088,7 +24088,7 @@ msgstr ""
 msgid "Set up the Media Kit"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:483
+#: lib/vutuv_web/live/press_kit_live.ex:533
 #, elixir-autogen, elixir-format
 msgid "You cannot add a picture to this Media Kit."
 msgstr ""
@@ -24199,14 +24199,14 @@ msgstr ""
 msgid "Your uploads are not limited."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:622
+#: lib/vutuv_web/live/press_kit_live.ex:672
 #, elixir-autogen, elixir-format
 msgid "%{formatted} word"
 msgid_plural "%{formatted} words"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:706
+#: lib/vutuv_web/live/press_kit_live.ex:756
 #, elixir-autogen, elixir-format
 msgid "A paragraph an article can end on."
 msgstr ""
@@ -24218,22 +24218,22 @@ msgstr ""
 msgid "About %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:699
+#: lib/vutuv_web/live/press_kit_live.ex:749
 #, elixir-autogen, elixir-format
 msgid "About %{words} words. A paragraph at the end of an article."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:693
+#: lib/vutuv_web/live/press_kit_live.ex:743
 #, elixir-autogen, elixir-format
 msgid "About %{words} words. The two sentences under a photo."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:673
+#: lib/vutuv_web/live/press_kit_live.ex:723
 #, elixir-autogen, elixir-format
 msgid "An @handle links to that profile and notifies nobody."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:703
+#: lib/vutuv_web/live/press_kit_live.ex:753
 #, elixir-autogen, elixir-format
 msgid "As long as you like. The whole portrait."
 msgstr ""
@@ -24248,7 +24248,7 @@ msgstr ""
 msgid "Medium version"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:631
+#: lib/vutuv_web/live/press_kit_live.ex:681
 #, elixir-autogen, elixir-format
 msgid "Nothing written yet."
 msgstr ""
@@ -24263,22 +24263,22 @@ msgstr ""
 msgid "Take whichever length fits the space you have. Each one stands on its own."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:707
+#: lib/vutuv_web/live/press_kit_live.ex:757
 #, elixir-autogen, elixir-format
 msgid "The whole story, for as long as it needs."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:580
+#: lib/vutuv_web/live/press_kit_live.ex:630
 #, elixir-autogen, elixir-format
 msgid "Three bios in three lengths, so a journalist can take the one that fits. You write them; nothing is made out of your CV."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:705
+#: lib/vutuv_web/live/press_kit_live.ex:755
 #, elixir-autogen, elixir-format
 msgid "Two sentences a caption can carry."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:641
+#: lib/vutuv_web/live/press_kit_live.ex:691
 #, elixir-autogen, elixir-format
 msgid "Write"
 msgstr ""
@@ -24585,4 +24585,24 @@ msgstr[1] ""
 #: lib/vutuv_web/live/post_live/trending_tags.ex:48
 #, elixir-autogen, elixir-format
 msgid "Very busy on other servers right now:"
+msgstr ""
+
+#: lib/vutuv_web/live/press_kit_live.ex:904
+#, elixir-autogen, elixir-format
+msgid "A picture still being checked is not public yet."
+msgstr ""
+
+#: lib/vutuv_web/live/press_kit_live.ex:907
+#, elixir-autogen, elixir-format
+msgid "A visitor sees a pixelated stand-in in its place and can download nothing. The mark goes by itself when the check is through."
+msgstr ""
+
+#: lib/vutuv_web/live/press_kit_live.ex:1269
+#, elixir-autogen, elixir-format
+msgid "Logo variants, further down this page, take this format."
+msgstr ""
+
+#: lib/vutuv_web/live/press_kit_live.ex:1268
+#, elixir-autogen, elixir-format
+msgid "Press photos, further up this page, take this format."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -119,8 +119,8 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
 #: lib/vutuv_web/live/post_live/composer.ex:2081
-#: lib/vutuv_web/live/press_kit_live.ex:679
-#: lib/vutuv_web/live/press_kit_live.ex:1057
+#: lib/vutuv_web/live/press_kit_live.ex:729
+#: lib/vutuv_web/live/press_kit_live.ex:1139
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -218,8 +218,8 @@ msgstr ""
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
 #: lib/vutuv_web/live/job_posting_live/show.ex:201
 #: lib/vutuv_web/live/organization_live/show.ex:159
-#: lib/vutuv_web/live/press_kit_live.ex:641
-#: lib/vutuv_web/live/press_kit_live.ex:974
+#: lib/vutuv_web/live/press_kit_live.ex:691
+#: lib/vutuv_web/live/press_kit_live.ex:1056
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:19
@@ -620,8 +620,8 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:4934
 #: lib/vutuv_web/live/organization_live/edit.ex:376
 #: lib/vutuv_web/live/post_live/composer.ex:2408
-#: lib/vutuv_web/live/press_kit_live.ex:677
-#: lib/vutuv_web/live/press_kit_live.ex:1056
+#: lib/vutuv_web/live/press_kit_live.ex:727
+#: lib/vutuv_web/live/press_kit_live.ex:1138
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
@@ -933,8 +933,8 @@ msgid "You follow back %{name}."
 msgstr ""
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:178
-#: lib/vutuv_web/live/press_kit_live.ex:109
+#: lib/vutuv_web/live/post_live/feed.ex:179
+#: lib/vutuv_web/live/press_kit_live.ex:110
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1682,7 +1682,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:421
 #: lib/vutuv_web/live/organization_live/show.ex:602
 #: lib/vutuv_web/live/organization_live/show.ex:639
-#: lib/vutuv_web/live/post_live/feed.ex:1053
+#: lib/vutuv_web/live/post_live/feed.ex:1054
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
 #: lib/vutuv_web/templates/user/show.html.heex:1350
 #: lib/vutuv_web/views/user_html.ex:643
@@ -2079,7 +2079,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/composer.ex:2179
 #: lib/vutuv_web/live/post_live/composer.ex:2202
 #: lib/vutuv_web/live/post_live/composer.ex:2228
-#: lib/vutuv_web/live/press_kit_live.ex:1210
+#: lib/vutuv_web/live/press_kit_live.ex:1307
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2104,8 +2104,8 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:203
-#: lib/vutuv_web/live/post_live/feed.ex:364
-#: lib/vutuv_web/live/post_live/feed.ex:3530
+#: lib/vutuv_web/live/post_live/feed.ex:365
+#: lib/vutuv_web/live/post_live/feed.ex:3536
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1346
 #: lib/vutuv_web/live/shell_live.ex:1692
@@ -2151,7 +2151,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3870
+#: lib/vutuv_web/live/post_live/feed.ex:3876
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2228,7 +2228,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:666
 #: lib/vutuv_web/live/post_live/saved.ex:694
 #: lib/vutuv_web/live/post_rewrites_live.ex:376
-#: lib/vutuv_web/live/press_kit_live.ex:983
+#: lib/vutuv_web/live/press_kit_live.ex:1065
 #: lib/vutuv_web/templates/connection/index.html.heex:45
 #: lib/vutuv_web/views/settings_html.ex:386
 #, elixir-autogen, elixir-format
@@ -2245,7 +2245,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2706
+#: lib/vutuv_web/live/post_live/feed.ex:2712
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2260,7 +2260,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/composer.ex:1614
 #: lib/vutuv_web/live/post_live/composer.ex:1652
 #: lib/vutuv_web/live/post_live/composer.ex:1752
-#: lib/vutuv_web/live/press_kit_live.ex:491
+#: lib/vutuv_web/live/press_kit_live.ex:541
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
@@ -2468,7 +2468,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:476
 #: lib/vutuv_web/live/organization_live/show.ex:644
-#: lib/vutuv_web/live/post_live/feed.ex:1040
+#: lib/vutuv_web/live/post_live/feed.ex:1041
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:42
 #: lib/vutuv_web/views/user_html.ex:633
@@ -2783,7 +2783,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/live/job_board_live.ex:458
-#: lib/vutuv_web/live/post_live/feed.ex:1184
+#: lib/vutuv_web/live/post_live/feed.ex:1185
 #: lib/vutuv_web/templates/user/card_list.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -4490,7 +4490,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3875
+#: lib/vutuv_web/live/post_live/feed.ex:3881
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -5410,7 +5410,7 @@ msgstr ""
 msgid "Type of email address"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:578
+#: lib/vutuv_web/live/press_kit_live.ex:628
 #: lib/vutuv_web/templates/user/edit.html.heex:256
 #, elixir-autogen, elixir-format
 msgid "About you"
@@ -6175,7 +6175,7 @@ msgid "View all phone numbers"
 msgstr ""
 
 #: lib/vutuv_web/live/feed_languages_live.ex:235
-#: lib/vutuv_web/live/press_kit_live.ex:897
+#: lib/vutuv_web/live/press_kit_live.ex:979
 #: lib/vutuv_web/live/section_reorder_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder"
@@ -6188,7 +6188,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/feed_languages_live.ex:267
 #: lib/vutuv_web/live/post_rewrites_live.ex:364
-#: lib/vutuv_web/live/press_kit_live.ex:959
+#: lib/vutuv_web/live/press_kit_live.ex:1041
 #: lib/vutuv_web/live/section_reorder_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Move down"
@@ -6196,7 +6196,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/feed_languages_live.ex:256
 #: lib/vutuv_web/live/post_rewrites_live.ex:352
-#: lib/vutuv_web/live/press_kit_live.ex:948
+#: lib/vutuv_web/live/press_kit_live.ex:1030
 #: lib/vutuv_web/live/section_reorder_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -7388,9 +7388,9 @@ msgstr ""
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/media_live.ex:270
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:4169
+#: lib/vutuv_web/live/post_live/feed.ex:4175
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
-#: lib/vutuv_web/live/press_kit_live.ex:974
+#: lib/vutuv_web/live/press_kit_live.ex:1056
 #, elixir-autogen
 msgid "Done"
 msgstr ""
@@ -7831,7 +7831,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
 #: lib/vutuv_web/live/job_board_live.ex:468
-#: lib/vutuv_web/live/post_live/feed.ex:1193
+#: lib/vutuv_web/live/post_live/feed.ex:1194
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr ""
@@ -13373,7 +13373,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5556
 #: lib/vutuv_web/controllers/settings_controller.ex:643
-#: lib/vutuv_web/live/post_live/feed.ex:853
+#: lib/vutuv_web/live/post_live/feed.ex:854
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
@@ -14256,7 +14256,7 @@ msgstr ""
 msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1253
+#: lib/vutuv_web/live/post_live/feed.ex:1254
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -17790,7 +17790,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3893
+#: lib/vutuv_web/live/post_live/feed.ex:3899
 #: lib/vutuv_web/live/reference_check_live.ex:169
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Loading…"
@@ -18208,7 +18208,7 @@ msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4760
-#: lib/vutuv_web/live/press_kit_live.ex:478
+#: lib/vutuv_web/live/press_kit_live.ex:528
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "That file is larger than %{limit}. Please upload a smaller one."
@@ -20259,7 +20259,7 @@ msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:431
-#: lib/vutuv_web/live/post_live/feed.ex:1130
+#: lib/vutuv_web/live/post_live/feed.ex:1131
 #: lib/vutuv_web/views/user_html.ex:355
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -20879,12 +20879,12 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4063
+#: lib/vutuv_web/live/post_live/feed.ex:4069
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:854
+#: lib/vutuv_web/live/post_live/feed.ex:855
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr ""
@@ -20930,7 +20930,7 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1122
+#: lib/vutuv_web/live/post_live/feed.ex:1123
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
@@ -21282,7 +21282,7 @@ msgstr ""
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:979
+#: lib/vutuv_web/live/post_live/feed.ex:980
 #: lib/vutuv_web/live/post_live/filter_band.ex:350
 #, elixir-autogen, elixir-format
 msgid "A photo"
@@ -21298,7 +21298,7 @@ msgstr ""
 msgid "A–Z"
 msgstr "A–Z"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1080
+#: lib/vutuv_web/live/post_live/feed.ex:1081
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Browse the tags"
 msgstr ""
@@ -21313,7 +21313,7 @@ msgstr "Busiest first"
 msgid "Clear all"
 msgstr "Clear all"
 
-#: lib/vutuv_web/live/post_live/feed.ex:891
+#: lib/vutuv_web/live/post_live/feed.ex:892
 #, elixir-autogen, elixir-format
 msgid "Drag, or use the arrow keys"
 msgstr ""
@@ -21328,13 +21328,13 @@ msgstr "Expand or collapse"
 msgid "Find an account or a server …"
 msgstr "Find an account …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:915
+#: lib/vutuv_web/live/post_live/feed.ex:916
 #, elixir-autogen, elixir-format
 msgid "Fold %{card}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1051
 #: lib/vutuv_web/live/post_live/feed.ex:1052
+#: lib/vutuv_web/live/post_live/feed.ex:1053
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follow a tag …"
 msgstr ""
@@ -21351,19 +21351,19 @@ msgstr "Hide a tag …"
 msgid "Hide a word or a whole phrase …"
 msgstr "Hide a word or a whole phrase …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:852
-#: lib/vutuv_web/live/post_live/feed.ex:4226
+#: lib/vutuv_web/live/post_live/feed.ex:853
+#: lib/vutuv_web/live/post_live/feed.ex:4232
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Hide tags"
 
-#: lib/vutuv_web/live/post_live/feed.ex:851
-#: lib/vutuv_web/live/post_live/feed.ex:4215
+#: lib/vutuv_web/live/post_live/feed.ex:852
+#: lib/vutuv_web/live/post_live/feed.ex:4221
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Hide words"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1086
+#: lib/vutuv_web/live/post_live/feed.ex:1087
 #: lib/vutuv_web/live/post_live/filter_band.ex:394
 #, elixir-autogen, elixir-format
 msgid "In your feed right now:"
@@ -21379,7 +21379,7 @@ msgstr "Matches nothing in your feed right now — the rule still holds for what
 msgid "More of your %{formatted} accounts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:890
+#: lib/vutuv_web/live/post_live/feed.ex:891
 #, elixir-autogen, elixir-format
 msgid "Move %{card}"
 msgstr ""
@@ -21390,12 +21390,12 @@ msgstr ""
 msgid "No account found."
 msgstr "No account found."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1075
+#: lib/vutuv_web/live/post_live/feed.ex:1076
 #, elixir-autogen, elixir-format
 msgid "No tag called %{name} yet."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:844
+#: lib/vutuv_web/live/post_live/feed.ex:845
 #, elixir-autogen, elixir-format
 msgid "Not read yet"
 msgstr "Not read yet"
@@ -21425,13 +21425,13 @@ msgstr "Posts carrying one of these tags are folded the same way."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4089
+#: lib/vutuv_web/live/post_live/feed.ex:4095
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:936
 #: lib/vutuv_web/live/post_live/feed.ex:937
+#: lib/vutuv_web/live/post_live/feed.ex:938
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove %{card}"
 msgstr ""
@@ -21463,8 +21463,8 @@ msgstr ""
 msgid "Show posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:850
-#: lib/vutuv_web/live/post_live/feed.ex:4181
+#: lib/vutuv_web/live/post_live/feed.ex:851
+#: lib/vutuv_web/live/post_live/feed.ex:4187
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sources"
 msgstr ""
@@ -21474,12 +21474,12 @@ msgstr ""
 msgid "Switching off means muting, not unfollowing. You stay a follower, the posts just stop reaching your feed: permanently and on every device, until you switch them back on here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:914
+#: lib/vutuv_web/live/post_live/feed.ex:915
 #, elixir-autogen, elixir-format
 msgid "Unfold %{card}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1041
+#: lib/vutuv_web/live/post_live/feed.ex:1042
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unfollow the tag %{tag}"
 msgstr ""
@@ -21503,20 +21503,20 @@ msgid_plural "and %{formatted} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3647
-#: lib/vutuv_web/live/post_live/feed.ex:3674
+#: lib/vutuv_web/live/post_live/feed.ex:3653
+#: lib/vutuv_web/live/post_live/feed.ex:3680
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "feed filter sheet"
 msgid "Filter"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1261
+#: lib/vutuv_web/live/post_live/feed.ex:1262
 #, elixir-autogen, elixir-format
 msgctxt "filtered post"
 msgid "Hidden:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:989
+#: lib/vutuv_web/live/post_live/feed.ex:990
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} post in the feed"
 msgid_plural "Show %{formatted} posts in the feed"
@@ -21534,7 +21534,7 @@ msgid "Your organization page was updated. The new logo is being checked and app
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:290
-#: lib/vutuv_web/live/press_kit_live.ex:1143
+#: lib/vutuv_web/live/press_kit_live.ex:1225
 #: lib/vutuv_web/templates/user/edit.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "%{formats}, up to %{limit}"
@@ -21566,7 +21566,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3850
+#: lib/vutuv_web/live/post_live/feed.ex:3856
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Back to now"
 msgstr ""
@@ -21576,7 +21576,7 @@ msgstr ""
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3896
+#: lib/vutuv_web/live/post_live/feed.ex:3902
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -21598,7 +21598,7 @@ msgstr ""
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3846
+#: lib/vutuv_web/live/post_live/feed.ex:3852
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
@@ -21685,7 +21685,7 @@ msgstr ""
 msgid "Page management"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2700
+#: lib/vutuv_web/live/post_live/feed.ex:2706
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
@@ -21717,7 +21717,7 @@ msgstr ""
 msgid "{used} of {max} mentions"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2812
+#: lib/vutuv_web/live/post_live/feed.ex:2818
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr ""
@@ -21932,7 +21932,7 @@ msgctxt "phone tab bar"
 msgid "Write"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3984
+#: lib/vutuv_web/live/post_live/feed.ex:3990
 #: lib/vutuv_web/live/post_rewrites_live.ex:287
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} rule"
@@ -22729,8 +22729,8 @@ msgstr ""
 msgid "Posts loaded at once"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3920
-#: lib/vutuv_web/live/post_live/feed.ex:3924
+#: lib/vutuv_web/live/post_live/feed.ex:3926
+#: lib/vutuv_web/live/post_live/feed.ex:3930
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posts per page"
 msgstr ""
@@ -22756,14 +22756,14 @@ msgstr ""
 msgid "For whom %{thing} is hidden"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3981
-#: lib/vutuv_web/live/post_live/feed.ex:4145
-#: lib/vutuv_web/live/post_live/feed.ex:4154
+#: lib/vutuv_web/live/post_live/feed.ex:3987
+#: lib/vutuv_web/live/post_live/feed.ex:4151
+#: lib/vutuv_web/live/post_live/feed.ex:4160
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Hidden"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4119
+#: lib/vutuv_web/live/post_live/feed.ex:4125
 #, elixir-autogen, elixir-format
 msgid "Hide something from your feed"
 msgstr ""
@@ -22773,12 +22773,12 @@ msgstr ""
 msgid "Stop showing"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4160
+#: lib/vutuv_web/live/post_live/feed.ex:4166
 #, elixir-autogen, elixir-format
 msgid "Whatever these match is folded to a single line in your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4180
+#: lib/vutuv_web/live/post_live/feed.ex:4186
 #, elixir-autogen, elixir-format
 msgid "Words & tags"
 msgstr ""
@@ -23681,48 +23681,48 @@ msgid_plural "%{formatted} more entries (%{years})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1202
+#: lib/vutuv_web/live/press_kit_live.ex:1299
 #, elixir-autogen, elixir-format
 msgid "%{percent}%"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:797
+#: lib/vutuv_web/live/press_kit_live.ex:847
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{used} of %{max}"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1051
+#: lib/vutuv_web/live/press_kit_live.ex:1133
 #, elixir-autogen, elixir-format
 msgid "A photographer's @handle links to their profile and notifies nobody."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1136
+#: lib/vutuv_web/live/press_kit_live.ex:1218
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add a logo variant"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1137
+#: lib/vutuv_web/live/press_kit_live.ex:1219
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add a press photo"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1013
+#: lib/vutuv_web/live/press_kit_live.ex:1095
 #, elixir-autogen, elixir-format
 msgid "At the desk in the Bonn office"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1045
+#: lib/vutuv_web/live/press_kit_live.ex:1127
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Caption"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1023
-#: lib/vutuv_web/live/press_kit_live.ex:1088
+#: lib/vutuv_web/live/press_kit_live.ex:1105
+#: lib/vutuv_web/live/press_kit_live.ex:1170
 #, elixir-autogen, elixir-format
 msgid "Credit"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:814
+#: lib/vutuv_web/live/press_kit_live.ex:864
 #, elixir-autogen, elixir-format
 msgid "Dark"
 msgstr ""
@@ -23732,22 +23732,22 @@ msgstr ""
 msgid "Files a journalist may download and print"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:934
+#: lib/vutuv_web/live/press_kit_live.ex:1016
 #, elixir-autogen, elixir-format
 msgid "First: the main photo"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:933
+#: lib/vutuv_web/live/press_kit_live.ex:1015
 #, elixir-autogen, elixir-format
 msgid "First: the main variant"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1111
+#: lib/vutuv_web/live/press_kit_live.ex:1193
 #, elixir-autogen, elixir-format
 msgid "I hold the rights to this file and release it for editorial use, as long as the credit above is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:814
+#: lib/vutuv_web/live/press_kit_live.ex:864
 #, elixir-autogen, elixir-format
 msgid "Light"
 msgstr ""
@@ -23759,44 +23759,44 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:414
-#: lib/vutuv_web/live/press_kit_live.ex:788
+#: lib/vutuv_web/live/press_kit_live.ex:838
 #: lib/vutuv_web/templates/press_kit/index.html.heex:55
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Logo variants"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:828
+#: lib/vutuv_web/live/press_kit_live.ex:878
 #, elixir-autogen, elixir-format
 msgid "No logo here yet."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:468
+#: lib/vutuv_web/live/press_kit_live.ex:518
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No more than %{max} logo variants."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:471
+#: lib/vutuv_web/live/press_kit_live.ex:521
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No more than %{max} press photos."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:829
+#: lib/vutuv_web/live/press_kit_live.ex:879
 #, elixir-autogen, elixir-format
 msgid "No press photo here yet."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1032
-#: lib/vutuv_web/live/press_kit_live.ex:1098
+#: lib/vutuv_web/live/press_kit_live.ex:1114
+#: lib/vutuv_web/live/press_kit_live.ex:1180
 #, elixir-autogen, elixir-format
 msgid "Photo: Ada King"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:258
+#: lib/vutuv_web/live/press_kit_live.ex:262
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Picture removed."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:487
+#: lib/vutuv_web/live/press_kit_live.ex:537
 #, elixir-autogen, elixir-format
 msgid "Please confirm the rights first, then choose the file."
 msgstr ""
@@ -23808,63 +23808,63 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:122
 #: lib/vutuv_web/agent_docs/text.ex:413
-#: lib/vutuv_web/live/press_kit_live.ex:788
+#: lib/vutuv_web/live/press_kit_live.ex:838
 #: lib/vutuv_web/templates/press_kit/index.html.heex:46
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Press photos"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:812
+#: lib/vutuv_web/live/press_kit_live.ex:862
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Show tiles on:"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1035
+#: lib/vutuv_web/live/press_kit_live.ex:1117
 #, elixir-autogen, elixir-format
 msgid "Shown beside the picture and asked for with every download."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:500
+#: lib/vutuv_web/live/press_kit_live.ex:550
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That could not be saved."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1241
+#: lib/vutuv_web/live/press_kit_live.ex:1338
 #, elixir-autogen, elixir-format
 msgid "The first photo is the one shown first. Drag a tile, or use the arrows, to change the order."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:865
+#: lib/vutuv_web/live/press_kit_live.ex:947
 #, elixir-autogen, elixir-format
 msgid "This shelf is full. Remove one picture to add another."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:747
+#: lib/vutuv_web/live/press_kit_live.ex:797
 #, elixir-autogen, elixir-format
 msgid "What a journalist writing about you may download: photos in print quality and your logo as a file. Everything here is public and free for editorial use as long as your credit is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1001
+#: lib/vutuv_web/live/press_kit_live.ex:1083
 #, elixir-autogen, elixir-format, fuzzy
 msgid "What the picture shows"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1000
+#: lib/vutuv_web/live/press_kit_live.ex:1082
 #, elixir-autogen, elixir-format
 msgid "Which variant this is"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1012
+#: lib/vutuv_web/live/press_kit_live.ex:1094
 #, elixir-autogen, elixir-format
 msgid "White on a dark background"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1046
+#: lib/vutuv_web/live/press_kit_live.ex:1128
 #, elixir-autogen, elixir-format
 msgid "Who took it, where, and what may be cropped."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1233
+#: lib/vutuv_web/live/press_kit_live.ex:1330
 #, elixir-autogen, elixir-format
 msgid "Your logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
 msgstr ""
@@ -23923,22 +23923,22 @@ msgstr "These pictures are offered for editorial use. Use them freely in reporti
 msgid "Video is being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1169
+#: lib/vutuv_web/live/press_kit_live.ex:1251
 #, elixir-autogen, elixir-format
 msgid "Copies the vector file this page's logo was uploaded as onto this shelf."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1227
+#: lib/vutuv_web/live/press_kit_live.ex:1324
 #, elixir-autogen, elixir-format, fuzzy
 msgid "The page's logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1166
+#: lib/vutuv_web/live/press_kit_live.ex:1248
 #, elixir-autogen, elixir-format
 msgid "Use the page's own logo"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:729
+#: lib/vutuv_web/live/press_kit_live.ex:779
 #, elixir-autogen, elixir-format, fuzzy
 msgid "What a journalist writing about this page may download: photos in print quality and its logo as a file. Everything here is public and free for editorial use as long as the credit is shown."
 msgstr ""
@@ -24058,7 +24058,7 @@ msgstr ""
 #: lib/vutuv_web/components/press_kit_components.ex:100
 #: lib/vutuv_web/components/ui.ex:5455
 #: lib/vutuv_web/live/organization_live/show.ex:168
-#: lib/vutuv_web/live/press_kit_live.ex:135
+#: lib/vutuv_web/live/press_kit_live.ex:136
 #: lib/vutuv_web/views/press_kit_html.ex:28
 #: lib/vutuv_web/views/press_kit_html.ex:46
 #, elixir-autogen, elixir-format
@@ -24071,12 +24071,12 @@ msgstr ""
 msgid "Media Kit of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1247
+#: lib/vutuv_web/live/press_kit_live.ex:1344
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove this picture from this page's Media Kit?"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1249
+#: lib/vutuv_web/live/press_kit_live.ex:1346
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove this picture from your Media Kit?"
 msgstr ""
@@ -24086,7 +24086,7 @@ msgstr ""
 msgid "Set up the Media Kit"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:483
+#: lib/vutuv_web/live/press_kit_live.ex:533
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You cannot add a picture to this Media Kit."
 msgstr ""
@@ -24197,14 +24197,14 @@ msgstr ""
 msgid "Your uploads are not limited."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:622
+#: lib/vutuv_web/live/press_kit_live.ex:672
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} word"
 msgid_plural "%{formatted} words"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:706
+#: lib/vutuv_web/live/press_kit_live.ex:756
 #, elixir-autogen, elixir-format
 msgid "A paragraph an article can end on."
 msgstr ""
@@ -24216,22 +24216,22 @@ msgstr ""
 msgid "About %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:699
+#: lib/vutuv_web/live/press_kit_live.ex:749
 #, elixir-autogen, elixir-format
 msgid "About %{words} words. A paragraph at the end of an article."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:693
+#: lib/vutuv_web/live/press_kit_live.ex:743
 #, elixir-autogen, elixir-format
 msgid "About %{words} words. The two sentences under a photo."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:673
+#: lib/vutuv_web/live/press_kit_live.ex:723
 #, elixir-autogen, elixir-format
 msgid "An @handle links to that profile and notifies nobody."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:703
+#: lib/vutuv_web/live/press_kit_live.ex:753
 #, elixir-autogen, elixir-format
 msgid "As long as you like. The whole portrait."
 msgstr ""
@@ -24246,7 +24246,7 @@ msgstr ""
 msgid "Medium version"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:631
+#: lib/vutuv_web/live/press_kit_live.ex:681
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing written yet."
 msgstr ""
@@ -24261,22 +24261,22 @@ msgstr ""
 msgid "Take whichever length fits the space you have. Each one stands on its own."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:707
+#: lib/vutuv_web/live/press_kit_live.ex:757
 #, elixir-autogen, elixir-format
 msgid "The whole story, for as long as it needs."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:580
+#: lib/vutuv_web/live/press_kit_live.ex:630
 #, elixir-autogen, elixir-format
 msgid "Three bios in three lengths, so a journalist can take the one that fits. You write them; nothing is made out of your CV."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:705
+#: lib/vutuv_web/live/press_kit_live.ex:755
 #, elixir-autogen, elixir-format
 msgid "Two sentences a caption can carry."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:641
+#: lib/vutuv_web/live/press_kit_live.ex:691
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Write"
 msgstr ""
@@ -24583,4 +24583,24 @@ msgstr[1] ""
 #: lib/vutuv_web/live/post_live/trending_tags.ex:48
 #, elixir-autogen, elixir-format
 msgid "Very busy on other servers right now:"
+msgstr ""
+
+#: lib/vutuv_web/live/press_kit_live.ex:904
+#, elixir-autogen, elixir-format
+msgid "A picture still being checked is not public yet."
+msgstr ""
+
+#: lib/vutuv_web/live/press_kit_live.ex:907
+#, elixir-autogen, elixir-format
+msgid "A visitor sees a pixelated stand-in in its place and can download nothing. The mark goes by itself when the check is through."
+msgstr ""
+
+#: lib/vutuv_web/live/press_kit_live.ex:1269
+#, elixir-autogen, elixir-format
+msgid "Logo variants, further down this page, take this format."
+msgstr ""
+
+#: lib/vutuv_web/live/press_kit_live.ex:1268
+#, elixir-autogen, elixir-format
+msgid "Press photos, further up this page, take this format."
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -121,8 +121,8 @@ msgstr "Compleanno"
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
 #: lib/vutuv_web/live/post_live/composer.ex:2081
-#: lib/vutuv_web/live/press_kit_live.ex:679
-#: lib/vutuv_web/live/press_kit_live.ex:1057
+#: lib/vutuv_web/live/press_kit_live.ex:729
+#: lib/vutuv_web/live/press_kit_live.ex:1139
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -220,8 +220,8 @@ msgstr "Scarica"
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
 #: lib/vutuv_web/live/job_posting_live/show.ex:201
 #: lib/vutuv_web/live/organization_live/show.ex:159
-#: lib/vutuv_web/live/press_kit_live.ex:641
-#: lib/vutuv_web/live/press_kit_live.ex:974
+#: lib/vutuv_web/live/press_kit_live.ex:691
+#: lib/vutuv_web/live/press_kit_live.ex:1056
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:19
@@ -624,8 +624,8 @@ msgstr "Pubblico"
 #: lib/vutuv_web/components/ui.ex:4934
 #: lib/vutuv_web/live/organization_live/edit.ex:376
 #: lib/vutuv_web/live/post_live/composer.ex:2408
-#: lib/vutuv_web/live/press_kit_live.ex:677
-#: lib/vutuv_web/live/press_kit_live.ex:1056
+#: lib/vutuv_web/live/press_kit_live.ex:727
+#: lib/vutuv_web/live/press_kit_live.ex:1138
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
@@ -944,8 +944,8 @@ msgid "You follow back %{name}."
 msgstr "Ora segue anche %{name}."
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:178
-#: lib/vutuv_web/live/press_kit_live.ex:109
+#: lib/vutuv_web/live/post_live/feed.ex:179
+#: lib/vutuv_web/live/press_kit_live.ex:110
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1712,7 +1712,7 @@ msgstr "Conferma"
 #: lib/vutuv_web/live/organization_live/following.ex:421
 #: lib/vutuv_web/live/organization_live/show.ex:602
 #: lib/vutuv_web/live/organization_live/show.ex:639
-#: lib/vutuv_web/live/post_live/feed.ex:1053
+#: lib/vutuv_web/live/post_live/feed.ex:1054
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
 #: lib/vutuv_web/templates/user/show.html.heex:1350
 #: lib/vutuv_web/views/user_html.ex:643
@@ -2121,7 +2121,7 @@ msgstr "Torna al post"
 #: lib/vutuv_web/live/post_live/composer.ex:2179
 #: lib/vutuv_web/live/post_live/composer.ex:2202
 #: lib/vutuv_web/live/post_live/composer.ex:2228
-#: lib/vutuv_web/live/press_kit_live.ex:1210
+#: lib/vutuv_web/live/press_kit_live.ex:1307
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr "Annulla il caricamento"
@@ -2146,8 +2146,8 @@ msgstr "Modifica il post"
 #: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:203
-#: lib/vutuv_web/live/post_live/feed.ex:364
-#: lib/vutuv_web/live/post_live/feed.ex:3530
+#: lib/vutuv_web/live/post_live/feed.ex:365
+#: lib/vutuv_web/live/post_live/feed.ex:3536
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1346
 #: lib/vutuv_web/live/shell_live.ex:1692
@@ -2193,7 +2193,7 @@ msgstr "Visitatori non connessi"
 msgid "No more than %{max} images per post."
 msgstr "Non più di %{max} immagini per post."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3870
+#: lib/vutuv_web/live/post_live/feed.ex:3876
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2272,7 +2272,7 @@ msgstr "Mostra meno"
 #: lib/vutuv_web/live/post_live/saved.ex:666
 #: lib/vutuv_web/live/post_live/saved.ex:694
 #: lib/vutuv_web/live/post_rewrites_live.ex:376
-#: lib/vutuv_web/live/press_kit_live.ex:983
+#: lib/vutuv_web/live/press_kit_live.ex:1065
 #: lib/vutuv_web/templates/connection/index.html.heex:45
 #: lib/vutuv_web/views/settings_html.ex:386
 #, elixir-autogen, elixir-format
@@ -2291,7 +2291,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Salvataggio…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2706
+#: lib/vutuv_web/live/post_live/feed.ex:2712
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2306,7 +2306,7 @@ msgstr "Spiacenti, la pagina non è stata trovata."
 #: lib/vutuv_web/live/post_live/composer.ex:1614
 #: lib/vutuv_web/live/post_live/composer.ex:1652
 #: lib/vutuv_web/live/post_live/composer.ex:1752
-#: lib/vutuv_web/live/press_kit_live.ex:491
+#: lib/vutuv_web/live/press_kit_live.ex:541
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr "Non è stato possibile elaborare il file."
@@ -2514,7 +2514,7 @@ msgstr "Togli Mi piace"
 #: lib/vutuv_web/live/organization_live/following.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:476
 #: lib/vutuv_web/live/organization_live/show.ex:644
-#: lib/vutuv_web/live/post_live/feed.ex:1040
+#: lib/vutuv_web/live/post_live/feed.ex:1041
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:42
 #: lib/vutuv_web/views/user_html.ex:633
@@ -2836,7 +2836,7 @@ msgstr[0] "1 collegamento"
 msgstr[1] "%{formatted} collegamenti"
 
 #: lib/vutuv_web/live/job_board_live.ex:458
-#: lib/vutuv_web/live/post_live/feed.ex:1184
+#: lib/vutuv_web/live/post_live/feed.ex:1185
 #: lib/vutuv_web/templates/user/card_list.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -4658,7 +4658,7 @@ msgstr "Non ha bloccato nessuno."
 msgid "You unblocked @%{slug}."
 msgstr "Ha sbloccato @%{slug}."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3875
+#: lib/vutuv_web/live/post_live/feed.ex:3881
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Scopra persone da seguire"
@@ -5618,7 +5618,7 @@ msgstr "Tipo di indirizzo e-mail"
 msgid "Type of email address"
 msgstr "Tipo di indirizzo e-mail"
 
-#: lib/vutuv_web/live/press_kit_live.ex:578
+#: lib/vutuv_web/live/press_kit_live.ex:628
 #: lib/vutuv_web/templates/user/edit.html.heex:256
 #, elixir-autogen, elixir-format
 msgid "About you"
@@ -6399,7 +6399,7 @@ msgid "View all phone numbers"
 msgstr "Vedi tutti i numeri di telefono"
 
 #: lib/vutuv_web/live/feed_languages_live.ex:235
-#: lib/vutuv_web/live/press_kit_live.ex:897
+#: lib/vutuv_web/live/press_kit_live.ex:979
 #: lib/vutuv_web/live/section_reorder_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder"
@@ -6414,7 +6414,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/feed_languages_live.ex:267
 #: lib/vutuv_web/live/post_rewrites_live.ex:364
-#: lib/vutuv_web/live/press_kit_live.ex:959
+#: lib/vutuv_web/live/press_kit_live.ex:1041
 #: lib/vutuv_web/live/section_reorder_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Move down"
@@ -6422,7 +6422,7 @@ msgstr "Sposta giù"
 
 #: lib/vutuv_web/live/feed_languages_live.ex:256
 #: lib/vutuv_web/live/post_rewrites_live.ex:352
-#: lib/vutuv_web/live/press_kit_live.ex:948
+#: lib/vutuv_web/live/press_kit_live.ex:1030
 #: lib/vutuv_web/live/section_reorder_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -7674,9 +7674,9 @@ msgstr "Si aggiorna da sola. Può lasciare questa pagina: l'invio prosegue."
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/media_live.ex:270
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:4169
+#: lib/vutuv_web/live/post_live/feed.ex:4175
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
-#: lib/vutuv_web/live/press_kit_live.ex:974
+#: lib/vutuv_web/live/press_kit_live.ex:1056
 #, elixir-autogen
 msgid "Done"
 msgstr "Fatto"
@@ -8154,7 +8154,7 @@ msgstr "Amministratori"
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
 #: lib/vutuv_web/live/job_board_live.ex:468
-#: lib/vutuv_web/live/post_live/feed.ex:1193
+#: lib/vutuv_web/live/post_live/feed.ex:1194
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr "Tutti i membri"
@@ -14100,7 +14100,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5556
 #: lib/vutuv_web/controllers/settings_controller.ex:643
-#: lib/vutuv_web/live/post_live/feed.ex:853
+#: lib/vutuv_web/live/post_live/feed.ex:854
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
@@ -15050,7 +15050,7 @@ msgstr ""
 "Scelga qui sotto un titolo di studio o un istituto da mostrare in cima al "
 "Suo profilo al posto di una qualifica."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1253
+#: lib/vutuv_web/live/post_live/feed.ex:1254
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr "Mostra comunque"
@@ -18908,7 +18908,7 @@ msgstr "Rilasciato il"
 msgid "Label"
 msgstr "Etichetta"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3893
+#: lib/vutuv_web/live/post_live/feed.ex:3899
 #: lib/vutuv_web/live/reference_check_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -19356,7 +19356,7 @@ msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr "PDF, JPG, PNG o WebP, fino a %{limit}"
 
 #: lib/vutuv_web/components/ui.ex:4760
-#: lib/vutuv_web/live/press_kit_live.ex:478
+#: lib/vutuv_web/live/press_kit_live.ex:528
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "That file is larger than %{limit}. Please upload a smaller one."
@@ -21632,7 +21632,7 @@ msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Consigliato: quadrata, almeno %{width} × %{height} pixel."
 
 #: lib/vutuv_web/live/job_board_live.ex:431
-#: lib/vutuv_web/live/post_live/feed.ex:1130
+#: lib/vutuv_web/live/post_live/feed.ex:1131
 #: lib/vutuv_web/views/user_html.ex:355
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -22328,12 +22328,12 @@ msgstr ""
 "Segua #%{tag} da Mastodon o da qualsiasi altra app del Fediverso e i suoi "
 "post pubblici arriveranno nella Sua cronologia. Non serve un account vutuv."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4063
+#: lib/vutuv_web/live/post_live/feed.ex:4069
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Saluti gli altri membri"
 
-#: lib/vutuv_web/live/post_live/feed.ex:854
+#: lib/vutuv_web/live/post_live/feed.ex:855
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr "Nuovi qui"
@@ -22383,7 +22383,7 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr "Con un account vutuv"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1122
+#: lib/vutuv_web/live/post_live/feed.ex:1123
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr "Alcuni fra i membri più recenti. Seguirli è un bel benvenuto."
@@ -22744,7 +22744,7 @@ msgstr "Tutti i membri vutuv, in ordine alfabetico per cognome."
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr "Tutti i membri vutuv, raggruppati per la prima lettera del cognome."
 
-#: lib/vutuv_web/live/post_live/feed.ex:979
+#: lib/vutuv_web/live/post_live/feed.ex:980
 #: lib/vutuv_web/live/post_live/filter_band.ex:350
 #, elixir-autogen, elixir-format
 msgid "A photo"
@@ -22760,7 +22760,7 @@ msgstr "Anche dentro parole più lunghe: %{word} trova anche %{example}."
 msgid "A–Z"
 msgstr "A–Z"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1080
+#: lib/vutuv_web/live/post_live/feed.ex:1081
 #, elixir-autogen, elixir-format
 msgid "Browse the tags"
 msgstr "Sfoglia i tag"
@@ -22775,7 +22775,7 @@ msgstr "Più attivi per primi"
 msgid "Clear all"
 msgstr "Cancella tutto"
 
-#: lib/vutuv_web/live/post_live/feed.ex:891
+#: lib/vutuv_web/live/post_live/feed.ex:892
 #, elixir-autogen, elixir-format
 msgid "Drag, or use the arrow keys"
 msgstr "Trascina, oppure usa i tasti freccia"
@@ -22790,13 +22790,13 @@ msgstr "Espandi o comprimi"
 msgid "Find an account or a server …"
 msgstr "Cerca un account o un server …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:915
+#: lib/vutuv_web/live/post_live/feed.ex:916
 #, elixir-autogen, elixir-format
 msgid "Fold %{card}"
 msgstr "Riduci %{card}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1051
 #: lib/vutuv_web/live/post_live/feed.ex:1052
+#: lib/vutuv_web/live/post_live/feed.ex:1053
 #, elixir-autogen, elixir-format
 msgid "Follow a tag …"
 msgstr "Segui un tag …"
@@ -22813,19 +22813,19 @@ msgstr "Nascondi un tag …"
 msgid "Hide a word or a whole phrase …"
 msgstr "Nascondi una parola o un'intera frase …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:852
-#: lib/vutuv_web/live/post_live/feed.ex:4226
+#: lib/vutuv_web/live/post_live/feed.ex:853
+#: lib/vutuv_web/live/post_live/feed.ex:4232
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Nascondi tag"
 
-#: lib/vutuv_web/live/post_live/feed.ex:851
-#: lib/vutuv_web/live/post_live/feed.ex:4215
+#: lib/vutuv_web/live/post_live/feed.ex:852
+#: lib/vutuv_web/live/post_live/feed.ex:4221
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Nascondi parole"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1086
+#: lib/vutuv_web/live/post_live/feed.ex:1087
 #: lib/vutuv_web/live/post_live/filter_band.ex:394
 #, elixir-autogen, elixir-format
 msgid "In your feed right now:"
@@ -22841,7 +22841,7 @@ msgstr "Ora non corrisponde a nulla nel suo feed — la regola vale comunque per
 msgid "More of your %{formatted} accounts"
 msgstr "Altri dei tuoi %{formatted} account"
 
-#: lib/vutuv_web/live/post_live/feed.ex:890
+#: lib/vutuv_web/live/post_live/feed.ex:891
 #, elixir-autogen, elixir-format
 msgid "Move %{card}"
 msgstr "Sposta %{card}"
@@ -22852,12 +22852,12 @@ msgstr "Sposta %{card}"
 msgid "No account found."
 msgstr "Nessun account trovato."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1075
+#: lib/vutuv_web/live/post_live/feed.ex:1076
 #, elixir-autogen, elixir-format
 msgid "No tag called %{name} yet."
 msgstr "Nessun tag chiamato %{name} finora."
 
-#: lib/vutuv_web/live/post_live/feed.ex:844
+#: lib/vutuv_web/live/post_live/feed.ex:845
 #, elixir-autogen, elixir-format
 msgid "Not read yet"
 msgstr "Non ancora letti"
@@ -22887,13 +22887,13 @@ msgstr "I post con uno di questi tag vengono ridotti allo stesso modo."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "I post che contengono una di queste parole vengono ridotti a una riga — non eliminati, e con un modo per aprirli comunque."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4089
+#: lib/vutuv_web/live/post_live/feed.ex:4095
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Messe da parte:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:936
 #: lib/vutuv_web/live/post_live/feed.ex:937
+#: lib/vutuv_web/live/post_live/feed.ex:938
 #, elixir-autogen, elixir-format
 msgid "Remove %{card}"
 msgstr "Rimuovi %{card}"
@@ -22925,8 +22925,8 @@ msgstr "Mostra solo %{source}"
 msgid "Show posts by %{name}"
 msgstr "Mostra i post di %{name}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:850
-#: lib/vutuv_web/live/post_live/feed.ex:4181
+#: lib/vutuv_web/live/post_live/feed.ex:851
+#: lib/vutuv_web/live/post_live/feed.ex:4187
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr "Fonti"
@@ -22936,12 +22936,12 @@ msgstr "Fonti"
 msgid "Switching off means muting, not unfollowing. You stay a follower, the posts just stop reaching your feed: permanently and on every device, until you switch them back on here."
 msgstr "Disattivare significa silenziare, non smettere di seguire. Continui a seguire, ma i post non arrivano più nel tuo feed: in modo permanente e su tutti i dispositivi, finché non li riattivi qui."
 
-#: lib/vutuv_web/live/post_live/feed.ex:914
+#: lib/vutuv_web/live/post_live/feed.ex:915
 #, elixir-autogen, elixir-format
 msgid "Unfold %{card}"
 msgstr "Espandi %{card}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1041
+#: lib/vutuv_web/live/post_live/feed.ex:1042
 #, elixir-autogen, elixir-format
 msgid "Unfollow the tag %{tag}"
 msgstr "Smetti di seguire il tag %{tag}"
@@ -22965,20 +22965,20 @@ msgid_plural "and %{formatted} more"
 msgstr[0] "e 1 altro"
 msgstr[1] "e altri %{formatted}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3647
-#: lib/vutuv_web/live/post_live/feed.ex:3674
+#: lib/vutuv_web/live/post_live/feed.ex:3653
+#: lib/vutuv_web/live/post_live/feed.ex:3680
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
 msgstr "Filtri"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1261
+#: lib/vutuv_web/live/post_live/feed.ex:1262
 #, elixir-autogen, elixir-format
 msgctxt "filtered post"
 msgid "Hidden:"
 msgstr "Nascosto:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:989
+#: lib/vutuv_web/live/post_live/feed.ex:990
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} post in the feed"
 msgid_plural "Show %{formatted} posts in the feed"
@@ -22998,7 +22998,7 @@ msgstr ""
 "verifica e comparirà al termine del controllo."
 
 #: lib/vutuv_web/live/organization_live/edit.ex:290
-#: lib/vutuv_web/live/press_kit_live.ex:1143
+#: lib/vutuv_web/live/press_kit_live.ex:1225
 #: lib/vutuv_web/templates/user/edit.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "%{formats}, up to %{limit}"
@@ -23032,7 +23032,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} post il %{day}"
 msgstr[1] "%{count} post il %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3850
+#: lib/vutuv_web/live/post_live/feed.ex:3856
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Torna al presente"
@@ -23042,7 +23042,7 @@ msgstr "Torna al presente"
 msgid "Busy month: the shading counts at least this much."
 msgstr "Mese intenso: la tonalità indica almeno questo valore."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3896
+#: lib/vutuv_web/live/post_live/feed.ex:3902
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -23064,7 +23064,7 @@ msgstr "Mese successivo"
 msgid "Next year"
 msgstr "Anno successivo"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3846
+#: lib/vutuv_web/live/post_live/feed.ex:3852
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Il %{day} non è arrivato nulla nel Suo feed."
@@ -23151,7 +23151,7 @@ msgstr "È pronta una nuova versione."
 msgid "Page management"
 msgstr "Gestione"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2700
+#: lib/vutuv_web/live/post_live/feed.ex:2706
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
@@ -23183,7 +23183,7 @@ msgstr "Menziona un account"
 msgid "{used} of {max} mentions"
 msgstr "{used} di {max} menzioni"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2812
+#: lib/vutuv_web/live/post_live/feed.ex:2818
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr ""
@@ -23398,7 +23398,7 @@ msgctxt "phone tab bar"
 msgid "Write"
 msgstr "Scrivi"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3984
+#: lib/vutuv_web/live/post_live/feed.ex:3990
 #: lib/vutuv_web/live/post_rewrites_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "%{formatted} rule"
@@ -24195,8 +24195,8 @@ msgstr ""
 msgid "Posts loaded at once"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3920
-#: lib/vutuv_web/live/post_live/feed.ex:3924
+#: lib/vutuv_web/live/post_live/feed.ex:3926
+#: lib/vutuv_web/live/post_live/feed.ex:3930
 #, elixir-autogen, elixir-format
 msgid "Posts per page"
 msgstr "Post per pagina"
@@ -24222,14 +24222,14 @@ msgstr "Una parola o un'espressione …"
 msgid "For whom %{thing} is hidden"
 msgstr "Per chi %{thing} viene nascosto"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3981
-#: lib/vutuv_web/live/post_live/feed.ex:4145
-#: lib/vutuv_web/live/post_live/feed.ex:4154
+#: lib/vutuv_web/live/post_live/feed.ex:3987
+#: lib/vutuv_web/live/post_live/feed.ex:4151
+#: lib/vutuv_web/live/post_live/feed.ex:4160
 #, elixir-autogen, elixir-format
 msgid "Hidden"
 msgstr "Nascosti"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4119
+#: lib/vutuv_web/live/post_live/feed.ex:4125
 #, elixir-autogen, elixir-format
 msgid "Hide something from your feed"
 msgstr "Nascondi qualcosa dal tuo feed"
@@ -24239,12 +24239,12 @@ msgstr "Nascondi qualcosa dal tuo feed"
 msgid "Stop showing"
 msgstr "Non mostrare più"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4160
+#: lib/vutuv_web/live/post_live/feed.ex:4166
 #, elixir-autogen, elixir-format
 msgid "Whatever these match is folded to a single line in your feed."
 msgstr "Ciò che corrisponde viene ridotto a una riga nel tuo feed."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4180
+#: lib/vutuv_web/live/post_live/feed.ex:4186
 #, elixir-autogen, elixir-format
 msgid "Words & tags"
 msgstr "Parole e tag"
@@ -25194,48 +25194,48 @@ msgid_plural "%{formatted} more entries (%{years})"
 msgstr[0] "Un'altra voce (%{years})"
 msgstr[1] "Altre %{formatted} voci (%{years})"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1202
+#: lib/vutuv_web/live/press_kit_live.ex:1299
 #, elixir-autogen, elixir-format
 msgid "%{percent}%"
 msgstr "%{percent}%"
 
-#: lib/vutuv_web/live/press_kit_live.ex:797
+#: lib/vutuv_web/live/press_kit_live.ex:847
 #, elixir-autogen, elixir-format
 msgid "%{used} of %{max}"
 msgstr "%{used} di %{max}"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1051
+#: lib/vutuv_web/live/press_kit_live.ex:1133
 #, elixir-autogen, elixir-format
 msgid "A photographer's @handle links to their profile and notifies nobody."
 msgstr "L'@handle di un fotografo rimanda al suo profilo e non avvisa nessuno."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1136
+#: lib/vutuv_web/live/press_kit_live.ex:1218
 #, elixir-autogen, elixir-format
 msgid "Add a logo variant"
 msgstr "Aggiungere una variante del logo"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1137
+#: lib/vutuv_web/live/press_kit_live.ex:1219
 #, elixir-autogen, elixir-format
 msgid "Add a press photo"
 msgstr "Aggiungere una foto per la stampa"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1013
+#: lib/vutuv_web/live/press_kit_live.ex:1095
 #, elixir-autogen, elixir-format
 msgid "At the desk in the Bonn office"
 msgstr "Alla scrivania nell'ufficio di Bonn"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1045
+#: lib/vutuv_web/live/press_kit_live.ex:1127
 #, elixir-autogen, elixir-format
 msgid "Caption"
 msgstr "Didascalia"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1023
-#: lib/vutuv_web/live/press_kit_live.ex:1088
+#: lib/vutuv_web/live/press_kit_live.ex:1105
+#: lib/vutuv_web/live/press_kit_live.ex:1170
 #, elixir-autogen, elixir-format
 msgid "Credit"
 msgstr "Crediti"
 
-#: lib/vutuv_web/live/press_kit_live.ex:814
+#: lib/vutuv_web/live/press_kit_live.ex:864
 #, elixir-autogen, elixir-format
 msgid "Dark"
 msgstr "Scuro"
@@ -25245,22 +25245,22 @@ msgstr "Scuro"
 msgid "Files a journalist may download and print"
 msgstr "File che una redazione può scaricare e stampare"
 
-#: lib/vutuv_web/live/press_kit_live.ex:934
+#: lib/vutuv_web/live/press_kit_live.ex:1016
 #, elixir-autogen, elixir-format
 msgid "First: the main photo"
 msgstr "Al primo posto: la foto principale"
 
-#: lib/vutuv_web/live/press_kit_live.ex:933
+#: lib/vutuv_web/live/press_kit_live.ex:1015
 #, elixir-autogen, elixir-format
 msgid "First: the main variant"
 msgstr "Al primo posto: la variante principale"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1111
+#: lib/vutuv_web/live/press_kit_live.ex:1193
 #, elixir-autogen, elixir-format
 msgid "I hold the rights to this file and release it for editorial use, as long as the credit above is shown."
 msgstr "Detengo i diritti su questo file e lo rilascio per uso editoriale, purché vengano indicati i crediti qui sopra."
 
-#: lib/vutuv_web/live/press_kit_live.ex:814
+#: lib/vutuv_web/live/press_kit_live.ex:864
 #, elixir-autogen, elixir-format
 msgid "Light"
 msgstr "Chiaro"
@@ -25272,44 +25272,44 @@ msgstr "Variante del logo"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:414
-#: lib/vutuv_web/live/press_kit_live.ex:788
+#: lib/vutuv_web/live/press_kit_live.ex:838
 #: lib/vutuv_web/templates/press_kit/index.html.heex:55
 #, elixir-autogen, elixir-format
 msgid "Logo variants"
 msgstr "Varianti del logo"
 
-#: lib/vutuv_web/live/press_kit_live.ex:828
+#: lib/vutuv_web/live/press_kit_live.ex:878
 #, elixir-autogen, elixir-format
 msgid "No logo here yet."
 msgstr "Qui non c'è ancora nessun logo."
 
-#: lib/vutuv_web/live/press_kit_live.ex:468
+#: lib/vutuv_web/live/press_kit_live.ex:518
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} logo variants."
 msgstr "Non più di %{max} varianti del logo."
 
-#: lib/vutuv_web/live/press_kit_live.ex:471
+#: lib/vutuv_web/live/press_kit_live.ex:521
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} press photos."
 msgstr "Non più di %{max} foto per la stampa."
 
-#: lib/vutuv_web/live/press_kit_live.ex:829
+#: lib/vutuv_web/live/press_kit_live.ex:879
 #, elixir-autogen, elixir-format
 msgid "No press photo here yet."
 msgstr "Qui non c'è ancora nessuna foto per la stampa."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1032
-#: lib/vutuv_web/live/press_kit_live.ex:1098
+#: lib/vutuv_web/live/press_kit_live.ex:1114
+#: lib/vutuv_web/live/press_kit_live.ex:1180
 #, elixir-autogen, elixir-format
 msgid "Photo: Ada King"
 msgstr "Foto: Ada King"
 
-#: lib/vutuv_web/live/press_kit_live.ex:258
+#: lib/vutuv_web/live/press_kit_live.ex:262
 #, elixir-autogen, elixir-format
 msgid "Picture removed."
 msgstr "Immagine rimossa."
 
-#: lib/vutuv_web/live/press_kit_live.ex:487
+#: lib/vutuv_web/live/press_kit_live.ex:537
 #, elixir-autogen, elixir-format
 msgid "Please confirm the rights first, then choose the file."
 msgstr "Confermi prima i diritti e scelga poi il file."
@@ -25321,63 +25321,63 @@ msgstr "Foto per la stampa"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:122
 #: lib/vutuv_web/agent_docs/text.ex:413
-#: lib/vutuv_web/live/press_kit_live.ex:788
+#: lib/vutuv_web/live/press_kit_live.ex:838
 #: lib/vutuv_web/templates/press_kit/index.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "Press photos"
 msgstr "Foto per la stampa"
 
-#: lib/vutuv_web/live/press_kit_live.ex:812
+#: lib/vutuv_web/live/press_kit_live.ex:862
 #, elixir-autogen, elixir-format
 msgid "Show tiles on:"
 msgstr "Mostrare i riquadri su:"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1035
+#: lib/vutuv_web/live/press_kit_live.ex:1117
 #, elixir-autogen, elixir-format
 msgid "Shown beside the picture and asked for with every download."
 msgstr "Compaiono accanto all'immagine e sono richiesti a ogni download."
 
-#: lib/vutuv_web/live/press_kit_live.ex:500
+#: lib/vutuv_web/live/press_kit_live.ex:550
 #, elixir-autogen, elixir-format
 msgid "That could not be saved."
 msgstr "Non è stato possibile salvare."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1241
+#: lib/vutuv_web/live/press_kit_live.ex:1338
 #, elixir-autogen, elixir-format
 msgid "The first photo is the one shown first. Drag a tile, or use the arrows, to change the order."
 msgstr "La prima foto è quella mostrata per prima. Trascini un riquadro oppure usi le frecce per cambiare l'ordine."
 
-#: lib/vutuv_web/live/press_kit_live.ex:865
+#: lib/vutuv_web/live/press_kit_live.ex:947
 #, elixir-autogen, elixir-format
 msgid "This shelf is full. Remove one picture to add another."
 msgstr "Qui non c'è più spazio. Rimuova un'immagine per aggiungerne un'altra."
 
-#: lib/vutuv_web/live/press_kit_live.ex:747
+#: lib/vutuv_web/live/press_kit_live.ex:797
 #, elixir-autogen, elixir-format
 msgid "What a journalist writing about you may download: photos in print quality and your logo as a file. Everything here is public and free for editorial use as long as your credit is shown."
 msgstr "Ciò che una redazione che scrive di Lei può scaricare: foto in qualità di stampa e il Suo logo come file. Tutto qui è pubblico e libero per uso editoriale, purché vengano indicati i Suoi crediti."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1001
+#: lib/vutuv_web/live/press_kit_live.ex:1083
 #, elixir-autogen, elixir-format
 msgid "What the picture shows"
 msgstr "Che cosa mostra l'immagine"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1000
+#: lib/vutuv_web/live/press_kit_live.ex:1082
 #, elixir-autogen, elixir-format
 msgid "Which variant this is"
 msgstr "Di quale variante si tratta"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1012
+#: lib/vutuv_web/live/press_kit_live.ex:1094
 #, elixir-autogen, elixir-format
 msgid "White on a dark background"
 msgstr "Bianco su sfondo scuro"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1046
+#: lib/vutuv_web/live/press_kit_live.ex:1128
 #, elixir-autogen, elixir-format
 msgid "Who took it, where, and what may be cropped."
 msgstr "Chi l'ha scattata, dove e che cosa si può ritagliare."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1233
+#: lib/vutuv_web/live/press_kit_live.ex:1330
 #, elixir-autogen, elixir-format
 msgid "Your logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
 msgstr "Il Suo logo come file, un riquadro per variante. Una tipografia chiede un vettoriale (SVG); tutti gli altri possono aprire un PNG."
@@ -25436,22 +25436,22 @@ msgstr "Queste immagini sono offerte per uso editoriale. Usatele liberamente nei
 msgid "Video is being checked"
 msgstr "Il video è in fase di controllo"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1169
+#: lib/vutuv_web/live/press_kit_live.ex:1251
 #, elixir-autogen, elixir-format
 msgid "Copies the vector file this page's logo was uploaded as onto this shelf."
 msgstr "Copia qui il file vettoriale con cui è stato caricato il logo di questa pagina."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1227
+#: lib/vutuv_web/live/press_kit_live.ex:1324
 #, elixir-autogen, elixir-format
 msgid "The page's logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
 msgstr "Il logo di questa pagina come file, un riquadro per variante. Una tipografia chiede un vettoriale (SVG); tutti gli altri possono aprire un PNG."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1166
+#: lib/vutuv_web/live/press_kit_live.ex:1248
 #, elixir-autogen, elixir-format
 msgid "Use the page's own logo"
 msgstr "Usa il logo di questa pagina"
 
-#: lib/vutuv_web/live/press_kit_live.ex:729
+#: lib/vutuv_web/live/press_kit_live.ex:779
 #, elixir-autogen, elixir-format
 msgid "What a journalist writing about this page may download: photos in print quality and its logo as a file. Everything here is public and free for editorial use as long as the credit is shown."
 msgstr "Ciò che una redazione che scrive di questa pagina può scaricare: foto in qualità di stampa e il suo logo come file. Tutto qui è pubblico e libero per uso editoriale, purché vengano indicati i crediti."
@@ -25571,7 +25571,7 @@ msgstr "Tutto il Media Kit"
 #: lib/vutuv_web/components/press_kit_components.ex:100
 #: lib/vutuv_web/components/ui.ex:5455
 #: lib/vutuv_web/live/organization_live/show.ex:168
-#: lib/vutuv_web/live/press_kit_live.ex:135
+#: lib/vutuv_web/live/press_kit_live.ex:136
 #: lib/vutuv_web/views/press_kit_html.ex:28
 #: lib/vutuv_web/views/press_kit_html.ex:46
 #, elixir-autogen, elixir-format
@@ -25584,12 +25584,12 @@ msgstr "Media Kit"
 msgid "Media Kit of %{name}"
 msgstr "Media Kit di %{name}"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1247
+#: lib/vutuv_web/live/press_kit_live.ex:1344
 #, elixir-autogen, elixir-format
 msgid "Remove this picture from this page's Media Kit?"
 msgstr "Rimuovere questa immagine dal Media Kit di questa pagina?"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1249
+#: lib/vutuv_web/live/press_kit_live.ex:1346
 #, elixir-autogen, elixir-format
 msgid "Remove this picture from your Media Kit?"
 msgstr "Rimuovere questa immagine dal Suo Media Kit?"
@@ -25599,7 +25599,7 @@ msgstr "Rimuovere questa immagine dal Suo Media Kit?"
 msgid "Set up the Media Kit"
 msgstr "Configura il Media Kit"
 
-#: lib/vutuv_web/live/press_kit_live.ex:483
+#: lib/vutuv_web/live/press_kit_live.ex:533
 #, elixir-autogen, elixir-format
 msgid "You cannot add a picture to this Media Kit."
 msgstr "Non può aggiungere un'immagine a questo Media Kit."
@@ -25710,14 +25710,14 @@ msgstr "Ha esaurito il Suo limite di caricamento per oggi. Si libera di nuovo ne
 msgid "Your uploads are not limited."
 msgstr "I Suoi caricamenti non hanno limiti."
 
-#: lib/vutuv_web/live/press_kit_live.ex:622
+#: lib/vutuv_web/live/press_kit_live.ex:672
 #, elixir-autogen, elixir-format
 msgid "%{formatted} word"
 msgid_plural "%{formatted} words"
 msgstr[0] "%{formatted} parola"
 msgstr[1] "%{formatted} parole"
 
-#: lib/vutuv_web/live/press_kit_live.ex:706
+#: lib/vutuv_web/live/press_kit_live.ex:756
 #, elixir-autogen, elixir-format
 msgid "A paragraph an article can end on."
 msgstr "Un paragrafo con cui un articolo può chiudersi."
@@ -25729,22 +25729,22 @@ msgstr "Un paragrafo con cui un articolo può chiudersi."
 msgid "About %{name}"
 msgstr "Su %{name}"
 
-#: lib/vutuv_web/live/press_kit_live.ex:699
+#: lib/vutuv_web/live/press_kit_live.ex:749
 #, elixir-autogen, elixir-format
 msgid "About %{words} words. A paragraph at the end of an article."
 msgstr "Circa %{words} parole. Un paragrafo alla fine di un articolo."
 
-#: lib/vutuv_web/live/press_kit_live.ex:693
+#: lib/vutuv_web/live/press_kit_live.ex:743
 #, elixir-autogen, elixir-format
 msgid "About %{words} words. The two sentences under a photo."
 msgstr "Circa %{words} parole. Le due frasi sotto una foto."
 
-#: lib/vutuv_web/live/press_kit_live.ex:673
+#: lib/vutuv_web/live/press_kit_live.ex:723
 #, elixir-autogen, elixir-format
 msgid "An @handle links to that profile and notifies nobody."
 msgstr "Una @handle rimanda a quel profilo e non avvisa nessuno."
 
-#: lib/vutuv_web/live/press_kit_live.ex:703
+#: lib/vutuv_web/live/press_kit_live.ex:753
 #, elixir-autogen, elixir-format
 msgid "As long as you like. The whole portrait."
 msgstr "Lunga quanto vuole. Il ritratto completo."
@@ -25759,7 +25759,7 @@ msgstr "Versione lunga"
 msgid "Medium version"
 msgstr "Versione media"
 
-#: lib/vutuv_web/live/press_kit_live.ex:631
+#: lib/vutuv_web/live/press_kit_live.ex:681
 #, elixir-autogen, elixir-format
 msgid "Nothing written yet."
 msgstr "Non ha ancora scritto nulla."
@@ -25774,22 +25774,22 @@ msgstr "Versione breve"
 msgid "Take whichever length fits the space you have. Each one stands on its own."
 msgstr "Prenda la lunghezza che entra nello spazio che ha. Ognuna sta in piedi da sola."
 
-#: lib/vutuv_web/live/press_kit_live.ex:707
+#: lib/vutuv_web/live/press_kit_live.ex:757
 #, elixir-autogen, elixir-format
 msgid "The whole story, for as long as it needs."
 msgstr "Tutta la storia, per quanto serve."
 
-#: lib/vutuv_web/live/press_kit_live.ex:580
+#: lib/vutuv_web/live/press_kit_live.ex:630
 #, elixir-autogen, elixir-format
 msgid "Three bios in three lengths, so a journalist can take the one that fits. You write them; nothing is made out of your CV."
 msgstr "Tre biografie in tre lunghezze, così una redazione prende quella che le serve. Le scrive Lei; dal Suo curriculum non viene ricavato nulla."
 
-#: lib/vutuv_web/live/press_kit_live.ex:705
+#: lib/vutuv_web/live/press_kit_live.ex:755
 #, elixir-autogen, elixir-format
 msgid "Two sentences a caption can carry."
 msgstr "Due frasi che entrano in una didascalia."
 
-#: lib/vutuv_web/live/press_kit_live.ex:641
+#: lib/vutuv_web/live/press_kit_live.ex:691
 #, elixir-autogen, elixir-format
 msgid "Write"
 msgstr "Scrivi"
@@ -26097,3 +26097,23 @@ msgstr[1] "Segui %{tag}. Oggi %{uses} post su %{servers} server, contro %{baseli
 #, elixir-autogen, elixir-format
 msgid "Very busy on other servers right now:"
 msgstr "Ora molto attivi su altri server:"
+
+#: lib/vutuv_web/live/press_kit_live.ex:904
+#, elixir-autogen, elixir-format
+msgid "A picture still being checked is not public yet."
+msgstr "Un'immagine ancora in verifica non è ancora pubblica."
+
+#: lib/vutuv_web/live/press_kit_live.ex:907
+#, elixir-autogen, elixir-format
+msgid "A visitor sees a pixelated stand-in in its place and can download nothing. The mark goes by itself when the check is through."
+msgstr "Un visitatore vede al suo posto un'anteprima pixelata e non può scaricare nulla. Il contrassegno sparisce da solo quando la verifica è conclusa."
+
+#: lib/vutuv_web/live/press_kit_live.ex:1269
+#, elixir-autogen, elixir-format
+msgid "Logo variants, further down this page, take this format."
+msgstr "Le varianti del logo, più in basso in questa pagina, accettano questo formato."
+
+#: lib/vutuv_web/live/press_kit_live.ex:1268
+#, elixir-autogen, elixir-format
+msgid "Press photos, further up this page, take this format."
+msgstr "Le foto per la stampa, più in alto in questa pagina, accettano questo formato."

--- a/test/vutuv_web/live/press_kit_live_test.exs
+++ b/test/vutuv_web/live/press_kit_live_test.exs
@@ -40,9 +40,12 @@ defmodule VutuvWeb.PressKitLiveTest do
     {:ok, conn: conn, user: user, tmp: tmp}
   end
 
-  defp photo_path(tmp, name \\ "portrait.jpg") do
+  # The size is a parameter because #2141's tests tell a batch apart by the
+  # stored `width` — a press picture keeps no copy of the name it arrived under
+  # (`Vutuv.PressKit.download_name/2`), so the pixels are what survives.
+  defp photo_path(tmp, name \\ "portrait.jpg", {width, height} \\ {600, 400}) do
     path = Path.join(tmp, "#{System.unique_integer([:positive])}-#{name}")
-    {:ok, img} = Image.new(600, 400, color: [200, 40, 40])
+    {:ok, img} = Image.new(width, height, color: [200, 40, 40])
     {:ok, _} = Image.write(img, path)
     path
   end
@@ -65,14 +68,18 @@ defmodule VutuvWeb.PressKitLiveTest do
     live
   end
 
-  defp photo_entry(tmp, name) do
-    %{
-      last_modified: 1_594_171_879_000,
-      name: name,
-      content: File.read!(photo_path(tmp, name)),
-      type: "image/jpeg"
-    }
+  defp photo_entry(tmp, name, size \\ {600, 400}) do
+    file_entry(name, File.read!(photo_path(tmp, name, size)), "image/jpeg")
   end
+
+  # The one place a `Phoenix.LiveViewTest` upload entry is built.
+  defp file_entry(name, content, type) do
+    %{last_modified: 1_594_171_879_000, name: name, content: content, type: type}
+  end
+
+  # Drives one of the in-flight uploads of the #2141 batch to its last chunk.
+  # The percentage is a **step**, not a target, and the batch already sent 10.
+  defp finish(inflight, name), do: render_upload(Map.fetch!(inflight, name), name, 90)
 
   defp upload_photo(live, tmp, name \\ "portrait.jpg") do
     input = file_input(live, "#press-add-photo", :photo, [photo_entry(tmp, name)])
@@ -84,12 +91,7 @@ defmodule VutuvWeb.PressKitLiveTest do
     {:ok, img} = Image.new(240, 80, color: [0, 170, 85])
     {:ok, _} = Image.write(img, path)
 
-    entry = %{
-      last_modified: 1_594_171_879_000,
-      name: "mark.png",
-      content: File.read!(path),
-      type: "image/png"
-    }
+    entry = file_entry("mark.png", File.read!(path), "image/png")
 
     input = file_input(live, "#press-add-logo", :logo, [entry])
     render_upload(input, "mark.png")
@@ -687,6 +689,171 @@ defmodule VutuvWeb.PressKitLiveTest do
     end
   end
 
+  # Issue #2141. Three pictures in flight at once, finishing in the reverse of
+  # the order they were picked, which is what a batch with one big file among
+  # small ones does every time.
+  #
+  # **One `file_input` per picture, deliberately.** `Phoenix.LiveViewTest`'s
+  # upload client stops the moment one of *its* entries is consumed, and its
+  # channels go with it, so a single input can carry exactly one completed
+  # upload — with three in one input the second `render_upload/3` exits with
+  # "no process". Three clients registered before any of them finishes give the
+  # server the same picture a real multi-pick does: three entries in the picked
+  # order, all in flight, finishing in another order.
+  describe "several pictures in flight at once (issue #2141)" do
+    setup %{conn: conn, tmp: tmp} do
+      {:ok, live, _html} = open(conn)
+      confirm_rights(live, "photo", "Foto: Ada King")
+
+      inflight =
+        Map.new(
+          [{"hero.jpg", 600}, {"second.jpg", 500}, {"third.jpg", 400}],
+          fn {name, width} ->
+            input =
+              file_input(live, "#press-add-photo", :photo, [photo_entry(tmp, name, {width, 400})])
+
+            render_upload(input, name, 10)
+            {name, input}
+          end
+        )
+
+      {:ok, live: live, inflight: inflight}
+    end
+
+    test "the shelf keeps the order they were picked in", %{
+      user: user,
+      inflight: inflight
+    } do
+      finish(inflight, "third.jpg")
+      finish(inflight, "second.jpg")
+      finish(inflight, "hero.jpg")
+
+      assert Enum.map(PressKit.shelves(user).photos, & &1.width) == [600, 500, 400]
+    end
+
+    test "a picture that lands first keeps the slots of the ones picked before it", %{
+      user: user,
+      inflight: inflight
+    } do
+      finish(inflight, "third.jpg")
+
+      assert [%{width: 400, position: 2}] = PressKit.shelves(user).photos
+    end
+
+    test "the hero note sits on the photo that was picked first", %{
+      live: live,
+      user: user,
+      inflight: inflight
+    } do
+      finish(inflight, "third.jpg")
+      finish(inflight, "hero.jpg")
+
+      [hero, _third] = PressKit.shelves(user).photos
+
+      assert hero.width == 600
+      assert has_element?(live, "[data-press-picture='#{hero.id}'] [data-press-hero]")
+    end
+
+    test "a picture picked afterwards goes behind them all", %{
+      live: live,
+      user: user,
+      tmp: tmp,
+      inflight: inflight
+    } do
+      later =
+        file_input(live, "#press-add-photo", :photo, [photo_entry(tmp, "later.jpg", {300, 200})])
+
+      render_upload(later, "later.jpg")
+      finish(inflight, "hero.jpg")
+
+      assert Enum.map(PressKit.shelves(user).photos, & &1.width) == [600, 300]
+    end
+
+    # A batch reserves ahead of itself, so the shelf can hold one picture at
+    # position 2 while positions 0 and 1 are still climbing, and a picture
+    # picked after all of them belongs behind them. The layer that enforces it
+    # is `PressKit.take_slot/3`, which hands out only free slots — so this stays
+    # green with `note_slots/2`'s floor spelled either way, and is kept because
+    # the promise is worth pinning rather than because it measures that floor.
+    test "a picture picked afterwards goes behind the slots still being climbed", %{
+      live: live,
+      user: user,
+      tmp: tmp,
+      inflight: inflight
+    } do
+      finish(inflight, "third.jpg")
+
+      later =
+        file_input(live, "#press-add-photo", :photo, [photo_entry(tmp, "later.jpg", {300, 200})])
+
+      render_upload(later, "later.jpg")
+
+      shelf = PressKit.shelves(user).photos
+      positions = Enum.map(shelf, & &1.position)
+
+      assert positions == Enum.uniq(positions)
+      assert Enum.map(shelf, & &1.width) == [400, 300]
+    end
+  end
+
+  # A reserved slot is one socket's wish about order, taken from a snapshot of
+  # one moment. Two things make that snapshot wrong, and both are ordinary.
+  describe "a reserved slot the shelf cannot honour (issue #2141)" do
+    # The commonest edit a full shelf gets. Nine rows and a highest position of
+    # nine means the next wish is for ten, which is past the cap — but there is
+    # a free slot, the one the deleted picture left, and the counter is already
+    # promising it ("2 of 3", add form offered).
+    test "a full shelf that loses one picture takes another", %{
+      conn: conn,
+      user: user,
+      tmp: tmp
+    } do
+      put_config(:press_kit, max_filesize: 30_000_000, max_photos: 3, max_logos: 5)
+      Enum.each(1..3, fn _ -> add_photo!(user, tmp) end)
+      [_first, middle, _last] = PressKit.shelves(user).photos
+
+      {:ok, live, _html} = open(conn)
+      render_click(live, "delete", %{"id" => middle.id})
+
+      assert live |> element("[data-press-count='photo']") |> render() =~ "2 of 3"
+      assert has_element?(live, "#press-add-photo")
+
+      live |> confirm_rights("photo", "Foto: Ada King") |> upload_photo(tmp)
+
+      refute render(live) =~ "No more than"
+      assert [_a, _b, _c] = shelf = PressKit.shelves(user).photos
+      # The gap the delete left, filled, rather than a fourth number nobody has.
+      assert Enum.map(shelf, & &1.position) == [0, 1, 2]
+    end
+
+    # A phone and a laptop, both open on the editor. Each socket sees an empty
+    # shelf, so each wishes for slot 0; two pictures answering to one slot are
+    # two downloads called `<handle>-press-1.jpg`.
+    test "two tabs of one member are given two slots", %{conn: conn, user: user, tmp: tmp} do
+      {:ok, phone, _html} = open(conn)
+      {:ok, laptop, _html} = open(recycle(conn))
+
+      confirm_rights(phone, "photo", "Foto: Ada King")
+      confirm_rights(laptop, "photo", "Foto: Ada King")
+
+      phone
+      |> file_input("#press-add-photo", :photo, [photo_entry(tmp, "phone.jpg", {600, 400})])
+      |> render_upload("phone.jpg")
+
+      laptop
+      |> file_input("#press-add-photo", :photo, [photo_entry(tmp, "laptop.jpg", {500, 400})])
+      |> render_upload("laptop.jpg")
+
+      shelf = PressKit.shelves(user).photos
+
+      assert Enum.map(shelf, & &1.position) == [0, 1]
+      assert Enum.map(shelf, & &1.width) == [600, 500]
+
+      assert Enum.map(shelf, &PressKit.download_name(&1, ".jpg")) ==
+               Enum.uniq(Enum.map(shelf, &PressKit.download_name(&1, ".jpg")))
+    end
+  end
+
   describe "a picture the AI gate is still looking at" do
     test "wears the being-checked badge on its tile", %{conn: conn, user: user, tmp: tmp} do
       put_config(:moderate_images, true)
@@ -697,6 +864,77 @@ defmodule VutuvWeb.PressKitLiveTest do
       {:ok, live, _html} = open(conn)
 
       assert live |> element("[data-press-picture='#{photo.id}']") |> render() =~ "Being checked"
+    end
+
+    # Issue #2144: ten identical grey badges and nothing else read like a failed
+    # upload, so the shelf says once what a visitor meets meanwhile.
+    test "the shelf says what a visitor sees meanwhile", %{conn: conn, user: user, tmp: tmp} do
+      put_config(:moderate_images, true)
+      add_photo!(user, tmp)
+
+      {:ok, live, _html} = open(conn)
+
+      assert live |> element("[data-press-pending='photo']") |> render() =~
+               "sees a pixelated stand-in in its place"
+
+      refute has_element?(live, "[data-press-pending='logo']")
+    end
+
+    test "a released shelf says nothing of the kind", %{conn: conn, user: user, tmp: tmp} do
+      add_photo!(user, tmp)
+
+      {:ok, live, _html} = open(conn)
+
+      refute has_element?(live, "[data-press-pending='photo']")
+    end
+  end
+
+  describe "a file on the wrong shelf (issue #2144)" do
+    test "the logo shelf points at the photo shelf that would have taken it", %{
+      conn: conn,
+      tmp: tmp
+    } do
+      {:ok, live, _html} = open(conn)
+      confirm_rights(live, "logo", "Logo: Ada King")
+
+      input =
+        file_input(live, "#press-add-logo", :logo, [photo_entry(tmp, "portrait.jpg", {60, 40})])
+
+      assert {:error, [[_ref, :not_accepted]]} = render_upload(input, "portrait.jpg")
+      assert render(live) =~ "That file type is not allowed."
+
+      assert live |> element("[data-press-wrong-shelf='logo']") |> render() =~ "Press photos"
+    end
+
+    test "the photo shelf points at the logo shelf for a vector", %{conn: conn} do
+      {:ok, live, _html} = open(conn)
+      confirm_rights(live, "photo", "Foto: Ada King")
+
+      entry =
+        file_entry(
+          "mark.svg",
+          ~s(<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"></svg>),
+          "image/svg+xml"
+        )
+
+      input = file_input(live, "#press-add-photo", :photo, [entry])
+
+      assert {:error, [[_ref, :not_accepted]]} = render_upload(input, "mark.svg")
+
+      assert live |> element("[data-press-wrong-shelf='photo']") |> render() =~ "Logo variants"
+    end
+
+    test "a format neither shelf takes is pointed nowhere", %{conn: conn} do
+      {:ok, live, _html} = open(conn)
+      confirm_rights(live, "photo", "Foto: Ada King")
+
+      entry = file_entry("mappe.pdf", "%PDF-1.4", "application/pdf")
+
+      input = file_input(live, "#press-add-photo", :photo, [entry])
+
+      assert {:error, [[_ref, :not_accepted]]} = render_upload(input, "mappe.pdf")
+      assert render(live) =~ "That file type is not allowed."
+      refute has_element?(live, "[data-press-wrong-shelf='photo']")
     end
   end
 
@@ -981,6 +1219,36 @@ defmodule VutuvWeb.PressKitLiveTest do
       # The rights sentence is the gate; a fuzzy-filled German for it would
       # promise something else entirely.
       assert html =~ "Rechte"
+    end
+
+    # Issue #2144's two new sentences, asserted by name: both are fresh msgids,
+    # and a `gettext.extract --merge` fuzzy-fill would ship a German sentence
+    # written for something else while every English test stayed green.
+    test "the still-being-checked note says the German words", %{
+      conn: conn,
+      user: user,
+      tmp: tmp
+    } do
+      put_config(:moderate_images, true)
+      add_photo!(user, tmp)
+
+      {:ok, live, _html} = open(conn)
+
+      assert live |> element("[data-press-pending='photo']") |> render() =~
+               "Besucher sehen an seiner Stelle eine verpixelte Vorschau"
+    end
+
+    test "the wrong-shelf pointer says the German words", %{conn: conn, tmp: tmp} do
+      {:ok, live, _html} = open(conn)
+      confirm_rights(live, "logo", "Logo: Ada King")
+
+      input =
+        file_input(live, "#press-add-logo", :logo, [photo_entry(tmp, "portrait.jpg", {60, 40})])
+
+      assert {:error, [[_ref, :not_accepted]]} = render_upload(input, "portrait.jpg")
+
+      assert live |> element("[data-press-wrong-shelf='logo']") |> render() =~
+               "Pressefotos, weiter oben auf dieser Seite"
     end
 
     test "the bios card says the German words (issue #2101)", %{conn: conn} do


### PR DESCRIPTION
Two defects in the Media Kit editor, `/settings/media-kit` (`VutuvWeb.PressKitLive`).

A picture took its slot when its upload finished, and several climb in parallel, so the biggest landed last. Measured in a browser: picking portrait (16 MB), p2, p3, p4 gave p2, p4, p3, portrait, the hero note on the wrong photo. The editor now notes each file's slot at first sight of the upload entry list, which is the picker's own order.

Ten grey "Wird geprüft" badges were the whole message. A shelf still in the AI check now says once, in the composer's amber wait panel, that a visitor meets a pixelated stand-in and that the mark clears itself. No duration, because nothing measures one. A refused file points at the shelf that takes its format.

Closes #2141
Closes #2144

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01WPMGFtmCZNip8EJiRrx6ch
