### PR TITLE
An empty Media Kit tells crawlers there is nothing to keep

### DIFF
--- a/docs/architecture/images.md
+++ b/docs/architecture/images.md
@@ -1003,8 +1003,8 @@ Every other section page goes through the router's `:user_pipe` and its
 `NoIndex` because it shows personal data; a press kit is published in order to
 be found, so the route sits outside that pipeline, declares the pipeline's other
 three plugs itself, carries the member's own `noindex?`/`noai?`, is listed in the
-sitemap (`Vutuv.Sitemap.press_entries/1`, gated on
-`PressKit.public_query/0`) and publishes a schema.org `CollectionPage` whose
+sitemap (`Vutuv.Sitemap.press_entries/1`, gated on `PressKit.public_query/0` or
+`PressKit.written_bio_query/0`) and publishes a schema.org `CollectionPage` whose
 `associatedMedia` are `ImageObject`s with `creditText`, `copyrightNotice`,
 `license` and `acquireLicensePage` — the four properties image search reads to
 call a picture licensable (`VutuvWeb.JsonLd.press_kit_page/3`). **One
@@ -1022,6 +1022,32 @@ since a document that names a file must name one that can be fetched. A picture
 whose owner typed no label is titled by its **shelf** — "Logo variant" or
 "Press photo" — in `PressKitDoc.entry/1` rather than in each renderer, which
 sees a flat map and so called every unlabelled logo a press picture (#2142).
+
+**An empty Media Kit keeps its 200 and says `noindex` (issue #2143).** Every
+member and every page has this address whether or not anybody ever put
+something on it, and on the day this shipped every one of them was empty: 6,025
+members and 12 pages in the dev copy of production, 0 press pictures and 0 bios
+between them. Nothing on the site links an empty kit and the sitemap left it
+out, but `/llms.txt` handed out the bare `/<username>/media-kit` pattern, so an
+assistant reading that document walked 6,037 pages — 30,185 counting the four
+agent siblings — that each answered 200 with no `x-robots-tag` at all. The
+answer is not a 404: the page belongs to its owner, who is about to upload, and
+a 404 would make its existence depend on its content and would answer a
+machine's "does this member offer press material?" with an error where a 200
+answers "no". Instead `PressKit.empty?/2` (both shelves empty and no written
+bio) feeds `PressKit.robots_axes/2`, which adds `noindex` — and **only**
+`noindex`, because emptiness is a statement about what is here, not about who
+may use it, so an empty kit never invents the `noai` its owner did not choose.
+That one answer reaches the response header, the page's own `<meta
+name="robots">` (`LayoutHTML.robots_directives/1` now prefers an explicit
+`conn.assigns[:robots_directives]` over re-deriving it from the member) and all
+four documents. Each surface asks `empty?/2` about what it itself carries, so a
+picture still in the AI queue leaves the HTML page indexable — it draws a
+stand-in — while the document, which may only name a fetchable file, says
+`noindex`. `/llms.txt` now says most kits are empty and points at the sitemap
+chunks instead of the pattern, and `Sitemap.press_entries/1` grew a second
+source so the claim holds: a member who wrote a bio and uploaded nothing is
+listed (`PressKit.written_bio_query/0`), because that kit has something on it.
 
 **A page has the same section, kept by its team (issue #2087).** The card, the
 section page, the documents, the schema.org block and the sitemap entry are the

--- a/lib/vutuv/press_kit.ex
+++ b/lib/vutuv/press_kit.ex
@@ -217,17 +217,87 @@ defmodule Vutuv.PressKit do
   def public_query, do: released(from(i in Image, where: i.kind == ^@kind))
 
   @doc """
-  The two robots axes for an owner's press page: `{noindex?, noai?}`.
+  The bio rows that actually say something, as a query — the other half of
+  "this kit is worth walking", beside `public_query/0`.
 
-  A press kit is published in order to be found, so the page carries the
+  `Vutuv.Sitemap.press_entries/1`'s second source: a member who wrote three
+  bios and uploaded no picture still has a Media Kit a journalist can use, and
+  before issue #2143 nothing told a crawler it existed. Built by folding
+  `Vutuv.PressKit.Bio.lengths/0` rather than naming the three columns, so the
+  list of lengths stays the one vocabulary.
+
+  The SQL twin of `Bio.any?/1` (`any_bio?/1` here), which asks the same thing of
+  a row already in memory; the two agree because a blank field is stored as
+  `nil` rather than `""` — that rule is `Bio`'s, and it is what keeps them from
+  drifting.
+
+  Members only. `bio/1` answers `%Bio{}` for a page, which has no row here.
+  """
+  def written_bio_query do
+    [first | rest] = Bio.lengths()
+
+    written =
+      Enum.reduce(rest, dynamic([b], not is_nil(field(b, ^first))), fn length, acc ->
+        dynamic([b], ^acc or not is_nil(field(b, ^length)))
+      end)
+
+    from(b in Bio, where: ^written)
+  end
+
+  @doc """
+  How many pictures this kit holds altogether — both shelves, since every
+  surface that counts a kit counts what it draws.
+  """
+  def picture_count(%{photos: photos, logos: logos}), do: length(photos) + length(logos)
+
+  @doc "Whether there is anything on either shelf."
+  def any_pictures?(shelves), do: picture_count(shelves) > 0
+
+  @doc """
+  Whether this kit says nothing at all — no picture on either shelf and no
+  written bio (issue #2143).
+
+  Asked of the shelves the surface in hand already holds, so the HTML page
+  answers for what it *draws* (`public_shelves/2`) and a document for what it
+  *lists* (`published_shelves/1`); those differ only while every picture is
+  still in the AI queue, and in that window each surface is right about itself.
+  Never a query of its own: this is asked on every Media Kit response, and the
+  shelves and the bio are already read.
+
+  The in-memory twin of the pair `Vutuv.Sitemap.press_entries/1` asks in SQL
+  (`public_query/0` and `written_bio_query/0`), so the page and the sitemap
+  answer "is there anything here" from the same two rules — a kit the sitemap
+  lists never answers `noindex`.
+  """
+  def empty?(shelves, bio), do: not any_pictures?(shelves) and not any_bio?(bio)
+
+  @doc """
+  The two robots axes for an owner's Media Kit page: `{noindex?, noai?}`.
+  `empty?` is `empty?/2`'s answer for the surface being served.
+
+  A Media Kit is published in order to be found, so the page carries the
   **owner's own** opt-outs rather than the blanket refusal every other
   profile sub-page wears. Stated once here because the controller sets the
-  header from it and the agent documents stamp their `Content-Signal` from it,
-  and `VutuvWeb.AgentDocs.PostDoc.robots_axes/2`'s docstring is the war story of
+  header *and the page's `<meta>` tag* from it and the agent documents stamp
+  their `Content-Signal` from it, and
+  `VutuvWeb.AgentDocs.PostDoc.robots_axes/2`'s docstring is the war story of
   what happens when two such derivations disagree.
+
+  **An empty kit adds `noindex`, and only that** (issue #2143). Every member
+  and every page has this address whether or not anybody ever put something on
+  it, so almost all of them answer 200 with nothing on them, and a crawler that
+  keeps such a page is keeping an empty one — the same reasoning
+  `VutuvWeb.TagController` already applies to a tag page below the indexability
+  bar. The `noai` axis deliberately stays the owner's: emptiness is a statement
+  about what is here, not about who may use it, and deriving an AI opt-out from
+  it would tell an agent a member refused something they never refused. That is
+  the one way this differs from `PostDoc.robots_axes/2`, where a restriction is
+  a privacy fact and so moves both axes.
   """
-  def robots_axes(%User{} = user), do: {user.noindex?, user.noai?}
-  def robots_axes(%Organization{} = organization), do: {not organization.seo?, false}
+  def robots_axes(%User{} = user, empty?), do: {user.noindex? or empty?, user.noai?}
+
+  def robots_axes(%Organization{} = organization, empty?),
+    do: {not organization.seo? or empty?, false}
 
   @doc """
   A shelf's own word, the one token the DOM, the event names and the data

--- a/lib/vutuv/sitemap.ex
+++ b/lib/vutuv/sitemap.ex
@@ -92,8 +92,9 @@ defmodule Vutuv.Sitemap do
   end
 
   @doc """
-  `{path, lastmod_date}` entries of one press chunk (1-based): the press page of
-  every crawlable member who actually offers a picture (issue #2086).
+  `{path, lastmod_date}` entries of one press chunk (1-based): the Media Kit of
+  every crawlable member who actually put something on it — a picture (issue
+  #2086) or a written bio (issue #2143).
 
   The one profile **sub**-page in the sitemap, and deliberately so: every other
   one is noindexed because it shows personal data, while a press kit is
@@ -225,18 +226,32 @@ defmodule Vutuv.Sitemap do
   # `rel="nofollow"`, while this set still leaves them out.
   defp indexable_users, do: Vutuv.Directory.indexable_users()
 
-  # A crawlable member who has at least one press picture a crawler can fetch.
-  # The "which pictures count" half is `Vutuv.PressKit.public_query/0`, so the
-  # sitemap and the page cannot disagree about what is published.
+  # A crawlable member whose Media Kit has something on it: a press picture a
+  # crawler can fetch, **or** a written bio (issue #2143). The two halves are
+  # `Vutuv.PressKit.public_query/0` and `written_bio_query/0`, so the sitemap
+  # and the page cannot disagree about what counts as published — the page says
+  # `noindex` for exactly the kits missing from both lists.
   #
   # An `IN` over the owner ids rather than a join: a member with ten photos must
   # be one row here, and a join would list their press page ten times. The
   # explicit `not is_nil(user_id)` is the nullable-pair rule — a page's press
   # picture leaves that column empty, and a NULL in this list is a row that
   # belongs on `/organizations/<slug>/media-kit` (issue #2087), not here.
+  #
+  # **One `IN` over a `UNION`, never two `IN`s joined by `or`.** Postgres pulls
+  # a lone `IN (subquery)` up into a semi-join and can then skip `users`
+  # entirely when the id set is empty — which is the normal case here, since
+  # almost nobody has a kit. An `OR` between two of them blocks that rewrite:
+  # both become hashed SubPlans filtered over a full `Seq Scan on users`.
+  # Measured on the dev copy (6,025 members, no kits): 1 buffer / 0.12 ms for
+  # the UNION against 225 buffers / 1.4-2.2 ms for the `or`, and the `or` form's
+  # cost grows with the **membership** rather than with the number of kits. This
+  # query runs on every `/sitemap.xml` (one of `chunk_counts/0`'s aggregates) as
+  # well as on every `/sitemaps/press-N.xml`.
   defp indexable_press_users do
     owner_ids =
       from(i in PressKit.public_query(), where: not is_nil(i.user_id), select: i.user_id)
+      |> union(^from(b in PressKit.written_bio_query(), select: b.user_id))
 
     where(indexable_users(), [u], u.id in subquery(owner_ids))
   end

--- a/lib/vutuv_web/agent_docs/press_kit_doc.ex
+++ b/lib/vutuv_web/agent_docs/press_kit_doc.ex
@@ -43,7 +43,10 @@ defmodule VutuvWeb.AgentDocs.PressKitDoc do
     name = Identity.display_name(owner)
     photos = entries(shelves.photos)
     logos = entries(shelves.logos)
-    {noindex?, noai?} = PressKit.robots_axes(owner)
+    # A document that lists no picture and quotes no bio is nothing to keep, so
+    # it says `noindex` however its owner feels about search engines — the same
+    # statement the HTML page makes about itself (issue #2143).
+    {noindex?, noai?} = PressKit.robots_axes(owner, PressKit.empty?(shelves, bio))
 
     AgentDocs.doc_meta("press_kit", PressKit.page_path(owner),
       noindex: noindex?,

--- a/lib/vutuv_web/components/press_kit_components.ex
+++ b/lib/vutuv_web/components/press_kit_components.ex
@@ -126,11 +126,16 @@ defmodule VutuvWeb.PressKitComponents do
   @doc """
   How many press pictures this kit holds altogether — both shelves, since the
   card shows both and its footer counts what it shows.
+
+  The context's, not a copy: `Vutuv.PressKit.empty?/2` asks the same question to
+  decide whether the section page says `noindex`, and a card that drew nothing
+  while the page called itself worth indexing is the drift this delegate
+  prevents.
   """
-  def press_total(%{photos: photos, logos: logos}), do: length(photos) + length(logos)
+  defdelegate press_total(press), to: PressKit, as: :picture_count
 
   @doc "Whether there is anything on either shelf."
-  def press_any?(press), do: press_total(press) > 0
+  defdelegate press_any?(press), to: PressKit, as: :any_pictures?
 
   @doc """
   The rights line on the **card**: the one sentence that makes the download

--- a/lib/vutuv_web/controllers/page_controller.ex
+++ b/lib/vutuv_web/controllers/page_controller.ex
@@ -412,7 +412,11 @@ defmodule VutuvWeb.PageController do
   - `/<username>/media-kit` — the member's Media Kit: the bio they wrote in up to
     three lengths, plus press photos and logo variants offered for editorial use,
     each with its credit, dimensions, file size and a direct download of the
-    print-quality original
+    print-quality original. **Most members and pages have none.** An address
+    with nothing on it still answers 200 — it belongs to its owner — but
+    answers `X-Robots-Tag: noindex`, the page and its four documents alike;
+    the kits worth reading are the ones listed in the sitemap's `press` and
+    `organization_press` chunks, so walk those rather than this pattern
   - `/<username>/tags/<tag>/endorsers` — everyone who endorses this member for that tag
   - `/tags/<tag>` — a tag and its most endorsed members
   - `/system/members` — the member directory: every member, filed by last-name
@@ -429,7 +433,8 @@ defmodule VutuvWeb.PageController do
     name; the organization is the author, so there is no member behind it to look up
   - `/organizations/<slug>/media-kit` — the organization's Media Kit: the same
     press photos and logo variants a member offers, kept by the page's team and
-    offered for editorial use with the credit shown
+    offered for editorial use with the credit shown; the same `noindex` when
+    empty, and the same sitemap chunk to walk instead
   - `/jobs` — the public job board: open positions, filterable, newest first
   - `/jobs/<slug>` — a job posting: role, location, pay range, tags and how to apply
   - `/system/media-kit` — press material: boilerplate in three lengths, logo files,
@@ -454,7 +459,8 @@ defmodule VutuvWeb.PageController do
 
   ## Discovery
 
-  - `/sitemap.xml` — sitemap index (members, posts, tags, static pages)
+  - `/sitemap.xml` — sitemap index; the child sitemaps enumerate every page
+    worth indexing, among them the Media Kits that have something on them
   - `/<username>/posts/feed.xml` — a member's posts as RSS 2.0, full content
   - `/posts/feed.xml` — the latest public posts site-wide (RSS 2.0)
   - `/.well-known/agent-skills/index.json` — agent-skills discovery

--- a/lib/vutuv_web/controllers/press_kit_controller.ex
+++ b/lib/vutuv_web/controllers/press_kit_controller.ex
@@ -18,8 +18,9 @@ defmodule VutuvWeb.PressKitController do
   results — the right rule for a phone number and the exact opposite of what a
   press kit is for. So this action resolves the slug with the same three plugs
   the profile itself uses, carries the owner's *own* opt-outs
-  (`Vutuv.PressKit.robots_axes/1`, a member's `noindex?`/`noai?` and a page's
-  `seo?`), is listed in the sitemap (`Vutuv.Sitemap`) and publishes schema.org
+  (`Vutuv.PressKit.robots_axes/2`, a member's `noindex?`/`noai?` and a page's
+  `seo?`, plus `noindex` when the kit is empty — issue #2143), is listed in the
+  sitemap (`Vutuv.Sitemap`) and publishes schema.org
   `ImageObject` markup with `license` and `acquireLicensePage` — what image
   search reads to mark a picture licensable, and the whole reason the page
   exists.
@@ -104,16 +105,23 @@ defmodule VutuvWeb.PressKitController do
   end
 
   defp render_press(conn, owner) do
-    {noindex?, noai?} = PressKit.robots_axes(owner)
+    shelves = PressKit.public_shelves(owner, conn.assigns[:current_user])
+    # The three written bios (issue #2101). Public whoever asks: unlike a
+    # picture, a bio passes through no AI gate and has nothing to hold back.
+    bio = PressKit.bio(owner)
+    {noindex?, noai?} = PressKit.robots_axes(owner, PressKit.empty?(shelves, bio))
 
     conn
     |> ContentPolicy.put_robots_header(noindex?, noai?)
+    # …and the same answer into the page's own `<meta name="robots">`, which
+    # `VutuvWeb.LayoutHTML.robots_directives/1` would otherwise derive a second
+    # time from `conn.assigns[:user]` — the member's flags, which know nothing
+    # about whether this kit is empty (issue #2143).
+    |> assign(:robots_directives, ContentPolicy.robots_directives(noindex?, noai?))
     |> render("index.html",
       owner: owner,
-      shelves: PressKit.public_shelves(owner, conn.assigns[:current_user]),
-      # The three written bios (issue #2101). Public whoever asks: unlike a
-      # picture, a bio passes through no AI gate and has nothing to hold back.
-      bio: PressKit.bio(owner),
+      shelves: shelves,
+      bio: bio,
       page_title: PressKitHTML.press_page_title(owner)
     )
   end

--- a/lib/vutuv_web/templates/press_kit/index.html.heex
+++ b/lib/vutuv_web/templates/press_kit/index.html.heex
@@ -26,9 +26,9 @@ question for a member and for a page alike). --%>
   data={JsonLd.press_kit_page(@owner, pictures, Vutuv.PressKit.rights_line())}
 />
 
-<% pictures? = @shelves.photos != [] or @shelves.logos != [] %>
+<% pictures? = Vutuv.PressKit.any_pictures?(@shelves) %>
 <% bios? = Vutuv.PressKit.any_bio?(@bio) %>
-<.card_section empty={not pictures? and not bios?}>
+<.card_section empty={Vutuv.PressKit.empty?(@shelves, @bio)}>
   <%!-- The written bios first (#2101): a journalist reads about the person,
   then picks a picture of them. --%>
   <.press_bios :if={bios?} owner={@owner} bio={@bio} />

--- a/lib/vutuv_web/views/layout_html.ex
+++ b/lib/vutuv_web/views/layout_html.ex
@@ -258,10 +258,30 @@ defmodule VutuvWeb.LayoutHTML do
   assigns): the member's search-engine and AI opt-outs rendered by
   `VutuvWeb.ContentPolicy.robots_directives/2`. `nil` (no meta tag) when
   the page is about nobody or the member opted out of nothing.
+
+  A controller that already worked the answer out assigns
+  `:robots_directives` and that wins — the member's two flags are the
+  *fallback*, not the source. The Media Kit is the page that needs it: it
+  adds `noindex` when the kit is empty (issue #2143), and a tag derived a
+  second time from the member would have said nothing while the response
+  header said `noindex`.
+
+  **Where this wants to end up:** in `ContentPolicy.put_robots_header/3`
+  itself, so every page whose header it stamps also gets the matching tag.
+  Measured today, `/:slug/links` sends `noindex, noai, noimageai` and
+  `/:slug/cv` sends `noindex`, and neither renders a `<meta name="robots">`
+  of any kind, because the fallback below knows only the member's own two
+  flags. Moving it has one trap: `put_robots_header/3` is a no-op when
+  there is nothing to declare, and an unconditional
+  `assign(:robots_directives, nil)` would match the first clause below and
+  *suppress* that fallback, so the assign has to be skipped on `nil`.
   """
   def robots_directives(%{conn: conn}) when not is_nil(conn) do
-    case conn.assigns[:user] do
-      %Vutuv.Accounts.User{} = user ->
+    case conn.assigns do
+      %{robots_directives: directives} ->
+        directives
+
+      %{user: %Vutuv.Accounts.User{} = user} ->
         VutuvWeb.ContentPolicy.robots_directives(user.noindex?, user.noai?)
 
       _ ->

--- a/test/vutuv_web/empty_media_kit_test.exs
+++ b/test/vutuv_web/empty_media_kit_test.exs
@@ -1,0 +1,212 @@
+defmodule VutuvWeb.EmptyMediaKitTest do
+  @moduledoc """
+  An empty Media Kit tells a crawler it is not worth keeping (issue #2143).
+
+  Every member and every page has a Media Kit address whether or not anybody
+  ever put something on it, and on the day this was written **all** of them were
+  empty: 6,025 members and 12 pages in the dev copy of production, 0 press
+  pictures and 0 bios between them. Nothing on the site links an empty one and
+  the sitemap leaves it out, but `/llms.txt` published the bare
+  `/<username>/media-kit` pattern, so an assistant reading that document walked
+  6,037 pages — 30,185 with the four agent siblings — that each answered 200 and
+  said nothing, with no `x-robots-tag` at all.
+
+  The answer these tests hold:
+
+    * an empty kit keeps its **200**. The page belongs to its owner, who is
+      about to upload; a 404 would make its existence depend on its content and
+      would answer a machine's "does this member offer press material?" with an
+      error where a 200 answers "no";
+    * it carries `noindex` — the response header, the page's own `<meta>` tag
+      and every one of the four documents, from the one derivation
+      (`Vutuv.PressKit.robots_axes/2`), because a page that says one thing in
+      its header and another in its markup is the failure `PostDoc.robots_axes/2`
+      is named after;
+    * **only** the noindex axis. Emptiness is a statement about worth, not the
+      member's stance on machine use, so an empty kit never invents `noai`;
+    * the moment there is a picture or a bio the `noindex` is gone, which is the
+      one thing that must not break;
+    * and `/llms.txt` no longer advertises the pattern as if everybody had one.
+
+  Calibrated against the un-fixed code: every `assert … == ["noindex"]` below is
+  `[]` there, `/llms.txt` fails on "Most members and pages have none", and both
+  sitemap tests fail because the old query had no `press` chunk to answer with.
+  """
+  use VutuvWeb.ConnCase, async: true
+
+  import Vutuv.ImageHelpers, only: [put_press_picture: 1, put_press_picture: 2]
+
+  alias Vutuv.PressKit
+  alias Vutuv.Repo
+
+  @formats ~w(.md .txt .json .xml)
+
+  defp de(conn), do: put_req_header(conn, "accept-language", "de-DE,de;q=0.9")
+
+  defp robots(conn), do: get_resp_header(conn, "x-robots-tag")
+
+  setup do
+    {:ok,
+     user: insert_activated_user(username: "leeres.kit", first_name: "Ada", last_name: "King")}
+  end
+
+  describe "an empty member kit" do
+    test "still answers 200 to its owner and to a stranger", %{conn: conn, user: user} do
+      assert conn |> get(~p"/#{user}/media-kit") |> html_response(200) =~ "Nothing here yet."
+
+      {owner_conn, owner} = create_and_login_user(conn)
+
+      assert owner_conn |> get(~p"/#{owner}/media-kit") |> html_response(200) =~
+               "Nothing here yet."
+    end
+
+    test "and says so in German", %{conn: conn, user: user} do
+      html = conn |> de() |> get(~p"/#{user}/media-kit") |> html_response(200)
+
+      assert html =~ "Hier gibt es noch nichts."
+      assert html =~ "Media Kit von Ada King"
+    end
+
+    test "carries noindex in the header and in the meta tag", %{conn: conn, user: user} do
+      conn = get(conn, ~p"/#{user}/media-kit")
+
+      assert robots(conn) == ["noindex"]
+      assert html_response(conn, 200) =~ ~s(<meta name="robots" content="noindex")
+    end
+
+    test "carries it in all four agent formats too", %{conn: conn, user: user} do
+      for format <- @formats do
+        sibling = get(conn, "/#{user.username}/media-kit#{format}")
+
+        assert sibling.status == 200, "#{format} answered #{sibling.status}"
+        assert robots(sibling) == ["noindex"], "#{format} carried #{inspect(robots(sibling))}"
+
+        assert get_resp_header(sibling, "content-signal") == [
+                 "ai-train=yes, search=no, ai-input=yes"
+               ]
+      end
+    end
+
+    test "and the document body says it, without ever serving HTML", %{conn: conn, user: user} do
+      markdown = get(conn, "/#{user.username}/media-kit.md")
+
+      assert ["text/markdown; charset=utf-8"] = get_resp_header(markdown, "content-type")
+      refute markdown.resp_body =~ "<!doctype html"
+      # The frontmatter, which is where a `.md` reader meets the flag — the
+      # `.json` renderer drops it and speaks through the headers alone.
+      assert markdown.resp_body =~ "noindex: true"
+      refute markdown.resp_body =~ "noai: true"
+
+      doc = conn |> get("/#{user.username}/media-kit.json") |> json_response(200)
+
+      assert doc["total"] == 0
+      assert doc["photos"] == []
+    end
+
+    test "never invents the member's AI opt-out", %{conn: conn, user: user} do
+      assert robots(get(conn, ~p"/#{user}/media-kit")) == ["noindex"]
+
+      Repo.update!(Ecto.Changeset.change(user, noai?: true))
+
+      assert robots(get(conn, ~p"/#{user}/media-kit")) == ["noindex, noai, noimageai"]
+    end
+  end
+
+  describe "a kit that has something" do
+    test "one released picture takes the noindex away", %{conn: conn, user: user} do
+      assert robots(get(conn, ~p"/#{user}/media-kit")) == ["noindex"]
+
+      put_press_picture(user)
+
+      assert robots(get(conn, ~p"/#{user}/media-kit")) == []
+
+      for format <- @formats do
+        assert robots(get(conn, "/#{user.username}/media-kit#{format}")) == []
+      end
+    end
+
+    test "a written bio alone is content as well", %{conn: conn, user: user} do
+      {:ok, _bio} = PressKit.save_bio(user, user, %{"short" => "Ada King schreibt über Zahlen."})
+
+      assert robots(get(conn, ~p"/#{user}/media-kit")) == []
+      assert robots(get(conn, "/#{user.username}/media-kit.json")) == []
+    end
+
+    test "a member's own search opt-out still reaches a full kit", %{conn: conn, user: user} do
+      put_press_picture(user)
+      Repo.update!(Ecto.Changeset.change(user, noindex?: true))
+
+      assert robots(get(conn, ~p"/#{user}/media-kit")) == ["noindex"]
+    end
+
+    test "a picture still in the AI queue: the page draws a stand-in, the document lists nothing",
+         %{conn: conn, user: user} do
+      put_press_picture(user, moderation: "pending")
+
+      # The page has a tile and a heading on it, so it is not an empty page…
+      assert robots(get(conn, ~p"/#{user}/media-kit")) == []
+      # …while a document may only name a file a crawler can actually fetch, and
+      # a download URL that answers 404 is not content. Each surface answers
+      # `empty?/2` about what it itself carries; this minutes-long window is the
+      # only place the two differ.
+      assert robots(get(conn, "/#{user.username}/media-kit.json")) == ["noindex"]
+    end
+  end
+
+  describe "a page's kit answers the same way" do
+    setup do
+      {:ok, organization: insert(:organization, name: "Acme GmbH")}
+    end
+
+    test "empty says noindex, a picture takes it away", %{conn: conn, organization: organization} do
+      path = "/organizations/#{organization.slug}/media-kit"
+
+      assert conn |> get(path) |> html_response(200) =~ "Nothing here yet."
+      assert robots(get(conn, path)) == ["noindex"]
+      assert robots(get(conn, path <> ".json")) == ["noindex"]
+
+      put_press_picture(organization)
+
+      assert robots(get(conn, path)) == []
+      assert robots(get(conn, path <> ".json")) == []
+    end
+  end
+
+  describe "what a machine is told to walk" do
+    test "/llms.txt says most members have none and names the sitemap", %{conn: conn} do
+      body = conn |> get(~p"/llms.txt") |> Map.fetch!(:resp_body)
+
+      assert body =~ "/<username>/media-kit"
+      assert body =~ "sitemap"
+      assert body =~ "Most members and pages have none"
+    end
+
+    test "a bio-only kit joins the sitemap, an empty one stays out", %{conn: conn, user: user} do
+      writer = insert_activated_user(username: "nur.text")
+      {:ok, _bio} = PressKit.save_bio(writer, writer, %{"medium" => "Hundert Wörter über mich."})
+
+      index = conn |> get(~p"/sitemap.xml") |> Map.fetch!(:resp_body)
+      assert index =~ "/sitemaps/press-1.xml"
+
+      chunk = conn |> get(~p"/sitemaps/press-1.xml") |> Map.fetch!(:resp_body)
+      assert chunk =~ "/#{writer.username}/media-kit"
+      refute chunk =~ "/#{user.username}/media-kit"
+    end
+
+    test "nothing the sitemap lists answers noindex", %{conn: conn, user: user} do
+      put_press_picture(user)
+      writer = insert_activated_user(username: "nur.text")
+      {:ok, _bio} = PressKit.save_bio(writer, writer, %{"long" => "Sehr viele Wörter über mich."})
+
+      chunk = conn |> get(~p"/sitemaps/press-1.xml") |> Map.fetch!(:resp_body)
+
+      paths = Regex.scan(~r{<loc>[^<]*(/[^/<]+/media-kit)</loc>}, chunk, capture: :all_but_first)
+
+      assert length(paths) == 2
+
+      for [path] <- paths do
+        assert robots(get(conn, path)) == [], "#{path} is in the sitemap and says noindex"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Every member and page has a `/media-kit` address, and today every one is empty: 6,025 members and 12 pages in the dev copy of production, 0 pictures and 0 bios. `/llms.txt` published the bare pattern, so an assistant walked 6,037 pages — 30,185 with the agent siblings — each 200, none carrying `x-robots-tag`.

**What I chose.** The page keeps its **200**: it belongs to its owner, who is about to upload, and a `.json` that 404s answers "error" where `total: 0` answers "no". `PressKit.empty?/2` feeds `robots_axes/2`, which adds **`noindex`** to the header, the `<meta>` tag and all four documents — one derivation, as `PostDoc.robots_axes/2` insists.

**Rejected:** a 404, which makes existence depend on content; deriving `noai`, which would claim an opt-out the member never made.

`/llms.txt` now points at the sitemap's `press` chunks instead of the pattern, and a bio-only kit joins the sitemap so that is true.

Closes #2143

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01WPMGFtmCZNip8EJiRrx6ch
