### PR TITLE
The push gate resolves ~ and relative paths the way the shell does

### DIFF
--- a/.claude/hooks/precommit-before-push.sh
+++ b/.claude/hooks/precommit-before-push.sh
@@ -141,6 +141,31 @@ strip_quotes() {
   printf '%s' "$t"
 }
 
+# The path a directory argument names, as the shell would hand it over. A bare
+# leading `~`, alone or before a slash, is $HOME: that is how a dotfiles push is
+# usually typed, and read literally it named no directory and blocked the push
+# rule 4 exists to let through. A quoted `~` stays literal because the shell
+# leaves it literal too. An unset HOME, `~user` and `$HOME` stay unresolved,
+# which blocks.
+dir_word() {
+  case "$1" in
+    "~" | "~/"*)
+      [ -n "${HOME:-}" ] && printf '%s%s' "$HOME" "${1#"~"}" && return
+      ;;
+  esac
+  strip_quotes "$1"
+}
+
+# Where a shell standing in $1 arrives through the path $2. A relative path
+# continues from where the command line stands, never from where this hook
+# does, or `cd <other worktree> && git -C lib push` would gate this checkout.
+join_dir() {
+  case "$2" in
+    /*) printf '%s' "$2" ;;
+    *) printf '%s/%s' "$1" "$2" ;;
+  esac
+}
+
 # The command line, split into segments on the operators that separate one
 # command from the next. Splitting inside a quoted string only produces extra
 # segments that start with no command at all, which are ignored.
@@ -153,9 +178,10 @@ push_dir=""
 # really does carry the current branch and nothing besides.
 push_args=""
 push_args_unknown=0
-# A `cd` in an earlier segment governs a push in a later one
-# (`cd /tree && git push`), so the walk carries the last target along.
-chain_dir=""
+# Where the command line stands: the tool call's own directory, then wherever
+# each `cd` walks it. A push in a later segment leaves from there
+# (`cd /tree && git push`).
+cur=${payload_cwd:-$PWD}
 
 while IFS= read -r segment; do
   # Word-split on whitespace. Quoted arguments holding spaces are split too;
@@ -177,7 +203,7 @@ while IFS= read -r segment; do
   case "${argv0##*/}" in
     cd)
       next=$((idx + 1))
-      [ "$next" -lt "${#words[@]}" ] && chain_dir=$(strip_quotes "${words[$next]}")
+      [ "$next" -lt "${#words[@]}" ] && cur=$(join_dir "$cur" "$(dir_word "${words[$next]}")")
       continue
       ;;
     git) ;;
@@ -194,9 +220,10 @@ while IFS= read -r segment; do
     case "$w" in
       -C)
         j=$((j + 1))
-        [ "$j" -lt "${#words[@]}" ] && dir_opt=$(strip_quotes "${words[$j]}")
+        [ "$j" -lt "${#words[@]}" ] && dir_opt=$(join_dir "${dir_opt:-$cur}" "$(dir_word "${words[$j]}")")
         ;;
-      -C?*) dir_opt=${w#-C} ;;
+      # Glued to its option, the path gets no tilde expansion from the shell.
+      -C?*) dir_opt=$(join_dir "${dir_opt:-$cur}" "${w#-C}") ;;
       # Global options that swallow the following word.
       -c | --git-dir | --work-tree | --namespace | --exec-path | --config-env)
         j=$((j + 1))
@@ -228,18 +255,16 @@ while IFS= read -r segment; do
   fi
 
   if [ "$found_push" -eq 1 ]; then
-    push_dir=${dir_opt:-$chain_dir}
+    push_dir=${dir_opt:-$cur}
     break
   fi
 done <<<"$segments"
 
 [ "$found_push" -eq 1 ] || allow
 
