### PR TITLE
Give a revoked picture five minutes to leave the browser, not a year

### DIFF
--- a/docs/architecture/images.md
+++ b/docs/architecture/images.md
@@ -68,10 +68,11 @@ The lightbox opens `large` (1600 px) rather than `xl`
 the disk before naming a lite (`Vutuv.LowBandwidth.picture/2` runs the probe
 only for a viewer in the mode), so a row the regeneration has not reached
 keeps showing its full version. The post photo does this too although its
-proxy could fall back the way `xl` falls back to `large`: the proxy caches
-every version as immutable for a year, so a lite URL answered with the feed
-bytes would stay the feed for that year, on exactly the member the mode is
-for. A remote picture keeps no original, so only pictures fetched after the
+proxy could fall back the way `xl` falls back to `large`: a lite URL that
+resolved to the feed file would hand the full-size bytes to exactly the member
+the mode exists to spare, and a browser would keep them for as long as it
+holds them fresh. A remote picture keeps no original, so only pictures fetched
+after the
 version existed have one (`lite-<hash>.avif`, the same hash as the picture,
 opened by the same proxy rules). Adding the version made every row
 non-converged, so the deploy's `regenerate_images` step re-derives them all
@@ -892,6 +893,17 @@ root segment permanently burns a handle, and this kind therefore needs no
 `send_file` rather than the X-Accel handoff (`:post_image_serving`), so a new
 kind of proxied picture costs no nginx change.
 
