### PR TITLE
Reporting a foreign post takes every copy its own server vouches for

### DIFF
--- a/docs/architecture/social-graph.md
+++ b/docs/architecture/social-graph.md
@@ -284,13 +284,27 @@ it again on the way in, so a tombstone can only refuse what its own report could
 have blanked and a planted one cannot keep an honest post out of the table.
 `report/2` answers `{:ok, :every_copy}` or `{:ok, :this_copy}` because the
 member has to be told which of the two happened; the confirm dialog and the
-flash are two sentences for that reason. Measured over 78 rows of a production
-copy, the author's half of the key costs nothing (43 groups either way) and the
-authority half narrows 51 of the 78 possible reports to the clicked row — the
-relayed copies of posts whose author's server nobody here asked, and every one
-of them a row a stranger could equally have invented. The first attempt at this
-keyed the takedown on the description alone, shipped as `7cdfd4dc7` and was
-reverted as `8b2c1a862` within the hour.
+flash are two sentences for that reason. What the authority half costs is that
+most reports now take only the clicked row — every one of those was fetched
+from a server other than the author's, and so is a row a stranger could equally
+have invented; `reaches?/2`'s own doc carries the counts, measured over a
+production copy, and says to re-measure rather than trust them, because this
+table rolls over within hours. The first attempt at this keyed the takedown on
+the description alone, shipped as `7cdfd4dc7` and was reverted as `8b2c1a862`
+within the hour.
+
+**The `www.` fold belongs to the description and to nothing else.** `www.<host>`
+is a subdomain — a dangling CNAME or an old CDN target hands it to somebody who
+does not hold the apex — so `origin_key/1` folds it (two spellings of one post)
+and `home_copy?/1` does not (one server speaking for another's author). Folding
+in both places let a member have this installation poll a mirror at the
+author's alias and speak for them, and it cost nothing to close: the same rows
+of a production copy are the author's own either way.
+`Vutuv.Fediverse.strip_www/1` now
+folds **every** leading label rather than one, because folding once could be
+walked around by writing `www.www.<host>`, which
+`Vutuv.Tags.TagFollowSource.normalize_source/1` would then store and poll as
+`www.<host>`.
 
 The **Mastodon API drops these rows** rather than rendering them
 (`Vutuv.MastodonApi.Presenter.statuses/2`): every field of a `Status` that

--- a/docs/architecture/social-graph.md
+++ b/docs/architecture/social-graph.md
@@ -267,6 +267,31 @@ takedown is filed in the same content-free ledger a reported cached post is
 (`Vutuv.Fediverse.log_reported_post/1`), so the operator's "one troll or this
 whole server" question counts these alongside the rest.
 
+**How far it reaches is two questions, not one** (issue #2164). One status read
+off five servers under two tags is ten rows, and what relates them is
+`Vutuv.Tags.ExternalPost.origin_key/1`: the post's own normalised address plus
+the server its author lives on. That key only *describes* the copies — both
+halves are written by whichever server we polled, and a member may name any host
+as a tag source, so a card a hostile host invents can claim any address and any
+author in one line of JSON. Who may act on the key is `home_copy?/1`: the row we
+fetched **from the server the post and its author both live on**, the one claim
+here that something outside itself backs, since we chose that host and asked it
+ourselves. So reporting the author's own copy takes every copy of the original,
+and reporting a relayed one takes the rows that same server filed — its own
+words under the reader's other tags — and leaves everybody else's standing.
+`Vutuv.Tags.ExternalPosts.reaches?/2` is that rule, and `reject_reported/1` asks
+it again on the way in, so a tombstone can only refuse what its own report could
+have blanked and a planted one cannot keep an honest post out of the table.
+`report/2` answers `{:ok, :every_copy}` or `{:ok, :this_copy}` because the
+member has to be told which of the two happened; the confirm dialog and the
+flash are two sentences for that reason. Measured over 78 rows of a production
+copy, the author's half of the key costs nothing (43 groups either way) and the
+authority half narrows 51 of the 78 possible reports to the clicked row — the
+relayed copies of posts whose author's server nobody here asked, and every one
+of them a row a stranger could equally have invented. The first attempt at this
+keyed the takedown on the description alone, shipped as `7cdfd4dc7` and was
+reverted as `8b2c1a862` within the hour.
+
 The **Mastodon API drops these rows** rather than rendering them
 (`Vutuv.MastodonApi.Presenter.statuses/2`): every field of a `Status` that
 matters hangs off an `Account` object, and inventing an id for an author we hold

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -907,8 +907,14 @@ defmodule Vutuv.Fediverse do
 
   @doc """
   Every spelling of "this installation" a stored actor URI could carry, as
-  plain lowercase hosts for a SQL comparison — the list `own_host?/1` answers
-  for one URI at a time.
+  plain lowercase hosts for a SQL comparison — the counting twin of
+  `own_host?/1`, which answers for one URI at a time.
+
+  **Not its exact mirror, and it cannot be**: a list has to be finite, so this
+  holds the apex, the tag host and one `www.` each, while `own_host?/1` folds
+  every leading `www.` (`strip_www/1`). A follower row at `www.www.<our host>`
+  would therefore be counted as foreign and refused as ours — the safe pair of
+  answers, and no remote server writes that spelling anyway.
 
   `main_host` is for the `people_snapshots` backfill, which reconstructs
   `distinct_follower_count/0` for past days in raw SQL and has to exclude the
@@ -2434,6 +2440,16 @@ defmodule Vutuv.Fediverse do
   Public because "is this us" and "did this document name the server it
   describes" (`Vutuv.Tags.SourceServerProbe`) are the same question, and the
   `www.` trap this answers is one this codebase has already paid for once.
+
+  **Read it in the refusing direction only.** Every caller here takes a `true`
+  as "treat this as us", "treat these as one post", "do not fetch" — and that is
+  what makes folding safe, because `www.<host>` is a *subdomain*: a dangling
+  CNAME, an old CDN target or a plain takeover hands it to somebody who does not
+  hold the apex. A `true` is therefore never permission for one of the two to
+  **speak** for the other. `Vutuv.Tags.ExternalPost.home_copy?/1` is the
+  cautionary tale: it asked this question to decide whether a server may take
+  down another server's author, and a mirror at that author's alias could
+  answer yes (PR #2176).
   """
   def same_site?(host, host), do: true
   def same_site?(host, other), do: strip_www(host) == strip_www(other)
@@ -2443,8 +2459,20 @@ defmodule Vutuv.Fediverse do
   address, published so anything else deciding whether two spellings name one
   server (`Vutuv.Tags.TagFollowSource`) applies the same rule rather than
   keeping its own copy of it.
+
+  **Every leading label, not one.** A fold that stops after the first one can be
+  walked around by writing it twice: `www.www.mastodon.social` came out of
+  `TagFollowSource.normalize_source/1` as `www.mastodon.social`, which is a
+  *subdomain* somebody other than that server may hold, and a member could
+  therefore have this installation poll it and store its answers (found on PR
+  #2176). Nobody serves a site at `www.www.<host>`, so folding to exhaustion
+  costs no honest address.
+
+  A fold for deciding whether two spellings mean one server, never for deciding
+  whether a server may **speak** for one — see `same_site?/2` above for what
+  that rules out and what it cost to learn.
   """
-  def strip_www("www." <> rest), do: rest
+  def strip_www("www." <> rest), do: strip_www(rest)
   def strip_www(host), do: host
 
   # Keyed on whoever is asking — a member or a page (issue #1336) — so a page

--- a/lib/vutuv/profiles/verified_links.ex
+++ b/lib/vutuv/profiles/verified_links.ex
@@ -25,9 +25,15 @@ defmodule Vutuv.Profiles.VerifiedLinks do
 
   Comparison follows the "recognising one of our own URLs" rule: parse with
   `URI.parse/1`, never a string prefix. Hosts compare case-insensitively with
-  a leading `www.` stripped on both sides (the same reading
-  `Vutuv.Fediverse.local_host?/1` uses — serving a site at both the apex and
-  its `www.` alias is the oldest convention on the web). `http` and `https`
+  **one** leading `www.` stripped on both sides — serving a site at both the
+  apex and its `www.` alias is the oldest convention on the web. That is
+  deliberately *not* `Vutuv.Fediverse.strip_www/1`, which folds every leading
+  label: this decides what a member's proof **covers**, and a proof of
+  `example.com` covering `www.www.example.com` would hand a subdomain somebody
+  else may hold (a dangling CNAME, an old CDN target) a verification mark it
+  never earned. The published fold is for "are these two spellings one site";
+  this one is an authority, so it stays as narrow as the convention it serves.
+  `http` and `https`
   are the same site, a trailing slash is not a different page, and the query
   and the fragment are ignored: a reader who pastes a link carrying
   `?utm_source=` is naming the same page. The **path** keeps its case, because

--- a/lib/vutuv/tags/external_post.ex
+++ b/lib/vutuv/tags/external_post.ex
@@ -31,6 +31,7 @@ defmodule Vutuv.Tags.ExternalPost do
 
   import Vutuv.ChangesetHelpers, only: [scrub_nul: 1]
 
+  alias Vutuv.Fediverse
   alias Vutuv.Fediverse.BlockedInstance
   alias Vutuv.Fediverse.Handle
 
@@ -159,8 +160,141 @@ defmodule Vutuv.Tags.ExternalPost do
   else), so this is the only address there is. The remote twin of
   `Vutuv.Posts.path/1`, and what `Vutuv.Fediverse.subject_origin/1` answers for
   this kind.
+
+  What a card links to, and never the test for "is this the same post" —
+  `origin_key/1` is that.
   """
   def origin(%__MODULE__{url: url}), do: url
+
+  @doc """
+  What makes two stored rows copies of **one** original: the normalised address
+  of the post, **and the server its author lives on** (issue #2164).
+
+  The rows are keyed on tag, server and remote id, so the same status read off
+  five servers under two tags is ten rows with nothing in that key to relate
+  them. This is what relates them — and it is only ever a **description**, never
+  a permission. Both halves are written by whichever server we polled (`url` is
+  `status["url"]` verbatim, `author_host` comes out of `status["account"]`), so
+  any host a member names as a tag source can claim this key for somebody else's
+  post in one line of JSON. That is not hypothetical: keying the takedown on
+  this pair alone shipped as `7cdfd4dc7` and was reverted the same hour, because
+  a planted card carrying a victim's permalink *and* their author host blanked
+  every honest copy of that post and kept it out of the table for as long as the
+  tombstone lived. Who may act on a key is a second question with a second
+  answer — `home_copy?/1` here, and `Vutuv.Tags.ExternalPosts.reaches?/2` over
+  it.
+
+  **`author_acct` cannot serve as the author's half.** Mastodon writes it bare
+  (`pruef_de`) on the author's own server and qualified
+  (`pruef_de@mastodon.social`) everywhere else, so four of the measured
+  originals carry two spellings of one author; `author_host` is the uniform one.
+
+  The address is **normalised**, and each rule is a shape the same post really
+  arrived under. A redirect wrapper is not a second original: Bridgy Fed serves
+  one Bluesky post as `bsky.brid.gy/r/<address>` and `fed.brid.gy/r/<address>`,
+  and both stood here, same author and same second, with nothing relating them.
+  A trailing slash or a fragment is the same address said differently, which the
+  ingest gate has to see through or a reported post walks back in under a variant
+  spelling. And the host follows the rule the rest of this codebase already
+  applies to a foreign host — `Vutuv.Fediverse.BlockedInstance.normalize_host/1`
+  for the case and the trailing dot, `Vutuv.Fediverse.strip_www/1` for the fold
+  that module publishes so nobody keeps their own copy of it.
+
+  **The query stays**, which is why neither `Vutuv.WebVerification.normalize_url/1`
+  nor `Vutuv.Profiles.VerifiedLinks.normalize/1` can serve here: both drop it,
+  and on software that names a post in its query string two different posts would
+  key alike — this key decides whose words get blanked, so it errs towards
+  telling two posts apart.
+  """
+  def origin_key(%{url: url, author_host: host}), do: {normalize_origin(url), host}
+
+  @doc """
+  Whether this row is the post as **its own server** handed it over: the server
+  we asked, the host in the post's address and the host the author lives on are
+  one and the same (issue #2164).
+
+  Everything in a row is a stranger's word except one thing — *which* stranger.
+  We chose the host, resolved it and asked it ourselves, so `source` is the one
+  field no answer can forge. A row where those three agree is therefore the only
+  one that says something we can check: this server served a post of its own, at
+  an address on itself, by an author living on it. Every other row — an honest
+  relay of somebody else's status, or a card a hostile host invented — is one
+  server's unverified claim about another server's member, and the two are
+  **byte-identical** in this table. That is why only this one may reach copies it
+  did not file itself (`Vutuv.Tags.ExternalPosts.reaches?/2`).
+
+  The hosts are compared the way the rest of this codebase compares a foreign
+  host: `Vutuv.Fediverse.BlockedInstance.normalize_host/1` for the case and the
+  trailing dot, `Vutuv.Fediverse.strip_www/1` for the `www.` fold, which a site
+  served at both its apex and its alias needs and which nothing here is entitled
+  to keep a second copy of. It fails **closed**: a host that will not normalise,
+  and a row from before #2127 with no author host at all, is not the post's own
+  copy.
+
+  The address is read as the server wrote it, **before** `origin_key/1` unwraps
+  a redirect wrapper: a bridge that serves a post at `bsky.brid.gy/r/<address>`
+  is serving it at its own address, and the wrapped one is somebody else's by
+  construction.
+  """
+  def home_copy?(%{source: source, url: url, author_host: host}) do
+    case normalized_host(host) do
+      nil -> false
+      author -> normalized_host(source) == author and normalized_host(address_host(url)) == author
+    end
+  end
+
+  defp address_host(url) when is_binary(url), do: URI.parse(url).host
+  defp address_host(_url), do: nil
+
+  # The one spelling of "this host, as this codebase writes a foreign host":
+  # `nil` for anything that will not normalise, so every comparison over it
+  # fails closed. `canonical_host/1` reads it too, which is what keeps the key's
+  # host and the authority test from drifting into two rules.
+  defp normalized_host(host) do
+    case BlockedInstance.normalize_host(host) do
+      nil -> nil
+      normalized -> Fediverse.strip_www(normalized)
+    end
+  end
+
+  defp normalize_origin(url) when is_binary(url),
+    do: url |> URI.parse() |> unwrap_redirect() |> canonical_address()
+
+  # `…/r/https://bsky.app/…`, and the same address percent-encoded — the wrapped
+  # address is the post's own either way. Read out of the **path** only: a query
+  # parameter is where a server puts somebody else's address for its own reasons,
+  # and unwrapping that would relate two unrelated posts. A post whose own path
+  # happens to end in an address is read as a wrapper around it, which the
+  # author's half of the key bounds to that one author's rows. Recurses, since
+  # each step is strictly shorter than the last.
+  defp unwrap_redirect(%URI{path: path} = uri) when is_binary(path) do
+    case Regex.run(~r{/(https?://.+)\z}, decoded(path)) do
+      [_whole, embedded] -> embedded |> URI.parse() |> unwrap_redirect()
+      nil -> uri
+    end
+  end
+
+  defp unwrap_redirect(uri), do: uri
+
+  defp decoded(path) do
+    URI.decode(path)
+  rescue
+    ArgumentError -> path
+  end
+
+  # `URI.to_string/1` puts it back together, so the default port, the userinfo
+  # and the query keep whatever rules it applies rather than a second set here.
+  # The path keeps its case, where two spellings really are two things.
+  defp canonical_address(%URI{} = uri) do
+    URI.to_string(%URI{
+      uri
+      | host: canonical_host(uri.host),
+        fragment: nil,
+        path: uri.path |> to_string() |> String.trim_trailing("/")
+    })
+  end
+
+  defp canonical_host(host), do: normalized_host(host) || host
 
   defp local_name(acct) when is_binary(acct), do: acct |> String.split("@") |> hd()
   defp local_name(_acct), do: nil

--- a/lib/vutuv/tags/external_post.ex
+++ b/lib/vutuv/tags/external_post.ex
@@ -284,16 +284,20 @@ defmodule Vutuv.Tags.ExternalPost do
     do: url |> URI.parse() |> unwrap_redirect() |> canonical_address()
 
   # `…/r/https://bsky.app/…`, and the same address percent-encoded — the wrapped
-  # address is the post's own either way. Pinned to that **one prefix**, and to
-  # the **path**: a query parameter is where a server puts somebody else's
-  # address for its own reasons, and any path ending in an address would let one
-  # tenant of a host that hands out paths reproduce a neighbour's key (both
-  # found on PR #2176). `/r/` is Bridgy Fed's shape and the only wrapper
-  # measured on real rows — 14 of 10,244 stored addresses embed an absolute one,
-  # every one of them behind it. Recurses, since each step is strictly shorter
+  # address is the post's own either way. Pinned to that **one prefix**, to the
+  # **path**, and to the **start** of it: a query parameter is where a server
+  # puts somebody else's address for its own reasons, and any path ending in an
+  # address would let one tenant of a host that hands out paths reproduce a
+  # neighbour's key (both found on PR #2176). The `\A` is the third of those and
+  # not decoration — `/r/` is a path a tenant may simply ask for, so without it
+  # `…/@mallory/r/<neighbour's address>` keys as the neighbour's and naming the
+  # wrapper shape buys nothing over reading an address out of any path at all.
+  # `/r/` is Bridgy Fed's shape and the only wrapper measured on real rows — 12
+  # of 9,945 stored addresses embed an absolute one, every one of them behind a
+  # root `/r/` on `fed.brid.gy`. Recurses, since each step is strictly shorter
   # than the last.
   defp unwrap_redirect(%URI{path: path} = uri) when is_binary(path) do
-    case Regex.run(~r{/r/(https?://.+)\z}, decoded(path)) do
+    case Regex.run(~r{\A/r/(https?://.+)\z}, decoded(path)) do
       [_whole, embedded] -> embedded |> URI.parse() |> unwrap_redirect()
       nil -> uri
     end

--- a/lib/vutuv/tags/external_post.ex
+++ b/lib/vutuv/tags/external_post.ex
@@ -190,23 +190,40 @@ defmodule Vutuv.Tags.ExternalPost do
   originals carry two spellings of one author; `author_host` is the uniform one.
 
   The address is **normalised**, and each rule is a shape the same post really
-  arrived under. A redirect wrapper is not a second original: Bridgy Fed serves
-  one Bluesky post as `bsky.brid.gy/r/<address>` and `fed.brid.gy/r/<address>`,
+  arrived under. A **Bridgy Fed** redirect wrapper is not a second original: one
+  Bluesky post is served as `bsky.brid.gy/r/<address>` and `fed.brid.gy/r/<address>`,
   and both stood here, same author and same second, with nothing relating them.
   A trailing slash or a fragment is the same address said differently, which the
   ingest gate has to see through or a reported post walks back in under a variant
   spelling. And the host follows the rule the rest of this codebase already
   applies to a foreign host — `Vutuv.Fediverse.BlockedInstance.normalize_host/1`
   for the case and the trailing dot, `Vutuv.Fediverse.strip_www/1` for the fold
-  that module publishes so nobody keeps their own copy of it.
+  that module publishes so nobody keeps their own copy of it. Folding `www.`
+  here is safe precisely because this is a description: `home_copy?/1`, which
+  decides who may *act*, deliberately does not fold.
 
-  **The query stays**, which is why neither `Vutuv.WebVerification.normalize_url/1`
-  nor `Vutuv.Profiles.VerifiedLinks.normalize/1` can serve here: both drop it,
-  and on software that names a post in its query string two different posts would
-  key alike — this key decides whose words get blanked, so it errs towards
-  telling two posts apart.
+  **The query stays on a plain address**, which is why neither
+  `Vutuv.WebVerification.normalize_url/1` nor
+  `Vutuv.Profiles.VerifiedLinks.normalize/1` can serve here: both drop it, and on
+  software that names a post in its query string two different posts would key
+  alike — this key decides whose words get blanked, so it errs towards telling
+  two posts apart. On a **wrapper** what follows the `?` belongs to the wrapper
+  rather than to the post (`URI.parse/1` stops the path at it), so it goes with
+  the wrapper, and two wrapped addresses differing only in a query would key
+  alike. That is one more reason the unwrap is pinned to the single `/r/` shape
+  measured on real rows rather than read out of any path.
+
+  An address that will not parse is **no key at all** rather than a raise. No
+  persisted row can reach that clause — `url` is `null: false` and required by
+  the changeset every row passes through — but this is asked of every row on the
+  way in (`reject_reported/1`), where a raise takes the whole store batch with
+  it, and a predicate that decides whose words get blanked is the wrong place to
+  find out that the guarantee moved.
   """
-  def origin_key(%{url: url, author_host: host}), do: {normalize_origin(url), host}
+  def origin_key(%{url: url, author_host: host}) when is_binary(url),
+    do: {normalize_origin(url), host}
+
+  def origin_key(_unusable), do: nil
 
   @doc """
   Whether this row is the post as **its own server** handed it over: the server
@@ -223,13 +240,22 @@ defmodule Vutuv.Tags.ExternalPost do
   **byte-identical** in this table. That is why only this one may reach copies it
   did not file itself (`Vutuv.Tags.ExternalPosts.reaches?/2`).
 
-  The hosts are compared the way the rest of this codebase compares a foreign
-  host: `Vutuv.Fediverse.BlockedInstance.normalize_host/1` for the case and the
-  trailing dot, `Vutuv.Fediverse.strip_www/1` for the `www.` fold, which a site
-  served at both its apex and its alias needs and which nothing here is entitled
-  to keep a second copy of. It fails **closed**: a host that will not normalise,
-  and a row from before #2127 with no author host at all, is not the post's own
-  copy.
+  The three are compared as `Vutuv.Fediverse.BlockedInstance.normalize_host/1`
+  writes a foreign host — the case and the trailing dot — and **the `www.` fold
+  stops at the door**. That is the one difference from `origin_key/1` above, and
+  it is the whole of it: a site served at both its apex and its alias is the
+  oldest convention on the web, so folding is right when the question is "are
+  these two spellings of one post", and wrong when it is "may this server speak
+  for that author". `www.<host>` is a *subdomain*: a dangling CNAME, an old CDN
+  target or a plain subdomain takeover hands it to somebody who does not hold
+  the apex, and the mirror image needs no takeover at all — an instance whose
+  handle domain is `www.X` would be spoken for by whoever holds the bare `X`.
+  Folding here let exactly that through, found on PR #2176 before it shipped;
+  `normalize_source/1` folds *every* leading `www.` since, so the honest cost is
+  a site at both spellings taking only its own rows down.
+
+  It fails **closed**: a host that will not normalise, and a row from before
+  #2127 with no author host at all, is not the post's own copy.
 
   The address is read as the server wrote it, **before** `origin_key/1` unwraps
   a redirect wrapper: a bridge that serves a post at `bsky.brid.gy/r/<address>`
@@ -237,38 +263,37 @@ defmodule Vutuv.Tags.ExternalPost do
   construction.
   """
   def home_copy?(%{source: source, url: url, author_host: host}) do
-    case normalized_host(host) do
+    case authority_host(host) do
       nil -> false
-      author -> normalized_host(source) == author and normalized_host(address_host(url)) == author
+      author -> authority_host(source) == author and authority_host(address_host(url)) == author
     end
   end
+
+  def home_copy?(_unusable), do: false
+
+  # A host as this test is allowed to read it, and the name is the point: the
+  # difference from `canonical_host/1` below is a **fold**, and a difference
+  # spelled as an absence is one a tidy-up merges back by accident. Whoever
+  # wants one helper for both has to delete a name that says why there are two.
+  defp authority_host(host), do: BlockedInstance.normalize_host(host)
 
   defp address_host(url) when is_binary(url), do: URI.parse(url).host
   defp address_host(_url), do: nil
-
-  # The one spelling of "this host, as this codebase writes a foreign host":
-  # `nil` for anything that will not normalise, so every comparison over it
-  # fails closed. `canonical_host/1` reads it too, which is what keeps the key's
-  # host and the authority test from drifting into two rules.
-  defp normalized_host(host) do
-    case BlockedInstance.normalize_host(host) do
-      nil -> nil
-      normalized -> Fediverse.strip_www(normalized)
-    end
-  end
 
   defp normalize_origin(url) when is_binary(url),
     do: url |> URI.parse() |> unwrap_redirect() |> canonical_address()
 
   # `…/r/https://bsky.app/…`, and the same address percent-encoded — the wrapped
-  # address is the post's own either way. Read out of the **path** only: a query
-  # parameter is where a server puts somebody else's address for its own reasons,
-  # and unwrapping that would relate two unrelated posts. A post whose own path
-  # happens to end in an address is read as a wrapper around it, which the
-  # author's half of the key bounds to that one author's rows. Recurses, since
-  # each step is strictly shorter than the last.
+  # address is the post's own either way. Pinned to that **one prefix**, and to
+  # the **path**: a query parameter is where a server puts somebody else's
+  # address for its own reasons, and any path ending in an address would let one
+  # tenant of a host that hands out paths reproduce a neighbour's key (both
+  # found on PR #2176). `/r/` is Bridgy Fed's shape and the only wrapper
+  # measured on real rows — 14 of 10,244 stored addresses embed an absolute one,
+  # every one of them behind it. Recurses, since each step is strictly shorter
+  # than the last.
   defp unwrap_redirect(%URI{path: path} = uri) when is_binary(path) do
-    case Regex.run(~r{/(https?://.+)\z}, decoded(path)) do
+    case Regex.run(~r{/r/(https?://.+)\z}, decoded(path)) do
       [_whole, embedded] -> embedded |> URI.parse() |> unwrap_redirect()
       nil -> uri
     end
@@ -294,7 +319,17 @@ defmodule Vutuv.Tags.ExternalPost do
     })
   end
 
-  defp canonical_host(host), do: normalized_host(host) || host
+  # The key's half of the host rule, and the only place the `www.` fold belongs:
+  # here it says "these two spellings are one post", where `home_copy?/1` would
+  # be saying "this server may speak for that author". Anything that will not
+  # normalise is kept as written, so two unparseable addresses still tell
+  # themselves apart.
+  defp canonical_host(host) do
+    case BlockedInstance.normalize_host(host) do
+      nil -> host
+      normalized -> Fediverse.strip_www(normalized)
+    end
+  end
 
   defp local_name(acct) when is_binary(acct), do: acct |> String.split("@") |> hd()
   defp local_name(_acct), do: nil

--- a/lib/vutuv/tags/external_posts.ex
+++ b/lib/vutuv/tags/external_posts.ex
@@ -269,20 +269,135 @@ defmodule Vutuv.Tags.ExternalPosts do
   end
 
   @doc """
-  Somebody reports one of these as not appropriate.
+  Whether reporting `reported` takes `other` down with it — the whole scope of
+  one report, as one predicate, asked by the takedown, by the gate on the way in
+  and by the feed when it clears the cards away (issue #2164).
 
-  **Blanks it rather than deleting it.** Reporting a post cached from a followed
-  account deletes the row, because nothing goes looking for it again; this table
-  is re-read every ten minutes to three hours with `on_conflict: :nothing`, so a
-  deleted row would simply be written back — a report that undoes itself is not
-  a control. So the words go, the key stays, and every reader skips it
-  (`showable_query/0`).
+  Two questions, and the second is the one this change was reverted over.
+  *Which rows are copies of one original* is `ExternalPost.origin_key/1`, a
+  description a stranger's server writes. *Whose report may reach a copy it did
+  not file* is `ExternalPost.home_copy?/1`: only the row we fetched from the
+  server the post and its author both live on, because that is the only claim
+  here backed by something outside itself. An honest relay of somebody else's
+  status and a card a hostile host invented are the same three columns, so a
+  rule that let the first reach across servers would let the second — which is
+  precisely what a member could do with any host they add as a tag source, and
+  precisely why `8b2c1a862` pulled the first attempt out of production.
+
+  Every other row still takes down **what its own server filed**: the same
+  status under a second followed tag is a second row from that same host, and
+  one server's word covers its own rows without reaching anybody else's. The
+  sources are compared byte for byte on purpose — that column is written by our
+  own picker, not by the answer, and it is what the SQL prefilter can narrow on
+  without a second spelling of the rule.
+
+  The tempting third rule — let any row reach the whole original *when we also
+  hold the author's own copy of it* — is the same hole again: the planted card
+  would be the thing escalating itself, and the honest copy's presence is what
+  it would escalate against.
+
+  Measured over the 78 rows a copy of production holds, taking every row in turn
+  as the one clicked: 27 reports reach exactly what they did before the guard,
+  51 reach fewer, none reach more, and the total falls from 198 rows to 92. The
+  51 are relayed copies of posts whose author's server nobody here asked (only 7
+  of the 78 rows, and 6 of the 42 originals, are the author's own copy) — and
+  every one of them is a row that could equally have been a stranger's
+  invention. That is the cost, and the sentence over the button says it rather
+  than promising past it (issue #2164).
+  """
+  def reaches?(reported, other), do: reached_by(reported).(other)
+
+  @doc """
+  How far a report on `post` goes, as the word the member is told:
+  `:every_copy` or `:this_copy`.
+
+  The same question `reaches?/2` asks, published because the dialog over the
+  button, the flash under it and the takedown itself must not answer it
+  separately — a promise and an act that agree only because two modules spell
+  the same `if` is issue #2164 written the other way round.
+  """
+  def report_scope(post),
+    do: if(ExternalPost.home_copy?(post), do: :every_copy, else: :this_copy)
+
+  # The same rule with the reported row's half worked out once, for the two
+  # callers that ask it of a whole list. Measured here over 6,000 candidate rows
+  # — the table's ceiling with one author host holding 60 % of it — the filter
+  # costs 315 ms recomputing that half per candidate and 80 ms this way, because
+  # a key is two `URI.parse/1`s and the authority test five; at today's 78 rows
+  # neither is visible. It is a closure rather than a second predicate so that
+  # `reaches?/2` above stays the only spelling of the rule.
+  defp reached_by(reported) do
+    key = ExternalPost.origin_key(reported)
+    every_copy? = ExternalPost.home_copy?(reported)
+
+    fn other ->
+      key == ExternalPost.origin_key(other) and
+        (every_copy? or reported.source == other.source)
+    end
+  end
+
+  # Every row a report on one of `rows` could possibly reach — the SQL half of
+  # `reaches?/2`, narrowed to what an index can answer.
+  #
+  # Only the author's half of the key is a column; the address half is
+  # normalised in Elixir, where the one normaliser lives, and whether the
+  # reporting row may reach across servers at all is not a column at all. So
+  # this prefilters on `author_host` and the predicate decides. **It is a second
+  # spelling of that half**, and it is a superset of it only because the key
+  # keeps `author_host` exactly as the column holds it: normalise the Elixir
+  # side alone and this silently starts dropping copies, so the two move
+  # together or not at all.
+  #
+  # What it costs at the table's 10,000-row ceiling with one author host holding
+  # 60 % of them: the takedown's scan is 1.0-3.7 ms — sequential, since it names
+  # no `reported_at` and `external_tag_posts_reported_author_index` is partial
+  # on exactly that — and the filter over the 6,000 rows it returns is 80 ms, so
+  # one click is around 85 ms. The gate's own query does name `reported_at` and
+  # is the one that index serves. (Over the 78 rows a copy of production holds,
+  # the whole thing is well under a millisecond.) Storing the key as a column
+  # would make it constant, and that is the lever if it ever matters; it is not
+  # taken today because a key two days old would arrive backfill-versioned, and
+  # the per-tag cap rolls ordinary rows over within hours anyway.
+  defp possible_copies_query(rows) when is_list(rows) do
+    hosts = rows |> Enum.map(& &1.author_host) |> Enum.reject(&is_nil/1) |> Enum.uniq()
+
+    from(p in ExternalPost,
+      where: p.author_host in ^hosts,
+      select: %{id: p.id, url: p.url, author_host: p.author_host, source: p.source}
+    )
+  end
+
+  @doc """
+  Somebody reports one of these as not appropriate. Answers
+  `{:ok, :every_copy}` or `{:ok, :this_copy}` — which of the two is what the
+  member has to be told, so it comes back rather than being guessed at the call
+  site.
+
+  **What goes is every copy the reported row may speak for, not the one row that
+  was clicked.** A member pressing Report means "this post, off this site" — and
+  one status really did stand here as six rows, of which a report marked one, so
+  the reader met the post they had just reported two cards further down under
+  another "found through" line (issue #2164). How far that reaches is
+  `reaches?/2`: the whole original when the row came from the author's own
+  server, that server's own rows otherwise, because the alternative is a member
+  blanking somebody else's honest copies with a card they had a server of their
+  own invent.
+
+  **Blanks them rather than deleting them.** Reporting a post cached from a
+  followed account deletes the row, because nothing goes looking for it again;
+  this table is re-read every ten minutes to three hours with
+  `on_conflict: :nothing`, so a deleted row would simply be written back — a
+  report that undoes itself is not a control. So the words go, the key stays,
+  and every reader skips it (`showable_query/0`). What the tombstones cannot do
+  by themselves is refuse a copy arriving under a tag nobody followed at the
+  time, which is a *new* key: that is `reject_reported/1` on the way in.
 
   Like its sibling this sends no `Flag` and opens no case: the post still stands
   on its own server, untouched, and what a member here can ask for is that this
   installation stop showing it. The takedown is recorded in the same
-  content-free ledger, so the operator's "is this one troll or is this server
-  the problem" question counts these alongside the rest.
+  content-free ledger, **once per act** — the copies are an artefact of how we
+  cache, and counting them would answer the operator's "one troll or one bad
+  server" question with a number about ourselves.
 
   Rate limited per reporter.
   """
@@ -300,7 +415,7 @@ defmodule Vutuv.Tags.ExternalPosts do
   defp take_down(post_id, %User{} = reporter) do
     case UUIDv7.with_cast(post_id, &Repo.get(ExternalPost, &1)) do
       %ExternalPost{reported_at: nil} = post ->
-        blank(post)
+        post |> copy_ids() |> blank()
 
         Fediverse.log_reported_post(%{
           host: post.author_host || post.source,
@@ -312,17 +427,43 @@ defmodule Vutuv.Tags.ExternalPosts do
           actor_id: reporter.id
         })
 
-        :ok
+        {:ok, report_scope(post)}
 
       _gone_or_already_reported ->
         {:error, :not_found}
     end
   end
 
-  # What the row keeps is what the next pull's unique index needs: the tag, the
+  # Which rows the report reaches is read first and blanked second, because the
+  # address half of the key is normalised in Elixir rather than in a column; the
+  # **write** is still one statement, so no copy can be left in the other state.
+  #
+  # Every copy keeps its own tombstone rather than one standing for all of them:
+  # `trim/2` exempts them from both caps, so a report costs the table one row
+  # per copy until `prune/0` drops the pair with the last follow that wanted it.
+  # The alternative — one tombstone and a delete for the rest — leans on
+  # `reject_reported/1` alone to keep them out, where this leans on the row key
+  # as well.
+  #
+  # A row the release before #2127 wrote has no author host, so it has no key
+  # and nothing can be a copy of it — not even itself, which is how the report
+  # that took it down came to blank nothing at all while still answering `:ok`.
+  # It is its own only copy. Reachable from a stale page, since `showable_query/0`
+  # has never drawn one.
+  defp copy_ids(%ExternalPost{author_host: nil} = post), do: [post.id]
+
+  defp copy_ids(%ExternalPost{} = post) do
+    [post]
+    |> possible_copies_query()
+    |> Repo.all()
+    |> Enum.filter(reached_by(post))
+    |> Enum.map(& &1.id)
+  end
+
+  # What each row keeps is what the next pull's unique index needs: the tag, the
   # server, the remote id and the stamp. The words and the author go.
-  defp blank(%ExternalPost{id: id}) do
-    Repo.update_all(from(p in ExternalPost, where: p.id == ^id),
+  defp blank(ids) do
+    Repo.update_all(from(p in ExternalPost, where: p.id in ^ids),
       set: [
         text: "",
         author_name: nil,
@@ -641,13 +782,14 @@ defmodule Vutuv.Tags.ExternalPosts do
 
   defp store(tag_id, posts) do
     now = NaiveDateTime.utc_now(:second)
+    rows = posts |> Enum.flat_map(&row(&1, tag_id, now)) |> reject_reported()
 
     # The schema, never a bare table name: a schemaless insert_all holds no
     # field types and hands Postgrex a readable UUID string it cannot encode.
     # `on_conflict: :nothing` makes the count the number of rows that were
     # really new, which is what the cadence reads.
     {stored, nil} =
-      Repo.insert_all(ExternalPost, Enum.flat_map(posts, &row(&1, tag_id, now)),
+      Repo.insert_all(ExternalPost, rows,
         on_conflict: :nothing,
         conflict_target: [:tag_id, :source, :remote_id]
       )
@@ -657,6 +799,49 @@ defmodule Vutuv.Tags.ExternalPosts do
     if stored > 0, do: trim(from(p in ExternalPost, where: p.tag_id == ^tag_id), caps()[:per_tag])
 
     stored
+  end
+
+  # A reported original never comes back, whatever tag or server carries it in
+  # next (issue #2164). The tombstones `report/2` leaves only stop the rows they
+  # sit on from being rewritten, since `on_conflict: :nothing` needs the key to
+  # be there to do nothing about — but a tag nobody followed at the time is a
+  # **new** (tag, server, remote id), so the same status would arrive as a fresh
+  # row with its words intact. That is the promise "every copy goes" broken with
+  # one extra step, so the gate is here, on the way in, where the blocklist's
+  # is: `store/2` is the only way into this table.
+  #
+  # The tombstones are also the register of what has been reported, so the
+  # promise lasts exactly as long as they do — `prune/0` takes them with the
+  # last follow that wanted the pair, which is the retention answer this table
+  # already gives for a stranger's words.
+  #
+  # It asks `reaches?/2`, the same question the takedown asked, which is the
+  # half of this that was missing when the change was reverted: a tombstone can
+  # only refuse what that report could have blanked. Otherwise a member plants
+  # the tombstone *first*, from a server of their own, and the post is refused
+  # before it has ever arrived — the suppression working pre-emptively and for
+  # the whole installation, which is what `8b2c1a862` pulled out of production.
+  # A tombstone compares the **key**, never the raw column: a trailing slash or
+  # a fragment is the same address said differently, and comparing the two
+  # strings let a reported post walk straight back in under a variant spelling
+  # (`stored: 1`, measured).
+  #
+  # One statement per store that had rows to write; an empty timeline is an
+  # ordinary answer and pays nothing. The pairing is a nested walk rather than a
+  # set: at most twenty rows arrive from one timeline and the tombstones are the
+  # narrow side of a partial index, so the rule stays in one place instead of
+  # being re-spelled as a lookup key.
+  defp reject_reported([]), do: []
+
+  defp reject_reported(rows) do
+    refusals =
+      rows
+      |> possible_copies_query()
+      |> where([p], not is_nil(p.reported_at))
+      |> Repo.all()
+      |> Enum.map(&reached_by/1)
+
+    Enum.reject(rows, fn row -> Enum.any?(refusals, & &1.(row)) end)
   end
 
   # Through the changeset, because these values were written by a stranger's

--- a/lib/vutuv/tags/external_posts.ex
+++ b/lib/vutuv/tags/external_posts.ex
@@ -296,12 +296,14 @@ defmodule Vutuv.Tags.ExternalPosts do
   would be the thing escalating itself, and the honest copy's presence is what
   it would escalate against.
 
-  Measured over the 78 rows a copy of production holds, taking every row in turn
-  as the one clicked: 27 reports reach exactly what they did before the guard,
-  51 reach fewer, none reach more, and the total falls from 198 rows to 92. The
-  51 are relayed copies of posts whose author's server nobody here asked (only 7
-  of the 78 rows, and 6 of the 42 originals, are the author's own copy) — and
-  every one of them is a row that could equally have been a stranger's
+  Measured over the 78 rows a copy of production held that day (47 originals;
+  the table rolls over, so re-measure rather than trusting the figures), taking
+  every row in turn as the one clicked: 33 reports reach exactly what they did
+  before the guard, 45 reach fewer, none reach more, and the total falls from
+  176 rows to 92. Every one of the 45 was fetched from a server other than the
+  author's — relayed copies of posts whose author's server nobody here asked
+  (only 7 of the 78 rows, and 6 of the 47 originals, are the author's own copy)
+  — and every one of them is a row that could equally have been a stranger's
   invention. That is the cost, and the sentence over the button says it rather
   than promising past it (issue #2164).
   """
@@ -327,12 +329,19 @@ defmodule Vutuv.Tags.ExternalPosts do
   # neither is visible. It is a closure rather than a second predicate so that
   # `reaches?/2` above stays the only spelling of the rule.
   defp reached_by(reported) do
-    key = ExternalPost.origin_key(reported)
-    every_copy? = ExternalPost.home_copy?(reported)
+    case ExternalPost.origin_key(reported) do
+      # An address we cannot read is no key, and `nil == nil` would make two such
+      # rows copies of each other. Nothing is a copy of it, itself included.
+      nil ->
+        fn _other -> false end
 
-    fn other ->
-      key == ExternalPost.origin_key(other) and
-        (every_copy? or reported.source == other.source)
+      key ->
+        every_copy? = ExternalPost.home_copy?(reported)
+
+        fn other ->
+          key == ExternalPost.origin_key(other) and
+            (every_copy? or reported.source == other.source)
+        end
     end
   end
 

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -60,6 +60,7 @@ defmodule VutuvWeb.PostComponents do
   alias Vutuv.ReviewCover
   alias Vutuv.Tags
   alias Vutuv.Tags.ExternalPost
+  alias Vutuv.Tags.ExternalPosts
   alias Vutuv.Translations.Translation
   alias VutuvWeb.FediverseComponents
   alias VutuvWeb.Live.PostTranslations
@@ -3589,18 +3590,23 @@ defmodule VutuvWeb.PostComponents do
                 >
                   {gettext("View the original")}
                 </:item>
-                <%!-- The same lever the cached-post card offers, and the same
-                deal: our copy goes for everybody here at once, and the post
-                itself stands untouched where its author put it. --%>
+                <%!-- The same lever the cached-post card offers, and nearly the
+                same deal: what goes is every copy of the original this report
+                may speak for, and the post itself stands untouched where its
+                author put it. Its own two sentences for exactly that reason
+                (issue #2164) — the cached-post card's promises one copy, which
+                is all that one ever has, and here it depends on the row: only a
+                card the author's own server served takes the copies other
+                servers filed with it (`ExternalPost.home_copy?/1`). Both
+                promise the act and not the future: a tombstone keeps the post
+                out of the next pull, but only until `prune/0` drops it with the
+                last follow of that pair, so "we will not fetch it again" would
+                be the third spelling of this issue's own overclaim. --%>
                 <:item
                   click="report-external-post"
                   value={@post.id}
                   danger
-                  confirm={
-                    gettext(
-                      "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
-                    )
-                  }
+                  confirm={report_confirm(@post)}
                 >
                   {gettext("Report")}
                 </:item>
@@ -3637,6 +3643,24 @@ defmodule VutuvWeb.PostComponents do
       </div>
     </article>
     """
+  end
+
+  # Which of the two promises this card is entitled to make. The scope is the
+  # context's answer, the same one the takedown acts on and the flash reports,
+  # so the dialog cannot promise something the report will not do — that
+  # mismatch, in the other direction, is the whole of issue #2164.
+  defp report_confirm(post) do
+    case ExternalPosts.report_scope(post) do
+      :every_copy ->
+        gettext(
+          "Report this post as not appropriate? Every copy of it disappears right away, for everyone on this vutuv."
+        )
+
+      :this_copy ->
+        gettext(
+          "Report this post as not appropriate? This copy disappears right away, for everyone on this vutuv. Copies other servers sent us stay."
+        )
+    end
   end
 
   attr(:remote_post, :map, required: true, doc: "a Vutuv.Fediverse.RemotePost, quotes preloaded")

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -55,6 +55,7 @@ defmodule VutuvWeb.PostLive.Feed do
   alias Vutuv.Posts.Post
   alias Vutuv.Prefs
   alias Vutuv.Social
+  alias Vutuv.Tags.ExternalPosts
   alias Vutuv.Tags.SourceServers
   alias Vutuv.Tags.Tag
   alias Vutuv.Tags.Trending
@@ -1481,11 +1482,12 @@ defmodule VutuvWeb.PostLive.Feed do
   end
 
   # The same act on a post a followed tag brought back from another server
-  # (issue #2127). One row per copy here — a tag pull files one row per (tag,
-  # server, status), and only one of them can be on this page — so the entry to
-  # take away is the one carrying that id.
+  # (issue #2127). Several copies of one original can be on this page at once
+  # and the report takes all of them (issue #2164), so all of them have to
+  # leave: a row left standing here is the reader watching the promise they
+  # just read break.
   def handle_event("report-external-post", %{"id" => id}, socket) do
-    RemotePostActions.report_external(socket, id, &drop_external_entry(&1, id))
+    RemotePostActions.report_external(socket, id, &drop_external_copies(&1, id))
   end
 
   # "Not this account today": the private, reversible lever beside Report. The
@@ -3246,15 +3248,30 @@ defmodule VutuvWeb.PostLive.Feed do
     |> drop_entries(Enum.filter(socket.assigns.entries, &remote_entry?(&1, remote_post_id)))
   end
 
-  defp drop_external_entry(socket, external_post_id) do
-    drop_entries(
-      socket,
-      Enum.filter(socket.assigns.entries, &external_entry?(&1, external_post_id))
-    )
+  # How far a report reaches is `Vutuv.Tags.ExternalPosts`' answer, not this
+  # page's: the row that was clicked names the original *and* decides whether
+  # its report may speak for copies other servers filed, and the page asks the
+  # same `reaches?/2` the takedown ran. A copy of that rule here would be a
+  # second place for it to drift from — and this one decides what a member sees
+  # leave the page, which is where they check whether the promise held.
+  defp drop_external_copies(socket, external_post_id) do
+    entries = socket.assigns.entries
+
+    case Enum.find(entries, &external_entry?(&1, external_post_id)) do
+      %{external_post: reported} ->
+        drop_entries(socket, Enum.filter(entries, &external_copy?(&1, reported)))
+
+      _gone ->
+        socket
+    end
   end
 
   defp external_entry?(entry, external_post_id),
     do: Posts.external_feed_entry?(entry) and entry.external_post.id == external_post_id
+
+  defp external_copy?(entry, reported),
+    do:
+      Posts.external_feed_entry?(entry) and ExternalPosts.reaches?(reported, entry.external_post)
 
   # Taking a set of entries off the page: out of the list the page reasons with
   # and out of the stream the browser holds, then the empty state re-asked. One

--- a/lib/vutuv_web/live/remote_post_actions.ex
+++ b/lib/vutuv_web/live/remote_post_actions.ex
@@ -28,10 +28,26 @@ defmodule VutuvWeb.Live.RemotePostActions do
 
   import Phoenix.LiveView, only: [put_flash: 3]
 
+  alias Vutuv.Accounts.User
   alias Vutuv.Fediverse
   alias Vutuv.Mutes
   alias Vutuv.Tags.ExternalPosts
   alias VutuvWeb.MuteMessages
+
+  # Nobody is not an actor. Every act here names the reader — report, mute,
+  # unfollow — and the card renders the menu for a signed-in one only, so an
+  # anonymous socket arriving at one of these is a crafted client and not a
+  # member. Until issue #2164 each act carried that straight into a context
+  # function with a single `%User{}` head, where it raised and took the page
+  # down with it — and a tag timeline is a page anybody can open. One clause for
+  # all six, in the module that owns the events, rather than a nil clause per
+  # context weakening six honest heads.
+  defp with_viewer(socket, act) do
+    case socket.assigns[:current_user] do
+      %User{} = viewer -> act.(viewer)
+      _nobody -> {:noreply, socket}
+    end
+  end
 
   @doc """
   Handles a `"report-remote-post"` event for the cached post `id`, returning the
@@ -41,33 +57,50 @@ defmodule VutuvWeb.Live.RemotePostActions do
   to leave the page.
   """
   def report(socket, id, on_removed) when is_function(on_removed, 1) do
-    id
-    |> Fediverse.report_remote_post(socket.assigns.current_user)
-    |> reported(socket, on_removed)
+    with_viewer(socket, fn viewer ->
+      id
+      |> Fediverse.report_remote_post(viewer)
+      |> reported(socket, on_removed)
+    end)
   end
 
   @doc """
   The same for a `"report-external-post"` event — a post a followed tag brought
   back from another server's public tag timeline (issue #2127).
 
-  Same three answers and the same two sentences, because to the member it is the
-  same act on the same kind of thing: our copy of somebody else's post goes, and
-  the post itself stands where its author put it. How that copy goes differs and
-  is invisible from here — `Vutuv.Tags.ExternalPosts.report/2` says.
+  Same three answers, and **sentences of its own**: this act can take several
+  copies where its sibling takes the one row that exists. Promising a member a
+  single deleted copy while the twin stood two cards further down is the defect
+  issue #2164 exists for — and promising every copy where only one goes would be
+  the same defect with the words the other way round, so the receipt is the
+  scope the context answers with rather than a wording chosen here. How far a
+  report reaches, and why that depends on which server filed the row, is
+  `Vutuv.Tags.ExternalPosts.report/2`.
   """
   def report_external(socket, id, on_removed) when is_function(on_removed, 1) do
-    id
-    |> ExternalPosts.report(socket.assigns.current_user)
-    |> reported(socket, on_removed)
+    with_viewer(socket, fn viewer ->
+      id
+      |> ExternalPosts.report(viewer)
+      |> reported(socket, on_removed)
+    end)
   end
 
-  # The answer, whichever copy it was about.
-  defp reported(:ok, socket, on_removed) do
-    {:noreply,
-     socket
-     |> put_flash(:info, gettext("Thank you. Our copy was deleted right away."))
-     |> on_removed.()}
-  end
+  # The answer, whichever copy it was about. The cached post's sibling takes the
+  # one row that exists and says so; this one is handed the scope its context
+  # acted on, so the receipt cannot promise more or less than happened.
+  defp reported(:ok, socket, on_removed),
+    do: thanked(socket, gettext("Thank you. Our copy was deleted right away."), on_removed)
+
+  defp reported({:ok, :every_copy}, socket, on_removed),
+    do: thanked(socket, gettext("Thank you. Every copy on this vutuv is gone."), on_removed)
+
+  defp reported({:ok, :this_copy}, socket, on_removed),
+    do:
+      thanked(
+        socket,
+        gettext("Thank you. This copy is gone for everyone on this vutuv."),
+        on_removed
+      )
 
   defp reported({:error, :rate_limited}, socket, _on_removed) do
     {:noreply,
@@ -80,6 +113,13 @@ defmodule VutuvWeb.Live.RemotePostActions do
 
   defp reported({:error, :not_found}, socket, on_removed),
     do: {:noreply, on_removed.(socket)}
+
+  defp thanked(socket, message, on_removed) do
+    {:noreply,
+     socket
+     |> put_flash(:info, message)
+     |> on_removed.()}
+  end
 
   @doc """
   Handles a `"mute-remote-account"` event for the account `id`: the private,
@@ -94,21 +134,21 @@ defmodule VutuvWeb.Live.RemotePostActions do
   account they never followed is a confusing thing to read.
   """
   def mute(socket, account_id, on_muted) when is_function(on_muted, 1) do
-    viewer = socket.assigns.current_user
+    with_viewer(socket, fn viewer ->
+      case Mutes.target("remote_account", account_id) do
+        nil ->
+          {:noreply, on_muted.(socket)}
 
-    case Mutes.target("remote_account", account_id) do
-      nil ->
-        {:noreply, on_muted.(socket)}
+        account ->
+          following? = Fediverse.remote_follow_for(viewer, account) != nil
+          {:ok, _mute} = Mutes.mute(viewer, account, :all)
 
-      account ->
-        following? = Fediverse.remote_follow_for(viewer, account) != nil
-        {:ok, _mute} = Mutes.mute(viewer, account, :all)
-
-        {:noreply,
-         socket
-         |> put_flash(:info, muted_message(following?))
-         |> on_muted.()}
-    end
+          {:noreply,
+           socket
+           |> put_flash(:info, muted_message(following?))
+           |> on_muted.()}
+      end
+    end)
   end
 
   @doc """
@@ -139,18 +179,20 @@ defmodule VutuvWeb.Live.RemotePostActions do
   # differed by an atom and a sentence, which is two places for the next scope
   # to be forgotten in.
   defp mute_at(socket, account_id, scope, on_muted) when is_function(on_muted, 1) do
-    case Mutes.target("remote_account", account_id) do
-      nil ->
-        {:noreply, on_muted.(socket)}
+    with_viewer(socket, fn viewer ->
+      case Mutes.target("remote_account", account_id) do
+        nil ->
+          {:noreply, on_muted.(socket)}
 
-      account ->
-        {:ok, _mute} = Mutes.mute(socket.assigns.current_user, account, scope)
+        account ->
+          {:ok, _mute} = Mutes.mute(viewer, account, scope)
 
-        {:noreply,
-         socket
-         |> put_flash(:info, MuteMessages.flash(scope))
-         |> on_muted.()}
-    end
+          {:noreply,
+           socket
+           |> put_flash(:info, MuteMessages.flash(scope))
+           |> on_muted.()}
+      end
+    end)
   end
 
   defp muted_message(true),
@@ -168,15 +210,17 @@ defmodule VutuvWeb.Live.RemotePostActions do
   at may be gone from the database by the time it returns.
   """
   def unfollow(socket, account_id, on_removed) when is_function(on_removed, 1) do
-    case Fediverse.unfollow_remote_account(socket.assigns.current_user, account_id) do
-      :ok ->
-        {:noreply,
-         socket
-         |> put_flash(:info, gettext("Unfollowed. Their posts leave your feed."))
-         |> on_removed.()}
+    with_viewer(socket, fn viewer ->
+      case Fediverse.unfollow_remote_account(viewer, account_id) do
+        :ok ->
+          {:noreply,
+           socket
+           |> put_flash(:info, gettext("Unfollowed. Their posts leave your feed."))
+           |> on_removed.()}
 
-      {:error, :not_found} ->
-        {:noreply, on_removed.(socket)}
-    end
+        {:error, :not_found} ->
+          {:noreply, on_removed.(socket)}
+      end
+    end)
   end
 end

--- a/lib/vutuv_web/live/tag_live/timeline.ex
+++ b/lib/vutuv_web/live/tag_live/timeline.ex
@@ -125,8 +125,9 @@ defmodule VutuvWeb.TagLive.Timeline do
   end
 
   # The same for a post one of this tag's servers carried (issue #2127). The
-  # page is re-read rather than the row hunted down: unlike a cached post, one
-  # of these appears exactly once here, and a reload is what the other
+  # page is re-read rather than the rows hunted down: the report takes every
+  # copy of that original (issue #2164) and each of this tag's servers filed one
+  # of them, so several cards leave at once — and a reload is what the other
   # row-removing events on this page already do.
   def handle_event("report-external-post", %{"id" => id}, socket) do
     RemotePostActions.report_external(socket, id, &reload/1)

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -165,7 +165,7 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
-#: lib/vutuv_web/components/post_components.ex:4593
+#: lib/vutuv_web/components/post_components.ex:4613
 #: lib/vutuv_web/components/ui.ex:5042
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
@@ -213,7 +213,7 @@ msgstr "Inaktivieren"
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:4558
+#: lib/vutuv_web/components/post_components.ex:4578
 #: lib/vutuv_web/components/ui.ex:5033
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
@@ -657,7 +657,7 @@ msgstr "Speichern"
 #: lib/vutuv_web/live/search_live.ex:680
 #: lib/vutuv_web/live/shell_live.ex:1495
 #: lib/vutuv_web/live/shell_live.ex:1702
-#: lib/vutuv_web/live/tag_live/timeline.ex:352
+#: lib/vutuv_web/live/tag_live/timeline.ex:353
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:35
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:30
@@ -943,7 +943,7 @@ msgid "You follow back %{name}."
 msgstr "Sie folgen %{name} jetzt zurück."
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:179
+#: lib/vutuv_web/live/post_live/feed.ex:180
 #: lib/vutuv_web/live/press_kit_live.ex:110
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
@@ -1208,7 +1208,7 @@ msgstr "Alle Tag-Synonyme"
 msgid "All tag urls"
 msgstr "Alle Tag-URLs"
 
-#: lib/vutuv_web/components/post_components.ex:5211
+#: lib/vutuv_web/components/post_components.ex:5231
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:643
@@ -1711,7 +1711,7 @@ msgstr "Empfehlen"
 #: lib/vutuv_web/live/organization_live/following.ex:421
 #: lib/vutuv_web/live/organization_live/show.ex:602
 #: lib/vutuv_web/live/organization_live/show.ex:639
-#: lib/vutuv_web/live/post_live/feed.ex:1054
+#: lib/vutuv_web/live/post_live/feed.ex:1055
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
 #: lib/vutuv_web/templates/user/show.html.heex:1350
 #: lib/vutuv_web/views/user_html.ex:643
@@ -2129,7 +2129,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:4590
+#: lib/vutuv_web/components/post_components.ex:4610
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2144,8 +2144,8 @@ msgstr "Beitrag bearbeiten"
 #: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:203
-#: lib/vutuv_web/live/post_live/feed.ex:365
-#: lib/vutuv_web/live/post_live/feed.ex:3536
+#: lib/vutuv_web/live/post_live/feed.ex:366
+#: lib/vutuv_web/live/post_live/feed.ex:3555
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1346
 #: lib/vutuv_web/live/shell_live.ex:1692
@@ -2174,8 +2174,8 @@ msgstr "Vor einer bestimmten Person verbergen…"
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:4536
-#: lib/vutuv_web/components/post_components.ex:4538
+#: lib/vutuv_web/components/post_components.ex:4556
+#: lib/vutuv_web/components/post_components.ex:4558
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
@@ -2191,7 +2191,7 @@ msgstr "Nicht eingeloggte Besucher"
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3876
+#: lib/vutuv_web/live/post_live/feed.ex:3895
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2242,13 +2242,13 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:5084
-#: lib/vutuv_web/components/post_components.ex:5088
+#: lib/vutuv_web/components/post_components.ex:5104
+#: lib/vutuv_web/components/post_components.ex:5108
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:5085
+#: lib/vutuv_web/components/post_components.ex:5105
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2289,7 +2289,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2712
+#: lib/vutuv_web/live/post_live/feed.ex:2714
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2348,27 +2348,27 @@ msgstr "Was gibt's Neues?"
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:4533
+#: lib/vutuv_web/components/post_components.ex:4553
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:6851
+#: lib/vutuv_web/components/post_components.ex:6871
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:6855
+#: lib/vutuv_web/components/post_components.ex:6875
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:6853
+#: lib/vutuv_web/components/post_components.ex:6873
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:6854
+#: lib/vutuv_web/components/post_components.ex:6874
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2415,7 +2415,7 @@ msgid "All posts"
 msgstr "Alle Beiträge"
 
 #: lib/vutuv_web/components/post_components.ex:2185
-#: lib/vutuv_web/components/post_components.ex:6954
+#: lib/vutuv_web/components/post_components.ex:6974
 #: lib/vutuv_web/components/ui.ex:4476
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2434,7 +2434,7 @@ msgid "Bookmarks"
 msgstr "Lesezeichen"
 
 #: lib/vutuv_web/components/post_components.ex:2129
-#: lib/vutuv_web/components/post_components.ex:7195
+#: lib/vutuv_web/components/post_components.ex:7215
 #: lib/vutuv_web/components/ui.ex:4462
 #: lib/vutuv_web/notification_line.ex:317
 #: lib/vutuv_web/views/user_html.ex:486
@@ -2443,7 +2443,7 @@ msgid "Like"
 msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1301
-#: lib/vutuv_web/components/post_components.ex:7205
+#: lib/vutuv_web/components/post_components.ex:7225
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
 #: lib/vutuv_web/live/shell_live.ex:1596
@@ -2464,13 +2464,13 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:6942
+#: lib/vutuv_web/components/post_components.ex:6962
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
 #: lib/vutuv_web/components/post_components.ex:2184
-#: lib/vutuv_web/components/post_components.ex:6953
+#: lib/vutuv_web/components/post_components.ex:6973
 #: lib/vutuv_web/live/post_live/saved.ex:822
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2478,26 +2478,26 @@ msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
 #: lib/vutuv_web/components/post_components.ex:2165
-#: lib/vutuv_web/components/post_components.ex:6938
+#: lib/vutuv_web/components/post_components.ex:6958
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
 #: lib/vutuv_web/components/post_components.ex:2758
-#: lib/vutuv_web/components/post_components.ex:5957
+#: lib/vutuv_web/components/post_components.ex:5977
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
 #: lib/vutuv_web/components/post_components.ex:2164
-#: lib/vutuv_web/components/post_components.ex:6937
+#: lib/vutuv_web/components/post_components.ex:6957
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
 #: lib/vutuv_web/components/post_components.ex:2128
-#: lib/vutuv_web/components/post_components.ex:7194
+#: lib/vutuv_web/components/post_components.ex:7214
 #: lib/vutuv_web/live/post_live/saved.ex:821
 #: lib/vutuv_web/views/user_html.ex:486
 #, elixir-autogen, elixir-format
@@ -2512,7 +2512,7 @@ msgstr "Gefällt mir entfernen"
 #: lib/vutuv_web/live/organization_live/following.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:476
 #: lib/vutuv_web/live/organization_live/show.ex:644
-#: lib/vutuv_web/live/post_live/feed.ex:1041
+#: lib/vutuv_web/live/post_live/feed.ex:1042
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:42
 #: lib/vutuv_web/views/user_html.ex:633
@@ -2525,7 +2525,7 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:7249
+#: lib/vutuv_web/components/post_components.ex:7269
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
@@ -2537,8 +2537,8 @@ msgid "Replies"
 msgstr "Antworten"
 
 #: lib/vutuv_web/components/post_components.ex:2374
-#: lib/vutuv_web/components/post_components.ex:7232
-#: lib/vutuv_web/components/post_components.ex:7233
+#: lib/vutuv_web/components/post_components.ex:7252
+#: lib/vutuv_web/components/post_components.ex:7253
 #: lib/vutuv_web/live/notification_live/index.ex:993
 #: lib/vutuv_web/live/post_live/reply.ex:49
 #: lib/vutuv_web/notification_line.ex:314
@@ -2546,7 +2546,7 @@ msgstr "Antworten"
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:4492
+#: lib/vutuv_web/components/post_components.ex:4512
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
@@ -2567,7 +2567,7 @@ msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beitr
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
 
-#: lib/vutuv_web/components/post_components.ex:4010
+#: lib/vutuv_web/components/post_components.ex:4030
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:63
 #: lib/vutuv_web/live/post_live/remote_reply.ex:61
 #: lib/vutuv_web/live/post_live/reply.ex:63
@@ -2575,14 +2575,14 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:4464
+#: lib/vutuv_web/components/post_components.ex:4484
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:4455
-#: lib/vutuv_web/components/post_components.ex:4484
-#: lib/vutuv_web/components/post_components.ex:4487
+#: lib/vutuv_web/components/post_components.ex:4475
+#: lib/vutuv_web/components/post_components.ex:4504
+#: lib/vutuv_web/components/post_components.ex:4507
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
@@ -2830,7 +2830,7 @@ msgstr[0] "1 Vernetzung"
 msgstr[1] "%{formatted} Vernetzungen"
 
 #: lib/vutuv_web/live/job_board_live.ex:458
-#: lib/vutuv_web/live/post_live/feed.ex:1185
+#: lib/vutuv_web/live/post_live/feed.ex:1186
 #: lib/vutuv_web/templates/user/card_list.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -2884,7 +2884,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:6852
+#: lib/vutuv_web/components/post_components.ex:6872
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -3152,7 +3152,7 @@ msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:4431
+#: lib/vutuv_web/components/post_components.ex:4451
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solange eine Meldung zu diesem Beitrag bearbeitet wird, sehen nur Sie ihn."
@@ -3214,8 +3214,8 @@ msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
 #: lib/vutuv_web/components/post_components.ex:1466
 #: lib/vutuv_web/components/post_components.ex:3418
-#: lib/vutuv_web/components/post_components.ex:3605
-#: lib/vutuv_web/components/post_components.ex:4661
+#: lib/vutuv_web/components/post_components.ex:3610
+#: lib/vutuv_web/components/post_components.ex:4681
 #: lib/vutuv_web/live/organization_live/show.ex:684
 #: lib/vutuv_web/templates/user/show.html.heex:252
 #, elixir-autogen, elixir-format
@@ -4652,7 +4652,7 @@ msgstr "Sie haben niemanden blockiert."
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3881
+#: lib/vutuv_web/live/post_live/feed.ex:3900
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
@@ -5583,9 +5583,9 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:4741
-#: lib/vutuv_web/components/post_components.ex:5350
-#: lib/vutuv_web/components/post_components.ex:5688
+#: lib/vutuv_web/components/post_components.ex:4761
+#: lib/vutuv_web/components/post_components.ex:5370
+#: lib/vutuv_web/components/post_components.ex:5708
 #: lib/vutuv_web/live/notification_live/index.ex:1069
 #: lib/vutuv_web/views/user_html.ex:133
 #, elixir-autogen, elixir-format
@@ -5958,7 +5958,7 @@ msgid "Name (A-Z)"
 msgstr "Name (A-Z)"
 
 #: lib/vutuv_web/live/post_live/saved.ex:507
-#: lib/vutuv_web/live/tag_live/timeline.ex:448
+#: lib/vutuv_web/live/tag_live/timeline.ex:449
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr "Neueste zuerst"
@@ -5984,7 +5984,7 @@ msgid "Nothing here yet. People you like show up here."
 msgstr "Hier ist noch nichts. Personen, die Ihnen gefallen, erscheinen hier."
 
 #: lib/vutuv_web/live/post_live/saved.ex:508
-#: lib/vutuv_web/live/tag_live/timeline.ex:449
+#: lib/vutuv_web/live/tag_live/timeline.ex:450
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr "Älteste zuerst"
@@ -6006,7 +6006,7 @@ msgid "Search saved items"
 msgstr "Gespeicherte durchsuchen"
 
 #: lib/vutuv_web/live/post_live/saved.ex:570
-#: lib/vutuv_web/live/tag_live/timeline.ex:368
+#: lib/vutuv_web/live/tag_live/timeline.ex:369
 #, elixir-autogen, elixir-format
 msgid "Sort"
 msgstr "Sortieren"
@@ -6831,8 +6831,8 @@ msgstr ""
 "und Antworten über Sie mit. Mit beiden aus zum Beispiel:"
 
 #: lib/vutuv_web/components/post_components.ex:3345
-#: lib/vutuv_web/components/post_components.ex:4614
-#: lib/vutuv_web/components/post_components.ex:4628
+#: lib/vutuv_web/components/post_components.ex:4634
+#: lib/vutuv_web/components/post_components.ex:4648
 #: lib/vutuv_web/components/ui.ex:3226
 #: lib/vutuv_web/live/fediverse_account_live.ex:437
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6860,7 +6860,7 @@ msgstr "Neue Nachrichten und neue Vernetzungen"
 msgid "Remove this connection? You will stop following them."
 msgstr "Diese Vernetzung entfernen? Sie folgen der Person dann nicht mehr."
 
-#: lib/vutuv_web/components/post_components.ex:4614
+#: lib/vutuv_web/components/post_components.ex:4634
 #: lib/vutuv_web/components/ui.ex:3225
 #: lib/vutuv_web/live/fediverse_account_live.ex:435
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -7065,7 +7065,7 @@ msgid "Filter"
 msgstr "Filtern"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:591
-#: lib/vutuv_web/live/tag_live/timeline.ex:334
+#: lib/vutuv_web/live/tag_live/timeline.ex:335
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr "Filter"
@@ -7578,7 +7578,7 @@ msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:7105
+#: lib/vutuv_web/components/post_components.ex:7125
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #: lib/vutuv_web/live/shell_live.ex:1830
 #, elixir-autogen, elixir-format
@@ -7691,7 +7691,7 @@ msgstr ""
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/media_live.ex:270
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:4175
+#: lib/vutuv_web/live/post_live/feed.ex:4194
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #: lib/vutuv_web/live/press_kit_live.ex:1056
 #, elixir-autogen
@@ -8170,7 +8170,7 @@ msgstr "Administratoren"
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
 #: lib/vutuv_web/live/job_board_live.ex:468
-#: lib/vutuv_web/live/post_live/feed.ex:1194
+#: lib/vutuv_web/live/post_live/feed.ex:1195
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr "Alle Mitglieder"
@@ -8191,7 +8191,7 @@ msgstr "Prüfung ausstehend"
 #: lib/vutuv_web/live/admin/media_live.ex:146
 #: lib/vutuv_web/live/admin/user_live.ex:184
 #: lib/vutuv_web/live/job_board_live.ex:319
-#: lib/vutuv_web/live/tag_live/timeline.ex:398
+#: lib/vutuv_web/live/tag_live/timeline.ex:399
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr "Filter zurücksetzen"
@@ -9150,7 +9150,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:5960
+#: lib/vutuv_web/components/post_components.ex:5980
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -12627,7 +12627,7 @@ msgid "Everyone (public)"
 msgstr "Alle (öffentlich)"
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:681
-#: lib/vutuv_web/live/tag_live/timeline.ex:379
+#: lib/vutuv_web/live/tag_live/timeline.ex:380
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
 #, elixir-autogen, elixir-format
@@ -13573,7 +13573,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "E-Mail-Benachrichtigungen für Ihre gespeicherte Suche „%{label}“ stoppen?"
 
-#: lib/vutuv_web/components/post_components.ex:3969
+#: lib/vutuv_web/components/post_components.ex:3989
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:788
 #: lib/vutuv_web/controllers/settings_controller.ex:806
@@ -13971,7 +13971,7 @@ msgstr "In den Text einfügen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:259
 #: lib/vutuv_web/agent_docs/text.ex:221
-#: lib/vutuv_web/live/tag_live/timeline.ex:282
+#: lib/vutuv_web/live/tag_live/timeline.ex:283
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
 msgstr "Beiträge mit diesem Tag"
@@ -14028,7 +14028,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5556
 #: lib/vutuv_web/controllers/settings_controller.ex:643
-#: lib/vutuv_web/live/post_live/feed.ex:854
+#: lib/vutuv_web/live/post_live/feed.ex:855
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
@@ -14188,34 +14188,34 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:6648
+#: lib/vutuv_web/components/post_components.ex:6668
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6605
+#: lib/vutuv_web/components/post_components.ex:6625
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:6649
+#: lib/vutuv_web/components/post_components.ex:6669
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:6651
+#: lib/vutuv_web/components/post_components.ex:6671
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:6647
+#: lib/vutuv_web/components/post_components.ex:6667
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6604
+#: lib/vutuv_web/components/post_components.ex:6624
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
@@ -14226,12 +14226,12 @@ msgstr "Filmbesprechung"
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/components/post_components.ex:6646
+#: lib/vutuv_web/components/post_components.ex:6666
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/components/post_components.ex:6650
+#: lib/vutuv_web/components/post_components.ex:6670
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14251,7 +14251,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:6687
+#: lib/vutuv_web/components/post_components.ex:6707
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14259,30 +14259,30 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:6717
+#: lib/vutuv_web/components/post_components.ex:6737
 #: lib/vutuv_web/components/ui.ex:3884
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:6718
+#: lib/vutuv_web/components/post_components.ex:6738
 #: lib/vutuv_web/components/ui.ex:3885
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:6716
+#: lib/vutuv_web/components/post_components.ex:6736
 #: lib/vutuv_web/components/ui.ex:3877
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:6676
+#: lib/vutuv_web/components/post_components.ex:6696
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:6723
+#: lib/vutuv_web/components/post_components.ex:6743
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14312,7 +14312,7 @@ msgstr "Mit Qualifikation:"
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:6490
+#: lib/vutuv_web/components/post_components.ex:6510
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14355,7 +14355,7 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:6481
+#: lib/vutuv_web/components/post_components.ex:6501
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -14718,14 +14718,14 @@ msgstr "Konto zum Einfrieren suchen"
 msgid "See all frozen accounts"
 msgstr "Alle eingefrorenen Konten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:4258
+#: lib/vutuv_web/components/post_components.ex:4278
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "%{formatted} früheren Beitrag anzeigen"
 msgstr[1] "%{formatted} frühere Beiträge anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:4281
+#: lib/vutuv_web/components/post_components.ex:4301
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14752,7 +14752,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:7204
+#: lib/vutuv_web/components/post_components.ex:7224
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -14931,7 +14931,7 @@ msgstr ""
 "Wählen Sie unten einen Abschluss oder eine Schule, um ihn statt eines "
 "Jobtitels oben in Ihrem Profil anzuzeigen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1254
+#: lib/vutuv_web/live/post_live/feed.ex:1255
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr "Trotzdem anzeigen"
@@ -15468,7 +15468,7 @@ msgstr "Wir senden dorthin eine PIN, um zu bestätigen, dass die Adresse Ihnen g
 msgid "ZIP or postal code"
 msgstr "Postleitzahl"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:386
+#: lib/vutuv_web/live/tag_live/timeline.ex:387
 #: lib/vutuv_web/templates/education/form_content.html.heex:59
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:81
 #, elixir-autogen, elixir-format
@@ -15913,7 +15913,7 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:7150
+#: lib/vutuv_web/components/post_components.ex:7170
 #: lib/vutuv_web/live/notification_live/index.ex:1592
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -15921,7 +15921,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:7154
+#: lib/vutuv_web/components/post_components.ex:7174
 #: lib/vutuv_web/live/notification_live/index.ex:1586
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15929,7 +15929,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Like"
 msgstr[1] "%{formatted} Likes"
 
-#: lib/vutuv_web/components/post_components.ex:7158
+#: lib/vutuv_web/components/post_components.ex:7178
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15937,7 +15937,7 @@ msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1339
-#: lib/vutuv_web/components/post_components.ex:7109
+#: lib/vutuv_web/components/post_components.ex:7129
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Bereits in den Zahlen oben enthalten."
@@ -16036,7 +16036,7 @@ msgstr "Diese Antwort können Sie nicht entfernen."
 #: lib/vutuv_web/components/post_components.ex:1502
 #: lib/vutuv_web/components/post_components.ex:1733
 #: lib/vutuv_web/components/post_components.ex:3590
-#: lib/vutuv_web/components/post_components.ex:3827
+#: lib/vutuv_web/components/post_components.ex:3847
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "View the original"
@@ -16049,7 +16049,7 @@ msgstr "Original ansehen"
 msgid "What"
 msgstr "Was"
 
-#: lib/vutuv_web/live/remote_post_actions.ex:77
+#: lib/vutuv_web/live/remote_post_actions.ex:107
 #: lib/vutuv_web/live/remote_reply_actions.ex:61
 #, elixir-autogen, elixir-format
 msgid "You have reported a lot today. Please try again tomorrow."
@@ -16483,7 +16483,7 @@ msgstr "Hier ist noch nichts. Wenn Sie sich das nächste Mal anmelden oder eine 
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/admin/media_live.ex:155
 #: lib/vutuv_web/live/fediverse_following_live.ex:351
-#: lib/vutuv_web/live/tag_live/timeline.ex:473
+#: lib/vutuv_web/live/tag_live/timeline.ex:474
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr "Dazu passt nichts. Versuchen Sie eine kürzere Suche oder setzen Sie die Filter zurück."
@@ -16703,22 +16703,22 @@ msgstr "Was sich an welchem Konto geändert hat, wann, von welchem Gerät und wi
 msgid "device or detail"
 msgstr "Gerät oder Detail"
 
-#: lib/vutuv_web/components/post_components.ex:4443
+#: lib/vutuv_web/components/post_components.ex:4463
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Angehefteter Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:4577
+#: lib/vutuv_web/components/post_components.ex:4597
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "An Profil anheften"
 
-#: lib/vutuv_web/components/post_components.ex:4585
+#: lib/vutuv_web/components/post_components.ex:4605
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Vom Profil lösen"
 
-#: lib/vutuv_web/components/post_components.ex:4571
+#: lib/vutuv_web/components/post_components.ex:4591
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr "Es lässt sich nur ein Beitrag an Ihr Profil anheften. Diesen anheften und den anderen lösen?"
@@ -16847,19 +16847,19 @@ msgstr "Nächstes Foto"
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
 
-#: lib/vutuv_web/components/post_components.ex:4022
+#: lib/vutuv_web/components/post_components.ex:4042
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Fediverse-Einstellungen öffnen"
 
-#: lib/vutuv_web/components/post_components.ex:5526
-#: lib/vutuv_web/components/press_kit_components.ex:521
+#: lib/vutuv_web/components/post_components.ex:5546
+#: lib/vutuv_web/components/press_kit_components.ex:526
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:5754
-#: lib/vutuv_web/components/press_kit_components.ex:618
+#: lib/vutuv_web/components/post_components.ex:5774
+#: lib/vutuv_web/components/press_kit_components.ex:623
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
@@ -16872,7 +16872,7 @@ msgstr "Foto-Einstellungen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1500
 #: lib/vutuv_web/agent_docs/text.ex:909
-#: lib/vutuv_web/components/post_components.ex:5836
+#: lib/vutuv_web/components/post_components.ex:5856
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Fotos:"
@@ -16898,7 +16898,7 @@ msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qual
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:4075
+#: lib/vutuv_web/components/post_components.ex:4095
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
@@ -16918,7 +16918,7 @@ msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen S
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
 
-#: lib/vutuv_web/components/post_components.ex:4066
+#: lib/vutuv_web/components/post_components.ex:4086
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht öffentlich beantworten."
@@ -16928,12 +16928,12 @@ msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht �
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr "Diese Antwort wurde in einem anderen Netzwerk geschrieben. Sie zu beantworten heißt, Ihre Worte in dieses Netzwerk zu senden, und das tut vutuv nur für Mitglieder, die die Fediverse-Teilnahme eingeschaltet haben."
 
-#: lib/vutuv_web/components/post_components.ex:4084
+#: lib/vutuv_web/components/post_components.ex:4104
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Diese Seite nimmt nicht am Fediverse teil."
 
-#: lib/vutuv_web/components/post_components.ex:4018
+#: lib/vutuv_web/components/post_components.ex:4038
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Fediverse-Teilnahme einschalten, um zu antworten"
@@ -16948,7 +16948,7 @@ msgstr "Wer diese Fotos weiterverwenden darf"
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:4079
+#: lib/vutuv_web/components/post_components.ex:4099
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshalb werden von hier aus keine Antworten mehr gesendet."
@@ -16958,7 +16958,7 @@ msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshal
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
 
-#: lib/vutuv_web/components/post_components.ex:4032
+#: lib/vutuv_web/components/post_components.ex:4052
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fediverse-Follower. Auf vutuv ist sie ebenfalls ein öffentlicher Beitrag."
@@ -17033,13 +17033,13 @@ msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exak
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1357
-#: lib/vutuv_web/components/post_components.ex:7147
+#: lib/vutuv_web/components/post_components.ex:7167
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1355
-#: lib/vutuv_web/components/post_components.ex:7144
+#: lib/vutuv_web/components/post_components.ex:7164
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17049,7 +17049,7 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:7031
+#: lib/vutuv_web/components/post_components.ex:7051
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
@@ -17405,12 +17405,12 @@ msgstr "Zwischengespeicherte Beiträge"
 msgid "Only for this account's followers"
 msgstr "Nur für die Follower dieses Kontos"
 
-#: lib/vutuv_web/live/remote_post_actions.ex:68
+#: lib/vutuv_web/live/remote_post_actions.ex:63
 #, elixir-autogen, elixir-format
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Danke. Unsere Kopie wurde sofort gelöscht."
 
-#: lib/vutuv_web/components/post_components.ex:3826
+#: lib/vutuv_web/components/post_components.ex:3846
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Beim Original abstimmen"
@@ -17435,12 +17435,12 @@ msgstr "Von Mitgliedern entfernte Inhalte aus anderen Netzwerken"
 msgid "Hide"
 msgstr "Verbergen"
 
-#: lib/vutuv_web/components/post_components.ex:3767
+#: lib/vutuv_web/components/post_components.ex:3787
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Von der verfassenden Person als sensibel markiert"
 
-#: lib/vutuv_web/live/remote_post_actions.ex:157
+#: lib/vutuv_web/live/remote_post_actions.ex:189
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
 msgstr "Stummgeschaltet. Sie folgen dem Konto weiterhin; die Beiträge verschwinden aus Ihrem Feed."
@@ -17451,7 +17451,6 @@ msgid "Nobody has removed or reported anything yet."
 msgstr "Bisher hat niemand etwas entfernt oder gemeldet."
 
 #: lib/vutuv_web/components/post_components.ex:3413
-#: lib/vutuv_web/components/post_components.ex:3600
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr "Diesen Beitrag als unangemessen melden? Unsere Kopie wird sofort für alle auf diesem vutuv gelöscht."
@@ -17566,12 +17565,12 @@ msgstr "Wieder verdecken"
 msgid "Sensitive. Show the picture."
 msgstr "Heikles Motiv. Bild anzeigen."
 
-#: lib/vutuv_web/components/post_components.ex:3925
+#: lib/vutuv_web/components/post_components.ex:3945
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Das sind viele Likes in einer Stunde. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:3931
+#: lib/vutuv_web/components/post_components.ex:3951
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Diesen Beitrag gibt es hier nicht mehr."
@@ -17581,7 +17580,7 @@ msgstr "Diesen Beitrag gibt es hier nicht mehr."
 msgid "Back to the feed"
 msgstr "Zurück zum Feed"
 
-#: lib/vutuv_web/components/post_components.ex:4070
+#: lib/vutuv_web/components/post_components.ex:4090
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -18225,7 +18224,7 @@ msgstr ""
 msgid "View the conversation"
 msgstr "Unterhaltung ansehen"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:285
+#: lib/vutuv_web/live/tag_live/timeline.ex:286
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "%{formatted} post"
@@ -18233,32 +18232,32 @@ msgid_plural "%{formatted} posts"
 msgstr[0] "%{formatted} Beitrag"
 msgstr[1] "%{formatted} Beiträge"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:450
+#: lib/vutuv_web/live/tag_live/timeline.ex:451
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr "Meiste Likes"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:481
+#: lib/vutuv_web/live/tag_live/timeline.ex:482
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr "Zu diesem Tag gibt es noch keine Beiträge."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:479
+#: lib/vutuv_web/live/tag_live/timeline.ex:480
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr "Aus anderen Netzwerken gibt es zu diesem Tag noch keine Beiträge."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:476
+#: lib/vutuv_web/live/tag_live/timeline.ex:477
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr "Auf vutuv gibt es zu diesem Tag noch keine Beiträge."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:361
+#: lib/vutuv_web/live/tag_live/timeline.ex:362
 #, elixir-autogen, elixir-format
 msgid "word in a post"
 msgstr "Wort in einem Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:3928
+#: lib/vutuv_web/components/post_components.ex:3948
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Diese Antwort gibt es hier nicht mehr."
@@ -18330,19 +18329,19 @@ msgstr "Auf der Seite eines Beitrags stehen direkt unter der Zahl die Mitglieder
 msgid "Liked by"
 msgstr "Gefällt diesen Mitgliedern"
 
-#: lib/vutuv_web/components/post_components.ex:6130
+#: lib/vutuv_web/components/post_components.ex:6150
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Gefällt %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:6132
+#: lib/vutuv_web/components/post_components.ex:6152
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Gefällt %{name} und %{formatted} weiteren"
 msgstr[1] "Gefällt %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/components/post_components.ex:6143
+#: lib/vutuv_web/components/post_components.ex:6163
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr "Nur Sie sehen hier alle: Einige dieser Mitglieder werden anderen Lesern nicht genannt."
@@ -18516,7 +18515,7 @@ msgstr "Ausstellungsdatum"
 msgid "Label"
 msgstr "Bezeichnung"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3899
+#: lib/vutuv_web/live/post_live/feed.ex:3918
 #: lib/vutuv_web/live/reference_check_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -19941,7 +19940,7 @@ msgstr "Suchen Sie so oft Sie möchten und nehmen Sie dazu, was gehört. Abkürz
 msgid "Start over"
 msgstr "Von vorn beginnen"
 
-#: lib/vutuv_web/components/post_components.ex:3958
+#: lib/vutuv_web/components/post_components.ex:3978
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr "Ein Herz oder ein Repost geht zurück in das Netzwerk, aus dem dieser Beitrag stammt. Ihr Konto nimmt derzeit nicht am Fediverse teil. Einschalten können Sie das in den {settings}."
@@ -20828,27 +20827,27 @@ msgstr "Sprache"
 msgid "The language this post is written in"
 msgstr "Die Sprache, in der dieser Beitrag geschrieben ist"
 
-#: lib/vutuv_web/components/post_components.ex:6024
+#: lib/vutuv_web/components/post_components.ex:6044
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Original anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:6060
+#: lib/vutuv_web/components/post_components.ex:6080
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Übersetzen"
 
-#: lib/vutuv_web/components/post_components.ex:6069
+#: lib/vutuv_web/components/post_components.ex:6089
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Übersetzt"
 
-#: lib/vutuv_web/components/post_components.ex:6072
+#: lib/vutuv_web/components/post_components.ex:6092
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Übersetzt aus %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:6049
+#: lib/vutuv_web/components/post_components.ex:6069
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Wird übersetzt …"
@@ -20858,7 +20857,7 @@ msgstr "Wird übersetzt …"
 msgid "Feed language settings reset to the site defaults."
 msgstr "Feed-Spracheinstellungen auf die Website-Vorgaben zurückgesetzt."
 
-#: lib/vutuv_web/components/post_components.ex:6039
+#: lib/vutuv_web/components/post_components.ex:6059
 #: lib/vutuv_web/components/ui.ex:5549
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -20987,20 +20986,20 @@ msgstr "Wir haben den Link in Ihrem Profil noch nicht gefunden. Bitte versuchen 
 msgid "Your username, or paste the address of your profile page."
 msgstr "Ihr Benutzername – oder fügen Sie die Adresse Ihrer Profilseite ein."
 
-#: lib/vutuv_web/components/post_components.ex:5802
+#: lib/vutuv_web/components/post_components.ex:5822
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] "Unsere KI prüft es gerade. Sobald die Prüfung durch ist, erscheint das Foto von selbst."
 msgstr[1] "Unsere KI prüft sie gerade, %{done} von %{total} sind durch. Sobald die letzte durch ist, erscheinen die Fotos von selbst."
 
-#: lib/vutuv_web/components/post_components.ex:5799
+#: lib/vutuv_web/components/post_components.ex:5819
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Ihr Beitrag ist veröffentlicht, das Foto noch nicht."
 
 #: lib/vutuv_web/components/post_components.ex:2912
-#: lib/vutuv_web/components/post_components.ex:4868
+#: lib/vutuv_web/components/post_components.ex:4888
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -21018,7 +21017,7 @@ msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Empfohlen: quadratisch, mindestens %{width} × %{height} Pixel."
 
 #: lib/vutuv_web/live/job_board_live.ex:431
-#: lib/vutuv_web/live/post_live/feed.ex:1131
+#: lib/vutuv_web/live/post_live/feed.ex:1132
 #: lib/vutuv_web/views/user_html.ex:355
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -21518,7 +21517,7 @@ msgstr "Diese Seite folgt bereits so vielen Konten, wie hier erlaubt sind (%{max
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr "%{handle} nicht mehr folgen? Die Beiträge verschwinden aus Ihrem Feed."
 
-#: lib/vutuv_web/live/remote_post_actions.ex:175
+#: lib/vutuv_web/live/remote_post_actions.ex:208
 #, elixir-autogen, elixir-format
 msgid "Unfollowed. Their posts leave your feed."
 msgstr "Nicht mehr gefolgt. Die Beiträge verschwinden aus Ihrem Feed."
@@ -21593,7 +21592,7 @@ msgstr "Sie haben Browser-Benachrichtigungen eingeschaltet. Dieser Browser wurde
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr "e-mail email mail abbestellen abmelden newsletter glocke benachrichtigung weniger ruhe browser desktop popup push hinweis mitteilung"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:340
+#: lib/vutuv_web/live/tag_live/timeline.ex:341
 #, elixir-autogen, elixir-format
 msgid "%{formatted} active"
 msgstr "%{formatted} aktiv"
@@ -21639,12 +21638,12 @@ msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public po
 msgstr ""
 "Folgen Sie #%{tag} von Mastodon oder einer anderen Fediverse-App aus, dann landen die öffentlichen Beiträge in Ihrer Timeline. Ein vutuv-Konto brauchen Sie dafür nicht."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4069
+#: lib/vutuv_web/live/post_live/feed.ex:4088
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Andere Mitglieder begrüßen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:855
+#: lib/vutuv_web/live/post_live/feed.ex:856
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr "Neu dabei"
@@ -21690,7 +21689,7 @@ msgstr "Der beste Weg: Folgen Sie %{name} hier. Neue Beiträge landen in Ihrem F
 msgid "With a vutuv account"
 msgstr "Mit einem vutuv-Konto"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1123
+#: lib/vutuv_web/live/post_live/feed.ex:1124
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
@@ -22067,7 +22066,7 @@ msgstr "Alle vutuv Mitglieder, alphabetisch nach Nachname sortiert."
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr "Alle vutuv Mitglieder, gruppiert nach dem Anfangsbuchstaben des Nachnamens."
 
-#: lib/vutuv_web/live/post_live/feed.ex:980
+#: lib/vutuv_web/live/post_live/feed.ex:981
 #: lib/vutuv_web/live/post_live/filter_band.ex:350
 #, elixir-autogen, elixir-format
 msgid "A photo"
@@ -22083,7 +22082,7 @@ msgstr "Auch in längeren Wörtern: %{word} trifft auch %{example}."
 msgid "A–Z"
 msgstr "A–Z"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1081
+#: lib/vutuv_web/live/post_live/feed.ex:1082
 #, elixir-autogen, elixir-format
 msgid "Browse the tags"
 msgstr "Alle Tags ansehen"
@@ -22098,7 +22097,7 @@ msgstr "Aktivste zuerst"
 msgid "Clear all"
 msgstr "Alle löschen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:892
+#: lib/vutuv_web/live/post_live/feed.ex:893
 #, elixir-autogen, elixir-format
 msgid "Drag, or use the arrow keys"
 msgstr "Ziehen, oder die Pfeiltasten benutzen"
@@ -22113,13 +22112,13 @@ msgstr "Auf- und zuklappen"
 msgid "Find an account or a server …"
 msgstr "Konto oder Server suchen …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:916
+#: lib/vutuv_web/live/post_live/feed.ex:917
 #, elixir-autogen, elixir-format
 msgid "Fold %{card}"
 msgstr "%{card} einklappen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1052
 #: lib/vutuv_web/live/post_live/feed.ex:1053
+#: lib/vutuv_web/live/post_live/feed.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Follow a tag …"
 msgstr "Einem Tag folgen …"
@@ -22136,19 +22135,19 @@ msgstr "Tag ausblenden …"
 msgid "Hide a word or a whole phrase …"
 msgstr "Wort oder ganzen Satz ausblenden …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:853
-#: lib/vutuv_web/live/post_live/feed.ex:4232
+#: lib/vutuv_web/live/post_live/feed.ex:854
+#: lib/vutuv_web/live/post_live/feed.ex:4251
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Tags ausblenden"
 
-#: lib/vutuv_web/live/post_live/feed.ex:852
-#: lib/vutuv_web/live/post_live/feed.ex:4221
+#: lib/vutuv_web/live/post_live/feed.ex:853
+#: lib/vutuv_web/live/post_live/feed.ex:4240
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Wörter ausblenden"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1087
+#: lib/vutuv_web/live/post_live/feed.ex:1088
 #: lib/vutuv_web/live/post_live/filter_band.ex:394
 #, elixir-autogen, elixir-format
 msgid "In your feed right now:"
@@ -22164,7 +22163,7 @@ msgstr "Trifft gerade nichts in Ihrem Feed — für alles Neue gilt die Regel tr
 msgid "More of your %{formatted} accounts"
 msgstr "Mehr Ihrer %{formatted} Konten"
 
-#: lib/vutuv_web/live/post_live/feed.ex:891
+#: lib/vutuv_web/live/post_live/feed.ex:892
 #, elixir-autogen, elixir-format
 msgid "Move %{card}"
 msgstr "%{card} verschieben"
@@ -22175,12 +22174,12 @@ msgstr "%{card} verschieben"
 msgid "No account found."
 msgstr "Kein Konto gefunden."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1076
+#: lib/vutuv_web/live/post_live/feed.ex:1077
 #, elixir-autogen, elixir-format
 msgid "No tag called %{name} yet."
 msgstr "Noch kein Tag namens %{name}."
 
-#: lib/vutuv_web/live/post_live/feed.ex:845
+#: lib/vutuv_web/live/post_live/feed.ex:846
 #, elixir-autogen, elixir-format
 msgid "Not read yet"
 msgstr "Noch nicht gelesen"
@@ -22210,13 +22209,13 @@ msgstr "Beiträge mit einem dieser Tags werden genauso zugeklappt."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Beiträge mit einem dieser Wörter werden auf eine Zeile zugeklappt — nicht gelöscht, und mit einem Weg, sie doch zu lesen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4095
+#: lib/vutuv_web/live/post_live/feed.ex:4114
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Weggelegt:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:937
 #: lib/vutuv_web/live/post_live/feed.ex:938
+#: lib/vutuv_web/live/post_live/feed.ex:939
 #, elixir-autogen, elixir-format
 msgid "Remove %{card}"
 msgstr "%{card} entfernen"
@@ -22248,8 +22247,8 @@ msgstr "Nur %{source} anzeigen"
 msgid "Show posts by %{name}"
 msgstr "Beiträge von %{name} anzeigen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:851
-#: lib/vutuv_web/live/post_live/feed.ex:4187
+#: lib/vutuv_web/live/post_live/feed.ex:852
+#: lib/vutuv_web/live/post_live/feed.ex:4206
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr "Quellen"
@@ -22259,12 +22258,12 @@ msgstr "Quellen"
 msgid "Switching off means muting, not unfollowing. You stay a follower, the posts just stop reaching your feed: permanently and on every device, until you switch them back on here."
 msgstr "Ausschalten heißt stumm schalten, nicht entfolgen. Sie folgen weiter, die Beiträge bleiben nur aus Ihrem Feed: dauerhaft und auf allen Geräten, bis Sie hier wieder einschalten."
 
-#: lib/vutuv_web/live/post_live/feed.ex:915
+#: lib/vutuv_web/live/post_live/feed.ex:916
 #, elixir-autogen, elixir-format
 msgid "Unfold %{card}"
 msgstr "%{card} ausklappen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1042
+#: lib/vutuv_web/live/post_live/feed.ex:1043
 #, elixir-autogen, elixir-format
 msgid "Unfollow the tag %{tag}"
 msgstr "Dem Tag %{tag} nicht mehr folgen"
@@ -22288,20 +22287,20 @@ msgid_plural "and %{formatted} more"
 msgstr[0] "und 1 weiterer"
 msgstr[1] "und %{formatted} weitere"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3653
-#: lib/vutuv_web/live/post_live/feed.ex:3680
+#: lib/vutuv_web/live/post_live/feed.ex:3672
+#: lib/vutuv_web/live/post_live/feed.ex:3699
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
 msgstr "Filter"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1262
+#: lib/vutuv_web/live/post_live/feed.ex:1263
 #, elixir-autogen, elixir-format
 msgctxt "filtered post"
 msgid "Hidden:"
 msgstr "Ausgeblendet:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:990
+#: lib/vutuv_web/live/post_live/feed.ex:991
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} post in the feed"
 msgid_plural "Show %{formatted} posts in the feed"
@@ -22355,7 +22354,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} Beitrag am %{day}"
 msgstr[1] "%{count} Beiträge am %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3856
+#: lib/vutuv_web/live/post_live/feed.ex:3875
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Zurück zu jetzt"
@@ -22365,7 +22364,7 @@ msgstr "Zurück zu jetzt"
 msgid "Busy month: the shading counts at least this much."
 msgstr "Voller Monat: die Färbung zählt mindestens so viel."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3902
+#: lib/vutuv_web/live/post_live/feed.ex:3921
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -22387,7 +22386,7 @@ msgstr "Nächster Monat"
 msgid "Next year"
 msgstr "Nächstes Jahr"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3852
+#: lib/vutuv_web/live/post_live/feed.ex:3871
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Am %{day} ist nichts in Ihrem Feed angekommen."
@@ -22474,14 +22473,14 @@ msgstr "Neue Version bereit."
 msgid "Page management"
 msgstr "Verwaltung"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2706
+#: lib/vutuv_web/live/post_live/feed.ex:2708
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
 msgstr[0] "Neu:"
 msgstr[1] "Neu (%{formatted}):"
 
-#: lib/vutuv_web/components/post_components.ex:3694
+#: lib/vutuv_web/components/post_components.ex:3714
 #, elixir-autogen, elixir-format
 msgid "Quoted post"
 msgstr "Zitierter Beitrag"
@@ -22506,7 +22505,7 @@ msgstr "Ein Konto erwähnen"
 msgid "{used} of {max} mentions"
 msgstr "{used} von {max} Erwähnungen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2818
+#: lib/vutuv_web/live/post_live/feed.ex:2820
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr "Bis hier neu"
@@ -22537,7 +22536,7 @@ msgstr "Nur diese Accounts (leer = alle) …"
 msgid "only %{account}"
 msgstr "nur %{account}"
 
-#: lib/vutuv_web/components/post_components.ex:7492
+#: lib/vutuv_web/components/post_components.ex:7512
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -22721,7 +22720,7 @@ msgctxt "phone tab bar"
 msgid "Write"
 msgstr "Schreiben"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3990
+#: lib/vutuv_web/live/post_live/feed.ex:4009
 #: lib/vutuv_web/live/post_rewrites_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "%{formatted} rule"
@@ -22791,7 +22790,7 @@ msgstr "Regeln, die den Text der Beiträge eines Kontos umschreiben, bevor Sie i
 
 #: lib/vutuv_web/components/post_components.ex:1456
 #: lib/vutuv_web/components/post_components.ex:3406
-#: lib/vutuv_web/components/post_components.ex:4658
+#: lib/vutuv_web/components/post_components.ex:4678
 #: lib/vutuv_web/components/ui.ex:5541
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
@@ -23022,7 +23021,7 @@ msgstr[1] "%{formatted} neue Follower"
 msgid "Last 30 days: %{parts}"
 msgstr "Letzte 30 Tage: %{parts}"
 
-#: lib/vutuv_web/components/post_components.ex:5220
+#: lib/vutuv_web/components/post_components.ex:5240
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Less"
@@ -23337,7 +23336,7 @@ msgid "Hidden. What they pass on stays out of your feed; their own posts do not.
 msgstr "Ausgeblendet. Was dieses Konto weiterreicht, erscheint nicht mehr in Ihrem Feed, die eigenen Beiträge schon."
 
 #: lib/vutuv_web/components/post_components.ex:3378
-#: lib/vutuv_web/components/post_components.ex:4652
+#: lib/vutuv_web/components/post_components.ex:4672
 #, elixir-autogen, elixir-format
 msgid "Hide reposts"
 msgstr "Reposts ausblenden"
@@ -23518,8 +23517,8 @@ msgstr "Beiträge in Ihrem Feed"
 msgid "Posts loaded at once"
 msgstr "Beiträge auf einmal"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3926
-#: lib/vutuv_web/live/post_live/feed.ex:3930
+#: lib/vutuv_web/live/post_live/feed.ex:3945
+#: lib/vutuv_web/live/post_live/feed.ex:3949
 #, elixir-autogen, elixir-format
 msgid "Posts per page"
 msgstr "Beiträge pro Seite"
@@ -23534,60 +23533,60 @@ msgstr "Sie können das auch direkt im Feed ändern, gleich unter „Mehr laden�
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr "feed länge seitengröße beiträge anzahl menge mehr laden scrollen blättern seite umfang page size posts number load more"
 
-#: lib/vutuv_web/components/post_components.ex:7483
-#: lib/vutuv_web/components/post_components.ex:7484
+#: lib/vutuv_web/components/post_components.ex:7503
+#: lib/vutuv_web/components/post_components.ex:7504
 #, elixir-autogen, elixir-format
 msgid "A word or phrase …"
 msgstr "Ein Wort oder eine Wortgruppe …"
 
-#: lib/vutuv_web/components/post_components.ex:7511
+#: lib/vutuv_web/components/post_components.ex:7531
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr "Für wen %{thing} ausgeblendet wird"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3987
-#: lib/vutuv_web/live/post_live/feed.ex:4151
-#: lib/vutuv_web/live/post_live/feed.ex:4160
+#: lib/vutuv_web/live/post_live/feed.ex:4006
+#: lib/vutuv_web/live/post_live/feed.ex:4170
+#: lib/vutuv_web/live/post_live/feed.ex:4179
 #, elixir-autogen, elixir-format
 msgid "Hidden"
 msgstr "Ausgeblendet"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4125
+#: lib/vutuv_web/live/post_live/feed.ex:4144
 #, elixir-autogen, elixir-format
 msgid "Hide something from your feed"
 msgstr "Etwas aus dem Feed ausblenden"
 
-#: lib/vutuv_web/components/post_components.ex:7429
+#: lib/vutuv_web/components/post_components.ex:7449
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr "Nicht mehr zeigen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4166
+#: lib/vutuv_web/live/post_live/feed.ex:4185
 #, elixir-autogen, elixir-format
 msgid "Whatever these match is folded to a single line in your feed."
 msgstr "Was hiervon getroffen wird, klappt im Feed auf eine Zeile zu."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4186
+#: lib/vutuv_web/live/post_live/feed.ex:4205
 #, elixir-autogen, elixir-format
 msgid "Words & tags"
 msgstr "Wörter & Tags"
 
-#: lib/vutuv_web/components/post_components.ex:7515
+#: lib/vutuv_web/components/post_components.ex:7535
 #, elixir-autogen, elixir-format
 msgid "everyone"
 msgstr "bei allen"
 
-#: lib/vutuv_web/components/post_components.ex:7518
+#: lib/vutuv_web/components/post_components.ex:7538
 #, elixir-autogen, elixir-format
 msgid "only %{handle}"
 msgstr "nur %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:7487
+#: lib/vutuv_web/components/post_components.ex:7507
 #, elixir-autogen, elixir-format
 msgid "this word"
 msgstr "dieses Wort"
 
-#: lib/vutuv_web/components/post_components.ex:7528
+#: lib/vutuv_web/components/post_components.ex:7548
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr "nur %{server}"
@@ -23639,7 +23638,7 @@ msgstr "Diese Website ist gerade offline."
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr "Die Website läuft, nur diese Adresse gibt es hier nicht. Wahrscheinlich ist der Link alt oder enthält einen Tippfehler."
 
-#: lib/vutuv_web/components/post_components.ex:6833
+#: lib/vutuv_web/components/post_components.ex:6853
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr "Screenshot vergrößern"
@@ -23730,7 +23729,7 @@ msgid "Hidden. What other people pass on of them stays out of your feed; their o
 msgstr "Ausgeblendet. Was andere von diesem Konto weiterreichen, erscheint nicht mehr in Ihrem Feed, die eigenen Beiträge schon."
 
 #: lib/vutuv_web/components/post_components.ex:3364
-#: lib/vutuv_web/components/post_components.ex:4640
+#: lib/vutuv_web/components/post_components.ex:4660
 #, elixir-autogen, elixir-format
 msgid "Hide when others repost them"
 msgstr "Ausblenden, wenn andere reposten"
@@ -24493,13 +24492,13 @@ msgstr "das Meldeformular"
 msgid "“%{note}”"
 msgstr "„%{note}“"
 
-#: lib/vutuv_web/components/post_components.ex:5398
-#: lib/vutuv_web/components/press_kit_components.ex:211
+#: lib/vutuv_web/components/post_components.ex:5418
+#: lib/vutuv_web/components/press_kit_components.ex:216
 #, elixir-autogen, elixir-format
 msgid "Show these photos larger"
 msgstr "Fotos vergrößern"
 
-#: lib/vutuv_web/components/post_components.ex:5584
+#: lib/vutuv_web/components/post_components.ex:5604
 #, elixir-autogen, elixir-format
 msgid "Show this photo larger"
 msgstr "Foto vergrößern"
@@ -24589,7 +24588,7 @@ msgstr "Ich habe die Rechte an dieser Datei und gebe sie zur redaktionellen Nutz
 msgid "Light"
 msgstr "Hell"
 
-#: lib/vutuv/press_kit.ex:251
+#: lib/vutuv/press_kit.ex:321
 #, elixir-autogen, elixir-format
 msgid "Logo variant"
 msgstr "Logo-Variante"
@@ -24638,7 +24637,7 @@ msgstr "Bild entfernt."
 msgid "Please confirm the rights first, then choose the file."
 msgstr "Bitte bestätigen Sie zuerst die Rechte und wählen Sie dann die Datei."
 
-#: lib/vutuv/press_kit.ex:251
+#: lib/vutuv/press_kit.ex:321
 #, elixir-autogen, elixir-format
 msgid "Press photo"
 msgstr "Pressefoto"
@@ -24724,18 +24723,18 @@ msgstr[1] "%{count} Bytes"
 msgid "Credit: %{credit}"
 msgstr "Bildnachweis: %{credit}"
 
-#: lib/vutuv_web/components/press_kit_components.ex:375
-#: lib/vutuv_web/components/press_kit_components.ex:378
+#: lib/vutuv_web/components/press_kit_components.ex:380
+#: lib/vutuv_web/components/press_kit_components.ex:383
 #, elixir-autogen, elixir-format
 msgid "Download %{format}"
 msgstr "%{format} herunterladen"
 
-#: lib/vutuv_web/components/press_kit_components.ex:331
+#: lib/vutuv_web/components/press_kit_components.ex:336
 #, elixir-autogen, elixir-format
 msgid "Download photo"
 msgstr "Foto herunterladen"
 
-#: lib/vutuv/press_kit.ex:715
+#: lib/vutuv/press_kit.ex:785
 #, elixir-autogen, elixir-format
 msgid "Free for editorial use with credit."
 msgstr "Zur freien redaktionellen Verwendung mit Bildnachweis."
@@ -24745,7 +24744,7 @@ msgstr "Zur freien redaktionellen Verwendung mit Bildnachweis."
 msgid "PNG version"
 msgstr "PNG-Fassung"
 
-#: lib/vutuv_web/agent_docs/press_kit_doc.ex:55
+#: lib/vutuv_web/agent_docs/press_kit_doc.ex:58
 #, elixir-autogen, elixir-format
 msgid "Press pictures %{name} offers for download, free for editorial use with credit."
 msgstr "Pressebilder, die %{name} zum Herunterladen anbietet, zur freien redaktionellen Verwendung mit Bildnachweis."
@@ -24780,7 +24779,7 @@ msgstr "Logo dieser Seite verwenden"
 msgid "What a journalist writing about this page may download: photos in print quality and its logo as a file. Everything here is public and free for editorial use as long as the credit is shown."
 msgstr "Was eine Redaktion, die über diese Seite schreibt, herunterladen darf: Fotos in Druckqualität und das Logo als Datei. Alles hier ist öffentlich und zur redaktionellen Nutzung frei, solange der Bildnachweis genannt wird."
 
-#: lib/vutuv_web/components/press_kit_components.ex:565
+#: lib/vutuv_web/components/press_kit_components.ex:570
 #: lib/vutuv_web/components/ui.ex:3281
 #, elixir-autogen, elixir-format
 msgid "Report this picture"
@@ -24882,7 +24881,7 @@ msgid "nobody"
 msgstr "niemand"
 
 #: lib/vutuv_web/components/press_kit_components.ex:120
-#: lib/vutuv_web/components/press_kit_components.ex:176
+#: lib/vutuv_web/components/press_kit_components.ex:181
 #, elixir-autogen, elixir-format
 msgid "All Media Kit files"
 msgstr "Das ganze Media Kit"
@@ -24902,7 +24901,7 @@ msgstr "Das ganze Media Kit"
 msgid "Media Kit"
 msgstr "Media Kit"
 
-#: lib/vutuv_web/agent_docs/press_kit_doc.ex:53
+#: lib/vutuv_web/agent_docs/press_kit_doc.ex:56
 #: lib/vutuv_web/views/press_kit_html.ex:32
 #, elixir-autogen, elixir-format
 msgid "Media Kit of %{name}"
@@ -24933,8 +24932,8 @@ msgstr "Sie können diesem Media Kit kein Bild hinzufügen."
 msgid "press kit media journalist photographer download original print logo svg credit copyright presse pressefotos pressemappe medienkit mediakit fotos logo herunterladen bildnachweis"
 msgstr "media kit medienkit mediakit pressemappe presse medien redaktion journalist fotograf download original druck logo svg bildnachweis urheberrecht pressefotos herunterladen press kit"
 
-#: lib/vutuv_web/components/post_components.ex:4556
-#: lib/vutuv_web/components/post_components.ex:4606
+#: lib/vutuv_web/components/post_components.ex:4576
+#: lib/vutuv_web/components/post_components.ex:4626
 #, elixir-autogen, elixir-format
 msgid "Copy link to post"
 msgstr "Link zum Beitrag kopieren"
@@ -25037,7 +25036,7 @@ msgstr "Ein Absatz, mit dem ein Artikel enden kann."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:121
 #: lib/vutuv_web/agent_docs/text.ex:412
-#: lib/vutuv_web/components/press_kit_components.ex:269
+#: lib/vutuv_web/components/press_kit_components.ex:274
 #, elixir-autogen, elixir-format
 msgid "About %{name}"
 msgstr "Über %{name}"
@@ -25062,12 +25061,12 @@ msgstr "Ein @handle verlinkt auf das Profil und benachrichtigt niemanden."
 msgid "As long as you like. The whole portrait."
 msgstr "So lang, wie Sie mögen. Das ganze Porträt."
 
-#: lib/vutuv/press_kit.ex:460
+#: lib/vutuv/press_kit.ex:530
 #, elixir-autogen, elixir-format
 msgid "Long version"
 msgstr "Lange Fassung"
 
-#: lib/vutuv/press_kit.ex:459
+#: lib/vutuv/press_kit.ex:529
 #, elixir-autogen, elixir-format
 msgid "Medium version"
 msgstr "Mittlere Fassung"
@@ -25077,12 +25076,12 @@ msgstr "Mittlere Fassung"
 msgid "Nothing written yet."
 msgstr "Noch nichts geschrieben."
 
-#: lib/vutuv/press_kit.ex:458
+#: lib/vutuv/press_kit.ex:528
 #, elixir-autogen, elixir-format
 msgid "Short version"
 msgstr "Kurze Fassung"
 
-#: lib/vutuv_web/components/press_kit_components.ex:272
+#: lib/vutuv_web/components/press_kit_components.ex:277
 #, elixir-autogen, elixir-format
 msgid "Take whichever length fits the space you have. Each one stands on its own."
 msgstr "Nehmen Sie die Fassung, die in Ihren Platz passt. Jede steht für sich."
@@ -25212,7 +25211,7 @@ msgstr "abgelehnt"
 msgid "Your post appears as soon as the video is ready"
 msgstr "Ihr Beitrag erscheint, sobald das Video fertig ist"
 
-#: lib/vutuv_web/components/post_components.ex:3626
+#: lib/vutuv_web/components/post_components.ex:3631
 #, elixir-autogen, elixir-format
 msgid "Found through %{server}"
 msgstr "Gefunden über %{server}"
@@ -25500,3 +25499,23 @@ msgstr "Dieses Bild konnte nicht gelesen werden."
 #, elixir-autogen, elixir-format
 msgid "You can only send files to members you are connected with."
 msgstr "Dateien können Sie nur an Mitglieder senden, mit denen Sie vernetzt sind."
+
+#: lib/vutuv_web/components/post_components.ex:3652
+#, elixir-autogen, elixir-format
+msgid "Report this post as not appropriate? Every copy of it disappears right away, for everyone on this vutuv."
+msgstr "Diesen Beitrag als unangemessen melden? Jede Kopie verschwindet sofort für alle auf diesem vutuv."
+
+#: lib/vutuv_web/live/remote_post_actions.ex:89
+#, elixir-autogen, elixir-format
+msgid "Thank you. Every copy on this vutuv is gone."
+msgstr "Danke. Jede Kopie auf diesem vutuv ist weg."
+
+#: lib/vutuv_web/components/post_components.ex:3656
+#, elixir-autogen, elixir-format
+msgid "Report this post as not appropriate? This copy disappears right away, for everyone on this vutuv. Copies other servers sent us stay."
+msgstr "Diesen Beitrag als unangemessen melden? Diese Kopie verschwindet sofort für alle auf diesem vutuv. Kopien von anderen Servern bleiben stehen."
+
+#: lib/vutuv_web/live/remote_post_actions.ex:92
+#, elixir-autogen, elixir-format
+msgid "Thank you. This copy is gone for everyone on this vutuv."
+msgstr "Danke. Diese Kopie ist für alle auf diesem vutuv weg."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -165,7 +165,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4593
+#: lib/vutuv_web/components/post_components.ex:4613
 #: lib/vutuv_web/components/ui.ex:5042
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
@@ -213,7 +213,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4558
+#: lib/vutuv_web/components/post_components.ex:4578
 #: lib/vutuv_web/components/ui.ex:5033
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
@@ -657,7 +657,7 @@ msgstr ""
 #: lib/vutuv_web/live/search_live.ex:680
 #: lib/vutuv_web/live/shell_live.ex:1495
 #: lib/vutuv_web/live/shell_live.ex:1702
-#: lib/vutuv_web/live/tag_live/timeline.ex:352
+#: lib/vutuv_web/live/tag_live/timeline.ex:353
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:35
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:30
@@ -935,7 +935,7 @@ msgid "You follow back %{name}."
 msgstr ""
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:179
+#: lib/vutuv_web/live/post_live/feed.ex:180
 #: lib/vutuv_web/live/press_kit_live.ex:110
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
@@ -1189,7 +1189,7 @@ msgstr ""
 msgid "All tag urls"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5211
+#: lib/vutuv_web/components/post_components.ex:5231
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:643
@@ -1684,7 +1684,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:421
 #: lib/vutuv_web/live/organization_live/show.ex:602
 #: lib/vutuv_web/live/organization_live/show.ex:639
-#: lib/vutuv_web/live/post_live/feed.ex:1054
+#: lib/vutuv_web/live/post_live/feed.ex:1055
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
 #: lib/vutuv_web/templates/user/show.html.heex:1350
 #: lib/vutuv_web/views/user_html.ex:643
@@ -2091,7 +2091,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4590
+#: lib/vutuv_web/components/post_components.ex:4610
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2106,8 +2106,8 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:203
-#: lib/vutuv_web/live/post_live/feed.ex:365
-#: lib/vutuv_web/live/post_live/feed.ex:3536
+#: lib/vutuv_web/live/post_live/feed.ex:366
+#: lib/vutuv_web/live/post_live/feed.ex:3555
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1346
 #: lib/vutuv_web/live/shell_live.ex:1692
@@ -2136,8 +2136,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4536
-#: lib/vutuv_web/components/post_components.ex:4538
+#: lib/vutuv_web/components/post_components.ex:4556
+#: lib/vutuv_web/components/post_components.ex:4558
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2153,7 +2153,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3876
+#: lib/vutuv_web/live/post_live/feed.ex:3895
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2202,13 +2202,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5084
-#: lib/vutuv_web/components/post_components.ex:5088
+#: lib/vutuv_web/components/post_components.ex:5104
+#: lib/vutuv_web/components/post_components.ex:5108
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5085
+#: lib/vutuv_web/components/post_components.ex:5105
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2247,7 +2247,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2712
+#: lib/vutuv_web/live/post_live/feed.ex:2714
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2306,27 +2306,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4533
+#: lib/vutuv_web/components/post_components.ex:4553
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6851
+#: lib/vutuv_web/components/post_components.ex:6871
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6855
+#: lib/vutuv_web/components/post_components.ex:6875
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6853
+#: lib/vutuv_web/components/post_components.ex:6873
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6854
+#: lib/vutuv_web/components/post_components.ex:6874
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2373,7 +2373,7 @@ msgid "All posts"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2185
-#: lib/vutuv_web/components/post_components.ex:6954
+#: lib/vutuv_web/components/post_components.ex:6974
 #: lib/vutuv_web/components/ui.ex:4476
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2392,7 +2392,7 @@ msgid "Bookmarks"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2129
-#: lib/vutuv_web/components/post_components.ex:7195
+#: lib/vutuv_web/components/post_components.ex:7215
 #: lib/vutuv_web/components/ui.ex:4462
 #: lib/vutuv_web/notification_line.ex:317
 #: lib/vutuv_web/views/user_html.ex:486
@@ -2401,7 +2401,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1301
-#: lib/vutuv_web/components/post_components.ex:7205
+#: lib/vutuv_web/components/post_components.ex:7225
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
 #: lib/vutuv_web/live/shell_live.ex:1596
@@ -2422,13 +2422,13 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6942
+#: lib/vutuv_web/components/post_components.ex:6962
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2184
-#: lib/vutuv_web/components/post_components.ex:6953
+#: lib/vutuv_web/components/post_components.ex:6973
 #: lib/vutuv_web/live/post_live/saved.ex:822
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2436,26 +2436,26 @@ msgid "Remove bookmark"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2165
-#: lib/vutuv_web/components/post_components.ex:6938
+#: lib/vutuv_web/components/post_components.ex:6958
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2758
-#: lib/vutuv_web/components/post_components.ex:5957
+#: lib/vutuv_web/components/post_components.ex:5977
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2164
-#: lib/vutuv_web/components/post_components.ex:6937
+#: lib/vutuv_web/components/post_components.ex:6957
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2128
-#: lib/vutuv_web/components/post_components.ex:7194
+#: lib/vutuv_web/components/post_components.ex:7214
 #: lib/vutuv_web/live/post_live/saved.ex:821
 #: lib/vutuv_web/views/user_html.ex:486
 #, elixir-autogen, elixir-format
@@ -2470,7 +2470,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:476
 #: lib/vutuv_web/live/organization_live/show.ex:644
-#: lib/vutuv_web/live/post_live/feed.ex:1041
+#: lib/vutuv_web/live/post_live/feed.ex:1042
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:42
 #: lib/vutuv_web/views/user_html.ex:633
@@ -2483,7 +2483,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7249
+#: lib/vutuv_web/components/post_components.ex:7269
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2495,8 +2495,8 @@ msgid "Replies"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2374
-#: lib/vutuv_web/components/post_components.ex:7232
-#: lib/vutuv_web/components/post_components.ex:7233
+#: lib/vutuv_web/components/post_components.ex:7252
+#: lib/vutuv_web/components/post_components.ex:7253
 #: lib/vutuv_web/live/notification_live/index.ex:993
 #: lib/vutuv_web/live/post_live/reply.ex:49
 #: lib/vutuv_web/notification_line.ex:314
@@ -2504,7 +2504,7 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4492
+#: lib/vutuv_web/components/post_components.ex:4512
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2525,7 +2525,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4010
+#: lib/vutuv_web/components/post_components.ex:4030
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:63
 #: lib/vutuv_web/live/post_live/remote_reply.ex:61
 #: lib/vutuv_web/live/post_live/reply.ex:63
@@ -2533,14 +2533,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4464
+#: lib/vutuv_web/components/post_components.ex:4484
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4455
-#: lib/vutuv_web/components/post_components.ex:4484
-#: lib/vutuv_web/components/post_components.ex:4487
+#: lib/vutuv_web/components/post_components.ex:4475
+#: lib/vutuv_web/components/post_components.ex:4504
+#: lib/vutuv_web/components/post_components.ex:4507
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2786,7 +2786,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/live/job_board_live.ex:458
-#: lib/vutuv_web/live/post_live/feed.ex:1185
+#: lib/vutuv_web/live/post_live/feed.ex:1186
 #: lib/vutuv_web/templates/user/card_list.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -2840,7 +2840,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6852
+#: lib/vutuv_web/components/post_components.ex:6872
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4431
+#: lib/vutuv_web/components/post_components.ex:4451
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3152,8 +3152,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1466
 #: lib/vutuv_web/components/post_components.ex:3418
-#: lib/vutuv_web/components/post_components.ex:3605
-#: lib/vutuv_web/components/post_components.ex:4661
+#: lib/vutuv_web/components/post_components.ex:3610
+#: lib/vutuv_web/components/post_components.ex:4681
 #: lib/vutuv_web/live/organization_live/show.ex:684
 #: lib/vutuv_web/templates/user/show.html.heex:252
 #, elixir-autogen, elixir-format
@@ -4494,7 +4494,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3881
+#: lib/vutuv_web/live/post_live/feed.ex:3900
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -5371,9 +5371,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4741
-#: lib/vutuv_web/components/post_components.ex:5350
-#: lib/vutuv_web/components/post_components.ex:5688
+#: lib/vutuv_web/components/post_components.ex:4761
+#: lib/vutuv_web/components/post_components.ex:5370
+#: lib/vutuv_web/components/post_components.ex:5708
 #: lib/vutuv_web/live/notification_live/index.ex:1069
 #: lib/vutuv_web/views/user_html.ex:133
 #, elixir-autogen, elixir-format
@@ -5739,7 +5739,7 @@ msgid "Name (A-Z)"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:507
-#: lib/vutuv_web/live/tag_live/timeline.ex:448
+#: lib/vutuv_web/live/tag_live/timeline.ex:449
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr ""
@@ -5765,7 +5765,7 @@ msgid "Nothing here yet. People you like show up here."
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:508
-#: lib/vutuv_web/live/tag_live/timeline.ex:449
+#: lib/vutuv_web/live/tag_live/timeline.ex:450
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr ""
@@ -5787,7 +5787,7 @@ msgid "Search saved items"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:570
-#: lib/vutuv_web/live/tag_live/timeline.ex:368
+#: lib/vutuv_web/live/tag_live/timeline.ex:369
 #, elixir-autogen, elixir-format
 msgid "Sort"
 msgstr ""
@@ -6565,8 +6565,8 @@ msgid "Turn a switch off and the matching opt-out rides along on the pages and r
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3345
-#: lib/vutuv_web/components/post_components.ex:4614
-#: lib/vutuv_web/components/post_components.ex:4628
+#: lib/vutuv_web/components/post_components.ex:4634
+#: lib/vutuv_web/components/post_components.ex:4648
 #: lib/vutuv_web/components/ui.ex:3226
 #: lib/vutuv_web/live/fediverse_account_live.ex:437
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6594,7 +6594,7 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4614
+#: lib/vutuv_web/components/post_components.ex:4634
 #: lib/vutuv_web/components/ui.ex:3225
 #: lib/vutuv_web/live/fediverse_account_live.ex:435
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6788,7 +6788,7 @@ msgid "Filter"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:591
-#: lib/vutuv_web/live/tag_live/timeline.ex:334
+#: lib/vutuv_web/live/tag_live/timeline.ex:335
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr ""
@@ -7287,7 +7287,7 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:7105
+#: lib/vutuv_web/components/post_components.ex:7125
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #: lib/vutuv_web/live/shell_live.ex:1830
 #, elixir-autogen, elixir-format
@@ -7392,7 +7392,7 @@ msgstr ""
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/media_live.ex:270
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:4175
+#: lib/vutuv_web/live/post_live/feed.ex:4194
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #: lib/vutuv_web/live/press_kit_live.ex:1056
 #, elixir-autogen
@@ -7835,7 +7835,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
 #: lib/vutuv_web/live/job_board_live.ex:468
-#: lib/vutuv_web/live/post_live/feed.ex:1194
+#: lib/vutuv_web/live/post_live/feed.ex:1195
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr ""
@@ -7856,7 +7856,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/media_live.ex:146
 #: lib/vutuv_web/live/admin/user_live.ex:184
 #: lib/vutuv_web/live/job_board_live.ex:319
-#: lib/vutuv_web/live/tag_live/timeline.ex:398
+#: lib/vutuv_web/live/tag_live/timeline.ex:399
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr ""
@@ -8733,7 +8733,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5960
+#: lib/vutuv_web/components/post_components.ex:5980
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -11995,7 +11995,7 @@ msgid "Everyone (public)"
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:681
-#: lib/vutuv_web/live/tag_live/timeline.ex:379
+#: lib/vutuv_web/live/tag_live/timeline.ex:380
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
 #, elixir-autogen, elixir-format
@@ -12935,7 +12935,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3969
+#: lib/vutuv_web/components/post_components.ex:3989
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:788
 #: lib/vutuv_web/controllers/settings_controller.ex:806
@@ -13325,7 +13325,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:259
 #: lib/vutuv_web/agent_docs/text.ex:221
-#: lib/vutuv_web/live/tag_live/timeline.ex:282
+#: lib/vutuv_web/live/tag_live/timeline.ex:283
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
 msgstr ""
@@ -13377,7 +13377,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5556
 #: lib/vutuv_web/controllers/settings_controller.ex:643
-#: lib/vutuv_web/live/post_live/feed.ex:854
+#: lib/vutuv_web/live/post_live/feed.ex:855
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
@@ -13535,34 +13535,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6648
+#: lib/vutuv_web/components/post_components.ex:6668
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6605
+#: lib/vutuv_web/components/post_components.ex:6625
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6649
+#: lib/vutuv_web/components/post_components.ex:6669
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6651
+#: lib/vutuv_web/components/post_components.ex:6671
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6647
+#: lib/vutuv_web/components/post_components.ex:6667
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6604
+#: lib/vutuv_web/components/post_components.ex:6624
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13573,12 +13573,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6646
+#: lib/vutuv_web/components/post_components.ex:6666
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6650
+#: lib/vutuv_web/components/post_components.ex:6670
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13598,7 +13598,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6687
+#: lib/vutuv_web/components/post_components.ex:6707
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13606,30 +13606,30 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6717
+#: lib/vutuv_web/components/post_components.ex:6737
 #: lib/vutuv_web/components/ui.ex:3884
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6718
+#: lib/vutuv_web/components/post_components.ex:6738
 #: lib/vutuv_web/components/ui.ex:3885
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6716
+#: lib/vutuv_web/components/post_components.ex:6736
 #: lib/vutuv_web/components/ui.ex:3877
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6676
+#: lib/vutuv_web/components/post_components.ex:6696
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6723
+#: lib/vutuv_web/components/post_components.ex:6743
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13659,7 +13659,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6490
+#: lib/vutuv_web/components/post_components.ex:6510
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13702,7 +13702,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6481
+#: lib/vutuv_web/components/post_components.ex:6501
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14049,14 +14049,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4258
+#: lib/vutuv_web/components/post_components.ex:4278
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4281
+#: lib/vutuv_web/components/post_components.ex:4301
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14083,7 +14083,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7204
+#: lib/vutuv_web/components/post_components.ex:7224
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14260,7 +14260,7 @@ msgstr ""
 msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1254
+#: lib/vutuv_web/live/post_live/feed.ex:1255
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -14797,7 +14797,7 @@ msgstr ""
 msgid "ZIP or postal code"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:386
+#: lib/vutuv_web/live/tag_live/timeline.ex:387
 #: lib/vutuv_web/templates/education/form_content.html.heex:59
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:81
 #, elixir-autogen, elixir-format
@@ -15228,7 +15228,7 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7150
+#: lib/vutuv_web/components/post_components.ex:7170
 #: lib/vutuv_web/live/notification_live/index.ex:1592
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -15236,7 +15236,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:7154
+#: lib/vutuv_web/components/post_components.ex:7174
 #: lib/vutuv_web/live/notification_live/index.ex:1586
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15244,7 +15244,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:7158
+#: lib/vutuv_web/components/post_components.ex:7178
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15252,7 +15252,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1339
-#: lib/vutuv_web/components/post_components.ex:7109
+#: lib/vutuv_web/components/post_components.ex:7129
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15351,7 +15351,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1502
 #: lib/vutuv_web/components/post_components.ex:1733
 #: lib/vutuv_web/components/post_components.ex:3590
-#: lib/vutuv_web/components/post_components.ex:3827
+#: lib/vutuv_web/components/post_components.ex:3847
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "View the original"
@@ -15364,7 +15364,7 @@ msgstr ""
 msgid "What"
 msgstr ""
 
-#: lib/vutuv_web/live/remote_post_actions.ex:77
+#: lib/vutuv_web/live/remote_post_actions.ex:107
 #: lib/vutuv_web/live/remote_reply_actions.ex:61
 #, elixir-autogen, elixir-format
 msgid "You have reported a lot today. Please try again tomorrow."
@@ -15794,7 +15794,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/admin/media_live.ex:155
 #: lib/vutuv_web/live/fediverse_following_live.ex:351
-#: lib/vutuv_web/live/tag_live/timeline.ex:473
+#: lib/vutuv_web/live/tag_live/timeline.ex:474
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr ""
@@ -16014,22 +16014,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4443
+#: lib/vutuv_web/components/post_components.ex:4463
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4577
+#: lib/vutuv_web/components/post_components.ex:4597
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4585
+#: lib/vutuv_web/components/post_components.ex:4605
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4571
+#: lib/vutuv_web/components/post_components.ex:4591
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16152,19 +16152,19 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4022
+#: lib/vutuv_web/components/post_components.ex:4042
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5526
-#: lib/vutuv_web/components/press_kit_components.ex:521
+#: lib/vutuv_web/components/post_components.ex:5546
+#: lib/vutuv_web/components/press_kit_components.ex:526
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5754
-#: lib/vutuv_web/components/press_kit_components.ex:618
+#: lib/vutuv_web/components/post_components.ex:5774
+#: lib/vutuv_web/components/press_kit_components.ex:623
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16177,7 +16177,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1500
 #: lib/vutuv_web/agent_docs/text.ex:909
-#: lib/vutuv_web/components/post_components.ex:5836
+#: lib/vutuv_web/components/post_components.ex:5856
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr ""
@@ -16203,7 +16203,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4075
+#: lib/vutuv_web/components/post_components.ex:4095
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16223,7 +16223,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4066
+#: lib/vutuv_web/components/post_components.ex:4086
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16233,12 +16233,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4084
+#: lib/vutuv_web/components/post_components.ex:4104
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4018
+#: lib/vutuv_web/components/post_components.ex:4038
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16253,7 +16253,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4079
+#: lib/vutuv_web/components/post_components.ex:4099
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16263,7 +16263,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4032
+#: lib/vutuv_web/components/post_components.ex:4052
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16338,13 +16338,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1357
-#: lib/vutuv_web/components/post_components.ex:7147
+#: lib/vutuv_web/components/post_components.ex:7167
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1355
-#: lib/vutuv_web/components/post_components.ex:7144
+#: lib/vutuv_web/components/post_components.ex:7164
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16354,7 +16354,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7031
+#: lib/vutuv_web/components/post_components.ex:7051
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
@@ -16701,12 +16701,12 @@ msgstr ""
 msgid "Only for this account's followers"
 msgstr ""
 
-#: lib/vutuv_web/live/remote_post_actions.ex:68
+#: lib/vutuv_web/live/remote_post_actions.ex:63
 #, elixir-autogen, elixir-format
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3826
+#: lib/vutuv_web/components/post_components.ex:3846
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16731,12 +16731,12 @@ msgstr ""
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3767
+#: lib/vutuv_web/components/post_components.ex:3787
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr ""
 
-#: lib/vutuv_web/live/remote_post_actions.ex:157
+#: lib/vutuv_web/live/remote_post_actions.ex:189
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
 msgstr ""
@@ -16747,7 +16747,6 @@ msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3413
-#: lib/vutuv_web/components/post_components.ex:3600
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -16862,12 +16861,12 @@ msgstr ""
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3925
+#: lib/vutuv_web/components/post_components.ex:3945
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3931
+#: lib/vutuv_web/components/post_components.ex:3951
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr ""
@@ -16877,7 +16876,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4070
+#: lib/vutuv_web/components/post_components.ex:4090
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17505,7 +17504,7 @@ msgstr ""
 msgid "View the conversation"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:285
+#: lib/vutuv_web/live/tag_live/timeline.ex:286
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "%{formatted} post"
@@ -17513,32 +17512,32 @@ msgid_plural "%{formatted} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:450
+#: lib/vutuv_web/live/tag_live/timeline.ex:451
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:481
+#: lib/vutuv_web/live/tag_live/timeline.ex:482
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:479
+#: lib/vutuv_web/live/tag_live/timeline.ex:480
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:476
+#: lib/vutuv_web/live/tag_live/timeline.ex:477
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:361
+#: lib/vutuv_web/live/tag_live/timeline.ex:362
 #, elixir-autogen, elixir-format
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3928
+#: lib/vutuv_web/components/post_components.ex:3948
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -17610,19 +17609,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6130
+#: lib/vutuv_web/components/post_components.ex:6150
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6132
+#: lib/vutuv_web/components/post_components.ex:6152
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6143
+#: lib/vutuv_web/components/post_components.ex:6163
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -17794,7 +17793,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3899
+#: lib/vutuv_web/live/post_live/feed.ex:3918
 #: lib/vutuv_web/live/reference_check_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -19205,7 +19204,7 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3958
+#: lib/vutuv_web/components/post_components.ex:3978
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -20073,27 +20072,27 @@ msgstr ""
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6024
+#: lib/vutuv_web/components/post_components.ex:6044
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6060
+#: lib/vutuv_web/components/post_components.ex:6080
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6069
+#: lib/vutuv_web/components/post_components.ex:6089
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6072
+#: lib/vutuv_web/components/post_components.ex:6092
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6049
+#: lib/vutuv_web/components/post_components.ex:6069
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
@@ -20103,7 +20102,7 @@ msgstr ""
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6039
+#: lib/vutuv_web/components/post_components.ex:6059
 #: lib/vutuv_web/components/ui.ex:5549
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -20232,20 +20231,20 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5802
+#: lib/vutuv_web/components/post_components.ex:5822
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5799
+#: lib/vutuv_web/components/post_components.ex:5819
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2912
-#: lib/vutuv_web/components/post_components.ex:4868
+#: lib/vutuv_web/components/post_components.ex:4888
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -20263,7 +20262,7 @@ msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:431
-#: lib/vutuv_web/live/post_live/feed.ex:1131
+#: lib/vutuv_web/live/post_live/feed.ex:1132
 #: lib/vutuv_web/views/user_html.ex:355
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -20763,7 +20762,7 @@ msgstr ""
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/remote_post_actions.ex:175
+#: lib/vutuv_web/live/remote_post_actions.ex:208
 #, elixir-autogen, elixir-format
 msgid "Unfollowed. Their posts leave your feed."
 msgstr ""
@@ -20838,7 +20837,7 @@ msgstr ""
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:340
+#: lib/vutuv_web/live/tag_live/timeline.ex:341
 #, elixir-autogen, elixir-format
 msgid "%{formatted} active"
 msgstr ""
@@ -20883,12 +20882,12 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4069
+#: lib/vutuv_web/live/post_live/feed.ex:4088
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:855
+#: lib/vutuv_web/live/post_live/feed.ex:856
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr ""
@@ -20934,7 +20933,7 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1123
+#: lib/vutuv_web/live/post_live/feed.ex:1124
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
@@ -21286,7 +21285,7 @@ msgstr ""
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:980
+#: lib/vutuv_web/live/post_live/feed.ex:981
 #: lib/vutuv_web/live/post_live/filter_band.ex:350
 #, elixir-autogen, elixir-format
 msgid "A photo"
@@ -21302,7 +21301,7 @@ msgstr ""
 msgid "A–Z"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1081
+#: lib/vutuv_web/live/post_live/feed.ex:1082
 #, elixir-autogen, elixir-format
 msgid "Browse the tags"
 msgstr ""
@@ -21317,7 +21316,7 @@ msgstr ""
 msgid "Clear all"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:892
+#: lib/vutuv_web/live/post_live/feed.ex:893
 #, elixir-autogen, elixir-format
 msgid "Drag, or use the arrow keys"
 msgstr ""
@@ -21332,13 +21331,13 @@ msgstr ""
 msgid "Find an account or a server …"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:916
+#: lib/vutuv_web/live/post_live/feed.ex:917
 #, elixir-autogen, elixir-format
 msgid "Fold %{card}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1052
 #: lib/vutuv_web/live/post_live/feed.ex:1053
+#: lib/vutuv_web/live/post_live/feed.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Follow a tag …"
 msgstr ""
@@ -21355,19 +21354,19 @@ msgstr ""
 msgid "Hide a word or a whole phrase …"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:853
-#: lib/vutuv_web/live/post_live/feed.ex:4232
+#: lib/vutuv_web/live/post_live/feed.ex:854
+#: lib/vutuv_web/live/post_live/feed.ex:4251
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:852
-#: lib/vutuv_web/live/post_live/feed.ex:4221
+#: lib/vutuv_web/live/post_live/feed.ex:853
+#: lib/vutuv_web/live/post_live/feed.ex:4240
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1087
+#: lib/vutuv_web/live/post_live/feed.ex:1088
 #: lib/vutuv_web/live/post_live/filter_band.ex:394
 #, elixir-autogen, elixir-format
 msgid "In your feed right now:"
@@ -21383,7 +21382,7 @@ msgstr ""
 msgid "More of your %{formatted} accounts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:891
+#: lib/vutuv_web/live/post_live/feed.ex:892
 #, elixir-autogen, elixir-format
 msgid "Move %{card}"
 msgstr ""
@@ -21394,12 +21393,12 @@ msgstr ""
 msgid "No account found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1076
+#: lib/vutuv_web/live/post_live/feed.ex:1077
 #, elixir-autogen, elixir-format
 msgid "No tag called %{name} yet."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:845
+#: lib/vutuv_web/live/post_live/feed.ex:846
 #, elixir-autogen, elixir-format
 msgid "Not read yet"
 msgstr ""
@@ -21429,13 +21428,13 @@ msgstr ""
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4095
+#: lib/vutuv_web/live/post_live/feed.ex:4114
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:937
 #: lib/vutuv_web/live/post_live/feed.ex:938
+#: lib/vutuv_web/live/post_live/feed.ex:939
 #, elixir-autogen, elixir-format
 msgid "Remove %{card}"
 msgstr ""
@@ -21467,8 +21466,8 @@ msgstr ""
 msgid "Show posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:851
-#: lib/vutuv_web/live/post_live/feed.ex:4187
+#: lib/vutuv_web/live/post_live/feed.ex:852
+#: lib/vutuv_web/live/post_live/feed.ex:4206
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr ""
@@ -21478,12 +21477,12 @@ msgstr ""
 msgid "Switching off means muting, not unfollowing. You stay a follower, the posts just stop reaching your feed: permanently and on every device, until you switch them back on here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:915
+#: lib/vutuv_web/live/post_live/feed.ex:916
 #, elixir-autogen, elixir-format
 msgid "Unfold %{card}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1042
+#: lib/vutuv_web/live/post_live/feed.ex:1043
 #, elixir-autogen, elixir-format
 msgid "Unfollow the tag %{tag}"
 msgstr ""
@@ -21507,20 +21506,20 @@ msgid_plural "and %{formatted} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3653
-#: lib/vutuv_web/live/post_live/feed.ex:3680
+#: lib/vutuv_web/live/post_live/feed.ex:3672
+#: lib/vutuv_web/live/post_live/feed.ex:3699
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1262
+#: lib/vutuv_web/live/post_live/feed.ex:1263
 #, elixir-autogen, elixir-format
 msgctxt "filtered post"
 msgid "Hidden:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:990
+#: lib/vutuv_web/live/post_live/feed.ex:991
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} post in the feed"
 msgid_plural "Show %{formatted} posts in the feed"
@@ -21570,7 +21569,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3856
+#: lib/vutuv_web/live/post_live/feed.ex:3875
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr ""
@@ -21580,7 +21579,7 @@ msgstr ""
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3902
+#: lib/vutuv_web/live/post_live/feed.ex:3921
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -21602,7 +21601,7 @@ msgstr ""
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3852
+#: lib/vutuv_web/live/post_live/feed.ex:3871
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
@@ -21689,14 +21688,14 @@ msgstr ""
 msgid "Page management"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2706
+#: lib/vutuv_web/live/post_live/feed.ex:2708
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3694
+#: lib/vutuv_web/components/post_components.ex:3714
 #, elixir-autogen, elixir-format
 msgid "Quoted post"
 msgstr ""
@@ -21721,7 +21720,7 @@ msgstr ""
 msgid "{used} of {max} mentions"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2818
+#: lib/vutuv_web/live/post_live/feed.ex:2820
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr ""
@@ -21752,7 +21751,7 @@ msgstr ""
 msgid "only %{account}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7492
+#: lib/vutuv_web/components/post_components.ex:7512
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -21936,7 +21935,7 @@ msgctxt "phone tab bar"
 msgid "Write"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3990
+#: lib/vutuv_web/live/post_live/feed.ex:4009
 #: lib/vutuv_web/live/post_rewrites_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "%{formatted} rule"
@@ -22006,7 +22005,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1456
 #: lib/vutuv_web/components/post_components.ex:3406
-#: lib/vutuv_web/components/post_components.ex:4658
+#: lib/vutuv_web/components/post_components.ex:4678
 #: lib/vutuv_web/components/ui.ex:5541
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
@@ -22237,7 +22236,7 @@ msgstr[1] ""
 msgid "Last 30 days: %{parts}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5220
+#: lib/vutuv_web/components/post_components.ex:5240
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Less"
@@ -22552,7 +22551,7 @@ msgid "Hidden. What they pass on stays out of your feed; their own posts do not.
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3378
-#: lib/vutuv_web/components/post_components.ex:4652
+#: lib/vutuv_web/components/post_components.ex:4672
 #, elixir-autogen, elixir-format
 msgid "Hide reposts"
 msgstr ""
@@ -22733,8 +22732,8 @@ msgstr ""
 msgid "Posts loaded at once"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3926
-#: lib/vutuv_web/live/post_live/feed.ex:3930
+#: lib/vutuv_web/live/post_live/feed.ex:3945
+#: lib/vutuv_web/live/post_live/feed.ex:3949
 #, elixir-autogen, elixir-format
 msgid "Posts per page"
 msgstr ""
@@ -22749,60 +22748,60 @@ msgstr ""
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7483
-#: lib/vutuv_web/components/post_components.ex:7484
+#: lib/vutuv_web/components/post_components.ex:7503
+#: lib/vutuv_web/components/post_components.ex:7504
 #, elixir-autogen, elixir-format
 msgid "A word or phrase …"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7511
+#: lib/vutuv_web/components/post_components.ex:7531
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3987
-#: lib/vutuv_web/live/post_live/feed.ex:4151
-#: lib/vutuv_web/live/post_live/feed.ex:4160
+#: lib/vutuv_web/live/post_live/feed.ex:4006
+#: lib/vutuv_web/live/post_live/feed.ex:4170
+#: lib/vutuv_web/live/post_live/feed.ex:4179
 #, elixir-autogen, elixir-format
 msgid "Hidden"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4125
+#: lib/vutuv_web/live/post_live/feed.ex:4144
 #, elixir-autogen, elixir-format
 msgid "Hide something from your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7429
+#: lib/vutuv_web/components/post_components.ex:7449
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4166
+#: lib/vutuv_web/live/post_live/feed.ex:4185
 #, elixir-autogen, elixir-format
 msgid "Whatever these match is folded to a single line in your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4186
+#: lib/vutuv_web/live/post_live/feed.ex:4205
 #, elixir-autogen, elixir-format
 msgid "Words & tags"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7515
+#: lib/vutuv_web/components/post_components.ex:7535
 #, elixir-autogen, elixir-format
 msgid "everyone"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7518
+#: lib/vutuv_web/components/post_components.ex:7538
 #, elixir-autogen, elixir-format
 msgid "only %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7487
+#: lib/vutuv_web/components/post_components.ex:7507
 #, elixir-autogen, elixir-format
 msgid "this word"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7528
+#: lib/vutuv_web/components/post_components.ex:7548
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr ""
@@ -22854,7 +22853,7 @@ msgstr ""
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6833
+#: lib/vutuv_web/components/post_components.ex:6853
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr ""
@@ -22945,7 +22944,7 @@ msgid "Hidden. What other people pass on of them stays out of your feed; their o
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3364
-#: lib/vutuv_web/components/post_components.ex:4640
+#: lib/vutuv_web/components/post_components.ex:4660
 #, elixir-autogen, elixir-format
 msgid "Hide when others repost them"
 msgstr ""
@@ -23660,13 +23659,13 @@ msgstr ""
 msgid "“%{note}”"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5398
-#: lib/vutuv_web/components/press_kit_components.ex:211
+#: lib/vutuv_web/components/post_components.ex:5418
+#: lib/vutuv_web/components/press_kit_components.ex:216
 #, elixir-autogen, elixir-format
 msgid "Show these photos larger"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5584
+#: lib/vutuv_web/components/post_components.ex:5604
 #, elixir-autogen, elixir-format
 msgid "Show this photo larger"
 msgstr ""
@@ -23756,7 +23755,7 @@ msgstr ""
 msgid "Light"
 msgstr ""
 
-#: lib/vutuv/press_kit.ex:251
+#: lib/vutuv/press_kit.ex:321
 #, elixir-autogen, elixir-format
 msgid "Logo variant"
 msgstr ""
@@ -23805,7 +23804,7 @@ msgstr ""
 msgid "Please confirm the rights first, then choose the file."
 msgstr ""
 
-#: lib/vutuv/press_kit.ex:251
+#: lib/vutuv/press_kit.ex:321
 #, elixir-autogen, elixir-format
 msgid "Press photo"
 msgstr ""
@@ -23891,18 +23890,18 @@ msgstr[1] ""
 msgid "Credit: %{credit}"
 msgstr ""
 
-#: lib/vutuv_web/components/press_kit_components.ex:375
-#: lib/vutuv_web/components/press_kit_components.ex:378
+#: lib/vutuv_web/components/press_kit_components.ex:380
+#: lib/vutuv_web/components/press_kit_components.ex:383
 #, elixir-autogen, elixir-format
 msgid "Download %{format}"
 msgstr ""
 
-#: lib/vutuv_web/components/press_kit_components.ex:331
+#: lib/vutuv_web/components/press_kit_components.ex:336
 #, elixir-autogen, elixir-format
 msgid "Download photo"
 msgstr ""
 
-#: lib/vutuv/press_kit.ex:715
+#: lib/vutuv/press_kit.ex:785
 #, elixir-autogen, elixir-format
 msgid "Free for editorial use with credit."
 msgstr ""
@@ -23912,7 +23911,7 @@ msgstr ""
 msgid "PNG version"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/press_kit_doc.ex:55
+#: lib/vutuv_web/agent_docs/press_kit_doc.ex:58
 #, elixir-autogen, elixir-format
 msgid "Press pictures %{name} offers for download, free for editorial use with credit."
 msgstr ""
@@ -23947,7 +23946,7 @@ msgstr ""
 msgid "What a journalist writing about this page may download: photos in print quality and its logo as a file. Everything here is public and free for editorial use as long as the credit is shown."
 msgstr ""
 
-#: lib/vutuv_web/components/press_kit_components.ex:565
+#: lib/vutuv_web/components/press_kit_components.ex:570
 #: lib/vutuv_web/components/ui.ex:3281
 #, elixir-autogen, elixir-format
 msgid "Report this picture"
@@ -24049,7 +24048,7 @@ msgid "nobody"
 msgstr ""
 
 #: lib/vutuv_web/components/press_kit_components.ex:120
-#: lib/vutuv_web/components/press_kit_components.ex:176
+#: lib/vutuv_web/components/press_kit_components.ex:181
 #, elixir-autogen, elixir-format
 msgid "All Media Kit files"
 msgstr ""
@@ -24069,7 +24068,7 @@ msgstr ""
 msgid "Media Kit"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/press_kit_doc.ex:53
+#: lib/vutuv_web/agent_docs/press_kit_doc.ex:56
 #: lib/vutuv_web/views/press_kit_html.ex:32
 #, elixir-autogen, elixir-format
 msgid "Media Kit of %{name}"
@@ -24100,8 +24099,8 @@ msgstr ""
 msgid "press kit media journalist photographer download original print logo svg credit copyright presse pressefotos pressemappe medienkit mediakit fotos logo herunterladen bildnachweis"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4556
-#: lib/vutuv_web/components/post_components.ex:4606
+#: lib/vutuv_web/components/post_components.ex:4576
+#: lib/vutuv_web/components/post_components.ex:4626
 #, elixir-autogen, elixir-format
 msgid "Copy link to post"
 msgstr ""
@@ -24204,7 +24203,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:121
 #: lib/vutuv_web/agent_docs/text.ex:412
-#: lib/vutuv_web/components/press_kit_components.ex:269
+#: lib/vutuv_web/components/press_kit_components.ex:274
 #, elixir-autogen, elixir-format
 msgid "About %{name}"
 msgstr ""
@@ -24229,12 +24228,12 @@ msgstr ""
 msgid "As long as you like. The whole portrait."
 msgstr ""
 
-#: lib/vutuv/press_kit.ex:460
+#: lib/vutuv/press_kit.ex:530
 #, elixir-autogen, elixir-format
 msgid "Long version"
 msgstr ""
 
-#: lib/vutuv/press_kit.ex:459
+#: lib/vutuv/press_kit.ex:529
 #, elixir-autogen, elixir-format
 msgid "Medium version"
 msgstr ""
@@ -24244,12 +24243,12 @@ msgstr ""
 msgid "Nothing written yet."
 msgstr ""
 
-#: lib/vutuv/press_kit.ex:458
+#: lib/vutuv/press_kit.ex:528
 #, elixir-autogen, elixir-format
 msgid "Short version"
 msgstr ""
 
-#: lib/vutuv_web/components/press_kit_components.ex:272
+#: lib/vutuv_web/components/press_kit_components.ex:277
 #, elixir-autogen, elixir-format
 msgid "Take whichever length fits the space you have. Each one stands on its own."
 msgstr ""
@@ -24379,7 +24378,7 @@ msgstr ""
 msgid "Your post appears as soon as the video is ready"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3626
+#: lib/vutuv_web/components/post_components.ex:3631
 #, elixir-autogen, elixir-format
 msgid "Found through %{server}"
 msgstr ""
@@ -24666,4 +24665,24 @@ msgstr ""
 #: lib/vutuv_web/live/message_live/index.ex:627
 #, elixir-autogen, elixir-format
 msgid "You can only send files to members you are connected with."
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:3652
+#, elixir-autogen, elixir-format
+msgid "Report this post as not appropriate? Every copy of it disappears right away, for everyone on this vutuv."
+msgstr ""
+
+#: lib/vutuv_web/live/remote_post_actions.ex:89
+#, elixir-autogen, elixir-format
+msgid "Thank you. Every copy on this vutuv is gone."
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:3656
+#, elixir-autogen, elixir-format
+msgid "Report this post as not appropriate? This copy disappears right away, for everyone on this vutuv. Copies other servers sent us stay."
+msgstr ""
+
+#: lib/vutuv_web/live/remote_post_actions.ex:92
+#, elixir-autogen, elixir-format
+msgid "Thank you. This copy is gone for everyone on this vutuv."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -163,7 +163,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4593
+#: lib/vutuv_web/components/post_components.ex:4613
 #: lib/vutuv_web/components/ui.ex:5042
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
@@ -211,7 +211,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4558
+#: lib/vutuv_web/components/post_components.ex:4578
 #: lib/vutuv_web/components/ui.ex:5033
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
@@ -655,7 +655,7 @@ msgstr ""
 #: lib/vutuv_web/live/search_live.ex:680
 #: lib/vutuv_web/live/shell_live.ex:1495
 #: lib/vutuv_web/live/shell_live.ex:1702
-#: lib/vutuv_web/live/tag_live/timeline.ex:352
+#: lib/vutuv_web/live/tag_live/timeline.ex:353
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:35
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:30
@@ -933,7 +933,7 @@ msgid "You follow back %{name}."
 msgstr ""
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:179
+#: lib/vutuv_web/live/post_live/feed.ex:180
 #: lib/vutuv_web/live/press_kit_live.ex:110
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
@@ -1187,7 +1187,7 @@ msgstr ""
 msgid "All tag urls"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5211
+#: lib/vutuv_web/components/post_components.ex:5231
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:643
@@ -1682,7 +1682,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:421
 #: lib/vutuv_web/live/organization_live/show.ex:602
 #: lib/vutuv_web/live/organization_live/show.ex:639
-#: lib/vutuv_web/live/post_live/feed.ex:1054
+#: lib/vutuv_web/live/post_live/feed.ex:1055
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
 #: lib/vutuv_web/templates/user/show.html.heex:1350
 #: lib/vutuv_web/views/user_html.ex:643
@@ -2089,7 +2089,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4590
+#: lib/vutuv_web/components/post_components.ex:4610
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2104,8 +2104,8 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:203
-#: lib/vutuv_web/live/post_live/feed.ex:365
-#: lib/vutuv_web/live/post_live/feed.ex:3536
+#: lib/vutuv_web/live/post_live/feed.ex:366
+#: lib/vutuv_web/live/post_live/feed.ex:3555
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1346
 #: lib/vutuv_web/live/shell_live.ex:1692
@@ -2134,8 +2134,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4536
-#: lib/vutuv_web/components/post_components.ex:4538
+#: lib/vutuv_web/components/post_components.ex:4556
+#: lib/vutuv_web/components/post_components.ex:4558
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2151,7 +2151,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3876
+#: lib/vutuv_web/live/post_live/feed.ex:3895
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2200,13 +2200,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5084
-#: lib/vutuv_web/components/post_components.ex:5088
+#: lib/vutuv_web/components/post_components.ex:5104
+#: lib/vutuv_web/components/post_components.ex:5108
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5085
+#: lib/vutuv_web/components/post_components.ex:5105
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2245,7 +2245,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2712
+#: lib/vutuv_web/live/post_live/feed.ex:2714
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2304,27 +2304,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4533
+#: lib/vutuv_web/components/post_components.ex:4553
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6851
+#: lib/vutuv_web/components/post_components.ex:6871
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6855
+#: lib/vutuv_web/components/post_components.ex:6875
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6853
+#: lib/vutuv_web/components/post_components.ex:6873
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6854
+#: lib/vutuv_web/components/post_components.ex:6874
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2371,7 +2371,7 @@ msgid "All posts"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2185
-#: lib/vutuv_web/components/post_components.ex:6954
+#: lib/vutuv_web/components/post_components.ex:6974
 #: lib/vutuv_web/components/ui.ex:4476
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2390,7 +2390,7 @@ msgid "Bookmarks"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2129
-#: lib/vutuv_web/components/post_components.ex:7195
+#: lib/vutuv_web/components/post_components.ex:7215
 #: lib/vutuv_web/components/ui.ex:4462
 #: lib/vutuv_web/notification_line.ex:317
 #: lib/vutuv_web/views/user_html.ex:486
@@ -2399,7 +2399,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1301
-#: lib/vutuv_web/components/post_components.ex:7205
+#: lib/vutuv_web/components/post_components.ex:7225
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
 #: lib/vutuv_web/live/shell_live.ex:1596
@@ -2420,13 +2420,13 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6942
+#: lib/vutuv_web/components/post_components.ex:6962
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2184
-#: lib/vutuv_web/components/post_components.ex:6953
+#: lib/vutuv_web/components/post_components.ex:6973
 #: lib/vutuv_web/live/post_live/saved.ex:822
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2434,26 +2434,26 @@ msgid "Remove bookmark"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2165
-#: lib/vutuv_web/components/post_components.ex:6938
+#: lib/vutuv_web/components/post_components.ex:6958
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2758
-#: lib/vutuv_web/components/post_components.ex:5957
+#: lib/vutuv_web/components/post_components.ex:5977
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2164
-#: lib/vutuv_web/components/post_components.ex:6937
+#: lib/vutuv_web/components/post_components.ex:6957
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2128
-#: lib/vutuv_web/components/post_components.ex:7194
+#: lib/vutuv_web/components/post_components.ex:7214
 #: lib/vutuv_web/live/post_live/saved.ex:821
 #: lib/vutuv_web/views/user_html.ex:486
 #, elixir-autogen, elixir-format
@@ -2468,7 +2468,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:476
 #: lib/vutuv_web/live/organization_live/show.ex:644
-#: lib/vutuv_web/live/post_live/feed.ex:1041
+#: lib/vutuv_web/live/post_live/feed.ex:1042
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:42
 #: lib/vutuv_web/views/user_html.ex:633
@@ -2481,7 +2481,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7249
+#: lib/vutuv_web/components/post_components.ex:7269
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2493,8 +2493,8 @@ msgid "Replies"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2374
-#: lib/vutuv_web/components/post_components.ex:7232
-#: lib/vutuv_web/components/post_components.ex:7233
+#: lib/vutuv_web/components/post_components.ex:7252
+#: lib/vutuv_web/components/post_components.ex:7253
 #: lib/vutuv_web/live/notification_live/index.ex:993
 #: lib/vutuv_web/live/post_live/reply.ex:49
 #: lib/vutuv_web/notification_line.ex:314
@@ -2502,7 +2502,7 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4492
+#: lib/vutuv_web/components/post_components.ex:4512
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2523,7 +2523,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4010
+#: lib/vutuv_web/components/post_components.ex:4030
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:63
 #: lib/vutuv_web/live/post_live/remote_reply.ex:61
 #: lib/vutuv_web/live/post_live/reply.ex:63
@@ -2531,14 +2531,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4464
+#: lib/vutuv_web/components/post_components.ex:4484
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4455
-#: lib/vutuv_web/components/post_components.ex:4484
-#: lib/vutuv_web/components/post_components.ex:4487
+#: lib/vutuv_web/components/post_components.ex:4475
+#: lib/vutuv_web/components/post_components.ex:4504
+#: lib/vutuv_web/components/post_components.ex:4507
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2784,7 +2784,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/live/job_board_live.ex:458
-#: lib/vutuv_web/live/post_live/feed.ex:1185
+#: lib/vutuv_web/live/post_live/feed.ex:1186
 #: lib/vutuv_web/templates/user/card_list.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -2838,7 +2838,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6852
+#: lib/vutuv_web/components/post_components.ex:6872
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3090,7 +3090,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4431
+#: lib/vutuv_web/components/post_components.ex:4451
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3150,8 +3150,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1466
 #: lib/vutuv_web/components/post_components.ex:3418
-#: lib/vutuv_web/components/post_components.ex:3605
-#: lib/vutuv_web/components/post_components.ex:4661
+#: lib/vutuv_web/components/post_components.ex:3610
+#: lib/vutuv_web/components/post_components.ex:4681
 #: lib/vutuv_web/live/organization_live/show.ex:684
 #: lib/vutuv_web/templates/user/show.html.heex:252
 #, elixir-autogen, elixir-format
@@ -4492,7 +4492,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3881
+#: lib/vutuv_web/live/post_live/feed.ex:3900
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -5369,9 +5369,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4741
-#: lib/vutuv_web/components/post_components.ex:5350
-#: lib/vutuv_web/components/post_components.ex:5688
+#: lib/vutuv_web/components/post_components.ex:4761
+#: lib/vutuv_web/components/post_components.ex:5370
+#: lib/vutuv_web/components/post_components.ex:5708
 #: lib/vutuv_web/live/notification_live/index.ex:1069
 #: lib/vutuv_web/views/user_html.ex:133
 #, elixir-autogen, elixir-format
@@ -5737,7 +5737,7 @@ msgid "Name (A-Z)"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:507
-#: lib/vutuv_web/live/tag_live/timeline.ex:448
+#: lib/vutuv_web/live/tag_live/timeline.ex:449
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr ""
@@ -5763,7 +5763,7 @@ msgid "Nothing here yet. People you like show up here."
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:508
-#: lib/vutuv_web/live/tag_live/timeline.ex:449
+#: lib/vutuv_web/live/tag_live/timeline.ex:450
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr ""
@@ -5785,7 +5785,7 @@ msgid "Search saved items"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:570
-#: lib/vutuv_web/live/tag_live/timeline.ex:368
+#: lib/vutuv_web/live/tag_live/timeline.ex:369
 #, elixir-autogen, elixir-format
 msgid "Sort"
 msgstr ""
@@ -6563,8 +6563,8 @@ msgid "Turn a switch off and the matching opt-out rides along on the pages and r
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3345
-#: lib/vutuv_web/components/post_components.ex:4614
-#: lib/vutuv_web/components/post_components.ex:4628
+#: lib/vutuv_web/components/post_components.ex:4634
+#: lib/vutuv_web/components/post_components.ex:4648
 #: lib/vutuv_web/components/ui.ex:3226
 #: lib/vutuv_web/live/fediverse_account_live.ex:437
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6592,7 +6592,7 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4614
+#: lib/vutuv_web/components/post_components.ex:4634
 #: lib/vutuv_web/components/ui.ex:3225
 #: lib/vutuv_web/live/fediverse_account_live.ex:435
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6786,7 +6786,7 @@ msgid "Filter"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:591
-#: lib/vutuv_web/live/tag_live/timeline.ex:334
+#: lib/vutuv_web/live/tag_live/timeline.ex:335
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr ""
@@ -7285,7 +7285,7 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:7105
+#: lib/vutuv_web/components/post_components.ex:7125
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #: lib/vutuv_web/live/shell_live.ex:1830
 #, elixir-autogen, elixir-format
@@ -7390,7 +7390,7 @@ msgstr ""
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/media_live.ex:270
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:4175
+#: lib/vutuv_web/live/post_live/feed.ex:4194
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #: lib/vutuv_web/live/press_kit_live.ex:1056
 #, elixir-autogen
@@ -7833,7 +7833,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
 #: lib/vutuv_web/live/job_board_live.ex:468
-#: lib/vutuv_web/live/post_live/feed.ex:1194
+#: lib/vutuv_web/live/post_live/feed.ex:1195
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr ""
@@ -7854,7 +7854,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/media_live.ex:146
 #: lib/vutuv_web/live/admin/user_live.ex:184
 #: lib/vutuv_web/live/job_board_live.ex:319
-#: lib/vutuv_web/live/tag_live/timeline.ex:398
+#: lib/vutuv_web/live/tag_live/timeline.ex:399
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr ""
@@ -8731,7 +8731,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5960
+#: lib/vutuv_web/components/post_components.ex:5980
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -11993,7 +11993,7 @@ msgid "Everyone (public)"
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:681
-#: lib/vutuv_web/live/tag_live/timeline.ex:379
+#: lib/vutuv_web/live/tag_live/timeline.ex:380
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
 #, elixir-autogen, elixir-format
@@ -12933,7 +12933,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3969
+#: lib/vutuv_web/components/post_components.ex:3989
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:788
 #: lib/vutuv_web/controllers/settings_controller.ex:806
@@ -13323,7 +13323,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:259
 #: lib/vutuv_web/agent_docs/text.ex:221
-#: lib/vutuv_web/live/tag_live/timeline.ex:282
+#: lib/vutuv_web/live/tag_live/timeline.ex:283
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
 msgstr ""
@@ -13375,7 +13375,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5556
 #: lib/vutuv_web/controllers/settings_controller.ex:643
-#: lib/vutuv_web/live/post_live/feed.ex:854
+#: lib/vutuv_web/live/post_live/feed.ex:855
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
@@ -13533,34 +13533,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6648
+#: lib/vutuv_web/components/post_components.ex:6668
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6605
+#: lib/vutuv_web/components/post_components.ex:6625
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6649
+#: lib/vutuv_web/components/post_components.ex:6669
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6651
+#: lib/vutuv_web/components/post_components.ex:6671
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6647
+#: lib/vutuv_web/components/post_components.ex:6667
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6604
+#: lib/vutuv_web/components/post_components.ex:6624
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13571,12 +13571,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6646
+#: lib/vutuv_web/components/post_components.ex:6666
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6650
+#: lib/vutuv_web/components/post_components.ex:6670
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13596,7 +13596,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6687
+#: lib/vutuv_web/components/post_components.ex:6707
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13604,30 +13604,30 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6717
+#: lib/vutuv_web/components/post_components.ex:6737
 #: lib/vutuv_web/components/ui.ex:3884
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6718
+#: lib/vutuv_web/components/post_components.ex:6738
 #: lib/vutuv_web/components/ui.ex:3885
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6716
+#: lib/vutuv_web/components/post_components.ex:6736
 #: lib/vutuv_web/components/ui.ex:3877
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6676
+#: lib/vutuv_web/components/post_components.ex:6696
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6723
+#: lib/vutuv_web/components/post_components.ex:6743
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13657,7 +13657,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6490
+#: lib/vutuv_web/components/post_components.ex:6510
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13700,7 +13700,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6481
+#: lib/vutuv_web/components/post_components.ex:6501
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14047,14 +14047,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4258
+#: lib/vutuv_web/components/post_components.ex:4278
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4281
+#: lib/vutuv_web/components/post_components.ex:4301
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14081,7 +14081,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7204
+#: lib/vutuv_web/components/post_components.ex:7224
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14258,7 +14258,7 @@ msgstr ""
 msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1254
+#: lib/vutuv_web/live/post_live/feed.ex:1255
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -14795,7 +14795,7 @@ msgstr ""
 msgid "ZIP or postal code"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:386
+#: lib/vutuv_web/live/tag_live/timeline.ex:387
 #: lib/vutuv_web/templates/education/form_content.html.heex:59
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:81
 #, elixir-autogen, elixir-format
@@ -15226,7 +15226,7 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7150
+#: lib/vutuv_web/components/post_components.ex:7170
 #: lib/vutuv_web/live/notification_live/index.ex:1592
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
@@ -15234,7 +15234,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:7154
+#: lib/vutuv_web/components/post_components.ex:7174
 #: lib/vutuv_web/live/notification_live/index.ex:1586
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15242,7 +15242,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:7158
+#: lib/vutuv_web/components/post_components.ex:7178
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15250,7 +15250,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1339
-#: lib/vutuv_web/components/post_components.ex:7109
+#: lib/vutuv_web/components/post_components.ex:7129
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15349,7 +15349,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1502
 #: lib/vutuv_web/components/post_components.ex:1733
 #: lib/vutuv_web/components/post_components.ex:3590
-#: lib/vutuv_web/components/post_components.ex:3827
+#: lib/vutuv_web/components/post_components.ex:3847
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "View the original"
@@ -15362,7 +15362,7 @@ msgstr ""
 msgid "What"
 msgstr ""
 
-#: lib/vutuv_web/live/remote_post_actions.ex:77
+#: lib/vutuv_web/live/remote_post_actions.ex:107
 #: lib/vutuv_web/live/remote_reply_actions.ex:61
 #, elixir-autogen, elixir-format
 msgid "You have reported a lot today. Please try again tomorrow."
@@ -15792,7 +15792,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/admin/media_live.ex:155
 #: lib/vutuv_web/live/fediverse_following_live.ex:351
-#: lib/vutuv_web/live/tag_live/timeline.ex:473
+#: lib/vutuv_web/live/tag_live/timeline.ex:474
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr ""
@@ -16012,22 +16012,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4443
+#: lib/vutuv_web/components/post_components.ex:4463
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4577
+#: lib/vutuv_web/components/post_components.ex:4597
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4585
+#: lib/vutuv_web/components/post_components.ex:4605
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4571
+#: lib/vutuv_web/components/post_components.ex:4591
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16150,19 +16150,19 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4022
+#: lib/vutuv_web/components/post_components.ex:4042
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5526
-#: lib/vutuv_web/components/press_kit_components.ex:521
+#: lib/vutuv_web/components/post_components.ex:5546
+#: lib/vutuv_web/components/press_kit_components.ex:526
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5754
-#: lib/vutuv_web/components/press_kit_components.ex:618
+#: lib/vutuv_web/components/post_components.ex:5774
+#: lib/vutuv_web/components/press_kit_components.ex:623
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16175,7 +16175,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1500
 #: lib/vutuv_web/agent_docs/text.ex:909
-#: lib/vutuv_web/components/post_components.ex:5836
+#: lib/vutuv_web/components/post_components.ex:5856
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
 msgstr ""
@@ -16201,7 +16201,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4075
+#: lib/vutuv_web/components/post_components.ex:4095
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16221,7 +16221,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4066
+#: lib/vutuv_web/components/post_components.ex:4086
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16231,12 +16231,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4084
+#: lib/vutuv_web/components/post_components.ex:4104
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4018
+#: lib/vutuv_web/components/post_components.ex:4038
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16251,7 +16251,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4079
+#: lib/vutuv_web/components/post_components.ex:4099
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16261,7 +16261,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4032
+#: lib/vutuv_web/components/post_components.ex:4052
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16336,13 +16336,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1357
-#: lib/vutuv_web/components/post_components.ex:7147
+#: lib/vutuv_web/components/post_components.ex:7167
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1355
-#: lib/vutuv_web/components/post_components.ex:7144
+#: lib/vutuv_web/components/post_components.ex:7164
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16352,7 +16352,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7031
+#: lib/vutuv_web/components/post_components.ex:7051
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
@@ -16699,12 +16699,12 @@ msgstr ""
 msgid "Only for this account's followers"
 msgstr ""
 
-#: lib/vutuv_web/live/remote_post_actions.ex:68
+#: lib/vutuv_web/live/remote_post_actions.ex:63
 #, elixir-autogen, elixir-format
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3826
+#: lib/vutuv_web/components/post_components.ex:3846
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16729,12 +16729,12 @@ msgstr ""
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3767
+#: lib/vutuv_web/components/post_components.ex:3787
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Marked as sensitive by its author"
 msgstr ""
 
-#: lib/vutuv_web/live/remote_post_actions.ex:157
+#: lib/vutuv_web/live/remote_post_actions.ex:189
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
 msgstr ""
@@ -16745,7 +16745,6 @@ msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3413
-#: lib/vutuv_web/components/post_components.ex:3600
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -16860,12 +16859,12 @@ msgstr ""
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3925
+#: lib/vutuv_web/components/post_components.ex:3945
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3931
+#: lib/vutuv_web/components/post_components.ex:3951
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That post is not here any more."
 msgstr ""
@@ -16875,7 +16874,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4070
+#: lib/vutuv_web/components/post_components.ex:4090
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17503,7 +17502,7 @@ msgstr ""
 msgid "View the conversation"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:285
+#: lib/vutuv_web/live/tag_live/timeline.ex:286
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "%{formatted} post"
@@ -17511,32 +17510,32 @@ msgid_plural "%{formatted} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:450
+#: lib/vutuv_web/live/tag_live/timeline.ex:451
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:481
+#: lib/vutuv_web/live/tag_live/timeline.ex:482
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:479
+#: lib/vutuv_web/live/tag_live/timeline.ex:480
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:476
+#: lib/vutuv_web/live/tag_live/timeline.ex:477
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:361
+#: lib/vutuv_web/live/tag_live/timeline.ex:362
 #, elixir-autogen, elixir-format
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3928
+#: lib/vutuv_web/components/post_components.ex:3948
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -17608,19 +17607,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6130
+#: lib/vutuv_web/components/post_components.ex:6150
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6132
+#: lib/vutuv_web/components/post_components.ex:6152
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6143
+#: lib/vutuv_web/components/post_components.ex:6163
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -17792,7 +17791,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3899
+#: lib/vutuv_web/live/post_live/feed.ex:3918
 #: lib/vutuv_web/live/reference_check_live.ex:169
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Loading…"
@@ -19203,7 +19202,7 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3958
+#: lib/vutuv_web/components/post_components.ex:3978
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -20071,27 +20070,27 @@ msgstr ""
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6024
+#: lib/vutuv_web/components/post_components.ex:6044
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6060
+#: lib/vutuv_web/components/post_components.ex:6080
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6069
+#: lib/vutuv_web/components/post_components.ex:6089
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6072
+#: lib/vutuv_web/components/post_components.ex:6092
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6049
+#: lib/vutuv_web/components/post_components.ex:6069
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
@@ -20101,7 +20100,7 @@ msgstr ""
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6039
+#: lib/vutuv_web/components/post_components.ex:6059
 #: lib/vutuv_web/components/ui.ex:5549
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -20230,20 +20229,20 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5802
+#: lib/vutuv_web/components/post_components.ex:5822
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5799
+#: lib/vutuv_web/components/post_components.ex:5819
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2912
-#: lib/vutuv_web/components/post_components.ex:4868
+#: lib/vutuv_web/components/post_components.ex:4888
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -20261,7 +20260,7 @@ msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:431
-#: lib/vutuv_web/live/post_live/feed.ex:1131
+#: lib/vutuv_web/live/post_live/feed.ex:1132
 #: lib/vutuv_web/views/user_html.ex:355
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -20761,7 +20760,7 @@ msgstr ""
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/remote_post_actions.ex:175
+#: lib/vutuv_web/live/remote_post_actions.ex:208
 #, elixir-autogen, elixir-format
 msgid "Unfollowed. Their posts leave your feed."
 msgstr ""
@@ -20836,7 +20835,7 @@ msgstr ""
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:340
+#: lib/vutuv_web/live/tag_live/timeline.ex:341
 #, elixir-autogen, elixir-format
 msgid "%{formatted} active"
 msgstr ""
@@ -20881,12 +20880,12 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4069
+#: lib/vutuv_web/live/post_live/feed.ex:4088
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:855
+#: lib/vutuv_web/live/post_live/feed.ex:856
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr ""
@@ -20932,7 +20931,7 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1123
+#: lib/vutuv_web/live/post_live/feed.ex:1124
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
@@ -21284,7 +21283,7 @@ msgstr ""
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:980
+#: lib/vutuv_web/live/post_live/feed.ex:981
 #: lib/vutuv_web/live/post_live/filter_band.ex:350
 #, elixir-autogen, elixir-format
 msgid "A photo"
@@ -21300,7 +21299,7 @@ msgstr ""
 msgid "A–Z"
 msgstr "A–Z"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1081
+#: lib/vutuv_web/live/post_live/feed.ex:1082
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Browse the tags"
 msgstr ""
@@ -21315,7 +21314,7 @@ msgstr "Busiest first"
 msgid "Clear all"
 msgstr "Clear all"
 
-#: lib/vutuv_web/live/post_live/feed.ex:892
+#: lib/vutuv_web/live/post_live/feed.ex:893
 #, elixir-autogen, elixir-format
 msgid "Drag, or use the arrow keys"
 msgstr ""
@@ -21330,13 +21329,13 @@ msgstr "Expand or collapse"
 msgid "Find an account or a server …"
 msgstr "Find an account …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:916
+#: lib/vutuv_web/live/post_live/feed.ex:917
 #, elixir-autogen, elixir-format
 msgid "Fold %{card}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1052
 #: lib/vutuv_web/live/post_live/feed.ex:1053
+#: lib/vutuv_web/live/post_live/feed.ex:1054
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follow a tag …"
 msgstr ""
@@ -21353,19 +21352,19 @@ msgstr "Hide a tag …"
 msgid "Hide a word or a whole phrase …"
 msgstr "Hide a word or a whole phrase …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:853
-#: lib/vutuv_web/live/post_live/feed.ex:4232
+#: lib/vutuv_web/live/post_live/feed.ex:854
+#: lib/vutuv_web/live/post_live/feed.ex:4251
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Hide tags"
 
-#: lib/vutuv_web/live/post_live/feed.ex:852
-#: lib/vutuv_web/live/post_live/feed.ex:4221
+#: lib/vutuv_web/live/post_live/feed.ex:853
+#: lib/vutuv_web/live/post_live/feed.ex:4240
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Hide words"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1087
+#: lib/vutuv_web/live/post_live/feed.ex:1088
 #: lib/vutuv_web/live/post_live/filter_band.ex:394
 #, elixir-autogen, elixir-format
 msgid "In your feed right now:"
@@ -21381,7 +21380,7 @@ msgstr "Matches nothing in your feed right now — the rule still holds for what
 msgid "More of your %{formatted} accounts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:891
+#: lib/vutuv_web/live/post_live/feed.ex:892
 #, elixir-autogen, elixir-format
 msgid "Move %{card}"
 msgstr ""
@@ -21392,12 +21391,12 @@ msgstr ""
 msgid "No account found."
 msgstr "No account found."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1076
+#: lib/vutuv_web/live/post_live/feed.ex:1077
 #, elixir-autogen, elixir-format
 msgid "No tag called %{name} yet."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:845
+#: lib/vutuv_web/live/post_live/feed.ex:846
 #, elixir-autogen, elixir-format
 msgid "Not read yet"
 msgstr "Not read yet"
@@ -21427,13 +21426,13 @@ msgstr "Posts carrying one of these tags are folded the same way."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4095
+#: lib/vutuv_web/live/post_live/feed.ex:4114
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:937
 #: lib/vutuv_web/live/post_live/feed.ex:938
+#: lib/vutuv_web/live/post_live/feed.ex:939
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove %{card}"
 msgstr ""
@@ -21465,8 +21464,8 @@ msgstr ""
 msgid "Show posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:851
-#: lib/vutuv_web/live/post_live/feed.ex:4187
+#: lib/vutuv_web/live/post_live/feed.ex:852
+#: lib/vutuv_web/live/post_live/feed.ex:4206
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sources"
 msgstr ""
@@ -21476,12 +21475,12 @@ msgstr ""
 msgid "Switching off means muting, not unfollowing. You stay a follower, the posts just stop reaching your feed: permanently and on every device, until you switch them back on here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:915
+#: lib/vutuv_web/live/post_live/feed.ex:916
 #, elixir-autogen, elixir-format
 msgid "Unfold %{card}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1042
+#: lib/vutuv_web/live/post_live/feed.ex:1043
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unfollow the tag %{tag}"
 msgstr ""
@@ -21505,20 +21504,20 @@ msgid_plural "and %{formatted} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3653
-#: lib/vutuv_web/live/post_live/feed.ex:3680
+#: lib/vutuv_web/live/post_live/feed.ex:3672
+#: lib/vutuv_web/live/post_live/feed.ex:3699
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "feed filter sheet"
 msgid "Filter"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1262
+#: lib/vutuv_web/live/post_live/feed.ex:1263
 #, elixir-autogen, elixir-format
 msgctxt "filtered post"
 msgid "Hidden:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:990
+#: lib/vutuv_web/live/post_live/feed.ex:991
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} post in the feed"
 msgid_plural "Show %{formatted} posts in the feed"
@@ -21568,7 +21567,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3856
+#: lib/vutuv_web/live/post_live/feed.ex:3875
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Back to now"
 msgstr ""
@@ -21578,7 +21577,7 @@ msgstr ""
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3902
+#: lib/vutuv_web/live/post_live/feed.ex:3921
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -21600,7 +21599,7 @@ msgstr ""
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3852
+#: lib/vutuv_web/live/post_live/feed.ex:3871
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
@@ -21687,14 +21686,14 @@ msgstr ""
 msgid "Page management"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2706
+#: lib/vutuv_web/live/post_live/feed.ex:2708
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3694
+#: lib/vutuv_web/components/post_components.ex:3714
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Quoted post"
 msgstr ""
@@ -21719,7 +21718,7 @@ msgstr ""
 msgid "{used} of {max} mentions"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2818
+#: lib/vutuv_web/live/post_live/feed.ex:2820
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr ""
@@ -21750,7 +21749,7 @@ msgstr ""
 msgid "only %{account}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7492
+#: lib/vutuv_web/components/post_components.ex:7512
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -21934,7 +21933,7 @@ msgctxt "phone tab bar"
 msgid "Write"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3990
+#: lib/vutuv_web/live/post_live/feed.ex:4009
 #: lib/vutuv_web/live/post_rewrites_live.ex:287
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} rule"
@@ -22004,7 +22003,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1456
 #: lib/vutuv_web/components/post_components.ex:3406
-#: lib/vutuv_web/components/post_components.ex:4658
+#: lib/vutuv_web/components/post_components.ex:4678
 #: lib/vutuv_web/components/ui.ex:5541
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
@@ -22235,7 +22234,7 @@ msgstr[1] ""
 msgid "Last 30 days: %{parts}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5220
+#: lib/vutuv_web/components/post_components.ex:5240
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Less"
@@ -22550,7 +22549,7 @@ msgid "Hidden. What they pass on stays out of your feed; their own posts do not.
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3378
-#: lib/vutuv_web/components/post_components.ex:4652
+#: lib/vutuv_web/components/post_components.ex:4672
 #, elixir-autogen, elixir-format
 msgid "Hide reposts"
 msgstr ""
@@ -22731,8 +22730,8 @@ msgstr ""
 msgid "Posts loaded at once"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3926
-#: lib/vutuv_web/live/post_live/feed.ex:3930
+#: lib/vutuv_web/live/post_live/feed.ex:3945
+#: lib/vutuv_web/live/post_live/feed.ex:3949
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posts per page"
 msgstr ""
@@ -22747,60 +22746,60 @@ msgstr ""
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7483
-#: lib/vutuv_web/components/post_components.ex:7484
+#: lib/vutuv_web/components/post_components.ex:7503
+#: lib/vutuv_web/components/post_components.ex:7504
 #, elixir-autogen, elixir-format, fuzzy
 msgid "A word or phrase …"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7511
+#: lib/vutuv_web/components/post_components.ex:7531
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3987
-#: lib/vutuv_web/live/post_live/feed.ex:4151
-#: lib/vutuv_web/live/post_live/feed.ex:4160
+#: lib/vutuv_web/live/post_live/feed.ex:4006
+#: lib/vutuv_web/live/post_live/feed.ex:4170
+#: lib/vutuv_web/live/post_live/feed.ex:4179
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Hidden"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4125
+#: lib/vutuv_web/live/post_live/feed.ex:4144
 #, elixir-autogen, elixir-format
 msgid "Hide something from your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7429
+#: lib/vutuv_web/components/post_components.ex:7449
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4166
+#: lib/vutuv_web/live/post_live/feed.ex:4185
 #, elixir-autogen, elixir-format
 msgid "Whatever these match is folded to a single line in your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4186
+#: lib/vutuv_web/live/post_live/feed.ex:4205
 #, elixir-autogen, elixir-format
 msgid "Words & tags"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7515
+#: lib/vutuv_web/components/post_components.ex:7535
 #, elixir-autogen, elixir-format, fuzzy
 msgid "everyone"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7518
+#: lib/vutuv_web/components/post_components.ex:7538
 #, elixir-autogen, elixir-format, fuzzy
 msgid "only %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7487
+#: lib/vutuv_web/components/post_components.ex:7507
 #, elixir-autogen, elixir-format, fuzzy
 msgid "this word"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7528
+#: lib/vutuv_web/components/post_components.ex:7548
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr "only %{server}"
@@ -22852,7 +22851,7 @@ msgstr ""
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6833
+#: lib/vutuv_web/components/post_components.ex:6853
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr ""
@@ -22943,7 +22942,7 @@ msgid "Hidden. What other people pass on of them stays out of your feed; their o
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3364
-#: lib/vutuv_web/components/post_components.ex:4640
+#: lib/vutuv_web/components/post_components.ex:4660
 #, elixir-autogen, elixir-format
 msgid "Hide when others repost them"
 msgstr ""
@@ -23658,13 +23657,13 @@ msgstr ""
 msgid "“%{note}”"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5398
-#: lib/vutuv_web/components/press_kit_components.ex:211
+#: lib/vutuv_web/components/post_components.ex:5418
+#: lib/vutuv_web/components/press_kit_components.ex:216
 #, elixir-autogen, elixir-format
 msgid "Show these photos larger"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5584
+#: lib/vutuv_web/components/post_components.ex:5604
 #, elixir-autogen, elixir-format
 msgid "Show this photo larger"
 msgstr ""
@@ -23754,7 +23753,7 @@ msgstr ""
 msgid "Light"
 msgstr ""
 
-#: lib/vutuv/press_kit.ex:251
+#: lib/vutuv/press_kit.ex:321
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Logo variant"
 msgstr ""
@@ -23803,7 +23802,7 @@ msgstr ""
 msgid "Please confirm the rights first, then choose the file."
 msgstr ""
 
-#: lib/vutuv/press_kit.ex:251
+#: lib/vutuv/press_kit.ex:321
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Press photo"
 msgstr ""
@@ -23889,18 +23888,18 @@ msgstr[1] "%{count} bytes"
 msgid "Credit: %{credit}"
 msgstr "Credit: %{credit}"
 
-#: lib/vutuv_web/components/press_kit_components.ex:375
-#: lib/vutuv_web/components/press_kit_components.ex:378
+#: lib/vutuv_web/components/press_kit_components.ex:380
+#: lib/vutuv_web/components/press_kit_components.ex:383
 #, elixir-autogen, elixir-format
 msgid "Download %{format}"
 msgstr "Download %{format}"
 
-#: lib/vutuv_web/components/press_kit_components.ex:331
+#: lib/vutuv_web/components/press_kit_components.ex:336
 #, elixir-autogen, elixir-format
 msgid "Download photo"
 msgstr "Download photo"
 
-#: lib/vutuv/press_kit.ex:715
+#: lib/vutuv/press_kit.ex:785
 #, elixir-autogen, elixir-format
 msgid "Free for editorial use with credit."
 msgstr "Free for editorial use with credit."
@@ -23910,7 +23909,7 @@ msgstr "Free for editorial use with credit."
 msgid "PNG version"
 msgstr "PNG version"
 
-#: lib/vutuv_web/agent_docs/press_kit_doc.ex:55
+#: lib/vutuv_web/agent_docs/press_kit_doc.ex:58
 #, elixir-autogen, elixir-format
 msgid "Press pictures %{name} offers for download, free for editorial use with credit."
 msgstr "Press pictures %{name} offers for download, free for editorial use with credit."
@@ -23945,7 +23944,7 @@ msgstr ""
 msgid "What a journalist writing about this page may download: photos in print quality and its logo as a file. Everything here is public and free for editorial use as long as the credit is shown."
 msgstr ""
 
-#: lib/vutuv_web/components/press_kit_components.ex:565
+#: lib/vutuv_web/components/press_kit_components.ex:570
 #: lib/vutuv_web/components/ui.ex:3281
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report this picture"
@@ -24047,7 +24046,7 @@ msgid "nobody"
 msgstr ""
 
 #: lib/vutuv_web/components/press_kit_components.ex:120
-#: lib/vutuv_web/components/press_kit_components.ex:176
+#: lib/vutuv_web/components/press_kit_components.ex:181
 #, elixir-autogen, elixir-format
 msgid "All Media Kit files"
 msgstr ""
@@ -24067,7 +24066,7 @@ msgstr ""
 msgid "Media Kit"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/press_kit_doc.ex:53
+#: lib/vutuv_web/agent_docs/press_kit_doc.ex:56
 #: lib/vutuv_web/views/press_kit_html.ex:32
 #, elixir-autogen, elixir-format
 msgid "Media Kit of %{name}"
@@ -24098,8 +24097,8 @@ msgstr ""
 msgid "press kit media journalist photographer download original print logo svg credit copyright presse pressefotos pressemappe medienkit mediakit fotos logo herunterladen bildnachweis"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4556
-#: lib/vutuv_web/components/post_components.ex:4606
+#: lib/vutuv_web/components/post_components.ex:4576
+#: lib/vutuv_web/components/post_components.ex:4626
 #, elixir-autogen, elixir-format
 msgid "Copy link to post"
 msgstr ""
@@ -24202,7 +24201,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:121
 #: lib/vutuv_web/agent_docs/text.ex:412
-#: lib/vutuv_web/components/press_kit_components.ex:269
+#: lib/vutuv_web/components/press_kit_components.ex:274
 #, elixir-autogen, elixir-format, fuzzy
 msgid "About %{name}"
 msgstr ""
@@ -24227,12 +24226,12 @@ msgstr ""
 msgid "As long as you like. The whole portrait."
 msgstr ""
 
-#: lib/vutuv/press_kit.ex:460
+#: lib/vutuv/press_kit.ex:530
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Long version"
 msgstr ""
 
-#: lib/vutuv/press_kit.ex:459
+#: lib/vutuv/press_kit.ex:529
 #, elixir-autogen, elixir-format
 msgid "Medium version"
 msgstr ""
@@ -24242,12 +24241,12 @@ msgstr ""
 msgid "Nothing written yet."
 msgstr ""
 
-#: lib/vutuv/press_kit.ex:458
+#: lib/vutuv/press_kit.ex:528
 #, elixir-autogen, elixir-format
 msgid "Short version"
 msgstr ""
 
-#: lib/vutuv_web/components/press_kit_components.ex:272
+#: lib/vutuv_web/components/press_kit_components.ex:277
 #, elixir-autogen, elixir-format
 msgid "Take whichever length fits the space you have. Each one stands on its own."
 msgstr ""
@@ -24377,7 +24376,7 @@ msgstr ""
 msgid "Your post appears as soon as the video is ready"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3626
+#: lib/vutuv_web/components/post_components.ex:3631
 #, elixir-autogen, elixir-format
 msgid "Found through %{server}"
 msgstr ""
@@ -24664,4 +24663,24 @@ msgstr ""
 #: lib/vutuv_web/live/message_live/index.ex:627
 #, elixir-autogen, elixir-format
 msgid "You can only send files to members you are connected with."
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:3652
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Report this post as not appropriate? Every copy of it disappears right away, for everyone on this vutuv."
+msgstr ""
+
+#: lib/vutuv_web/live/remote_post_actions.ex:89
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Thank you. Every copy on this vutuv is gone."
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:3656
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Report this post as not appropriate? This copy disappears right away, for everyone on this vutuv. Copies other servers sent us stay."
+msgstr ""
+
+#: lib/vutuv_web/live/remote_post_actions.ex:92
+#, elixir-autogen, elixir-format
+msgid "Thank you. This copy is gone for everyone on this vutuv."
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -165,7 +165,7 @@ msgstr "Contatto"
 msgid "Couldn't follow back to %{name}."
 msgstr "Non è stato possibile ricambiare il follow a %{name}."
 
-#: lib/vutuv_web/components/post_components.ex:4593
+#: lib/vutuv_web/components/post_components.ex:4613
 #: lib/vutuv_web/components/ui.ex:5042
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
@@ -213,7 +213,7 @@ msgstr "Disattiva"
 msgid "Download"
 msgstr "Scarica"
 
-#: lib/vutuv_web/components/post_components.ex:4558
+#: lib/vutuv_web/components/post_components.ex:4578
 #: lib/vutuv_web/components/ui.ex:5033
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
@@ -659,7 +659,7 @@ msgstr "Salva"
 #: lib/vutuv_web/live/search_live.ex:680
 #: lib/vutuv_web/live/shell_live.ex:1495
 #: lib/vutuv_web/live/shell_live.ex:1702
-#: lib/vutuv_web/live/tag_live/timeline.ex:352
+#: lib/vutuv_web/live/tag_live/timeline.ex:353
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:35
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:30
@@ -944,7 +944,7 @@ msgid "You follow back %{name}."
 msgstr "Ora segue anche %{name}."
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:179
+#: lib/vutuv_web/live/post_live/feed.ex:180
 #: lib/vutuv_web/live/press_kit_live.ex:110
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
@@ -1210,7 +1210,7 @@ msgstr "Tutti i sinonimi dei tag"
 msgid "All tag urls"
 msgstr "Tutti gli URL dei tag"
 
-#: lib/vutuv_web/components/post_components.ex:5211
+#: lib/vutuv_web/components/post_components.ex:5231
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:643
@@ -1712,7 +1712,7 @@ msgstr "Conferma"
 #: lib/vutuv_web/live/organization_live/following.ex:421
 #: lib/vutuv_web/live/organization_live/show.ex:602
 #: lib/vutuv_web/live/organization_live/show.ex:639
-#: lib/vutuv_web/live/post_live/feed.ex:1054
+#: lib/vutuv_web/live/post_live/feed.ex:1055
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
 #: lib/vutuv_web/templates/user/show.html.heex:1350
 #: lib/vutuv_web/views/user_html.ex:643
@@ -2131,7 +2131,7 @@ msgstr "Annulla il caricamento"
 msgid "Delete post"
 msgstr "Elimina il post"
 
-#: lib/vutuv_web/components/post_components.ex:4590
+#: lib/vutuv_web/components/post_components.ex:4610
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2146,8 +2146,8 @@ msgstr "Modifica il post"
 #: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:203
-#: lib/vutuv_web/live/post_live/feed.ex:365
-#: lib/vutuv_web/live/post_live/feed.ex:3536
+#: lib/vutuv_web/live/post_live/feed.ex:366
+#: lib/vutuv_web/live/post_live/feed.ex:3555
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1346
 #: lib/vutuv_web/live/shell_live.ex:1692
@@ -2176,8 +2176,8 @@ msgstr "Nascondi a una persona specifica…"
 msgid "Hide this post from…"
 msgstr "Nascondi questo post a…"
 
-#: lib/vutuv_web/components/post_components.ex:4536
-#: lib/vutuv_web/components/post_components.ex:4538
+#: lib/vutuv_web/components/post_components.ex:4556
+#: lib/vutuv_web/components/post_components.ex:4558
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Pubblico limitato"
@@ -2193,7 +2193,7 @@ msgstr "Visitatori non connessi"
 msgid "No more than %{max} images per post."
 msgstr "Non più di %{max} immagini per post."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3876
+#: lib/vutuv_web/live/post_live/feed.ex:3895
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2244,13 +2244,13 @@ msgstr "Post eliminato."
 msgid "Posts"
 msgstr "Post"
 
-#: lib/vutuv_web/components/post_components.ex:5084
-#: lib/vutuv_web/components/post_components.ex:5088
+#: lib/vutuv_web/components/post_components.ex:5104
+#: lib/vutuv_web/components/post_components.ex:5108
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Leggi tutto"
 
-#: lib/vutuv_web/components/post_components.ex:5085
+#: lib/vutuv_web/components/post_components.ex:5105
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2291,7 +2291,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Salvataggio…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2712
+#: lib/vutuv_web/live/post_live/feed.ex:2714
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2350,27 +2350,27 @@ msgstr "Che c'è di nuovo?"
 msgid "What's new? Markdown is supported."
 msgstr "Che c'è di nuovo? Markdown è supportato."
 
-#: lib/vutuv_web/components/post_components.ex:4533
+#: lib/vutuv_web/components/post_components.ex:4553
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "modificato"
 
-#: lib/vutuv_web/components/post_components.ex:6851
+#: lib/vutuv_web/components/post_components.ex:6871
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "tutti gli altri"
 
-#: lib/vutuv_web/components/post_components.ex:6855
+#: lib/vutuv_web/components/post_components.ex:6875
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "visitatori non connessi"
 
-#: lib/vutuv_web/components/post_components.ex:6853
+#: lib/vutuv_web/components/post_components.ex:6873
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "persone che non La seguono"
 
-#: lib/vutuv_web/components/post_components.ex:6854
+#: lib/vutuv_web/components/post_components.ex:6874
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "persone che non segue"
@@ -2417,7 +2417,7 @@ msgid "All posts"
 msgstr "Tutti i post"
 
 #: lib/vutuv_web/components/post_components.ex:2185
-#: lib/vutuv_web/components/post_components.ex:6954
+#: lib/vutuv_web/components/post_components.ex:6974
 #: lib/vutuv_web/components/ui.ex:4476
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2436,7 +2436,7 @@ msgid "Bookmarks"
 msgstr "Salvati"
 
 #: lib/vutuv_web/components/post_components.ex:2129
-#: lib/vutuv_web/components/post_components.ex:7195
+#: lib/vutuv_web/components/post_components.ex:7215
 #: lib/vutuv_web/components/ui.ex:4462
 #: lib/vutuv_web/notification_line.ex:317
 #: lib/vutuv_web/views/user_html.ex:486
@@ -2445,7 +2445,7 @@ msgid "Like"
 msgstr "Mi piace"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1301
-#: lib/vutuv_web/components/post_components.ex:7205
+#: lib/vutuv_web/components/post_components.ex:7225
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
 #: lib/vutuv_web/live/shell_live.ex:1596
@@ -2466,13 +2466,13 @@ msgstr "Qui non c'è ancora nulla. I post che salva compaiono qui."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Qui non c'è ancora nulla. I post a cui mette Mi piace compaiono qui."
 
-#: lib/vutuv_web/components/post_components.ex:6942
+#: lib/vutuv_web/components/post_components.ex:6962
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Solo i post pubblici possono essere ripubblicati."
 
 #: lib/vutuv_web/components/post_components.ex:2184
-#: lib/vutuv_web/components/post_components.ex:6953
+#: lib/vutuv_web/components/post_components.ex:6973
 #: lib/vutuv_web/live/post_live/saved.ex:822
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2480,26 +2480,26 @@ msgid "Remove bookmark"
 msgstr "Rimuovi dai salvati"
 
 #: lib/vutuv_web/components/post_components.ex:2165
-#: lib/vutuv_web/components/post_components.ex:6938
+#: lib/vutuv_web/components/post_components.ex:6958
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Ripubblica"
 
 #: lib/vutuv_web/components/post_components.ex:2758
-#: lib/vutuv_web/components/post_components.ex:5957
+#: lib/vutuv_web/components/post_components.ex:5977
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Ripubblicato da %{name}"
 
 #: lib/vutuv_web/components/post_components.ex:2164
-#: lib/vutuv_web/components/post_components.ex:6937
+#: lib/vutuv_web/components/post_components.ex:6957
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Annulla la ripubblicazione"
 
 #: lib/vutuv_web/components/post_components.ex:2128
-#: lib/vutuv_web/components/post_components.ex:7194
+#: lib/vutuv_web/components/post_components.ex:7214
 #: lib/vutuv_web/live/post_live/saved.ex:821
 #: lib/vutuv_web/views/user_html.ex:486
 #, elixir-autogen, elixir-format
@@ -2514,7 +2514,7 @@ msgstr "Togli Mi piace"
 #: lib/vutuv_web/live/organization_live/following.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:476
 #: lib/vutuv_web/live/organization_live/show.ex:644
-#: lib/vutuv_web/live/post_live/feed.ex:1041
+#: lib/vutuv_web/live/post_live/feed.ex:1042
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:42
 #: lib/vutuv_web/views/user_html.ex:633
@@ -2527,7 +2527,7 @@ msgstr "Non seguire più"
 msgid "Welcome to vutuv!"
 msgstr "Benvenuto su vutuv."
 
-#: lib/vutuv_web/components/post_components.ex:7249
+#: lib/vutuv_web/components/post_components.ex:7269
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Solo ai post pubblici si può rispondere."
@@ -2539,8 +2539,8 @@ msgid "Replies"
 msgstr "Risposte"
 
 #: lib/vutuv_web/components/post_components.ex:2374
-#: lib/vutuv_web/components/post_components.ex:7232
-#: lib/vutuv_web/components/post_components.ex:7233
+#: lib/vutuv_web/components/post_components.ex:7252
+#: lib/vutuv_web/components/post_components.ex:7253
 #: lib/vutuv_web/live/notification_live/index.ex:993
 #: lib/vutuv_web/live/post_live/reply.ex:49
 #: lib/vutuv_web/notification_line.ex:314
@@ -2548,7 +2548,7 @@ msgstr "Risposte"
 msgid "Reply"
 msgstr "Rispondi"
 
-#: lib/vutuv_web/components/post_components.ex:4492
+#: lib/vutuv_web/components/post_components.ex:4512
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Risposta a un post eliminato"
@@ -2574,7 +2574,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr "ha risposto al Suo post."
 
-#: lib/vutuv_web/components/post_components.ex:4010
+#: lib/vutuv_web/components/post_components.ex:4030
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:63
 #: lib/vutuv_web/live/post_live/remote_reply.ex:61
 #: lib/vutuv_web/live/post_live/reply.ex:63
@@ -2582,14 +2582,14 @@ msgstr "ha risposto al Suo post."
 msgid "Reply to %{handle}"
 msgstr "Rispondi a %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:4464
+#: lib/vutuv_web/components/post_components.ex:4484
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Risposta a un post di %{handle} ora eliminato"
 
-#: lib/vutuv_web/components/post_components.ex:4455
-#: lib/vutuv_web/components/post_components.ex:4484
-#: lib/vutuv_web/components/post_components.ex:4487
+#: lib/vutuv_web/components/post_components.ex:4475
+#: lib/vutuv_web/components/post_components.ex:4504
+#: lib/vutuv_web/components/post_components.ex:4507
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "In risposta a %{handle}"
@@ -2837,7 +2837,7 @@ msgstr[0] "1 collegamento"
 msgstr[1] "%{formatted} collegamenti"
 
 #: lib/vutuv_web/live/job_board_live.ex:458
-#: lib/vutuv_web/live/post_live/feed.ex:1185
+#: lib/vutuv_web/live/post_live/feed.ex:1186
 #: lib/vutuv_web/templates/user/card_list.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -2891,7 +2891,7 @@ msgid_plural "connections"
 msgstr[0] "collegamento"
 msgstr[1] "collegamenti"
 
-#: lib/vutuv_web/components/post_components.ex:6852
+#: lib/vutuv_web/components/post_components.ex:6872
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "persone che non sono Suoi collegamenti"
@@ -3158,7 +3158,7 @@ msgstr "Nudità, violenza o altri contenuti che non hanno posto su vutuv."
 msgid "Only visible to you"
 msgstr "Visibile solo a Lei"
 
-#: lib/vutuv_web/components/post_components.ex:4431
+#: lib/vutuv_web/components/post_components.ex:4451
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solo Lei può vedere questo post finché la segnalazione è in corso."
@@ -3220,8 +3220,8 @@ msgstr "Lo rimuova. La segnalazione si chiude, senza altre domande."
 
 #: lib/vutuv_web/components/post_components.ex:1466
 #: lib/vutuv_web/components/post_components.ex:3418
-#: lib/vutuv_web/components/post_components.ex:3605
-#: lib/vutuv_web/components/post_components.ex:4661
+#: lib/vutuv_web/components/post_components.ex:3610
+#: lib/vutuv_web/components/post_components.ex:4681
 #: lib/vutuv_web/live/organization_live/show.ex:684
 #: lib/vutuv_web/templates/user/show.html.heex:252
 #, elixir-autogen, elixir-format
@@ -4660,7 +4660,7 @@ msgstr "Non ha bloccato nessuno."
 msgid "You unblocked @%{slug}."
 msgstr "Ha sbloccato @%{slug}."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3881
+#: lib/vutuv_web/live/post_live/feed.ex:3900
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Scopra persone da seguire"
@@ -5577,9 +5577,9 @@ msgstr "Navigazione principale"
 msgid "Footer navigation"
 msgstr "Navigazione a piè di pagina"
 
-#: lib/vutuv_web/components/post_components.ex:4741
-#: lib/vutuv_web/components/post_components.ex:5350
-#: lib/vutuv_web/components/post_components.ex:5688
+#: lib/vutuv_web/components/post_components.ex:4761
+#: lib/vutuv_web/components/post_components.ex:5370
+#: lib/vutuv_web/components/post_components.ex:5708
 #: lib/vutuv_web/live/notification_live/index.ex:1069
 #: lib/vutuv_web/views/user_html.ex:133
 #, elixir-autogen, elixir-format
@@ -5949,7 +5949,7 @@ msgid "Name (A-Z)"
 msgstr "Nome (A-Z)"
 
 #: lib/vutuv_web/live/post_live/saved.ex:507
-#: lib/vutuv_web/live/tag_live/timeline.ex:448
+#: lib/vutuv_web/live/tag_live/timeline.ex:449
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr "Prima i più recenti"
@@ -5976,7 +5976,7 @@ msgstr ""
 "Qui non c'è ancora nulla. Le persone a cui mette Mi piace compaiono qui."
 
 #: lib/vutuv_web/live/post_live/saved.ex:508
-#: lib/vutuv_web/live/tag_live/timeline.ex:449
+#: lib/vutuv_web/live/tag_live/timeline.ex:450
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr "Prima i meno recenti"
@@ -5998,7 +5998,7 @@ msgid "Search saved items"
 msgstr "Cerchi negli elementi salvati"
 
 #: lib/vutuv_web/live/post_live/saved.ex:570
-#: lib/vutuv_web/live/tag_live/timeline.ex:368
+#: lib/vutuv_web/live/tag_live/timeline.ex:369
 #, elixir-autogen, elixir-format
 msgid "Sort"
 msgstr "Ordina"
@@ -6820,8 +6820,8 @@ msgstr ""
 "risposte che La riguardano. Con entrambe disattivate, ad esempio:"
 
 #: lib/vutuv_web/components/post_components.ex:3345
-#: lib/vutuv_web/components/post_components.ex:4614
-#: lib/vutuv_web/components/post_components.ex:4628
+#: lib/vutuv_web/components/post_components.ex:4634
+#: lib/vutuv_web/components/post_components.ex:4648
 #: lib/vutuv_web/components/ui.ex:3226
 #: lib/vutuv_web/live/fediverse_account_live.ex:437
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6849,7 +6849,7 @@ msgstr "Nuovi messaggi e nuovi collegamenti"
 msgid "Remove this connection? You will stop following them."
 msgstr "Rimuovere questo collegamento? Smetterà di seguire questa persona."
 
-#: lib/vutuv_web/components/post_components.ex:4614
+#: lib/vutuv_web/components/post_components.ex:4634
 #: lib/vutuv_web/components/ui.ex:3225
 #: lib/vutuv_web/live/fediverse_account_live.ex:435
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -7052,7 +7052,7 @@ msgid "Filter"
 msgstr "Filtro"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:591
-#: lib/vutuv_web/live/tag_live/timeline.ex:334
+#: lib/vutuv_web/live/tag_live/timeline.ex:335
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr "Filtri"
@@ -7566,7 +7566,7 @@ msgid "applies to the whole list, not just this page"
 msgstr "vale per l'intero elenco, non solo per questa pagina"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:7105
+#: lib/vutuv_web/components/post_components.ex:7125
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #: lib/vutuv_web/live/shell_live.ex:1830
 #, elixir-autogen, elixir-format
@@ -7676,7 +7676,7 @@ msgstr "Si aggiorna da sola. Può lasciare questa pagina: l'invio prosegue."
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/media_live.ex:270
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:4175
+#: lib/vutuv_web/live/post_live/feed.ex:4194
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #: lib/vutuv_web/live/press_kit_live.ex:1056
 #, elixir-autogen
@@ -8156,7 +8156,7 @@ msgstr "Amministratori"
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
 #: lib/vutuv_web/live/job_board_live.ex:468
-#: lib/vutuv_web/live/post_live/feed.ex:1194
+#: lib/vutuv_web/live/post_live/feed.ex:1195
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr "Tutti i membri"
@@ -8177,7 +8177,7 @@ msgstr "In attesa di verifica"
 #: lib/vutuv_web/live/admin/media_live.ex:146
 #: lib/vutuv_web/live/admin/user_live.ex:184
 #: lib/vutuv_web/live/job_board_live.ex:319
-#: lib/vutuv_web/live/tag_live/timeline.ex:398
+#: lib/vutuv_web/live/tag_live/timeline.ex:399
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr "Azzera i filtri"
@@ -9121,7 +9121,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Download del CV"
 
-#: lib/vutuv_web/components/post_components.ex:5960
+#: lib/vutuv_web/components/post_components.ex:5980
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -12611,7 +12611,7 @@ msgid "Everyone (public)"
 msgstr "Tutti (pubblico)"
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:681
-#: lib/vutuv_web/live/tag_live/timeline.ex:379
+#: lib/vutuv_web/live/tag_live/timeline.ex:380
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
 #, elixir-autogen, elixir-format
@@ -13604,7 +13604,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "Interrompere gli avvisi via e-mail per la Sua ricerca salvata \"%{label}\"?"
 
-#: lib/vutuv_web/components/post_components.ex:3969
+#: lib/vutuv_web/components/post_components.ex:3989
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:788
 #: lib/vutuv_web/controllers/settings_controller.ex:806
@@ -14045,7 +14045,7 @@ msgstr "Inserisci nel testo"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:259
 #: lib/vutuv_web/agent_docs/text.ex:221
-#: lib/vutuv_web/live/tag_live/timeline.ex:282
+#: lib/vutuv_web/live/tag_live/timeline.ex:283
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
 msgstr "Post con questo tag"
@@ -14102,7 +14102,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5556
 #: lib/vutuv_web/controllers/settings_controller.ex:643
-#: lib/vutuv_web/live/post_live/feed.ex:854
+#: lib/vutuv_web/live/post_live/feed.ex:855
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
@@ -14270,34 +14270,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr "ha aggiunto %{count} nuove voci al proprio CV:"
 
-#: lib/vutuv_web/components/post_components.ex:6648
+#: lib/vutuv_web/components/post_components.ex:6668
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Audiolibro"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6605
+#: lib/vutuv_web/components/post_components.ex:6625
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Recensione di un libro"
 
-#: lib/vutuv_web/components/post_components.ex:6649
+#: lib/vutuv_web/components/post_components.ex:6669
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Cinema"
 
-#: lib/vutuv_web/components/post_components.ex:6651
+#: lib/vutuv_web/components/post_components.ex:6671
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:6647
+#: lib/vutuv_web/components/post_components.ex:6667
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6604
+#: lib/vutuv_web/components/post_components.ex:6624
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Recensione di un film"
@@ -14308,12 +14308,12 @@ msgstr "Recensione di un film"
 msgid "Look up"
 msgstr "Cerca"
 
-#: lib/vutuv_web/components/post_components.ex:6646
+#: lib/vutuv_web/components/post_components.ex:6666
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Libro cartaceo"
 
-#: lib/vutuv_web/components/post_components.ex:6650
+#: lib/vutuv_web/components/post_components.ex:6670
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14333,7 +14333,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Anno"
 
-#: lib/vutuv_web/components/post_components.ex:6687
+#: lib/vutuv_web/components/post_components.ex:6707
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14341,30 +14341,30 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} pagina"
 msgstr[1] "%{formatted} pagine"
 
-#: lib/vutuv_web/components/post_components.ex:6717
+#: lib/vutuv_web/components/post_components.ex:6737
 #: lib/vutuv_web/components/ui.ex:3884
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} h"
 
-#: lib/vutuv_web/components/post_components.ex:6718
+#: lib/vutuv_web/components/post_components.ex:6738
 #: lib/vutuv_web/components/ui.ex:3885
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} h %{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:6716
+#: lib/vutuv_web/components/post_components.ex:6736
 #: lib/vutuv_web/components/ui.ex:3877
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:6676
+#: lib/vutuv_web/components/post_components.ex:6696
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(edizione cartacea)"
 
-#: lib/vutuv_web/components/post_components.ex:6723
+#: lib/vutuv_web/components/post_components.ex:6743
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "circa %{duration}"
@@ -14396,7 +14396,7 @@ msgstr "Con certificazione:"
 msgid "With qualification: %{name}"
 msgstr "Con certificazione: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:6490
+#: lib/vutuv_web/components/post_components.ex:6510
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Editore:"
@@ -14439,7 +14439,7 @@ msgstr "ora La seguono."
 msgid "endorsed you for %{tags}."
 msgstr "L'ha confermata per %{tags}."
 
-#: lib/vutuv_web/components/post_components.ex:6481
+#: lib/vutuv_web/components/post_components.ex:6501
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "di:"
@@ -14816,14 +14816,14 @@ msgstr "Cerchi un account da bloccare"
 msgid "See all frozen accounts"
 msgstr "Vedi tutti gli account bloccati"
 
-#: lib/vutuv_web/components/post_components.ex:4258
+#: lib/vutuv_web/components/post_components.ex:4278
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "Mostra %{formatted} post precedente"
 msgstr[1] "Mostra %{formatted} post precedenti"
 
-#: lib/vutuv_web/components/post_components.ex:4281
+#: lib/vutuv_web/components/post_components.ex:4301
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14852,7 +14852,7 @@ msgstr ""
 "Digiti un nome, un @handle o un indirizzo e-mail per trovare un account da "
 "bloccare."
 
-#: lib/vutuv_web/components/post_components.ex:7204
+#: lib/vutuv_web/components/post_components.ex:7224
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Non può mettere Mi piace al Suo stesso post."
@@ -15052,7 +15052,7 @@ msgstr ""
 "Scelga qui sotto un titolo di studio o un istituto da mostrare in cima al "
 "Suo profilo al posto di una qualifica."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1254
+#: lib/vutuv_web/live/post_live/feed.ex:1255
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr "Mostra comunque"
@@ -15647,7 +15647,7 @@ msgstr "Inviamo lì un PIN per confermare che l'indirizzo è Suo."
 msgid "ZIP or postal code"
 msgstr "CAP"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:386
+#: lib/vutuv_web/live/tag_live/timeline.ex:387
 #: lib/vutuv_web/templates/education/form_content.html.heex:59
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:81
 #, elixir-autogen, elixir-format
@@ -16118,7 +16118,7 @@ msgstr ""
 " vedere dove va a finire. Modificare o eliminare un post su vutuv è solo una"
 " richiesta rivolta a quei server, e non tutti la rispettano."
 
-#: lib/vutuv_web/components/post_components.ex:7150
+#: lib/vutuv_web/components/post_components.ex:7170
 #: lib/vutuv_web/live/notification_live/index.ex:1592
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -16126,7 +16126,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} risposta"
 msgstr[1] "%{formatted} risposte"
 
-#: lib/vutuv_web/components/post_components.ex:7154
+#: lib/vutuv_web/components/post_components.ex:7174
 #: lib/vutuv_web/live/notification_live/index.ex:1586
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -16134,7 +16134,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Mi piace"
 msgstr[1] "%{formatted} Mi piace"
 
-#: lib/vutuv_web/components/post_components.ex:7158
+#: lib/vutuv_web/components/post_components.ex:7178
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16142,7 +16142,7 @@ msgstr[0] "%{formatted} ripubblicazione"
 msgstr[1] "%{formatted} ripubblicazioni"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1339
-#: lib/vutuv_web/components/post_components.ex:7109
+#: lib/vutuv_web/components/post_components.ex:7129
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Già conteggiate nei numeri qui sopra."
@@ -16247,7 +16247,7 @@ msgstr "Questa risposta non spetta a Lei rimuoverla."
 #: lib/vutuv_web/components/post_components.ex:1502
 #: lib/vutuv_web/components/post_components.ex:1733
 #: lib/vutuv_web/components/post_components.ex:3590
-#: lib/vutuv_web/components/post_components.ex:3827
+#: lib/vutuv_web/components/post_components.ex:3847
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "View the original"
@@ -16260,7 +16260,7 @@ msgstr "Vedi l'originale"
 msgid "What"
 msgstr "Cosa"
 
-#: lib/vutuv_web/live/remote_post_actions.ex:77
+#: lib/vutuv_web/live/remote_post_actions.ex:107
 #: lib/vutuv_web/live/remote_reply_actions.ex:61
 #, elixir-autogen, elixir-format
 msgid "You have reported a lot today. Please try again tomorrow."
@@ -16710,7 +16710,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/admin/media_live.ex:155
 #: lib/vutuv_web/live/fediverse_following_live.ex:351
-#: lib/vutuv_web/live/tag_live/timeline.ex:473
+#: lib/vutuv_web/live/tag_live/timeline.ex:474
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr ""
@@ -16942,22 +16942,22 @@ msgstr ""
 msgid "device or detail"
 msgstr "dispositivo o dettaglio"
 
-#: lib/vutuv_web/components/post_components.ex:4443
+#: lib/vutuv_web/components/post_components.ex:4463
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Post fissato"
 
-#: lib/vutuv_web/components/post_components.ex:4577
+#: lib/vutuv_web/components/post_components.ex:4597
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "Fissa sul profilo"
 
-#: lib/vutuv_web/components/post_components.ex:4585
+#: lib/vutuv_web/components/post_components.ex:4605
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Togli dal profilo"
 
-#: lib/vutuv_web/components/post_components.ex:4571
+#: lib/vutuv_web/components/post_components.ex:4591
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -17089,19 +17089,19 @@ msgstr "Foto successiva"
 msgid "No image description yet"
 msgstr "Ancora nessuna descrizione dell'immagine"
 
-#: lib/vutuv_web/components/post_components.ex:4022
+#: lib/vutuv_web/components/post_components.ex:4042
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Apri le impostazioni del Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:5526
-#: lib/vutuv_web/components/press_kit_components.ex:521
+#: lib/vutuv_web/components/post_components.ex:5546
+#: lib/vutuv_web/components/press_kit_components.ex:526
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} di %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:5754
-#: lib/vutuv_web/components/press_kit_components.ex:618
+#: lib/vutuv_web/components/post_components.ex:5774
+#: lib/vutuv_web/components/press_kit_components.ex:623
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "La foto è in fase di controllo"
@@ -17114,7 +17114,7 @@ msgstr "Opzioni della foto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1500
 #: lib/vutuv_web/agent_docs/text.ex:909
-#: lib/vutuv_web/components/post_components.ex:5836
+#: lib/vutuv_web/components/post_components.ex:5856
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Foto:"
@@ -17142,7 +17142,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr "Mostra le impostazioni della fotocamera"
 
-#: lib/vutuv_web/components/post_components.ex:4075
+#: lib/vutuv_web/components/post_components.ex:4095
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -17168,7 +17168,7 @@ msgstr ""
 "Questa foto porta con sé il luogo in cui è stata scattata. Chiunque scarichi"
 " il file esatto può leggerlo."
 
-#: lib/vutuv_web/components/post_components.ex:4066
+#: lib/vutuv_web/components/post_components.ex:4086
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -17183,12 +17183,12 @@ msgstr ""
 "inviare le Sue parole a quella rete, cosa che vutuv fa solo per i membri che"
 " hanno attivato la partecipazione al Fediverso."
 
-#: lib/vutuv_web/components/post_components.ex:4084
+#: lib/vutuv_web/components/post_components.ex:4104
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Questo sito non partecipa al Fediverso."
 
-#: lib/vutuv_web/components/post_components.ex:4018
+#: lib/vutuv_web/components/post_components.ex:4038
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Attivi la partecipazione al Fediverso per rispondere"
@@ -17204,7 +17204,7 @@ msgid "You have sent a lot of answers to other networks in the past hour. Please
 msgstr ""
 "Nell'ultima ora ha inviato molte risposte ad altre reti. Riprovi più tardi."
 
-#: lib/vutuv_web/components/post_components.ex:4079
+#: lib/vutuv_web/components/post_components.ex:4099
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -17218,7 +17218,7 @@ msgstr ""
 "Al momento le Sue impostazioni del Fediverso non consentono di inviare una "
 "risposta."
 
-#: lib/vutuv_web/components/post_components.ex:4032
+#: lib/vutuv_web/components/post_components.ex:4052
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -17301,13 +17301,13 @@ msgstr[1] ""
 "il file esatto lo rivela."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1357
-#: lib/vutuv_web/components/post_components.ex:7147
+#: lib/vutuv_web/components/post_components.ex:7167
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "A %{handle} è piaciuto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1355
-#: lib/vutuv_web/components/post_components.ex:7144
+#: lib/vutuv_web/components/post_components.ex:7164
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} lo ha condiviso"
@@ -17317,7 +17317,7 @@ msgstr "%{handle} lo ha condiviso"
 msgid "Fediverse reactions"
 msgstr "Reazioni dal Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:7031
+#: lib/vutuv_web/components/post_components.ex:7051
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Da altre reti"
@@ -17710,12 +17710,12 @@ msgstr "Post in cache"
 msgid "Only for this account's followers"
 msgstr "Solo per i follower di questo account"
 
-#: lib/vutuv_web/live/remote_post_actions.ex:68
+#: lib/vutuv_web/live/remote_post_actions.ex:63
 #, elixir-autogen, elixir-format
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Grazie. La nostra copia è stata eliminata subito."
 
-#: lib/vutuv_web/components/post_components.ex:3826
+#: lib/vutuv_web/components/post_components.ex:3846
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Vota sull'originale"
@@ -17746,12 +17746,12 @@ msgstr "Contenuti da altre reti rimossi dai membri"
 msgid "Hide"
 msgstr "Nascondi"
 
-#: lib/vutuv_web/components/post_components.ex:3767
+#: lib/vutuv_web/components/post_components.ex:3787
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Contrassegnato come sensibile dal suo autore"
 
-#: lib/vutuv_web/live/remote_post_actions.ex:157
+#: lib/vutuv_web/live/remote_post_actions.ex:189
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
 msgstr "Silenziato. Continua a seguirlo; i suoi post spariscono dal Suo feed."
@@ -17762,7 +17762,6 @@ msgid "Nobody has removed or reported anything yet."
 msgstr "Nessuno ha ancora rimosso o segnalato nulla."
 
 #: lib/vutuv_web/components/post_components.ex:3413
-#: lib/vutuv_web/components/post_components.ex:3600
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -17892,12 +17891,12 @@ msgstr "Coprila di nuovo"
 msgid "Sensitive. Show the picture."
 msgstr "Contenuto sensibile. Mostra l'immagine."
 
-#: lib/vutuv_web/components/post_components.ex:3925
+#: lib/vutuv_web/components/post_components.ex:3945
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Sono molti Mi piace in un'ora. Riprovi più tardi."
 
-#: lib/vutuv_web/components/post_components.ex:3931
+#: lib/vutuv_web/components/post_components.ex:3951
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Quel post non è più qui."
@@ -17907,7 +17906,7 @@ msgstr "Quel post non è più qui."
 msgid "Back to the feed"
 msgstr "Torna al feed"
 
-#: lib/vutuv_web/components/post_components.ex:4070
+#: lib/vutuv_web/components/post_components.ex:4090
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -18606,7 +18605,7 @@ msgstr "Ancora nulla da vutuv. Segua persone qui per riempire questa scheda."
 msgid "View the conversation"
 msgstr "Vedi la conversazione"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:285
+#: lib/vutuv_web/live/tag_live/timeline.ex:286
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "%{formatted} post"
@@ -18614,32 +18613,32 @@ msgid_plural "%{formatted} posts"
 msgstr[0] "%{formatted} post"
 msgstr[1] "%{formatted} post"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:450
+#: lib/vutuv_web/live/tag_live/timeline.ex:451
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr "Più apprezzati"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:481
+#: lib/vutuv_web/live/tag_live/timeline.ex:482
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr "Nessun post porta ancora questo tag."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:479
+#: lib/vutuv_web/live/tag_live/timeline.ex:480
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr "Nessun post da altre reti porta ancora questo tag."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:476
+#: lib/vutuv_web/live/tag_live/timeline.ex:477
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr "Nessun post su vutuv porta ancora questo tag."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:361
+#: lib/vutuv_web/live/tag_live/timeline.ex:362
 #, elixir-autogen, elixir-format
 msgid "word in a post"
 msgstr "parola in un post"
 
-#: lib/vutuv_web/components/post_components.ex:3928
+#: lib/vutuv_web/components/post_components.ex:3948
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Quella risposta non è più qui."
@@ -18717,19 +18716,19 @@ msgstr ""
 msgid "Liked by"
 msgstr "Piace a"
 
-#: lib/vutuv_web/components/post_components.ex:6130
+#: lib/vutuv_web/components/post_components.ex:6150
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Piace a %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:6132
+#: lib/vutuv_web/components/post_components.ex:6152
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Piace a %{name} e a %{formatted} altro"
 msgstr[1] "Piace a %{name} e ad altri %{formatted}"
 
-#: lib/vutuv_web/components/post_components.ex:6143
+#: lib/vutuv_web/components/post_components.ex:6163
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -18910,7 +18909,7 @@ msgstr "Rilasciato il"
 msgid "Label"
 msgstr "Etichetta"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3899
+#: lib/vutuv_web/live/post_live/feed.ex:3918
 #: lib/vutuv_web/live/reference_check_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -20461,7 +20460,7 @@ msgstr ""
 msgid "Start over"
 msgstr "Ricomincia"
 
-#: lib/vutuv_web/components/post_components.ex:3958
+#: lib/vutuv_web/components/post_components.ex:3978
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -21423,27 +21422,27 @@ msgstr "Lingua"
 msgid "The language this post is written in"
 msgstr "La lingua in cui è scritto questo post"
 
-#: lib/vutuv_web/components/post_components.ex:6024
+#: lib/vutuv_web/components/post_components.ex:6044
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Mostra l'originale"
 
-#: lib/vutuv_web/components/post_components.ex:6060
+#: lib/vutuv_web/components/post_components.ex:6080
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Traduci"
 
-#: lib/vutuv_web/components/post_components.ex:6069
+#: lib/vutuv_web/components/post_components.ex:6089
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Tradotto"
 
-#: lib/vutuv_web/components/post_components.ex:6072
+#: lib/vutuv_web/components/post_components.ex:6092
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Tradotto da %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:6049
+#: lib/vutuv_web/components/post_components.ex:6069
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Traduzione in corso…"
@@ -21454,7 +21453,7 @@ msgid "Feed language settings reset to the site defaults."
 msgstr ""
 "Impostazioni delle lingue del feed riportate ai valori predefiniti del sito."
 
-#: lib/vutuv_web/components/post_components.ex:6039
+#: lib/vutuv_web/components/post_components.ex:6059
 #: lib/vutuv_web/components/ui.ex:5549
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -21597,7 +21596,7 @@ msgid "Your username, or paste the address of your profile page."
 msgstr ""
 "Il Suo nome utente, oppure incolli l'indirizzo della Sua pagina di profilo."
 
-#: lib/vutuv_web/components/post_components.ex:5802
+#: lib/vutuv_web/components/post_components.ex:5822
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
@@ -21608,13 +21607,13 @@ msgstr[1] ""
 "La nostra IA le sta ancora controllando, %{done} su %{total} fatte. Appena "
 "avrà finito con l'ultima, le foto compariranno da sé."
 
-#: lib/vutuv_web/components/post_components.ex:5799
+#: lib/vutuv_web/components/post_components.ex:5819
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Il Suo post è pubblicato, la foto non c'è ancora."
 
 #: lib/vutuv_web/components/post_components.ex:2912
-#: lib/vutuv_web/components/post_components.ex:4868
+#: lib/vutuv_web/components/post_components.ex:4888
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -21634,7 +21633,7 @@ msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Consigliato: quadrata, almeno %{width} × %{height} pixel."
 
 #: lib/vutuv_web/live/job_board_live.ex:431
-#: lib/vutuv_web/live/post_live/feed.ex:1131
+#: lib/vutuv_web/live/post_live/feed.ex:1132
 #: lib/vutuv_web/views/user_html.ex:355
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -22192,7 +22191,7 @@ msgstr ""
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr "Smettere di seguire %{handle}? I suoi post spariscono dal Suo feed."
 
-#: lib/vutuv_web/live/remote_post_actions.ex:175
+#: lib/vutuv_web/live/remote_post_actions.ex:208
 #, elixir-autogen, elixir-format
 msgid "Unfollowed. Their posts leave your feed."
 msgstr "Non lo segue più. I suoi post spariscono dal Suo feed."
@@ -22281,7 +22280,7 @@ msgstr ""
 "e-mail posta disiscrizione newsletter campanella avviso silenzio meno "
 "browser desktop popup push notifica"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:340
+#: lib/vutuv_web/live/tag_live/timeline.ex:341
 #, elixir-autogen, elixir-format
 msgid "%{formatted} active"
 msgstr "%{formatted} attivi"
@@ -22330,12 +22329,12 @@ msgstr ""
 "Segua #%{tag} da Mastodon o da qualsiasi altra app del Fediverso e i suoi "
 "post pubblici arriveranno nella Sua cronologia. Non serve un account vutuv."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4069
+#: lib/vutuv_web/live/post_live/feed.ex:4088
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Saluti gli altri membri"
 
-#: lib/vutuv_web/live/post_live/feed.ex:855
+#: lib/vutuv_web/live/post_live/feed.ex:856
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr "Nuovi qui"
@@ -22385,7 +22384,7 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr "Con un account vutuv"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1123
+#: lib/vutuv_web/live/post_live/feed.ex:1124
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr "Alcuni fra i membri più recenti. Seguirli è un bel benvenuto."
@@ -22746,7 +22745,7 @@ msgstr "Tutti i membri vutuv, in ordine alfabetico per cognome."
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr "Tutti i membri vutuv, raggruppati per la prima lettera del cognome."
 
-#: lib/vutuv_web/live/post_live/feed.ex:980
+#: lib/vutuv_web/live/post_live/feed.ex:981
 #: lib/vutuv_web/live/post_live/filter_band.ex:350
 #, elixir-autogen, elixir-format
 msgid "A photo"
@@ -22762,7 +22761,7 @@ msgstr "Anche dentro parole più lunghe: %{word} trova anche %{example}."
 msgid "A–Z"
 msgstr "A–Z"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1081
+#: lib/vutuv_web/live/post_live/feed.ex:1082
 #, elixir-autogen, elixir-format
 msgid "Browse the tags"
 msgstr "Sfoglia i tag"
@@ -22777,7 +22776,7 @@ msgstr "Più attivi per primi"
 msgid "Clear all"
 msgstr "Cancella tutto"
 
-#: lib/vutuv_web/live/post_live/feed.ex:892
+#: lib/vutuv_web/live/post_live/feed.ex:893
 #, elixir-autogen, elixir-format
 msgid "Drag, or use the arrow keys"
 msgstr "Trascina, oppure usa i tasti freccia"
@@ -22792,13 +22791,13 @@ msgstr "Espandi o comprimi"
 msgid "Find an account or a server …"
 msgstr "Cerca un account o un server …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:916
+#: lib/vutuv_web/live/post_live/feed.ex:917
 #, elixir-autogen, elixir-format
 msgid "Fold %{card}"
 msgstr "Riduci %{card}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1052
 #: lib/vutuv_web/live/post_live/feed.ex:1053
+#: lib/vutuv_web/live/post_live/feed.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Follow a tag …"
 msgstr "Segui un tag …"
@@ -22815,19 +22814,19 @@ msgstr "Nascondi un tag …"
 msgid "Hide a word or a whole phrase …"
 msgstr "Nascondi una parola o un'intera frase …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:853
-#: lib/vutuv_web/live/post_live/feed.ex:4232
+#: lib/vutuv_web/live/post_live/feed.ex:854
+#: lib/vutuv_web/live/post_live/feed.ex:4251
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Nascondi tag"
 
-#: lib/vutuv_web/live/post_live/feed.ex:852
-#: lib/vutuv_web/live/post_live/feed.ex:4221
+#: lib/vutuv_web/live/post_live/feed.ex:853
+#: lib/vutuv_web/live/post_live/feed.ex:4240
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Nascondi parole"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1087
+#: lib/vutuv_web/live/post_live/feed.ex:1088
 #: lib/vutuv_web/live/post_live/filter_band.ex:394
 #, elixir-autogen, elixir-format
 msgid "In your feed right now:"
@@ -22843,7 +22842,7 @@ msgstr "Ora non corrisponde a nulla nel suo feed — la regola vale comunque per
 msgid "More of your %{formatted} accounts"
 msgstr "Altri dei tuoi %{formatted} account"
 
-#: lib/vutuv_web/live/post_live/feed.ex:891
+#: lib/vutuv_web/live/post_live/feed.ex:892
 #, elixir-autogen, elixir-format
 msgid "Move %{card}"
 msgstr "Sposta %{card}"
@@ -22854,12 +22853,12 @@ msgstr "Sposta %{card}"
 msgid "No account found."
 msgstr "Nessun account trovato."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1076
+#: lib/vutuv_web/live/post_live/feed.ex:1077
 #, elixir-autogen, elixir-format
 msgid "No tag called %{name} yet."
 msgstr "Nessun tag chiamato %{name} finora."
 
-#: lib/vutuv_web/live/post_live/feed.ex:845
+#: lib/vutuv_web/live/post_live/feed.ex:846
 #, elixir-autogen, elixir-format
 msgid "Not read yet"
 msgstr "Non ancora letti"
@@ -22889,13 +22888,13 @@ msgstr "I post con uno di questi tag vengono ridotti allo stesso modo."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "I post che contengono una di queste parole vengono ridotti a una riga — non eliminati, e con un modo per aprirli comunque."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4095
+#: lib/vutuv_web/live/post_live/feed.ex:4114
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Messe da parte:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:937
 #: lib/vutuv_web/live/post_live/feed.ex:938
+#: lib/vutuv_web/live/post_live/feed.ex:939
 #, elixir-autogen, elixir-format
 msgid "Remove %{card}"
 msgstr "Rimuovi %{card}"
@@ -22927,8 +22926,8 @@ msgstr "Mostra solo %{source}"
 msgid "Show posts by %{name}"
 msgstr "Mostra i post di %{name}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:851
-#: lib/vutuv_web/live/post_live/feed.ex:4187
+#: lib/vutuv_web/live/post_live/feed.ex:852
+#: lib/vutuv_web/live/post_live/feed.ex:4206
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr "Fonti"
@@ -22938,12 +22937,12 @@ msgstr "Fonti"
 msgid "Switching off means muting, not unfollowing. You stay a follower, the posts just stop reaching your feed: permanently and on every device, until you switch them back on here."
 msgstr "Disattivare significa silenziare, non smettere di seguire. Continui a seguire, ma i post non arrivano più nel tuo feed: in modo permanente e su tutti i dispositivi, finché non li riattivi qui."
 
-#: lib/vutuv_web/live/post_live/feed.ex:915
+#: lib/vutuv_web/live/post_live/feed.ex:916
 #, elixir-autogen, elixir-format
 msgid "Unfold %{card}"
 msgstr "Espandi %{card}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1042
+#: lib/vutuv_web/live/post_live/feed.ex:1043
 #, elixir-autogen, elixir-format
 msgid "Unfollow the tag %{tag}"
 msgstr "Smetti di seguire il tag %{tag}"
@@ -22967,20 +22966,20 @@ msgid_plural "and %{formatted} more"
 msgstr[0] "e 1 altro"
 msgstr[1] "e altri %{formatted}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3653
-#: lib/vutuv_web/live/post_live/feed.ex:3680
+#: lib/vutuv_web/live/post_live/feed.ex:3672
+#: lib/vutuv_web/live/post_live/feed.ex:3699
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
 msgstr "Filtri"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1262
+#: lib/vutuv_web/live/post_live/feed.ex:1263
 #, elixir-autogen, elixir-format
 msgctxt "filtered post"
 msgid "Hidden:"
 msgstr "Nascosto:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:990
+#: lib/vutuv_web/live/post_live/feed.ex:991
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} post in the feed"
 msgid_plural "Show %{formatted} posts in the feed"
@@ -23034,7 +23033,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} post il %{day}"
 msgstr[1] "%{count} post il %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3856
+#: lib/vutuv_web/live/post_live/feed.ex:3875
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Torna al presente"
@@ -23044,7 +23043,7 @@ msgstr "Torna al presente"
 msgid "Busy month: the shading counts at least this much."
 msgstr "Mese intenso: la tonalità indica almeno questo valore."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3902
+#: lib/vutuv_web/live/post_live/feed.ex:3921
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -23066,7 +23065,7 @@ msgstr "Mese successivo"
 msgid "Next year"
 msgstr "Anno successivo"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3852
+#: lib/vutuv_web/live/post_live/feed.ex:3871
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Il %{day} non è arrivato nulla nel Suo feed."
@@ -23153,14 +23152,14 @@ msgstr "È pronta una nuova versione."
 msgid "Page management"
 msgstr "Gestione"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2706
+#: lib/vutuv_web/live/post_live/feed.ex:2708
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
 msgstr[0] "Nuovo:"
 msgstr[1] "Nuovi (%{formatted}):"
 
-#: lib/vutuv_web/components/post_components.ex:3694
+#: lib/vutuv_web/components/post_components.ex:3714
 #, elixir-autogen, elixir-format
 msgid "Quoted post"
 msgstr "Post citato"
@@ -23185,7 +23184,7 @@ msgstr "Menziona un account"
 msgid "{used} of {max} mentions"
 msgstr "{used} di {max} menzioni"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2818
+#: lib/vutuv_web/live/post_live/feed.ex:2820
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr ""
@@ -23216,7 +23215,7 @@ msgstr "Solo questi account (vuoto = tutti) …"
 msgid "only %{account}"
 msgstr "solo %{account}"
 
-#: lib/vutuv_web/components/post_components.ex:7492
+#: lib/vutuv_web/components/post_components.ex:7512
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -23400,7 +23399,7 @@ msgctxt "phone tab bar"
 msgid "Write"
 msgstr "Scrivi"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3990
+#: lib/vutuv_web/live/post_live/feed.ex:4009
 #: lib/vutuv_web/live/post_rewrites_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "%{formatted} rule"
@@ -23470,7 +23469,7 @@ msgstr "Regole che riscrivono il testo dei post di un account prima che Lei li l
 
 #: lib/vutuv_web/components/post_components.ex:1456
 #: lib/vutuv_web/components/post_components.ex:3406
-#: lib/vutuv_web/components/post_components.ex:4658
+#: lib/vutuv_web/components/post_components.ex:4678
 #: lib/vutuv_web/components/ui.ex:5541
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
@@ -23701,7 +23700,7 @@ msgstr[1] "%{formatted} nuovi follower"
 msgid "Last 30 days: %{parts}"
 msgstr "Ultimi 30 giorni: %{parts}"
 
-#: lib/vutuv_web/components/post_components.ex:5220
+#: lib/vutuv_web/components/post_components.ex:5240
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Less"
@@ -24016,7 +24015,7 @@ msgid "Hidden. What they pass on stays out of your feed; their own posts do not.
 msgstr "Nascosto. Ciò che questo account ripubblica non compare più nel Suo feed, i suoi post sì."
 
 #: lib/vutuv_web/components/post_components.ex:3378
-#: lib/vutuv_web/components/post_components.ex:4652
+#: lib/vutuv_web/components/post_components.ex:4672
 #, elixir-autogen, elixir-format
 msgid "Hide reposts"
 msgstr "Nascondi le ripubblicazioni"
@@ -24197,8 +24196,8 @@ msgstr ""
 msgid "Posts loaded at once"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3926
-#: lib/vutuv_web/live/post_live/feed.ex:3930
+#: lib/vutuv_web/live/post_live/feed.ex:3945
+#: lib/vutuv_web/live/post_live/feed.ex:3949
 #, elixir-autogen, elixir-format
 msgid "Posts per page"
 msgstr "Post per pagina"
@@ -24213,60 +24212,60 @@ msgstr ""
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7483
-#: lib/vutuv_web/components/post_components.ex:7484
+#: lib/vutuv_web/components/post_components.ex:7503
+#: lib/vutuv_web/components/post_components.ex:7504
 #, elixir-autogen, elixir-format
 msgid "A word or phrase …"
 msgstr "Una parola o un'espressione …"
 
-#: lib/vutuv_web/components/post_components.ex:7511
+#: lib/vutuv_web/components/post_components.ex:7531
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr "Per chi %{thing} viene nascosto"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3987
-#: lib/vutuv_web/live/post_live/feed.ex:4151
-#: lib/vutuv_web/live/post_live/feed.ex:4160
+#: lib/vutuv_web/live/post_live/feed.ex:4006
+#: lib/vutuv_web/live/post_live/feed.ex:4170
+#: lib/vutuv_web/live/post_live/feed.ex:4179
 #, elixir-autogen, elixir-format
 msgid "Hidden"
 msgstr "Nascosti"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4125
+#: lib/vutuv_web/live/post_live/feed.ex:4144
 #, elixir-autogen, elixir-format
 msgid "Hide something from your feed"
 msgstr "Nascondi qualcosa dal tuo feed"
 
-#: lib/vutuv_web/components/post_components.ex:7429
+#: lib/vutuv_web/components/post_components.ex:7449
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr "Non mostrare più"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4166
+#: lib/vutuv_web/live/post_live/feed.ex:4185
 #, elixir-autogen, elixir-format
 msgid "Whatever these match is folded to a single line in your feed."
 msgstr "Ciò che corrisponde viene ridotto a una riga nel tuo feed."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4186
+#: lib/vutuv_web/live/post_live/feed.ex:4205
 #, elixir-autogen, elixir-format
 msgid "Words & tags"
 msgstr "Parole e tag"
 
-#: lib/vutuv_web/components/post_components.ex:7515
+#: lib/vutuv_web/components/post_components.ex:7535
 #, elixir-autogen, elixir-format
 msgid "everyone"
 msgstr "per tutti"
 
-#: lib/vutuv_web/components/post_components.ex:7518
+#: lib/vutuv_web/components/post_components.ex:7538
 #, elixir-autogen, elixir-format
 msgid "only %{handle}"
 msgstr "solo %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:7487
+#: lib/vutuv_web/components/post_components.ex:7507
 #, elixir-autogen, elixir-format
 msgid "this word"
 msgstr "questa parola"
 
-#: lib/vutuv_web/components/post_components.ex:7528
+#: lib/vutuv_web/components/post_components.ex:7548
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr "solo %{server}"
@@ -24318,7 +24317,7 @@ msgstr "Questo sito è offline in questo momento."
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr "Il sito funziona, è questo indirizzo a non essere uno dei nostri. Probabilmente il link è vecchio oppure contiene un errore di battitura."
 
-#: lib/vutuv_web/components/post_components.ex:6833
+#: lib/vutuv_web/components/post_components.ex:6853
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr "Ingrandisci lo screenshot"
@@ -24409,7 +24408,7 @@ msgid "Hidden. What other people pass on of them stays out of your feed; their o
 msgstr "Nascosto. Ciò che altri ripubblicano di questo account non compare più nel Suo feed, i suoi post sì."
 
 #: lib/vutuv_web/components/post_components.ex:3364
-#: lib/vutuv_web/components/post_components.ex:4640
+#: lib/vutuv_web/components/post_components.ex:4660
 #, elixir-autogen, elixir-format
 msgid "Hide when others repost them"
 msgstr "Nascondi quando altri lo ripubblicano"
@@ -25171,13 +25170,13 @@ msgstr "il modulo di segnalazione"
 msgid "“%{note}”"
 msgstr "“%{note}”"
 
-#: lib/vutuv_web/components/post_components.ex:5398
-#: lib/vutuv_web/components/press_kit_components.ex:211
+#: lib/vutuv_web/components/post_components.ex:5418
+#: lib/vutuv_web/components/press_kit_components.ex:216
 #, elixir-autogen, elixir-format
 msgid "Show these photos larger"
 msgstr "Ingrandisci le foto"
 
-#: lib/vutuv_web/components/post_components.ex:5584
+#: lib/vutuv_web/components/post_components.ex:5604
 #, elixir-autogen, elixir-format
 msgid "Show this photo larger"
 msgstr "Ingrandisci la foto"
@@ -25267,7 +25266,7 @@ msgstr "Detengo i diritti su questo file e lo rilascio per uso editoriale, purch
 msgid "Light"
 msgstr "Chiaro"
 
-#: lib/vutuv/press_kit.ex:251
+#: lib/vutuv/press_kit.ex:321
 #, elixir-autogen, elixir-format
 msgid "Logo variant"
 msgstr "Variante del logo"
@@ -25316,7 +25315,7 @@ msgstr "Immagine rimossa."
 msgid "Please confirm the rights first, then choose the file."
 msgstr "Confermi prima i diritti e scelga poi il file."
 
-#: lib/vutuv/press_kit.ex:251
+#: lib/vutuv/press_kit.ex:321
 #, elixir-autogen, elixir-format
 msgid "Press photo"
 msgstr "Foto per la stampa"
@@ -25402,18 +25401,18 @@ msgstr[1] "%{count} byte"
 msgid "Credit: %{credit}"
 msgstr "Credito: %{credit}"
 
-#: lib/vutuv_web/components/press_kit_components.ex:375
-#: lib/vutuv_web/components/press_kit_components.ex:378
+#: lib/vutuv_web/components/press_kit_components.ex:380
+#: lib/vutuv_web/components/press_kit_components.ex:383
 #, elixir-autogen, elixir-format
 msgid "Download %{format}"
 msgstr "Scarica %{format}"
 
-#: lib/vutuv_web/components/press_kit_components.ex:331
+#: lib/vutuv_web/components/press_kit_components.ex:336
 #, elixir-autogen, elixir-format
 msgid "Download photo"
 msgstr "Scarica la foto"
 
-#: lib/vutuv/press_kit.ex:715
+#: lib/vutuv/press_kit.ex:785
 #, elixir-autogen, elixir-format
 msgid "Free for editorial use with credit."
 msgstr "Libera per uso editoriale, citando il credito."
@@ -25423,7 +25422,7 @@ msgstr "Libera per uso editoriale, citando il credito."
 msgid "PNG version"
 msgstr "Versione PNG"
 
-#: lib/vutuv_web/agent_docs/press_kit_doc.ex:55
+#: lib/vutuv_web/agent_docs/press_kit_doc.ex:58
 #, elixir-autogen, elixir-format
 msgid "Press pictures %{name} offers for download, free for editorial use with credit."
 msgstr "Immagini stampa che %{name} offre in download, libere per uso editoriale citando il credito."
@@ -25458,7 +25457,7 @@ msgstr "Usa il logo di questa pagina"
 msgid "What a journalist writing about this page may download: photos in print quality and its logo as a file. Everything here is public and free for editorial use as long as the credit is shown."
 msgstr "Ciò che una redazione che scrive di questa pagina può scaricare: foto in qualità di stampa e il suo logo come file. Tutto qui è pubblico e libero per uso editoriale, purché vengano indicati i crediti."
 
-#: lib/vutuv_web/components/press_kit_components.ex:565
+#: lib/vutuv_web/components/press_kit_components.ex:570
 #: lib/vutuv_web/components/ui.ex:3281
 #, elixir-autogen, elixir-format
 msgid "Report this picture"
@@ -25560,7 +25559,7 @@ msgid "nobody"
 msgstr "nessuno"
 
 #: lib/vutuv_web/components/press_kit_components.ex:120
-#: lib/vutuv_web/components/press_kit_components.ex:176
+#: lib/vutuv_web/components/press_kit_components.ex:181
 #, elixir-autogen, elixir-format
 msgid "All Media Kit files"
 msgstr "Tutto il Media Kit"
@@ -25580,7 +25579,7 @@ msgstr "Tutto il Media Kit"
 msgid "Media Kit"
 msgstr "Media Kit"
 
-#: lib/vutuv_web/agent_docs/press_kit_doc.ex:53
+#: lib/vutuv_web/agent_docs/press_kit_doc.ex:56
 #: lib/vutuv_web/views/press_kit_html.ex:32
 #, elixir-autogen, elixir-format
 msgid "Media Kit of %{name}"
@@ -25611,8 +25610,8 @@ msgstr "Non può aggiungere un'immagine a questo Media Kit."
 msgid "press kit media journalist photographer download original print logo svg credit copyright presse pressefotos pressemappe medienkit mediakit fotos logo herunterladen bildnachweis"
 msgstr "media kit mediakit kit stampa media redazione giornalista fotografo download originale stampa logo svg crediti copyright foto scaricare"
 
-#: lib/vutuv_web/components/post_components.ex:4556
-#: lib/vutuv_web/components/post_components.ex:4606
+#: lib/vutuv_web/components/post_components.ex:4576
+#: lib/vutuv_web/components/post_components.ex:4626
 #, elixir-autogen, elixir-format
 msgid "Copy link to post"
 msgstr "Copia il link al post"
@@ -25715,7 +25714,7 @@ msgstr "Un paragrafo con cui un articolo può chiudersi."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:121
 #: lib/vutuv_web/agent_docs/text.ex:412
-#: lib/vutuv_web/components/press_kit_components.ex:269
+#: lib/vutuv_web/components/press_kit_components.ex:274
 #, elixir-autogen, elixir-format
 msgid "About %{name}"
 msgstr "Su %{name}"
@@ -25740,12 +25739,12 @@ msgstr "Una @handle rimanda a quel profilo e non avvisa nessuno."
 msgid "As long as you like. The whole portrait."
 msgstr "Lunga quanto vuole. Il ritratto completo."
 
-#: lib/vutuv/press_kit.ex:460
+#: lib/vutuv/press_kit.ex:530
 #, elixir-autogen, elixir-format
 msgid "Long version"
 msgstr "Versione lunga"
 
-#: lib/vutuv/press_kit.ex:459
+#: lib/vutuv/press_kit.ex:529
 #, elixir-autogen, elixir-format
 msgid "Medium version"
 msgstr "Versione media"
@@ -25755,12 +25754,12 @@ msgstr "Versione media"
 msgid "Nothing written yet."
 msgstr "Non ha ancora scritto nulla."
 
-#: lib/vutuv/press_kit.ex:458
+#: lib/vutuv/press_kit.ex:528
 #, elixir-autogen, elixir-format
 msgid "Short version"
 msgstr "Versione breve"
 
-#: lib/vutuv_web/components/press_kit_components.ex:272
+#: lib/vutuv_web/components/press_kit_components.ex:277
 #, elixir-autogen, elixir-format
 msgid "Take whichever length fits the space you have. Each one stands on its own."
 msgstr "Prenda la lunghezza che entra nello spazio che ha. Ognuna sta in piedi da sola."
@@ -25890,7 +25889,7 @@ msgstr "rifiutato"
 msgid "Your post appears as soon as the video is ready"
 msgstr "Il suo post apparirà non appena il video sarà pronto"
 
-#: lib/vutuv_web/components/post_components.ex:3626
+#: lib/vutuv_web/components/post_components.ex:3631
 #, elixir-autogen, elixir-format
 msgid "Found through %{server}"
 msgstr "Trovato tramite %{server}"
@@ -26178,3 +26177,25 @@ msgstr "Non è stato possibile leggere questa immagine."
 #, elixir-autogen, elixir-format
 msgid "You can only send files to members you are connected with."
 msgstr "Può inviare file solo ai membri con cui è in contatto."
+
+#: lib/vutuv_web/components/post_components.ex:3652
+#, elixir-autogen, elixir-format
+msgid "Report this post as not appropriate? Every copy of it disappears right away, for everyone on this vutuv."
+msgstr ""
+"Segnalare questo post come non appropriato? Ogni copia sparisce subito, per "
+"tutti su questo vutuv."
+
+#: lib/vutuv_web/live/remote_post_actions.ex:89
+#, elixir-autogen, elixir-format
+msgid "Thank you. Every copy on this vutuv is gone."
+msgstr "Grazie. Ogni copia su questo vutuv è sparita."
+
+#: lib/vutuv_web/components/post_components.ex:3656
+#, elixir-autogen, elixir-format
+msgid "Report this post as not appropriate? This copy disappears right away, for everyone on this vutuv. Copies other servers sent us stay."
+msgstr "Segnalare questo post come non appropriato? Questa copia sparisce subito, per tutti su questo vutuv. Le copie che altri server ci hanno inviato restano."
+
+#: lib/vutuv_web/live/remote_post_actions.ex:92
+#, elixir-autogen, elixir-format
+msgid "Thank you. This copy is gone for everyone on this vutuv."
+msgstr "Grazie. Questa copia è sparita per tutti su questo vutuv."

--- a/test/vutuv/tag_follow_sources_test.exs
+++ b/test/vutuv/tag_follow_sources_test.exs
@@ -85,6 +85,19 @@ defmodule Vutuv.TagFollowSourcesTest do
       assert Tags.tag_follow_sources(follow) == ["vutuv", "mastodon.social"]
     end
 
+    # Folding one label let the fold itself be walked around: `www.www.host`
+    # came out as `www.host`, which is a subdomain somebody other than the
+    # author may hold, and this is the host we then poll and store rows from
+    # (PR #2176). Every leading `www.` goes, so no source can carry one.
+    test "folds every leading www., so the fold cannot be walked around" do
+      follow = member_follow(insert(:tag))
+
+      assert {:ok, %TagFollowSource{source: "mastodon.social"}} =
+               Tags.add_tag_follow_source(follow, "www.www.mastodon.social")
+
+      assert Tags.tag_follow_sources(follow) == ["vutuv", "mastodon.social"]
+    end
+
     test "every spelling of this installation's own address is the local source" do
       follow = member_follow(insert(:tag))
       # Taken from the endpoint, not written out: the rule under test is
@@ -93,7 +106,13 @@ defmodule Vutuv.TagFollowSourcesTest do
       # because it is us too, and it is the spelling a hardcoded test misses.
       host = VutuvWeb.Endpoint.host()
 
-      for ours <- [host, "www." <> host, "https://#{host}/tags/elixir", Fediverse.tag_host()] do
+      for ours <- [
+            host,
+            "www." <> host,
+            "www.www." <> host,
+            "https://#{host}/tags/elixir",
+            Fediverse.tag_host()
+          ] do
         assert {:ok, %TagFollowSource{source: "vutuv"}} = Tags.add_tag_follow_source(follow, ours)
       end
 

--- a/test/vutuv/tags/external_feed_source_test.exs
+++ b/test/vutuv/tags/external_feed_source_test.exs
@@ -108,7 +108,7 @@ defmodule Vutuv.Tags.ExternalFeedSourceTest do
          %{user: user, tag: tag} do
       post = external_post(tag, source: @source, text: "WAS WEG MUSS")
 
-      assert :ok = ExternalPosts.report(post.id, user)
+      assert {:ok, :every_copy} = ExternalPosts.report(post.id, user)
       refute "external-#{post.id}" in feed_ids(user)
 
       # The row survives as a tombstone, without its words: the pull's

--- a/test/vutuv/tags/external_posts_test.exs
+++ b/test/vutuv/tags/external_posts_test.exs
@@ -762,11 +762,16 @@ defmodule Vutuv.Tags.ExternalPostsTest do
 
     # And neither is an address at the end of any other path: one tenant of a
     # host that lets its members pick their own paths could otherwise write a
-    # page whose address ends in a neighbour's and key alike (PR #2176).
+    # page whose address ends in a neighbour's and key alike (PR #2176). The
+    # second case is the one that matters, because `/r/` is a path a tenant may
+    # simply ask for: the prefix has to sit at the **start** of the path, or
+    # naming the wrapper shape buys nothing over reading an address out of any
+    # path at all.
     test "an address at the end of some other path is not a wrapper" do
       other = "https://elsewhere.test/@bob/9"
 
       refute key("https://#{@source}/@mallory/read/#{other}") == key(other)
+      refute key("https://#{@source}/@mallory/r/#{other}") == key(other)
     end
 
     # `reject_reported/1` asks this of every row on its way in, so a row whose

--- a/test/vutuv/tags/external_posts_test.exs
+++ b/test/vutuv/tags/external_posts_test.exs
@@ -454,6 +454,30 @@ defmodule Vutuv.Tags.ExternalPostsTest do
       end
     end
 
+    # The same attack through the `www.` door (found on PR #2176). A member may
+    # not add `www.<host>` — `normalize_source/1` folds it away — but it folds
+    # **once**, so `www.www.victim` is stored and polled as `www.victim`. A card
+    # served from there claiming the victim's permalink and author host must not
+    # be the victim's own server, whatever the fold says elsewhere.
+    test "a mirror at the author's www. alias takes only itself down", %{reporter: reporter} do
+      tag = followed_tag()
+      url = original("4760")
+
+      home = copy(tag, url, @source)
+      relayed = copy(tag, url, @other_source)
+
+      mirror = copy(tag, url, "www.#{@source}")
+
+      assert {:ok, :this_copy} = ExternalPosts.report(mirror.id, reporter)
+      assert Repo.get!(ExternalPost, mirror.id).reported_at
+
+      for id <- [home.id, relayed.id] do
+        row = Repo.get!(ExternalPost, id)
+        refute row.reported_at, "a mirror at the author's alias blanked an honest copy"
+        assert row.text == "Hello from over there"
+      end
+    end
+
     # The same forgery, played a move earlier: plant the tombstone before the
     # post has ever arrived and the ingest gate refuses it for as long as the
     # tombstone lives. That is a member keeping somebody else's post out of this
@@ -735,6 +759,32 @@ defmodule Vutuv.Tags.ExternalPostsTest do
 
       refute key("https://#{@source}/read?url=#{other}") == key(other)
     end
+
+    # And neither is an address at the end of any other path: one tenant of a
+    # host that lets its members pick their own paths could otherwise write a
+    # page whose address ends in a neighbour's and key alike (PR #2176).
+    test "an address at the end of some other path is not a wrapper" do
+      other = "https://elsewhere.test/@bob/9"
+
+      refute key("https://#{@source}/@mallory/read/#{other}") == key(other)
+    end
+
+    # `reject_reported/1` asks this of every row on its way in, so a row whose
+    # address is unusable has to answer rather than raise: a raise there aborts
+    # the whole store batch, which is the shape #1316 already cost us once.
+    test "an unusable address is no key at all" do
+      refute ExternalPost.origin_key(%{url: nil, author_host: @source})
+      refute ExternalPost.origin_key(%{url: 42, author_host: @source})
+    end
+
+    # Nothing can be a copy of a row with no usable address, itself included —
+    # the fail-closed twin of the test above, since `nil == nil` would otherwise
+    # make two such rows copies of each other.
+    test "a row with no usable address reaches nothing, not even itself" do
+      nothing = %{id: "a", url: nil, author_host: @source, source: @source}
+
+      refute ExternalPosts.reaches?(nothing, nothing)
+    end
   end
 
   # Which rows may speak for a copy they did not file. The one field an answer
@@ -761,10 +811,35 @@ defmodule Vutuv.Tags.ExternalPostsTest do
       refute ExternalPost.home_copy?(row(url: "https://elsewhere.test/@ada/1"))
     end
 
-    test "the www. alias and the host's case are the same server" do
+    # The case and the trailing dot are spellings of one name, and both are
+    # values `TagFollowSource.normalize_source/1` really does write.
+    test "the host's case and its trailing dot are the same server" do
       assert ExternalPost.home_copy?(
-               row(url: "https://www.#{@source}/@ada/1", source: "WWW.#{@source}.")
+               row(url: "https://#{String.upcase(@source)}/@ada/1", source: "#{@source}.")
              )
+    end
+
+    # **The `www.` fold is a description, never an authority.** A site served at
+    # both its apex and its alias is the oldest convention on the web, which is
+    # why `origin_key/1` folds — but `www.<host>` is a *subdomain*, and a
+    # dangling CNAME or an abandoned CDN target hands it to somebody who does not
+    # hold the apex. Folding here let a mirror at the author's alias speak for
+    # the author (found on PR #2176, before it shipped).
+    test "a mirror at the author's www. alias is not the author's own server" do
+      refute ExternalPost.home_copy?(
+               row(url: "https://#{@source}/@ada/1", source: "www.#{@source}")
+             )
+    end
+
+    # The same door from the other side, and this one needs no takeover at all:
+    # an instance whose handle domain is `www.X` would otherwise be spoken for by
+    # whoever holds the bare apex `X`.
+    test "the bare apex is not the author's server when the author lives on its alias" do
+      refute ExternalPost.home_copy?(%{
+               url: "https://www.#{@source}/@ada/1",
+               source: @source,
+               author_host: "www.#{@source}"
+             })
     end
 
     # The wrapper is an address on the bridge, and what it wraps is somebody
@@ -782,6 +857,7 @@ defmodule Vutuv.Tags.ExternalPostsTest do
     test "fails closed on a row with no author host and on an unusable address" do
       refute ExternalPost.home_copy?(row(url: "https://#{@source}/@ada/1", author_host: nil))
       refute ExternalPost.home_copy?(row(url: "not an address"))
+      refute ExternalPost.home_copy?(%{})
     end
   end
 end

--- a/test/vutuv/tags/external_posts_test.exs
+++ b/test/vutuv/tags/external_posts_test.exs
@@ -15,6 +15,7 @@ defmodule Vutuv.Tags.ExternalPostsTest do
   import Vutuv.ExternalTagHelpers
 
   alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.NoteEvent
   alias Vutuv.Repo
   alias Vutuv.Tags
   alias Vutuv.Tags.ExternalFetch
@@ -55,6 +56,23 @@ defmodule Vutuv.Tags.ExternalPostsTest do
   # Age a pair's schedule rather than sleeping until it comes due.
   defp overdue!(tag, at),
     do: tag |> fetch_row() |> Ecto.Changeset.change(next_fetch_at: at) |> Repo.update!()
+
+  # The address of one original, and one stored copy of it. Both given
+  # explicitly: the helper's default url is the same string for every fixture,
+  # and a test about matching on that column must not be able to match by
+  # accident.
+  defp original(path), do: "https://#{@source}/@ada/#{path}"
+
+  defp copy(tag, url, source),
+    do: external_post(tag, url: url, source: source, author_host: @source)
+
+  # The two keys asked directly, with no row in the table: the address plus the
+  # author it claims, and the three hosts the authority test compares. Above the
+  # describes they belong to, because a `defp` inside one compiles to module
+  # scope anyway and only looks scoped.
+  defp key(url, host \\ @source), do: ExternalPost.origin_key(%{url: url, author_host: host})
+
+  defp row(attrs), do: Enum.into(attrs, %{source: @source, author_host: @source})
 
   describe "due_sources/1" do
     test "answers a wanted pair that has never been fetched" do
@@ -390,6 +408,380 @@ defmodule Vutuv.Tags.ExternalPostsTest do
 
       assert %{stored: 1} = ExternalPosts.fetch_due()
       assert Repo.aggregate(ExternalPost, :count) == 2
+    end
+  end
+
+  # What a member means by Report is "this post, off this site", and what
+  # relates the copies is `Vutuv.Tags.ExternalPost.origin/1`. Measured on a copy
+  # of production: the one post somebody really did report stood as **six** rows
+  # of which two were marked (issue #2164).
+  describe "a report" do
+    setup do
+      {:ok, reporter: insert(:activated_user)}
+    end
+
+    # The attack this change was reverted for, and the reason it is back with a
+    # guard (`7cdfd4dc7`, reverted as `8b2c1a862`). Both halves of the key are
+    # written by the polled server and a member may name any host as a tag
+    # source, so one line of JSON claims the victim's permalink **and** the
+    # victim's author host at once. The first version keyed the takedown on
+    # exactly that pair, so reporting the planted card blanked every honest copy
+    # of the post, the one from the author's own server included.
+    test "a planted claim on somebody else's address and author takes only itself down", %{
+      reporter: reporter
+    } do
+      tag = followed_tag()
+      url = original("4740")
+
+      home = copy(tag, url, @source)
+      relayed = copy(tag, url, @other_source)
+
+      planted =
+        external_post(tag,
+          url: url,
+          source: "impostor.example",
+          author_host: @source,
+          author_acct: "ada@#{@source}"
+        )
+
+      assert {:ok, :this_copy} = ExternalPosts.report(planted.id, reporter)
+      assert Repo.get!(ExternalPost, planted.id).reported_at
+
+      for id <- [home.id, relayed.id] do
+        row = Repo.get!(ExternalPost, id)
+        refute row.reported_at, "a planted claim on this address blanked an honest copy of it"
+        assert row.text == "Hello from over there"
+      end
+    end
+
+    # The same forgery, played a move earlier: plant the tombstone before the
+    # post has ever arrived and the ingest gate refuses it for as long as the
+    # tombstone lives. That is a member keeping somebody else's post out of this
+    # installation altogether, which is why the gate asks the same question the
+    # takedown does.
+    test "a planted tombstone cannot keep the honest post out", %{reporter: reporter} do
+      tag = followed_tag()
+
+      planted =
+        external_post(tag,
+          url: original("s1"),
+          source: "impostor.example",
+          author_host: @source,
+          author_acct: "ada@#{@source}"
+        )
+
+      assert {:ok, :this_copy} = ExternalPosts.report(planted.id, reporter)
+
+      # The author's own server answers the tag we asked it for.
+      stub_tag_timeline([status(%{"id" => "s1", "url" => original("s1")})])
+      assert %{stored: 1} = ExternalPosts.fetch_due()
+
+      stored = Repo.get_by!(ExternalPost, source: @source, remote_id: "s1")
+      refute stored.reported_at
+      assert stored.text == "Hello from over there"
+    end
+
+    # What a server that is not the author's own may still take down: the rows
+    # **it** filed. A tag page and a feed hold one row per (tag, server), so the
+    # same relayed status under two followed tags is two cards, and the server's
+    # own word covers both of them.
+    test "a relayed copy takes that server's copies, and nobody else's", %{reporter: reporter} do
+      one = followed_tag()
+      two = followed_tag(@other_source)
+      url = original("4750")
+
+      clicked = copy(two, url, @other_source)
+      same_server = copy(one, url, @other_source)
+      home = copy(one, url, @source)
+      third_server = copy(one, url, "hachyderm.example")
+
+      assert {:ok, :this_copy} = ExternalPosts.report(clicked.id, reporter)
+
+      assert Repo.get!(ExternalPost, same_server.id).reported_at,
+             "the same server's copy under another tag kept standing"
+
+      refute Repo.get!(ExternalPost, home.id).reported_at
+      refute Repo.get!(ExternalPost, third_server.id).reported_at
+    end
+
+    test "takes every copy of the same original, across servers and across tags", %{
+      reporter: reporter
+    } do
+      one = followed_tag()
+      two = followed_tag(@other_source)
+      url = original("4711")
+
+      clicked = copy(one, url, @source)
+      other_server = copy(one, url, @other_source)
+      other_tag = copy(two, url, @source)
+      untouched = copy(one, original("4712"), @source)
+
+      assert {:ok, :every_copy} = ExternalPosts.report(clicked.id, reporter)
+
+      for id <- [clicked.id, other_server.id, other_tag.id] do
+        row = Repo.get!(ExternalPost, id)
+        assert row.reported_at, "a copy of the reported original kept standing"
+        assert row.text == ""
+        refute row.author_acct
+      end
+
+      standing = Repo.get!(ExternalPost, untouched.id)
+      refute standing.reported_at
+      assert standing.text == "Hello from over there"
+    end
+
+    # One server claiming another's permalink must not take down honest copies
+    # of somebody else's post — `ExternalPost.origin_key/1` says why the address
+    # alone cannot be the key.
+    test "a row claiming somebody else's address is not a copy of it", %{reporter: reporter} do
+      tag = followed_tag()
+      url = original("4720")
+
+      honest = external_post(tag, url: url, source: @source, author_host: @source)
+
+      planted =
+        external_post(tag,
+          url: url,
+          source: @other_source,
+          author_host: @other_source,
+          author_acct: "impostor@#{@other_source}"
+        )
+
+      assert {:ok, :this_copy} = ExternalPosts.report(planted.id, reporter)
+
+      standing = Repo.get!(ExternalPost, honest.id)
+      refute standing.reported_at, "a report reached a post by another author at the same address"
+      assert standing.text == "Hello from over there"
+
+      # And the honest author's post is still the one thing anybody may read.
+      assert Repo.all(from(p in ExternalPosts.showable_query(), select: p.id)) == [honest.id]
+    end
+
+    # A redirect wrapper is not a second original: Bridgy Fed serves one Bluesky
+    # post as both `bsky.brid.gy/r/<address>` and `fed.brid.gy/r/<address>`, and
+    # both stood here — same author, same second — with nothing relating them,
+    # which is this issue's own defect surviving for bridged posts. The bridge
+    # itself is the author's server here, and the wrapper is an address on it,
+    # so its own copy is the one that speaks for the pair.
+    test "a post behind two redirect wrappers is one original", %{reporter: reporter} do
+      tag = followed_tag()
+      bluesky = "https://bsky.app/profile/did:plc:abc/post/3mv2azzztuk2i"
+
+      clicked =
+        external_post(tag,
+          url: "https://bsky.brid.gy/r/#{bluesky}",
+          source: "bsky.brid.gy",
+          author_host: "bsky.brid.gy"
+        )
+
+      twin =
+        external_post(tag,
+          url: "https://fed.brid.gy/r/#{bluesky}",
+          source: @other_source,
+          author_host: "bsky.brid.gy"
+        )
+
+      assert {:ok, :every_copy} = ExternalPosts.report(clicked.id, reporter)
+
+      assert Repo.get!(ExternalPost, twin.id).reported_at,
+             "the same post under the other bridge alias kept standing"
+    end
+
+    # One act, one row in the operator's ledger: it answers "is this one troll
+    # or is this server the problem", and counting the copies we happened to
+    # hold would answer a question about our own cache instead.
+    test "writes one ledger row however many copies it took", %{reporter: reporter} do
+      tag = followed_tag()
+      url = original("4713")
+      clicked = copy(tag, url, @source)
+      copy(tag, url, @other_source)
+
+      assert {:ok, :every_copy} = ExternalPosts.report(clicked.id, reporter)
+
+      ledger = from(e in NoteEvent, where: e.action == "reported_post")
+      assert Repo.aggregate(ledger, :count) == 1
+    end
+
+    test "a later pull cannot write the words back into a copy it already holds", %{
+      reporter: reporter
+    } do
+      tag = followed_tag()
+      stub_tag_timeline([status(%{"id" => "s1", "url" => original("s1")})])
+      assert %{stored: 1} = ExternalPosts.fetch_due()
+
+      post = Repo.one!(ExternalPost)
+      assert {:ok, :every_copy} = ExternalPosts.report(post.id, reporter)
+
+      overdue!(tag, DateTime.utc_now(:second))
+      assert %{stored: 0} = ExternalPosts.fetch_due()
+
+      row = Repo.get!(ExternalPost, post.id)
+      assert row.reported_at
+      assert row.text == ""
+    end
+
+    # The tombstone only stops the row it sits on from being rewritten. A tag
+    # nobody followed at the time of the report is a **new** (tag, server) pair,
+    # so the same status arrives as a fresh row with its words intact — the
+    # promise broken with one extra step. The gate is on the way in.
+    test "a copy arriving under a tag followed later is refused", %{reporter: reporter} do
+      _one = followed_tag()
+      stub_tag_timeline([status(%{"id" => "s1", "url" => original("s1")})])
+      assert %{stored: 1} = ExternalPosts.fetch_due()
+
+      assert {:ok, :every_copy} = ExternalPosts.report(Repo.one!(ExternalPost).id, reporter)
+
+      _two = followed_tag()
+      assert %{stored: 0} = ExternalPosts.fetch_due()
+
+      assert Repo.aggregate(ExternalPost, :count) == 1
+      assert Repo.one!(ExternalPost).text == ""
+    end
+
+    # The gate compares the key, not the column. Comparing the two strings let
+    # the same post back in the moment a server spelled its address with one
+    # character more.
+    test "a variant spelling of a reported address is refused too", %{reporter: reporter} do
+      tag = followed_tag()
+      stub_tag_timeline([status(%{"id" => "s1", "url" => original("s1")})])
+      assert %{stored: 1} = ExternalPosts.fetch_due()
+
+      assert {:ok, :every_copy} = ExternalPosts.report(Repo.one!(ExternalPost).id, reporter)
+
+      # The same status, one trailing slash and a fragment later.
+      stub_tag_timeline([status(%{"id" => "s2", "url" => original("s1") <> "/#comments"})])
+      overdue!(tag, DateTime.utc_now(:second))
+      assert %{stored: 0} = ExternalPosts.fetch_due()
+
+      assert Repo.aggregate(ExternalPost, :count) == 1
+    end
+
+    # A row the release before #2127 wrote carries no author host, so it has no
+    # key — and nothing can be a copy of it, itself included. Without a clause
+    # of its own the report blanked nothing at all and still answered `:ok`.
+    test "a row from before the author host was stored takes itself down", %{reporter: reporter} do
+      tag = followed_tag()
+      post = external_post(tag, url: original("4730"), source: @source, author_host: nil)
+
+      assert {:ok, :this_copy} = ExternalPosts.report(post.id, reporter)
+
+      row = Repo.get!(ExternalPost, post.id)
+      assert row.reported_at, "the report wrote a ledger entry and took nothing down"
+      assert row.text == ""
+    end
+
+    test "the tombstone outlives both caps", %{reporter: reporter} do
+      put_config(:external_tag_post_caps, per_tag: 1, total: 1)
+      tag = followed_tag()
+
+      reported =
+        external_post(tag,
+          source: @source,
+          author_host: @source,
+          url: original("4715"),
+          published_at: ~U[2026-08-01 10:00:00Z]
+        )
+
+      assert {:ok, :every_copy} = ExternalPosts.report(reported.id, reporter)
+
+      # Newer rows arrive and both trims run over the table.
+      stub_tag_timeline([status(%{"id" => "s9", "created_at" => "2026-08-20T10:00:00.000Z"})])
+      assert %{stored: 1} = ExternalPosts.fetch_due()
+      ExternalPosts.enforce_ceiling()
+
+      assert Repo.get(ExternalPost, reported.id)
+    end
+  end
+
+  # The key itself, asked directly: each rule below is a spelling the same post
+  # really arrived under, and every one of them decides whose words a report
+  # blanks.
+  describe "the origin key" do
+    test "the author's server is half of it" do
+      assert key("https://#{@source}/@ada/1", @source) !=
+               key("https://#{@source}/@ada/1", "x.test")
+    end
+
+    test "a trailing slash, a fragment and the host's case are the same address" do
+      canonical = key("https://#{@source}/@ada/1")
+
+      assert key("https://#{@source}/@ada/1/") == canonical
+      assert key("https://#{@source}/@ada/1#comments") == canonical
+      assert key("https://#{String.upcase(@source)}/@ada/1") == canonical
+      assert key("https://www.#{@source}/@ada/1") == canonical
+      assert key("https://#{@source}./@ada/1") == canonical
+    end
+
+    test "the path keeps its case, where two spellings are two posts" do
+      refute key("https://#{@source}/@ada/AbC") == key("https://#{@source}/@ada/abc")
+    end
+
+    test "the query stays, where a post may be named in it" do
+      refute key("https://#{@source}/notes?id=1") == key("https://#{@source}/notes?id=2")
+    end
+
+    test "a redirect wrapper is the address it wraps, encoded or not" do
+      wrapped = "https://bsky.app/profile/did:plc:abc/post/3mv2azzztuk2i"
+
+      assert key("https://bsky.brid.gy/r/#{wrapped}") == key(wrapped)
+      assert key("https://fed.brid.gy/r/#{wrapped}") == key(wrapped)
+      assert key("https://fed.brid.gy/r/#{URI.encode_www_form(wrapped)}") == key(wrapped)
+    end
+
+    # A query parameter is where a server puts somebody else's address for its
+    # own reasons, so unwrapping one would relate two unrelated posts.
+    test "an address in the query is not a wrapper" do
+      other = "https://elsewhere.test/@bob/9"
+
+      refute key("https://#{@source}/read?url=#{other}") == key(other)
+    end
+  end
+
+  # Which rows may speak for a copy they did not file. The one field an answer
+  # cannot write is *which* server answered, so the test is that the server we
+  # asked, the address and the author all name it.
+  describe "the post's own copy" do
+    test "the server we asked, the address and the author naming one server" do
+      assert ExternalPost.home_copy?(row(url: "https://#{@source}/@ada/1"))
+    end
+
+    test "a relayed post is somebody else's word about it" do
+      refute ExternalPost.home_copy?(row(url: "https://#{@source}/@ada/1", source: @other_source))
+    end
+
+    # The forgery the revert was for: the address and the author agree with each
+    # other and with nothing else, because one server wrote both of them.
+    test "an address and an author a third server claims together" do
+      refute ExternalPost.home_copy?(
+               row(url: "https://#{@source}/@ada/1", source: "impostor.example")
+             )
+    end
+
+    test "a post at an address on a server other than the author's" do
+      refute ExternalPost.home_copy?(row(url: "https://elsewhere.test/@ada/1"))
+    end
+
+    test "the www. alias and the host's case are the same server" do
+      assert ExternalPost.home_copy?(
+               row(url: "https://www.#{@source}/@ada/1", source: "WWW.#{@source}.")
+             )
+    end
+
+    # The wrapper is an address on the bridge, and what it wraps is somebody
+    # else's by construction — so the raw address is what has to agree.
+    test "a bridge's own wrapper address is its own" do
+      assert ExternalPost.home_copy?(
+               row(
+                 url: "https://bsky.brid.gy/r/https://bsky.app/profile/x/post/1",
+                 source: "bsky.brid.gy",
+                 author_host: "bsky.brid.gy"
+               )
+             )
+    end
+
+    test "fails closed on a row with no author host and on an unusable address" do
+      refute ExternalPost.home_copy?(row(url: "https://#{@source}/@ada/1", author_host: nil))
+      refute ExternalPost.home_copy?(row(url: "not an address"))
     end
   end
 end

--- a/test/vutuv_web/live/external_tag_cards_test.exs
+++ b/test/vutuv_web/live/external_tag_cards_test.exs
@@ -27,6 +27,11 @@ defmodule VutuvWeb.ExternalTagCardsTest do
   @source Vutuv.ExternalTagHelpers.tag_source()
   @author_host Vutuv.ExternalTagHelpers.author_host()
 
+  # A second server this installation asked, for the copies one original leaves
+  # behind (issue #2164): the same status read off two servers is two rows, and
+  # what relates them needs two hostnames that are not the author's.
+  @other_source "social.example"
+
   setup do
     put_config(:fetch_external_tag_posts, true)
     :ok
@@ -123,6 +128,79 @@ defmodule VutuvWeb.ExternalTagCardsTest do
       refute again =~ "EIN FUND VON DRUEBEN"
     end
 
+    # The same post read off two servers under two tags is two rows and two
+    # cards, and a member who reports one of them has been told the post is
+    # gone from this site. It has to be — the reader who then meets the twin
+    # under another "Gefunden über" line is watching us break that promise
+    # (issue #2164).
+    test "reporting the author's own copy takes every copy of that original with it", %{
+      conn: conn,
+      user: user
+    } do
+      here = followed_tag(user, @author_host)
+      there = followed_tag(user, @other_source)
+      url = "https://#{@author_host}/@ada/4711"
+
+      clicked = found_post(here, url: url, source: @author_host)
+      twin = found_post(there, url: url, source: @other_source)
+
+      other =
+        found_post(here,
+          url: "https://#{@author_host}/@ada/4712",
+          source: @author_host,
+          text: "EIN ZWEITER FUND"
+        )
+
+      {:ok, view, html} = live(conn, ~p"/feed")
+      assert html =~ ~s(data-external-post="#{twin.id}")
+
+      html =
+        view
+        |> element(~s([data-external-post="#{clicked.id}"] [phx-click="report-external-post"]))
+        |> render_click()
+
+      refute html =~ ~s(data-external-post="#{clicked.id}")
+      refute html =~ ~s(data-external-post="#{twin.id}")
+      assert html =~ ~s(data-external-post="#{other.id}")
+
+      assert Repo.get!(ExternalPost, twin.id).reported_at
+
+      # And neither of them comes back on a fresh page.
+      {:ok, _view, again} = live(conn, ~p"/feed")
+      refute again =~ ~s(data-external-post="#{twin.id}")
+      assert again =~ "EIN ZWEITER FUND"
+    end
+
+    # And the other half of the same promise: a card some other server relayed
+    # speaks only for that server, so the copy beside it stays — and the dialog
+    # the member read says so before they press it. Any host a member names as
+    # a source may claim any address, so a rule that let this card reach the
+    # other one would let a planted card blank honest copies of somebody else's
+    # post (`8b2c1a862`).
+    test "reporting a relayed card leaves the copies other servers filed", %{
+      conn: conn,
+      user: user
+    } do
+      here = followed_tag(user)
+      there = followed_tag(user, @other_source)
+      url = "https://#{@author_host}/@ada/4713"
+
+      clicked = found_post(here, url: url)
+      twin = found_post(there, url: url, source: @other_source, text: "DIE ANDERE KOPIE")
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      html =
+        view
+        |> element(~s([data-external-post="#{clicked.id}"] [phx-click="report-external-post"]))
+        |> render_click()
+
+      refute html =~ ~s(data-external-post="#{clicked.id}")
+      assert html =~ ~s(data-external-post="#{twin.id}")
+      refute Repo.get!(ExternalPost, twin.id).reported_at
+      assert html =~ "DIE ANDERE KOPIE"
+    end
+
     # This card offers no Translate control and the table holds no translation
     # for it — but the page hands its whole subject list to the translation
     # sweep, which keys every entry by kind. A kind that module has no column
@@ -194,6 +272,22 @@ defmodule VutuvWeb.ExternalTagCardsTest do
       assert entry["found_via"] == @source
     end
 
+    # The page must neither take anything down nor fall over. Both report events
+    # are pushed, because the guard that answers them lives in the module that
+    # owns all six of this menu's events — see `VutuvWeb.Live.RemotePostActions`.
+    test "an anonymous reader's socket reports nothing", %{tag: tag} do
+      post = found_post(tag, text: "BLEIBT STEHEN")
+
+      {:ok, view, _html} =
+        live_isolated(build_conn(), VutuvWeb.TagLive.Timeline,
+          session: %{"tag_id" => tag.id, "source" => "fediverse"}
+        )
+
+      assert render_click(view, "report-external-post", %{"id" => post.id})
+      assert render_click(view, "report-remote-post", %{"id" => post.id})
+      refute Repo.get!(ExternalPost, post.id).reported_at
+    end
+
     # Enforced by the purge a block runs (`Vutuv.Fediverse.purge_instance/1`),
     # not by a clause on the read — see `ExternalPosts.showable_query/0`.
     test "a blocked server's post is on no public page", %{conn: conn, tag: tag} do
@@ -256,19 +350,62 @@ defmodule VutuvWeb.ExternalTagCardsTest do
   end
 
   describe "German" do
-    test "the card's own words are translated", %{conn: conn} do
+    # A German feed, which is what a real visitor sends
+    # (`Accept-Language: de-DE,de`) and what a plain English check never sees.
+    setup %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
-      tag = followed_tag(user)
-      found_post(tag)
+      tag = followed_tag(user, @author_host)
 
-      {:ok, _view, html} =
+      relayed = found_post(followed_tag(user))
+      own = found_post(tag, source: @author_host, url: "https://#{@author_host}/@ada/4714")
+
+      {:ok, view, html} =
         conn
         |> recycle()
         |> put_req_header("accept-language", "de-DE,de")
         |> live(~p"/feed")
 
+      {:ok, view: view, html: html, relayed: relayed, own: own}
+    end
+
+    test "the card's own words are translated", %{html: html} do
       # The quiet provenance line, in German, naming the server we asked.
       assert html =~ "Gefunden über #{@source}"
+    end
+
+    # Both sentences promise the act and nothing about the future: a tombstone
+    # keeps the post out of the next pull, but only until `prune/0` drops it
+    # with the last follow of that pair. The one they replaced promised a
+    # deletion of "unsere Kopie" — singular, and of a row that is blanked rather
+    # than deleted — while the copies it did not touch kept standing two cards
+    # further down (issue #2164).
+    test "the author's own copy promises every copy", %{view: view, html: html, own: own} do
+      assert html =~ "Jede Kopie verschwindet sofort für alle auf diesem vutuv."
+      refute html =~ "Unsere Kopie wird sofort für alle auf diesem vutuv gelöscht"
+      refute html =~ "holen ihn nicht wieder"
+
+      after_click =
+        view
+        |> element(~s([data-external-post="#{own.id}"] [phx-click="report-external-post"]))
+        |> render_click()
+
+      assert after_click =~ "Jede Kopie auf diesem vutuv ist weg."
+      refute after_click =~ "kommt nicht wieder"
+    end
+
+    # And a relayed card promises only itself, because that is all it may take:
+    # a sentence saying "jede Kopie" over a report that leaves the copy beside
+    # it standing is this issue's own defect written the other way round.
+    test "a relayed copy promises only itself", %{view: view, html: html, relayed: relayed} do
+      assert html =~
+               "Diese Kopie verschwindet sofort für alle auf diesem vutuv. Kopien von anderen Servern bleiben stehen."
+
+      after_click =
+        view
+        |> element(~s([data-external-post="#{relayed.id}"] [phx-click="report-external-post"]))
+        |> render_click()
+
+      assert after_click =~ "Diese Kopie ist für alle auf diesem vutuv weg."
     end
   end
 end


### PR DESCRIPTION
Reporting a post one of your followed tags pulled from another server blanked
the clicked row and left the identical copies from the other servers standing,
under a sentence promising they were gone.

This re-lands #2169, reverted as `8b2c1a862`. That version related the copies by
the post's address plus its author host, and the polled server writes both while
any member may add any host as a tag source. A planted card could blank honest
copies of somebody else's post, and a tombstone planted first kept it out of the
table for good.

The guard: only a row whose polled server, permalink host and author host all
name one server may reach copies it did not file; every other row reaches the
rows its own server filed. The ingest gate asks the same question, so a forged
tombstone refuses nothing. Two sentences now say which happened.

Where: `Vutuv.Tags.ExternalPosts.reaches?/2`, a card's ⋯ menu on `/feed`.

Closes #2164

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01AW11tx7rYiSEaRDjPFNghY