-# Resolve the worktree the push actually runs in: an explicit `git -C <dir>`
-# first, then a `cd` from the same command line, then the directory the tool
-# call was made in. Anything unresolvable blocks.
-dir=${push_dir:-$payload_cwd}
-dir=${dir:-$PWD}
+# The worktree the push actually runs in: an explicit `git -C <dir>`, else
+# where the command line stands. Anything unresolvable blocks.
+dir=$push_dir
 
 toplevel=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null)
 [ -n "$toplevel" ] ||

--- a/.claude/hooks/precommit-before-push.sh
+++ b/.claude/hooks/precommit-before-push.sh
@@ -49,7 +49,10 @@
 # a wrapper it does not know (`bash -c '…'`, `xargs git`, a shell function, a
 # script, a Makefile target, an editor's VCS integration), and quoting is
 # approximated rather than parsed. It is the last automatic reminder before
-# production, not a guarantee that nothing else can push.
+# production, not a guarantee that nothing else can push. And a hook that
+# outlives its `timeout` in `.claude/settings.json` does not block: Claude Code
+# cancels it and lets the push through, so that timeout must outlast the
+# slowest precommit (the test pins it above ~900 s).
 #
 # Run `bash precommit-before-push.sh --explain < payload.json` to print the
 # decision (ALLOW / SKIP <reason> / PUSH <toplevel> / BLOCK <reason>) without

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/precommit-before-push.sh\"",
-            "timeout": 300,
+            "timeout": 1800,
             "statusMessage": "Running mix precommit before push…"
           }
         ]

--- a/test/vutuv/precommit_hook_test.exs
+++ b/test/vutuv/precommit_hook_test.exs
@@ -350,6 +350,21 @@ defmodule Vutuv.PrecommitHookTest do
 
       assert {_, 0} = run_hook(ctx, push, [], path: path_with_mise("exit 0"))
     end
+
+    test "its timeout outlasts the slowest precommit", ctx do
+      # A command hook that times out does not block: Claude Code lets the
+      # tool call through. The hook's own header puts a loaded machine at
+      # ~900 s, and at the old 300 s every slower push went out unchecked.
+      timeout =
+        Path.join(ctx.root, ".claude/settings.json")
+        |> File.read!()
+        |> Jason.decode!()
+        |> get_in(["hooks", "PreToolUse"])
+        |> Enum.flat_map(& &1["hooks"])
+        |> Enum.find_value(&(&1["command"] =~ "precommit-before-push.sh" && &1["timeout"]))
+
+      assert is_integer(timeout) and timeout > 900, "timeout is #{inspect(timeout)}"
+    end
   end
 
   # Runs the hook in `--explain` mode against a payload and returns its verdict.

--- a/test/vutuv/precommit_hook_test.exs
+++ b/test/vutuv/precommit_hook_test.exs
@@ -168,6 +168,56 @@ defmodule Vutuv.PrecommitHookTest do
     end
   end
 
+  describe "the directory a push leaves from" do
+    # The hook walks a command line's directories the way the shell does; see
+    # `dir_word` and `join_dir` there for why each case matters.
+    test "a home-relative path names a stranger like its absolute path", ctx do
+      stranger = tmp_repo()
+      home = Path.dirname(stranger)
+      name = Path.basename(stranger)
+
+      assert decide(ctx, "cd ~/#{name} && git push", home: home) == "ALLOW"
+      assert decide(ctx, "git -C ~/#{name} push", home: home) == "ALLOW"
+    end
+
+    test "a relative path continues from the last cd", ctx do
+      stranger = tmp_repo()
+      parent = Path.dirname(stranger)
+      name = Path.basename(stranger)
+
+      assert decide(ctx, "cd #{parent} && git -C #{name} push") == "ALLOW"
+      assert decide(ctx, "cd #{parent} && cd #{name} && git push") == "ALLOW"
+    end
+
+    test "a relative -C after a cd names that tree, not this checkout", ctx do
+      repo = tmp_project(["lib/vutuv/thing.ex"])
+
+      assert decide(ctx, "cd #{repo} && git -C lib push") == "PUSH #{repo}"
+    end
+
+    test "a home-relative path still gates a checkout of this repository", ctx do
+      repo = tmp_project(["lib/vutuv/thing.ex"])
+      command = "git -C ~/#{Path.basename(repo)} push"
+
+      assert decide(ctx, command, home: Path.dirname(repo)) == "PUSH #{repo}"
+    end
+
+    test "a quoted tilde stays a literal, as it does for the shell", ctx do
+      stranger = tmp_repo()
+      command = ~s{cd "~/#{Path.basename(stranger)}"; git push}
+
+      decision = decide(ctx, command, home: Path.dirname(stranger))
+
+      assert decision =~ "BLOCK", "expected a block, got: #{decision}"
+    end
+
+    test "an unset HOME leaves a tilde unresolved", ctx do
+      decision = decide(ctx, "cd ~/#{Path.basename(tmp_repo())} && git push", home: nil)
+
+      assert decision =~ "BLOCK", "expected a block, got: #{decision}"
+    end
+  end
+
   describe "the documentation exemption" do
     # `mix precommit`'s cost is its ~9,100-test suite, and none of its five
     # steps can read a `docs/` page, a `.github/` workflow or a top-level