+**What a browser may remember (issue #2170).** Every proxy response is an
+authorization decision, and authorization gets revoked — a post switched to
+restricted, a picture frozen for copyright, an account suspended — while the
+header was `private, max-age=31536000, immutable`, which tells a browser not to
+ask again for a year. Two tiers now: a **derived version** (`send_version/3`,
+`send_derived/3`) answers `private, max-age=300, must-revalidate` plus an
+`ETag`, and a **file hand-over** (`hand_over/3`, `hand_over_private/4`)
+`private, no-store`. `VutuvWeb.ImageProxy`'s moduledoc holds the reasoning, the
+rejected alternatives and why the header may not be taken without the
+validator.
+
 **Born pending, and how it gets out (issue #2084).** A fresh row starts at
 `Vutuv.Moderation.ImageScans.initial_state/0`, so with the AI gate on it is
 `"pending"` and `PressKit.visible_to?/2` shows it to its owner alone — for a
@@ -1587,8 +1599,9 @@ released — a logo included, cut from the rasterisation the scan judges). Not
 avatars and covers, whose initials tile is the better placeholder at 36 pixels,
 and not organization or job-posting images, which no page shows to a stranger
 while they wait. The response is `ImageProxy.serve_pixelated/2`, the deliberate
-counter-rule to that module's immutable cache header: never X-Accel'd, always
-`no-store`, since the real picture takes the URL within seconds.
+counter-rule to that module's derived-version cache header: never X-Accel'd,
+always `no-store`, since the real picture takes the URL within seconds and
+even five minutes would outlive the wait.
 
 **The two drifts, and why the second one hurt (issue #1443).** Approval is two
 writes in one order: `apply_approved/1` flips the row with `update_all`, then

--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -1790,8 +1790,8 @@ the workbench**: the served versions and lightbox `xl` show the crop, the
 full-resolution cropped JPEG (`cropped.jpg` beside the original, dropped on
 re-crop) — the exact-file choice is forced off and blocked while cropped
 (`download_exact`), because the upload still shows what the author cut away.
-The proxy's cache header is immutable, so `PostImage.url/2` appends a
-crop-keyed `?v=<hash>` buster while a crop is set (bodies stored under an
+A re-crop rewrites the files under the same names, so `PostImage.url/2`
+appends a crop-keyed `?v=<hash>` buster while a crop is set (bodies stored under an
 older buster keep resolving: the inline-image whitelist strips `?v=` before
 lookup).
 

--- a/lib/vutuv/posts/post_image.ex
+++ b/lib/vutuv/posts/post_image.ex
@@ -182,10 +182,12 @@ defmodule Vutuv.Posts.PostImage do
   as `:src`, and as `:lite` the 640 px version while the viewer is in
   data-saving mode (`Vutuv.LowBandwidth`) and the file is on disk — a photo
   the regeneration has not reached yet keeps showing `feed`, never a broken
-  picture. Asked of the disk rather than handed out blind: the proxy caches
-  every version for a year as immutable, so a lite URL answered with the
-  feed bytes would stay the feed for that year, on exactly the member the
-  mode is for.
+  picture. Asked of the disk rather than handed out blind: a lite URL that
+  resolved to the feed file would hand the full-size bytes to exactly the
+  member the mode exists to spare, and a browser would keep them for as long as
+  it holds them fresh — five minutes now rather than the year the proxy's
+  immutable header once promised (`VutuvWeb.ImageProxy`, issue #2170), and the
+  wrong picture either way.
 
   Only the feed slot has a lite: the 320 px `thumb` is already small, and
   `large`/`xl` are the lightbox's, which `lightbox_url/1` answers.
@@ -206,11 +208,14 @@ defmodule Vutuv.Posts.PostImage do
     url(image, if(LowBandwidth.on?(), do: "large", else: "xl"))
   end
 
-  # The proxy serves every version under an immutable-cache header, so a
-  # re-crop (which overwrites the files in place) must change the URL or every
-  # browser that saw the old frame keeps it for a year. The buster is a short
-  # hash of the crop, so the same crop always names the same URL and an
-  # uncropped photo keeps its historical bare one.
+  # A re-crop overwrites the files in place, so the URL must change with it:
+  # otherwise a browser that saw the old frame keeps showing it until its copy
+  # is evicted, the proxy's `ETag` being the file's own size and mtime and its
+  # cache window five minutes (`VutuvWeb.ImageProxy`, issue #2170 — before that
+  # the window was a year and this buster was the only thing standing between a
+  # re-crop and a year of the old frame). The buster is a short hash of the
+  # crop, so the same crop always names the same URL and an uncropped photo
+  # keeps its historical bare one.
   defp crop_buster(%__MODULE__{crop: crop}) when is_binary(crop) and crop != "" do
     "?v=" <>
       (:sha256 |> :crypto.hash(crop) |> Base.url_encode64(padding: false) |> binary_part(0, 8))

--- a/lib/vutuv/posts/post_video.ex
+++ b/lib/vutuv/posts/post_video.ex
@@ -104,8 +104,8 @@ defmodule Vutuv.Posts.PostVideo do
 
   @doc """
   The poster's URL. It carries the cover frame's id as a cache buster: the
-  proxy serves every file as immutable for a year, and the author may pick
-  another frame, which rewrites the file under the same name.
+  proxy caches every file and revalidates it (`VutuvWeb.ImageProxy`), and the
+  author may pick another frame, which rewrites the file under the same name.
   """
   def cover_url(%__MODULE__{} = video), do: url(video, "cover.avif") <> cover_buster(video)
 

--- a/lib/vutuv/press_kit.ex
+++ b/lib/vutuv/press_kit.ex
@@ -615,9 +615,10 @@ defmodule Vutuv.PressKit do
   What a page loads for this viewer (`VutuvWeb.UI.picture/1`), the twin of
   `Vutuv.Posts.PostImage.picture/1`: a photo's `feed` version, with the 640 px
   `lite` in its place while the viewer is in data-saving mode and that file is
-  on disk. Asked of the disk rather than blind, because the proxy caches every
-  version for a year as immutable and a lite URL answered with the feed bytes
-  would stay the feed for that year.
+  on disk. Asked of the disk rather than blind, because a lite URL that
+  resolved to the feed file would hand the full-size bytes to exactly the
+  member the mode exists to spare, and a browser would keep them for as long as
+  it holds them fresh.
 
   A **logo** has no such pair — nothing crops a wordmark and its two versions
   are 320 and 1200 px — so it loads its `thumb` for everybody.

--- a/lib/vutuv/uploaders/post_image_store.ex
+++ b/lib/vutuv/uploaders/post_image_store.ex
@@ -317,9 +317,9 @@ defmodule Vutuv.PostImageStore do
   # `Vutuv.Uploads.Regenerator` has derived the bigger version — a slightly
   # softer picture on a big screen, never a broken one. `lite` (data-saving
   # mode) deliberately has no such fallback: `PostImage.picture/1` asks this
-  # module whether the file exists before naming it, because the proxy's
-  # year-long immutable cache would otherwise pin the feed bytes under the
-  # lite URL.
+  # module whether the file exists before naming it, because the lite URL would
+  # otherwise resolve to the feed file and hand the full-size bytes to exactly
+  # the member the mode exists to spare.
   defp version_filename(token, version) do
     if version in PostImage.versions() do
       dir = dir(token)

--- a/lib/vutuv_web/controllers/attachment_controller.ex
+++ b/lib/vutuv_web/controllers/attachment_controller.ex
@@ -37,7 +37,7 @@ defmodule VutuvWeb.AttachmentController do
   stranger's document on its own origin.
 
   Through `ImageProxy.hand_over_private/4`, which the moderation case page's
-  download shares: `private, no-store` rather than the immutable header,
+  download shares: `private, no-store` and the stored content type,
   because this URL does not answer the same way for ever — ending the
   connection closes it again, and a cached copy in a shared browser would
   outlive that.
@@ -78,7 +78,7 @@ defmodule VutuvWeb.AttachmentController do
       # user's cache" and a browser profile does not know the session changed.
       # A shared computer is exactly where that lands. The re-fetch is the
       # price of a picture whose permission can be revoked.
-      |> put_resp_header("cache-control", "private, no-store")
+      |> ImageProxy.put_no_store()
       |> put_resp_content_type(MIME.from_path(path), nil)
       |> send_file(200, path)
     else

--- a/lib/vutuv_web/controllers/controller_helpers.ex
+++ b/lib/vutuv_web/controllers/controller_helpers.ex
@@ -362,6 +362,34 @@ defmodule VutuvWeb.ControllerHelpers do
   end
 
   @doc """
+  Whether the request already holds `etag`, so the answer may be a 304.
+
+  `if-none-match` is a comma-separated **list**, a member of it may be `*`
+  (which matches anything that exists), and a validator may come back **weak**
+  (`W/"…"`) — nginx marks an ETag weak when it compresses the body, and a
+  strict `==` against our one strong tag would then never match, so every
+  check would fetch the whole file again and the 304 would be a promise
+  nothing keeps. Compare the entity-tags, not the header.
+
+  Two callers, and the second is why this moved here: the service worker's own
+  script (`VutuvWeb.ServiceWorkerController`) and every proxied image version
+  (`VutuvWeb.ImageProxy`, issue #2170). Only the first knew about weak
+  validators, and a second copy would have had to learn it again.
+  """
+  def fresh?(%Conn{} = conn, etag) when is_binary(etag) do
+    conn
+    |> Conn.get_req_header("if-none-match")
+    |> Enum.flat_map(&String.split(&1, ","))
+    |> Enum.any?(fn candidate ->
+      case candidate |> String.trim() |> String.replace_prefix("W/", "") do
+        ^etag -> true
+        "*" -> true
+        _other -> false
+      end
+    end)
+  end
+
+  @doc """
   Renders the bare `VutuvWeb.ErrorHTML` 403/404 page and halts: the one shape
   every auth/resolve plug and the controller-side guards use to refuse a
   request.

--- a/lib/vutuv_web/controllers/image_proxy.ex
+++ b/lib/vutuv_web/controllers/image_proxy.ex
@@ -11,11 +11,57 @@ defmodule VutuvWeb.ImageProxy do
   The controllers keep what genuinely differs: the row lookup, the
   visibility policy, and any per-response decoration (the post proxy's
   download filename and its on-the-fly `og.jpg`).
+
+  ## What a browser may remember (issue #2170)
+
+  Every response here is an **authorization** decision, and authorization is
+  revoked — a post is switched to restricted, a picture is frozen for
+  copyright, a member is suspended. The header said
+  `max-age=31536000, immutable`, which tells the browser not to ask again for a
+  year, so every revocation reached only the machines that had not loaded the
+  picture yet. `immutable` is a claim about the **bytes** (true here: the token
+  is random per image and a re-crop rotates the URL, `PostImage.url/2`) and the
+  browser cannot tell that from a claim about the reader.
+
+  Two tiers now, and both tighten:
+
+    * **A derived version** — a size of a picture, the thing a page renders —
+      answers `private, max-age=300, must-revalidate` plus an `ETag`. Five
+      minutes is one reading session, so a feed scroll still costs no request;
+      past it the browser asks, and because the bytes are content-addressed the
+      answer is a 304 rather than the file. A revocation therefore reaches a
+      browser that already holds the picture within five minutes instead of
+      within a year.
+    * **A file hand-over** — the full-resolution original a post author or a
+      Media Kit gives away — answers `private, no-store`. It is fetched by a
+      deliberate click, never by a page render, so storing nothing costs a page
+      nothing, and a takedown must not leave a print-quality copy behind.
+
+  Rejected, with the reason: `no-store` on the derived versions (a feed full of
+  pictures would re-download every one); `no-cache` on them (a conditional
+  request per picture per page load, for a promise five minutes already keeps);
+  a separate, sharper window for a **restricted** post (knowing whether a
+  response is also public costs an extra query per request, and the takedown
+  promise binds the public class just as hard — measured on this installation's
+  dev copy, 0 of 887 posts carried a denial); and `Vary`, which keys on a
+  **request header** — the allowed request and the revoked one carry the
+  identical `Cookie`, so no `Vary` value can tell them apart.
+
+  The conditional request is answered **inside** `serve/3`, which is only
+  reached once the controller's own `with` chain has authorized the reader, so
+  a 304 is as authorized as the 200 it stands in for and a revoked reader
+  arriving with the matching `ETag` still gets the 404.
   """
 
   import Plug.Conn
 
-  @cache_control "private, max-age=31536000, immutable"
+  alias VutuvWeb.ControllerHelpers
+
+  # Five minutes: one reading session, the same "fresh enough" unit the feed
+  # and the agent documents already use for public HTML.
+  @max_age 300
+  @cache_control "private, max-age=#{@max_age}, must-revalidate"
+  @no_store "private, no-store"
 
   @doc """
   Parses a `"<version>.<ext>"` path segment against the subject's `versions`
@@ -38,27 +84,28 @@ defmodule VutuvWeb.ImageProxy do
   Serves a resolved version through the configured mode: `:post_image_serving`
   set to `:accel_redirect` answers with the store's internal path for nginx
   to stream (auth in the app, bytes by nginx); anything else `send_file`s the
-  bytes (the sendfile syscall, no in-memory buffering). Version URLs are
-  immutable (the token is random per image), so responses carry a long
-  private cache lifetime.
+  bytes (the sendfile syscall, no in-memory buffering).
+
+  The `send_file` branch goes through `send_version/3`, so it carries an
+  `ETag` and answers a matching `if-none-match` with a 304. That branch is the
+  one production takes — `:post_image_serving` is `:send_file` there, the
+  X-Accel handoff having been tried and reverted (see `config/runtime.exs`) —
+  so the dormant X-Accel branch sets no validator of its own: nginx generates
+  one for the file it streams and answers the conditional request itself, and
+  a second `ETag` from here would only collide with it.
 
   Options — `:accel_path` and `:version_path` wrap the subject store's
-  functions (each receives the version); `:decorate` (optional) receives
-  `(conn, extname)` to add per-response headers, e.g. the post proxy's
-  download filename; `:send` (optional) receives `(conn, path)` and sends the
-  file, for a proxy that answers byte ranges (the video proxy) — the default
-  is the whole file with `send_file/3`.
+  functions (each receives the version); `:decorate` and `:send` are
+  `send_version/3`'s.
   """
   def serve(conn, version, opts) do
-    conn = put_cache_control(conn)
-    decorate = Keyword.get(opts, :decorate, fn conn, _ext -> conn end)
-    send = Keyword.get(opts, :send, &send_file(&1, 200, &2))
-
     case Application.get_env(:vutuv, :post_image_serving, :send_file) do
       :accel_redirect ->
+        decorate = Keyword.get(opts, :decorate, fn conn, _ext -> conn end)
         accel_path = opts[:accel_path].(version)
 
         conn
+        |> put_cache_control()
         |> put_resp_content_type(MIME.from_path(accel_path), nil)
         |> decorate.(Path.extname(accel_path))
         |> put_resp_header("x-accel-redirect", accel_path)
@@ -66,79 +113,168 @@ defmodule VutuvWeb.ImageProxy do
 
       _send_file ->
         case opts[:version_path].(version) do
-          nil ->
-            not_found(conn)
-
-          path ->
-            conn
-            |> put_resp_content_type(MIME.from_path(path), nil)
-            |> decorate.(Path.extname(path))
-            |> send.(path)
+          nil -> not_found(conn)
+          path -> send_version(conn, path, opts)
         end
     end
   end
 
-  @doc "The immutable private cache header every proxied image response carries."
-  def put_cache_control(conn), do: put_resp_header(conn, "cache-control", @cache_control)
+  @doc """
+  The **derived tier** for a file on disk: the five-minute cache header, the
+  `ETag`, the conditional answer, the content type and any per-response
+  decoration, in one call.
+
+  One call rather than a header helper a caller pairs with a send of its own,
+  because the header and the validator are one decision: five minutes without
+  an `ETag` re-sends the whole file every five minutes, where the year it
+  replaced re-sent it never. Six responses used to take the header on its own
+  — the two documents' previews, the crop workbench, the on-the-fly `og.jpg`
+  and a clip's cover — and every one of them would have paid that.
+
+  Options: `:decorate` (optional) receives `(conn, extname)` to add
+  per-response headers, e.g. the post proxy's download filename; `:send`
+  (optional) receives `(conn, path)` and sends the file, for a proxy that
+  answers byte ranges (the video proxy); `:content_type` (optional) overrides
+  the type read off the path.
+  """
+  def send_version(conn, path, opts \\ []) do
+    etag = etag(path)
+    conn = conn |> put_cache_control() |> put_resp_header("etag", etag)
+
+    if ControllerHelpers.fresh?(conn, etag) do
+      # A 304 carries the cache-updating fields and nothing else: the reader
+      # already holds the body, its type and its filename, so the content type
+      # and the `decorate` callback below are work this branch would only
+      # throw away.
+      send_resp(conn, 304, "")
+    else
+      decorate = Keyword.get(opts, :decorate, fn conn, _ext -> conn end)
+      send = Keyword.get(opts, :send, &send_file(&1, 200, &2))
+
+      conn
+      |> put_resp_content_type(opts[:content_type] || MIME.from_path(path), nil)
+      |> decorate.(Path.extname(path))
+      |> send.(path)
+    end
+  end
+
+  @doc """
+  The derived tier for bytes **generated in the app** rather than read off
+  disk: the post proxy's on-the-fly `og.jpg` and a clip's cover frame.
+
+  The validator is a hash of the bytes, which are in hand by then anyway. It
+  saves the send and not the derivation — but these are scraper fetches, one
+  per scrape, and the alternative is sending a fresh JPEG every five minutes
+  to a crawler that already has it.
+  """
+  def send_derived(conn, body, content_type) do
+    etag = ~s("#{Integer.to_string(:erlang.phash2(body), 16)}")
+    conn = conn |> put_cache_control() |> put_resp_header("etag", etag)
+
+    if ControllerHelpers.fresh?(conn, etag) do
+      send_resp(conn, 304, "")
+    else
+      conn
+      |> put_resp_content_type(content_type, nil)
+      |> send_resp(200, body)
+    end
+  end
+
+  @doc """
+  `private, no-store` — the counter-rule, for a response whose URL does not
+  answer the same way for long: a pixelated stand-in, an owner's unreleased
+  preview, a private file, and every full-resolution hand-over. Here rather
+  than spelled out at each call site, for the reason `hand_over/3` gives: the
+  next header must not land in only some of them.
+  """
+  def put_no_store(conn), do: put_resp_header(conn, "cache-control", @no_store)
+
+  # The derived tier's header on its own, which no caller outside this module
+  # may take: it is only affordable beside the validator, and `send_version/3`
+  # and `send_derived/3` are the two ways to get both.
+  defp put_cache_control(conn), do: put_resp_header(conn, "cache-control", @cache_control)
+
+  # The validator: the file's size and mtime, the shape `Plug.Static` uses. A
+  # hash of the URL would be cheaper and wrong — a re-derived file (a re-crop
+  # writing over the same names) has to hand out a new tag, or a browser would
+  # be told "not modified" for ever.
+  #
+  # `:raw` is not decoration. A plain `File.stat/1` routes every call through
+  # the node-wide `file_server_2` process, which on this path means one message
+  # round trip per picture on a page; `:raw` reads the file info in-process,
+  # and `time: :posix` keeps the mtime an integer rather than a date tuple for
+  # `phash2` to walk.
+  #
+  # `stat!` rather than a nil-tolerant branch: every caller's `version_path`
+  # has already established that the file is there, so a failure here is the
+  # same race `send_file` would hit on the next line, and both end as a 500.
+  defp etag(path) do
+    %File.Stat{size: size, mtime: mtime} = File.stat!(path, [:raw, time: :posix])
+    ~s("#{Integer.to_string(:erlang.phash2({size, mtime}), 16)}")
+  end
 
   @doc """
   Sends a **pixelated preview** (issue #1720) — the stand-in served while the
   AI image scan is still looking at a picture.
 
-  It is the one response here that must not carry the immutable header above:
-  the real picture takes this URL's place within seconds, so the file must not
-  outlive the wait in any cache. It is also never X-Accel'd — the traffic
-  exists only during an open scan, and `send_file` keeps nginx out of a path
-  that has to answer differently once the verdict lands. A missing file is the
-  proxy's usual 404, so a swept preview reads like any other unknown URL.
+  It is the one **version** here that must not be stored at all: the real
+  picture takes this URL's place within seconds, so even the five minutes a
+  derived version keeps would outlive the wait. It is also never X-Accel'd —
+  the traffic exists only during an open scan, and `send_file` keeps nginx out
+  of a path that has to answer differently once the verdict lands. A missing
+  file is the proxy's usual 404, so a swept preview reads like any other
+  unknown URL.
   """
   def serve_pixelated(conn, nil), do: not_found(conn)
 
   def serve_pixelated(conn, path) do
     conn
-    |> put_resp_header("cache-control", "private, no-store")
+    |> put_no_store()
     |> put_resp_content_type(MIME.from_path(path), nil)
     |> send_file(200, path)
   end
 
   @doc """
-  Hands a **file** over rather than a version of a picture: the immutable cache
-  header, the content type read off the path, `content-disposition: attachment`
-  under `filename`, and the bytes.
+  Hands a **file** over rather than a version of a picture: `no-store`, the
+  content type read off the path, `content-disposition: attachment` under
+  `filename`, and the bytes.
+
+  `no-store` rather than the derived versions' five minutes — the module doc
+  says why, under the two tiers. Two responses take this route: a post photo's
+  author-enabled download (#1104) and the print-quality picture a Media Kit
+  exists to give away (#2083).
 
   Deliberately not `serve/3`. That helper's X-Accel branch resolves paths inside
   the *served* versions location, and every file that leaves this way lives in
   the private originals tree, which nginx must never learn to resolve. It is
-  here rather than in each proxy because two of them now hand a file over — the
-  post photo's author-enabled download (#1104) and the press kit's, which is a
-  whole section built on it (#2083) — and the next header must not land in only
-  one of them.
+  here rather than in each proxy because two of them now hand a file over and
+  the next header must not land in only one of them.
   """
   def hand_over(conn, path, filename) do
     conn
-    |> put_cache_control()
+    |> put_no_store()
     |> put_resp_content_type(MIME.from_path(path), nil)
     |> put_resp_header("content-disposition", ~s(attachment; filename="#{filename}"))
     |> send_file(200, path)
   end
 
   @doc """
-  Hands a **private** file over: same shape as `hand_over/3`, but with
-  `cache-control: private, no-store` and the stored content type rather than
-  the immutable header and a type read off the path.
+  Hands a **private** file over: same shape as `hand_over/3` — `no-store`
+  included, since issue #2170 gave every hand-over that header — but with the
+  **stored** content type rather than one read off the path, and the name
+  through the RFC 5987 pair.
 
-  The two differences are one decision — these are files whose URL does not
-  answer the same way for ever. A reported file leaves the readable trees the
-  moment a copyright case freezes it (`VutuvWeb.ModerationCaseController`), and
-  a file in a message stops being readable when the two members stop being
-  connected (`VutuvWeb.AttachmentController`, issue #2110); a copy sitting in a
-  shared browser's cache would outlive either. The name goes through
+  A reported file leaves the readable trees the moment a copyright case freezes
+  it (`VutuvWeb.ModerationCaseController`), and a file in a message stops being
+  readable when the two members stop being connected
+  (`VutuvWeb.AttachmentController`, issue #2110); a copy sitting in a shared
+  browser's cache would outlive either. The name goes through
   `ControllerHelpers.disposition_filename/1`, the RFC 5987 pair, so a file
   called `Papier Müller.pdf` downloads under its own name.
   """
   def hand_over_private(conn, path, filename, content_type) do
     conn
-    |> put_resp_header("cache-control", "private, no-store")
+    |> put_no_store()
     |> put_resp_header(
       "content-disposition",
       "attachment; " <> VutuvWeb.ControllerHelpers.disposition_filename(filename)

--- a/lib/vutuv_web/controllers/job_reference_document_controller.ex
+++ b/lib/vutuv_web/controllers/job_reference_document_controller.ex
@@ -11,7 +11,8 @@ defmodule VutuvWeb.JobReferenceDocumentController do
   things must all hold before any byte leaves: the entry is published, the
   document cleared moderation, and the URL's fingerprint matches what is
   stored. The owner bypasses the first two, and nobody bypasses the third —
-  the URLs are cached hard, so stale bytes must 404 rather than be served.
+  the URL names the bytes, and a browser holding them revalidates rather than
+  re-fetching, so a stale fingerprint must 404 rather than be served.
 
   Every refusal is the same 404, so the proxy never reveals whether a private
   Zeugnis exists at a given id.
@@ -81,11 +82,7 @@ defmodule VutuvWeb.JobReferenceDocumentController do
   defp send_document(conn, nil, _decorate), do: ImageProxy.not_found(conn)
 
   defp send_document(conn, path, decorate) do
-    conn
-    |> ImageProxy.put_cache_control()
-    |> put_resp_content_type(MIME.from_path(path), nil)
-    |> decorate.()
-    |> send_file(200, path)
+    ImageProxy.send_version(conn, path, decorate: fn conn, _ext -> decorate.(conn) end)
   end
 
   # The save-as name is the member's original filename; the RFC 5987 pair that

--- a/lib/vutuv_web/controllers/moderation_case_controller.ex
+++ b/lib/vutuv_web/controllers/moderation_case_controller.ex
@@ -80,7 +80,7 @@ defmodule VutuvWeb.ModerationCaseController do
       conn
       # Never cached, anywhere: these are the bytes a takedown is about, and a
       # copy in a proxy would outlive the freeze that moved them.
-      |> put_resp_header("cache-control", "private, no-store")
+      |> ImageProxy.put_no_store()
       |> put_resp_content_type(MIME.from_path(path), nil)
       |> send_file(200, path)
     else

--- a/lib/vutuv_web/controllers/pending_image_controller.ex
+++ b/lib/vutuv_web/controllers/pending_image_controller.ex
@@ -32,7 +32,7 @@ defmodule VutuvWeb.PendingImageController do
          path when is_binary(path) <- pending_path(user, kind, version) do
       conn
       |> put_resp_content_type("image/avif", nil)
-      |> put_resp_header("cache-control", "private, no-store")
+      |> ImageProxy.put_no_store()
       |> send_file(200, path)
     else
       _ -> ImageProxy.not_found(conn)

--- a/lib/vutuv_web/controllers/post_image_controller.ex
+++ b/lib/vutuv_web/controllers/post_image_controller.ex
@@ -2,12 +2,17 @@ defmodule VutuvWeb.PostImageController do
   @moduledoc """
   The authorizing image proxy: every post-image byte is served through here,
   so a post's audience (deny-model, `Vutuv.Posts.visible_to?/2`) also guards
-  its images — switching a post from public to restricted locks its images
-  immediately, which statically served files could never do.
+  its images — switching a post from public to restricted shuts every reader
+  out of its pictures on their next request, which statically served files
+  could never do. **Not "immediately" on a machine that already loaded one**:
+  a browser holding the bytes asks again after five minutes and is refused
+  then (issue #2170, `VutuvWeb.ImageProxy`, which explains why five). Until
+  that issue the answer was a year, and the claim of immediacy made here was
+  simply false.
 
   The serving mechanics (X-Accel-Redirect vs `send_file`, the version parser,
-  the immutable cache header) live in `VutuvWeb.ImageProxy`, shared with the
-  job-posting and organization proxies; this controller owns the post policy,
+  the cache and revalidation headers) live in `VutuvWeb.ImageProxy`, shared
+  with the job-posting and organization proxies; this controller owns the post policy,
   the on-the-fly `og.jpg` and the download filename. Pending images (post not
   yet submitted) are visible to their uploader alone; denied and unknown
   tokens are both 404 — the proxy must not leak whether an image exists.
@@ -117,14 +122,14 @@ defmodule VutuvWeb.PostImageController do
   #
   #   * still waiting — the file, under `no-store`. It is replaced by the real
   #     picture within seconds and must not outlive that in any cache, which is
-  #     the one place this proxy's year-long immutable header would be wrong.
+  #     the one version even the proxy's five-minute window would be wrong for.
   #   * released — a redirect to the picture itself. The pixelated preview is deleted on
   #     the verdict, so without this a dead page that lazy-loads a tile after
   #     the swap would show a broken image where the photo now is.
   defp serve(conn, image, :pixelated) do
     if ImageScans.released?(image.moderation) do
       conn
-      |> put_resp_header("cache-control", "private, no-store")
+      |> ImageProxy.put_no_store()
       |> redirect(to: PostImage.url(image, "feed"))
     else
       ImageProxy.serve_pixelated(conn, existing(Vutuv.PostImageStore.pixelated_path(image.token)))
@@ -133,15 +138,15 @@ defmodule VutuvWeb.PostImageController do
 
   # The og.jpg bytes are generated in the app (Vutuv.PostImageStore.og_jpeg/1),
   # so they are sent directly in both serving modes — there is no file for
-  # nginx to accel-stream. Rare traffic: one fetch per scrape, then cached.
+  # nginx to accel-stream. Rare traffic: one fetch per scrape, and
+  # `send_derived/3`'s hash of the bytes then answers the next scrape's
+  # revalidation with a 304.
   defp serve(conn, image, :og) do
     case Vutuv.PostImageStore.og_jpeg(image) do
       {:ok, jpeg} ->
         conn
-        |> ImageProxy.put_cache_control()
         |> put_download_name(image, "og", "jpg")
-        |> put_resp_content_type("image/jpeg", nil)
-        |> send_resp(200, jpeg)
+        |> ImageProxy.send_derived(jpeg, "image/jpeg")
 
       :error ->
         ImageProxy.not_found(conn)
@@ -179,10 +184,7 @@ defmodule VutuvWeb.PostImageController do
 
     with true <- viewer != nil and viewer.id == image.user_id,
          path when not is_nil(path) <- Vutuv.PostImageStore.source_path(image) do
-      conn
-      |> ImageProxy.put_cache_control()
-      |> put_resp_content_type("image/avif", nil)
-      |> send_file(200, path)
+      ImageProxy.send_version(conn, path, content_type: "image/avif")
     else
       _ -> ImageProxy.not_found(conn)
     end

--- a/lib/vutuv_web/controllers/post_video_controller.ex
+++ b/lib/vutuv_web/controllers/post_video_controller.ex
@@ -78,10 +78,7 @@ defmodule VutuvWeb.PostVideoController do
   defp serve(conn, video, _viewer, :og) do
     with %{position: position} <- Videos.cover_frame(video),
          {:ok, jpeg} <- PostVideoStore.og_jpeg(video.token, position) do
-      conn
-      |> ImageProxy.put_cache_control()
-      |> put_resp_content_type("image/jpeg", nil)
-      |> send_resp(200, jpeg)
+      ImageProxy.send_derived(conn, jpeg, "image/jpeg")
     else
       _ -> ImageProxy.not_found(conn)
     end

--- a/lib/vutuv_web/controllers/press_kit_image_controller.ex
+++ b/lib/vutuv_web/controllers/press_kit_image_controller.ex
@@ -6,8 +6,8 @@ defmodule VutuvWeb.PressKitImageController do
   allowed to see it (`Vutuv.PressKit.visible_to?/2`).
 
   The serving mechanics (the version parser, the X-Accel / `send_file` switch,
-  the immutable cache header) are `VutuvWeb.ImageProxy`'s, shared with the post,
-  job-posting and organization proxies. What this one owns is the two addresses
+  the cache and revalidation headers) are `VutuvWeb.ImageProxy`'s, shared with
+  the post, job-posting and organization proxies. What this one owns is the two addresses
   a *file* leaves at, which no other proxy has as its main purpose:
 
     * `download.orig` — the picture a journalist takes away, always the
@@ -77,7 +77,7 @@ defmodule VutuvWeb.PressKitImageController do
   defp serve(conn, image, :pixelated) do
     if ImageScans.released?(image.moderation) do
       conn
-      |> put_resp_header("cache-control", "private, no-store")
+      |> ImageProxy.put_no_store()
       |> redirect(to: PressKit.url(image, "large"))
     else
       ImageProxy.serve_pixelated(conn, existing(PressKitStore.pixelated_path(image.token)))

--- a/lib/vutuv_web/controllers/qualification_document_controller.ex
+++ b/lib/vutuv_web/controllers/qualification_document_controller.ex
@@ -6,8 +6,9 @@ defmodule VutuvWeb.QualificationDocumentController do
   `/:slug/qualifications/:id/document/`.
 
   Access policy: the document must exist, the URL's fingerprint must match the
-  stored one (the URLs are immutable and cached hard, so stale bytes must 404
-  rather than be served), and while the AI image scan still holds it in limbo
+  stored one (the URL names the bytes, and a browser holding them revalidates
+  rather than re-fetching, so a stale fingerprint must 404 rather than be
+  served), and while the AI image scan still holds it in limbo
   only the owner gets the bytes (the review-cover pattern: no quarantine tree,
   the proxy checks the moderation state). Everything else — unknown ids, wrong
   fingerprints, a pending document to a visitor — is the same 404, so the
@@ -76,11 +77,7 @@ defmodule VutuvWeb.QualificationDocumentController do
   defp send_document(conn, nil, _decorate), do: ImageProxy.not_found(conn)
 
   defp send_document(conn, path, decorate) do
-    conn
-    |> ImageProxy.put_cache_control()
-    |> put_resp_content_type(MIME.from_path(path), nil)
-    |> decorate.()
-    |> send_file(200, path)
+    ImageProxy.send_version(conn, path, decorate: fn conn, _ext -> decorate.(conn) end)
   end
 
   # The save-as name is the member's original filename; the RFC 5987 pair that

--- a/lib/vutuv_web/controllers/service_worker_controller.ex
+++ b/lib/vutuv_web/controllers/service_worker_controller.ex
@@ -40,6 +40,7 @@ defmodule VutuvWeb.ServiceWorkerController do
 
   use VutuvWeb, :controller
 
+  alias VutuvWeb.ControllerHelpers
   alias VutuvWeb.Endpoint
   alias VutuvWeb.PushLine
 
@@ -76,26 +77,13 @@ defmodule VutuvWeb.ServiceWorkerController do
       |> put_resp_header("etag", etag)
       |> put_resp_header("cache-control", "no-cache")
 
-    if fresh?(conn, etag) do
+    if ControllerHelpers.fresh?(conn, etag) do
       send_resp(conn, 304, "")
     else
       conn
       |> put_resp_content_type("text/javascript")
       |> send_resp(200, body)
     end
-  end
-
-  # `If-None-Match` is a comma-separated LIST, and a validator may come back
-  # **weak** (`W/"…"`) — nginx marks an ETag weak when it compresses the body,
-  # and a strict `==` against our one strong tag would then never match, so
-  # every update check would fetch the whole file again and the 304 above would
-  # be a promise nothing keeps. Compare the entity-tags, not the header.
-  defp fresh?(conn, etag) do
-    conn
-    |> get_req_header("if-none-match")
-    |> Enum.flat_map(&String.split(&1, ","))
-    |> Enum.map(&(&1 |> String.trim() |> String.replace_prefix("W/", "")))
-    |> Enum.any?(&(&1 == etag))
   end
 
   # The keys are spelled camelCase here rather than converted, because the file

--- a/test/vutuv/uploaders/post_image_store_test.exs
+++ b/test/vutuv/uploaders/post_image_store_test.exs
@@ -217,8 +217,8 @@ defmodule Vutuv.PostImageStoreTest do
       assert {Image.width(lite), Image.height(lite)} == {40, 80}
     end
 
-    # No URL without the file: the proxy caches every version as immutable for
-    # a year, so a lite URL answered with the feed bytes would stay the feed.
+    # No URL without the file: a lite URL that resolved to the feed file would
+    # hand the full-size bytes to exactly the member the mode exists to spare.
     test "picture/1 names the lite only in data-saving mode and only once it exists", %{
       tmp: tmp
     } do

--- a/test/vutuv_web/controllers/image_proxy_cache_test.exs
+++ b/test/vutuv_web/controllers/image_proxy_cache_test.exs
@@ -1,0 +1,227 @@
+defmodule VutuvWeb.ImageProxyCacheTest do
+  @moduledoc """
+  What a browser is allowed to remember about a picture it was once shown
+  (issue #2170).
+
+  `VutuvWeb.ImageProxy` authorizes **per viewer** and then answered
+  `max-age=31536000, immutable`, which tells the browser not even to ask again
+  for a year. So a post switched to restricted went on feeding its pictures out
+  of every browser that had already seen them, and a Media Kit picture taken
+  down for copyright never disappeared from one either — the print-quality
+  original included.
+
+  Three claims here, one per tier:
+
+    * a **derived version** (a size of a picture, the thing a page renders) is
+      revalidatable: a short window, and an `ETag` so the check costs a 304
+      rather than the bytes;
+    * a **revoked** reader gets the 404 even when they arrive holding the
+      matching `ETag` — the conditional request is answered behind the same
+      authorization as the full one, never in front of it;
+    * a **file hand-over** (the full-resolution original a Media Kit exists to
+      give away) is not stored at all.
+
+  Not async: it flips `:uploads_dir_prefix` and `:moderate_images`, which are
+  global and outside the SQL sandbox.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Vutuv.WebPushHelpers, only: [put_config: 2]
+
+  alias Vutuv.Images
+  alias Vutuv.Posts
+  alias Vutuv.Posts.PostDenial
+  alias Vutuv.PressKit
+  alias Vutuv.Repo
+
+  @derived "private, max-age=300, must-revalidate"
+  @no_store "private, no-store"
+
+  setup %{conn: conn} do
+    tmp = Path.join(System.tmp_dir!(), "vutuv_proxy_cache_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    put_config(:uploads_dir_prefix, tmp)
+    put_config(:moderate_images, false)
+    on_exit(fn -> File.rm_rf(tmp) end)
+
+    {owner_conn, owner} = create_and_login_user(conn)
+    {:ok, tmp: tmp, owner: owner, owner_conn: owner_conn}
+  end
+
+  defp anonymous, do: Phoenix.ConnTest.build_conn() |> Plug.Test.init_test_session(%{})
+
+  defp cache_control(conn), do: conn |> get_resp_header("cache-control") |> List.first()
+  defp etag(conn), do: conn |> get_resp_header("etag") |> List.first()
+
+  defp photo_file!(tmp) do
+    src = Path.join(tmp, "shot-#{System.unique_integer([:positive])}.jpg")
+    {:ok, img} = Image.new(120, 90, color: [10, 120, 200])
+    {:ok, _} = Image.write(img, src)
+    src
+  end
+
+  defp post_photo!(author, tmp, image_attrs \\ %{}) do
+    {:ok, image} = Posts.create_pending_image(author, photo_file!(tmp), "photo.jpg")
+    {:ok, image} = Posts.update_image_settings(image, image_attrs)
+    {:ok, post} = Posts.create_post(author, %{body: "pic", image_ids: [image.id]})
+    {post, image}
+  end
+
+  defp press_photo!(owner, tmp) do
+    path = Path.join(tmp, "press-#{System.unique_integer([:positive])}.jpg")
+    {:ok, img} = Image.new(600, 400, color: [10, 120, 200])
+    {:ok, _} = Image.write(img, path)
+
+    {:ok, image} =
+      PressKit.create(owner, owner, {path, "press.jpg"}, %{
+        "rights_confirmed" => "true",
+        "credit" => "Foto: Ada King"
+      })
+
+    Repo.update!(Ecto.Changeset.change(image, moderation: "approved"))
+  end
+
+  describe "a derived version" do
+    test "on a public post is revalidatable, not immutable", %{owner: owner, tmp: tmp} do
+      {_post, image} = post_photo!(owner, tmp)
+
+      conn = get(anonymous(), "/post_images/#{image.token}/feed.avif")
+
+      assert conn.status == 200
+      assert cache_control(conn) == @derived
+      refute cache_control(conn) =~ "immutable"
+      assert etag(conn)
+    end
+
+    test "on a restricted post gets the same window as a public one", %{
+      owner: owner,
+      owner_conn: owner_conn,
+      tmp: tmp
+    } do
+      {post, image} = post_photo!(owner, tmp)
+      Repo.insert!(%PostDenial{post_id: post.id, wildcard: "everyone"})
+
+      conn = get(owner_conn, "/post_images/#{image.token}/feed.avif")
+
+      assert conn.status == 200
+      assert cache_control(conn) == @derived
+      assert get(anonymous(), "/post_images/#{image.token}/feed.avif").status == 404
+    end
+
+    test "still in the composer, with no post yet, gets it too", %{
+      owner: owner,
+      owner_conn: owner_conn,
+      tmp: tmp
+    } do
+      {:ok, image} = Posts.create_pending_image(owner, photo_file!(tmp), "photo.jpg")
+
+      conn = get(owner_conn, "/post_images/#{image.token}/feed.avif")
+
+      assert conn.status == 200
+      assert cache_control(conn) == @derived
+    end
+
+    test "on a released Media Kit picture gets it too", %{owner: owner, tmp: tmp} do
+      photo = press_photo!(owner, tmp)
+
+      conn = get(anonymous(), PressKit.url(photo, "large"))
+
+      assert conn.status == 200
+      assert cache_control(conn) == @derived
+    end
+  end
+
+  describe "revalidating" do
+    test "costs a 304 rather than the bytes while the reader is still allowed", %{
+      owner: owner,
+      tmp: tmp
+    } do
+      {_post, image} = post_photo!(owner, tmp)
+
+      first = get(anonymous(), "/post_images/#{image.token}/feed.avif")
+      assert first.status == 200
+      assert byte_size(first.resp_body) > 0
+
+      second =
+        anonymous()
+        |> put_req_header("if-none-match", etag(first))
+        |> get("/post_images/#{image.token}/feed.avif")
+
+      assert second.status == 304
+      assert second.resp_body == ""
+    end
+
+    # What enforces this today is placement, not a check: the conditional lives
+    # inside `ImageProxy.serve/3`, which no controller reaches before its own
+    # `with` chain has authorized the reader. The test pins that against the
+    # obvious future optimization — moving the ETag comparison into an endpoint
+    # plug, in front of the authorization — rather than covering a live branch.
+    test "answers a revoked reader 404, not 304, even when they hold the ETag", %{
+      owner: owner,
+      owner_conn: owner_conn,
+      tmp: tmp
+    } do
+      {post, image} = post_photo!(owner, tmp)
+
+      first = get(anonymous(), "/post_images/#{image.token}/feed.avif")
+      assert first.status == 200
+      tag = etag(first)
+
+      Repo.insert!(%PostDenial{post_id: post.id, wildcard: "everyone"})
+
+      revalidated =
+        anonymous()
+        |> put_req_header("if-none-match", tag)
+        |> get("/post_images/#{image.token}/feed.avif")
+
+      assert revalidated.status == 404
+
+      # And the author, who may still see it, is not locked out by the same tag.
+      # `recycle/1` because `put_req_header/3` — unlike `get/3` — does not do it
+      # for you, and this conn has already carried the login response.
+      assert owner_conn
+             |> recycle()
+             |> put_req_header("if-none-match", tag)
+             |> get("/post_images/#{image.token}/feed.avif")
+             |> Map.fetch!(:status) == 304
+    end
+
+    test "a frozen Media Kit picture 404s a browser holding its ETag", %{
+      owner: owner,
+      tmp: tmp
+    } do
+      photo = press_photo!(owner, tmp)
+
+      first = get(anonymous(), PressKit.url(photo, "large"))
+      assert first.status == 200
+      tag = etag(first)
+
+      :ok = Images.freeze(photo)
+
+      assert anonymous()
+             |> put_req_header("if-none-match", tag)
+             |> get(PressKit.url(photo, "large"))
+             |> Map.fetch!(:status) == 404
+    end
+  end
+
+  describe "a file hand-over" do
+    test "of a Media Kit original is never stored", %{owner: owner, tmp: tmp} do
+      photo = press_photo!(owner, tmp)
+
+      conn = get(anonymous(), PressKit.download_url(photo))
+
+      assert conn.status == 200
+      assert cache_control(conn) == @no_store
+    end
+
+    test "of a post photo's full-resolution original is never stored", %{owner: owner, tmp: tmp} do
+      {_post, image} = post_photo!(owner, tmp, %{"download_original" => true})
+
+      conn = get(anonymous(), "/post_images/#{image.token}/original.orig")
+
+      assert conn.status == 200
+      assert cache_control(conn) == @no_store
+    end
+  end
+end

--- a/test/vutuv_web/controllers/post_image_controller_test.exs
+++ b/test/vutuv_web/controllers/post_image_controller_test.exs
@@ -54,7 +54,10 @@ defmodule VutuvWeb.PostImageControllerTest do
   end
 
   describe "a public post's image" do
-    test "is served to anonymous visitors with immutable private caching", %{conn: conn, tmp: tmp} do
+    test "is served to anonymous visitors, revalidatable rather than immutable", %{
+      conn: conn,
+      tmp: tmp
+    } do
       author = insert(:user, email_confirmed?: true)
       {_post, image} = post_with_image!(author, tmp)
 
@@ -62,7 +65,7 @@ defmodule VutuvWeb.PostImageControllerTest do
 
       assert conn.status == 200
       assert get_resp_header(conn, "content-type") |> hd() =~ "image/avif"
-      assert get_resp_header(conn, "cache-control") == ["private, max-age=31536000, immutable"]
+      assert get_resp_header(conn, "cache-control") == ["private, max-age=300, must-revalidate"]
     end
 
     test "carries a Content-Disposition naming the download after the owner's handle", %{
@@ -167,7 +170,7 @@ defmodule VutuvWeb.PostImageControllerTest do
 
       assert conn.status == 200
       assert get_resp_header(conn, "content-type") |> hd() =~ "image/jpeg"
-      assert get_resp_header(conn, "cache-control") == ["private, max-age=31536000, immutable"]
+      assert get_resp_header(conn, "cache-control") == ["private, max-age=300, must-revalidate"]
 
       {:ok, jpeg} = Image.from_binary(conn.resp_body)
       assert {Image.width(jpeg), Image.height(jpeg)} == {1200, 300}

--- a/test/vutuv_web/controllers/post_image_pixelated_test.exs
+++ b/test/vutuv_web/controllers/post_image_pixelated_test.exs
@@ -129,8 +129,9 @@ defmodule VutuvWeb.PostImagePixelatedTest do
 
       assert pixelated.status == 200
       assert get_resp_header(pixelated, "content-type") |> hd() =~ "image/avif"
-      # The one response on this proxy that must not carry its year-long
-      # immutable header: the real picture takes this URL's place in seconds.
+      # The one version on this proxy that must not be stored at all: the real
+      # picture takes this URL's place in seconds, so even the five minutes a
+      # derived version keeps would outlive the wait.
       assert get_resp_header(pixelated, "cache-control") == ["private, no-store"]
 
       for version <- ~w(thumb feed large xl) do

--- a/test/vutuv_web/controllers/post_video_controller_test.exs
+++ b/test/vutuv_web/controllers/post_video_controller_test.exs
@@ -52,7 +52,7 @@ defmodule VutuvWeb.PostVideoControllerTest do
     assert conn.status == 200
     assert hd(get_resp_header(conn, "content-type")) =~ "video/mp4"
     assert get_resp_header(conn, "accept-ranges") == ["bytes"]
-    assert hd(get_resp_header(conn, "cache-control")) =~ "immutable"
+    assert hd(get_resp_header(conn, "cache-control")) =~ "max-age=300"
 
     assert byte_size(conn.resp_body) ==
              File.stat!(PostVideoStore.rendition_path(video.token, "h264")).size

--- a/test/vutuv_web/controllers/review_cover_controller_test.exs
+++ b/test/vutuv_web/controllers/review_cover_controller_test.exs
@@ -72,7 +72,7 @@ defmodule VutuvWeb.ReviewCoverControllerTest do
 
   defp cover_path(review), do: ReviewCover.url(review)
 
-  test "a public post's cover is served with immutable private caching", %{conn: conn} do
+  test "a public post's cover is served revalidatable rather than immutable", %{conn: conn} do
     author = insert(:user, email_confirmed?: true)
     {_post, review} = reviewed_post!(author)
 
@@ -80,7 +80,7 @@ defmodule VutuvWeb.ReviewCoverControllerTest do
 
     assert response(conn, 200)
     assert get_resp_header(conn, "content-type") |> hd() =~ "image/avif"
-    assert get_resp_header(conn, "cache-control") == ["private, max-age=31536000, immutable"]
+    assert get_resp_header(conn, "cache-control") == ["private, max-age=300, must-revalidate"]
     # Somebody else's book cover, quoted here at thumbnail size — it has no
     # business in an image search under our domain.
     assert get_resp_header(conn, "x-robots-tag") == ["noindex, noimageindex"]


### PR DESCRIPTION
`VutuvWeb.ImageProxy` authorizes per viewer and answered `private, max-age=31536000, immutable`, with no `ETag`, so a browser that once loaded a picture kept serving it for a year. Restricting a post or freezing a Media Kit picture reached nobody who already had it.

Two tiers now, both tighter:

- **Derived versions**, the sizes a page renders: `private, max-age=300, must-revalidate` plus an `ETag`. A reading session still costs no request; past five minutes the browser asks and gets a 304, so the bytes are not re-sent. Revocation lands in five minutes, not a year.
- **File hand-overs** (`original.orig`, the Media Kit's `download.orig` and `download.png`): `private, no-store` — click-fetched, never page-rendered, and a takedown must leave no print-quality copy.

Header and validator are one decision, so `put_cache_control/1` is private and `send_version/3` owns both. The conditional is answered after authorization: a revoked reader holding the tag gets the 404.

Closes #2170

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01WPMGFtmCZNip8EJiRrx6ch