@@ -287,44 +337,55 @@ defmodule Vutuv.PrecommitHookTest do
     end
   end
 
+  describe "the gate itself" do
+    # Everything above reads `--explain`, which never runs precommit; a
+    # stand-in `mise` answers for it here, so the suite does not run itself.
+    test "a red precommit blocks the push and a green one lets it through", ctx do
+      repo = tmp_project(["lib/vutuv/thing.ex"])
+      push = "git -C #{repo} push"
+
+      {out, status} = run_hook(ctx, push, [], path: path_with_mise("exit 1"))
+      assert status == 2, "a red precommit must block, got #{status}: #{out}"
+      assert out =~ "`mix precommit` failed"
+
+      assert {_, 0} = run_hook(ctx, push, [], path: path_with_mise("exit 0"))
+    end
+  end
+
   # Runs the hook in `--explain` mode against a payload and returns its verdict.
+  defp decide(ctx, command, opts \\ []) do
+    {out, _status} = run_hook(ctx, command, ["--explain"], opts)
+    out
+  end
+
+  # Runs the hook against a payload and returns its output and exit status.
   # `System.cmd/3` cannot feed stdin, so the payload goes in through a file
   # redirect run by `sh`.
-  defp decide(ctx, command, opts \\ []) do
+  defp run_hook(ctx, command, args, opts) do
     cwd = Keyword.get(opts, :cwd, ctx.root)
     payload = Jason.encode!(%{"cwd" => cwd, "tool_input" => %{"command" => command}})
 
-    payload_file =
-      Path.join(
-        System.tmp_dir!(),
-        "precommit-hook-payload-#{System.unique_integer([:positive])}.json"
-      )
-
+    payload_file = Path.join(tmp_dir!("precommit-hook-payload"), "payload.json")
     File.write!(payload_file, payload)
-    on_exit(fn -> File.rm(payload_file) end)
 
+    # A `nil` value unsets the variable in the child.
     env =
-      case Keyword.fetch(opts, :path) do
-        {:ok, path} -> [{"PATH", path}]
-        :error -> []
-      end
+      for {opt, var} <- [path: "PATH", home: "HOME"],
+          Keyword.has_key?(opts, opt),
+          do: {var, opts[opt]}
 
-    script = "bash #{shell_quote(ctx.hook)} --explain < #{shell_quote(payload_file)}"
+    script =
+      "bash #{shell_quote(ctx.hook)} #{Enum.join(args, " ")} < #{shell_quote(payload_file)}"
 
-    {out, _status} =
+    {out, status} =
       System.cmd("sh", ["-c", script], cd: ctx.root, env: env, stderr_to_stdout: true)
 
-    String.trim(out)
+    {String.trim(out), status}
   end
 
   # A throwaway git repository, optionally carrying an `origin` remote.
   defp tmp_repo(opts \\ []) do
-    tmp =
-      System.tmp_dir!()
-      |> Path.join("precommit-hook-test-#{System.unique_integer([:positive])}")
-
-    File.mkdir_p!(tmp)
-    on_exit(fn -> File.rm_rf!(tmp) end)
+    tmp = tmp_dir!("precommit-hook-test")
     {_, 0} = System.cmd("git", ["init", "--quiet", tmp])
 
     case Keyword.fetch(opts, :remote) do
@@ -432,16 +493,27 @@ defmodule Vutuv.PrecommitHookTest do
 
   defp shell_quote(value), do: "'" <> String.replace(value, "'", ~S('\'')) <> "'"
 
-  # A PATH holding every binary the hook needs except `jq`.
-  defp path_without_jq do
-    dir =
-      Path.join(
-        System.tmp_dir!(),
-        "precommit-hook-nojq-#{System.unique_integer([:positive])}"
-      )
-
+  # A fresh directory under the system temp dir, removed when the test exits.
+  defp tmp_dir!(prefix) do
+    dir = Path.join(System.tmp_dir!(), "#{prefix}-#{System.unique_integer([:positive])}")
     File.mkdir_p!(dir)
     on_exit(fn -> File.rm_rf!(dir) end)
+    dir
+  end
+
+  # The caller's PATH with a `mise` in front that runs `body` instead of mix.
+  defp path_with_mise(body) do
+    dir = tmp_dir!("precommit-hook-mise")
+    mise = Path.join(dir, "mise")
+    File.write!(mise, "#!/bin/sh\n#{body}\n")
+    File.chmod!(mise, 0o755)
+
+    dir <> ":" <> System.get_env("PATH")
+  end
+
+  # A PATH holding every binary the hook needs except `jq`.
+  defp path_without_jq do
+    dir = tmp_dir!("precommit-hook-nojq")
 
     for tool <- ~w(bash sh awk git cat sed grep env) do
       case System.find_executable(tool) do

--- a/test/vutuv/tags/merge_test.exs
+++ b/test/vutuv/tags/merge_test.exs
@@ -230,10 +230,13 @@ defmodule Vutuv.Tags.MergeTest do
     test "names differing only in characters the slugifier strips are refused", ctx do
       # The #1337 bucket: `c`, `c++`, `c#` and `µc` all slugify to `c`, and they
       # are four languages. This is a hard rule, not a matter of judgement, and
-      # it applies to a hand-driven merge as much as to a proposed one.
-      c = tag("c")
-      cpp = tag("c++")
-      csharp = tag("c#")
+      # it applies to a hand-driven merge as much as to a proposed one. A unique
+      # stem keeps the slugs off the `C#` and `C++` that the async `TagsTest`
+      # mints: two files inserting one slug deadlocked here.
+      stem = unique_tag_name("c")
+      c = tag(stem)
+      cpp = tag(stem <> "++")
+      csharp = tag(stem <> "#")
 
       assert {:error, :punctuation_only_difference} = Merge.merge(cpp, c, actor: ctx.admin)
       assert {:error, :punctuation_only_difference} = Merge.merge(csharp, c, actor: ctx.admin)


### PR DESCRIPTION
`cd ~/GitHub/dotfiles && git push` was blocked by `.claude/hooks/precommit-before-push.sh`, although its rule 4 lets pushes from other repositories through: the hook read `~` literally. Underneath, it resolved every relative path against its own directory, so `cd <other worktree> && git -C lib push` gated this checkout instead of the pushed one. It now expands a bare `~` and walks `cd` and `git -C` from the current directory; a quoted `~` and an unset `HOME` still block.

A hook that exceeds its `timeout` does not block, and the gate's 300 s was below today's 447 s precommit, so `.claude/settings.json` now gives it 1800 s.

`Vutuv.Tags.MergeTest` stops minting the slug `c` that the async `TagsTest` also mints, which deadlocked a precommit run.

Every case is tested and calibrated against the old code.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_0181gd1xg8dey7mHVWcNE8jY