### PR TITLE
Two attachment test files no longer hang on a browser deadline

### DIFF
--- a/test/vutuv/chat_attachments_test.exs
+++ b/test/vutuv/chat_attachments_test.exs
@@ -20,6 +20,20 @@ defmodule Vutuv.ChatAttachmentsTest do
   `async: false`: the chokepoint writes real files, and the module flips
   `:uploads_dir_prefix` and `:attachments`, which `Application.put_env/3` makes
   global state the SQL sandbox does not roll back.
+
+  ## Documents are PDFs; the one picture stays a picture (issue #2186)
+
+  Preview pages stay on: this module is one of the last places that exercises
+  the render at all. Only the renderer changed, because a text file's page goes
+  through headless Chromium and its 30-second deadline, which a loaded CI
+  runner misses (the mechanism is written out in
+  `VutuvWeb.MessageAttachmentWebTest`). An unfinished file is unreadable for
+  the recipient, so half the `refute readable_by?` claims below would have been
+  satisfied by the timeout rather than by the rule they are about; `settle!/1`
+  carries the assertion that keeps them honest. The cost is that the module now
+  needs poppler on the machine running it, as `pages_test.exs` already does:
+  without it the upload gate answers `{:error, :pdf_unavailable}` and
+  `upload!/2` raises on the match.
   """
 
   use Vutuv.DataCase, async: false
@@ -77,6 +91,14 @@ defmodule Vutuv.ChatAttachmentsTest do
   end
 
   # A real picture, written by the same library the derivations use.
+  #
+  # **Do not fold this into the PDF fixture**, however tidy that would look.
+  # `PageRender`'s picture branch (a photo's preview *being* the photo, hard
+  # linked rather than rendered) is reached by exactly one test in the whole
+  # tree, "its preview is the picture itself" below: `pages_test.exs` has no
+  # picture case, the web test is documents only, and the reporting and takedown
+  # tests are PDFs. Swapping this for a PDF, or switching previews off for the
+  # module, loses that branch silently, because the test would stay green.
   defp picture(dir, name \\ "photo.jpg") do
     path = Path.join(dir, name)
     {:ok, image} = Image.new(120, 80, color: [40, 90, 160])
@@ -85,19 +107,27 @@ defmodule Vutuv.ChatAttachmentsTest do
   end
 
   # Everything the pipeline does after the upload, run here rather than waited
-  # for: render the preview and let it out of the AI gate.
+  # for, and asserted rather than assumed: an unfinished file is unreadable for
+  # the recipient for the same reason a disconnected one is, so without these
+  # lines the tests that refute a read would be green on a render that never
+  # happened (issue #2186). One page, because every fixture here is a
+  # single-page document or one picture. The row is re-read so the assertion
+  # reads what the database holds rather than the struct the pipeline returned.
   defp settle!(%Attachment{} = attachment) do
     Pages.render(attachment)
 
-    for page <- Pages.list(attachment), do: Pages.release(page.id)
+    assert [%ImageRow{} = page] = Pages.list(attachment)
+    assert Pages.release(page.id) == :ok
 
-    Repo.get!(Attachment, attachment.id)
+    settled = Repo.get!(Attachment, attachment.id)
+    assert Attachments.settled?(settled)
+    settled
   end
 
   describe "the connection gate" do
     test "a file travels between connected members", %{files: files} do
       {sender, recipient, conversation} = connected_pair()
-      attachment = upload!(sender, Fixtures.text_file(files))
+      attachment = upload!(sender, Fixtures.plain_pdf(files))
 
       assert {:ok, %Message{} = message} =
                Chat.send_message(sender, conversation.id, "have a look",
@@ -114,7 +144,7 @@ defmodule Vutuv.ChatAttachmentsTest do
       sender = member()
       stranger = member()
       {:ok, conversation} = Chat.find_or_create_conversation(sender, stranger)
-      attachment = upload!(sender, Fixtures.text_file(files))
+      attachment = upload!(sender, Fixtures.plain_pdf(files))
 
       refute Chat.files_allowed?(conversation)
 
@@ -132,7 +162,7 @@ defmodule Vutuv.ChatAttachmentsTest do
       other = member()
       follow!(other, sender)
       {:ok, conversation} = Chat.find_or_create_conversation(sender, other)
-      attachment = upload!(sender, Fixtures.text_file(files))
+      attachment = upload!(sender, Fixtures.plain_pdf(files))
 
       refute Chat.files_allowed?(conversation)
 
@@ -151,7 +181,7 @@ defmodule Vutuv.ChatAttachmentsTest do
 
     test "breaking the connection takes the file out of reach for both sides", %{files: files} do
       {sender, recipient, conversation} = connected_pair()
-      attachment = upload!(sender, Fixtures.text_file(files))
+      attachment = upload!(sender, Fixtures.plain_pdf(files))
 
       {:ok, _message} =
         Chat.send_message(sender, conversation.id, "here", attachment_ids: [attachment.id])
@@ -172,7 +202,7 @@ defmodule Vutuv.ChatAttachmentsTest do
     test "somebody outside the conversation never reads it", %{files: files} do
       {sender, _recipient, conversation} = connected_pair()
       outsider = member()
-      attachment = upload!(sender, Fixtures.text_file(files))
+      attachment = upload!(sender, Fixtures.plain_pdf(files))
 
       {:ok, _message} =
         Chat.send_message(sender, conversation.id, "here", attachment_ids: [attachment.id])
@@ -184,7 +214,7 @@ defmodule Vutuv.ChatAttachmentsTest do
   describe "the recipient waits for the check" do
     test "a file still being worked on is the sender's alone", %{files: files} do
       {sender, recipient, conversation} = connected_pair()
-      attachment = upload!(sender, Fixtures.text_file(files))
+      attachment = upload!(sender, Fixtures.plain_pdf(files))
 
       {:ok, _message} =
         Chat.send_message(sender, conversation.id, "here", attachment_ids: [attachment.id])
@@ -197,7 +227,7 @@ defmodule Vutuv.ChatAttachmentsTest do
 
     test "a rendered page still in the AI gate is the sender's alone", %{files: files} do
       {sender, recipient, conversation} = connected_pair()
-      attachment = upload!(sender, Fixtures.text_file(files))
+      attachment = upload!(sender, Fixtures.plain_pdf(files))
 
       {:ok, _message} =
         Chat.send_message(sender, conversation.id, "here", attachment_ids: [attachment.id])
@@ -205,6 +235,12 @@ defmodule Vutuv.ChatAttachmentsTest do
       Pages.render(attachment)
       attachment = Repo.get!(Attachment, attachment.id)
 
+      # `Vutuv.Posts.Pending.file_state/1`'s branch for a page that is still
+      # `pending`, which #2185 left to this file and its web sibling. A file
+      # whose render never finished answers `:working` too, through the stage
+      # branch above it, so both halves are pinned ahead of the two claims
+      # below: the render is over, and the page is what is still waiting.
+      assert attachment.stage == "ready"
       assert [%ImageRow{moderation: "pending"}] = Pages.list(attachment)
       refute Attachments.readable_by?(attachment, recipient)
       assert Attachments.readable_by?(attachment, sender)
@@ -212,13 +248,17 @@ defmodule Vutuv.ChatAttachmentsTest do
 
     test "a refused file never reaches the recipient", %{files: files} do
       {sender, recipient, conversation} = connected_pair()
-      attachment = upload!(sender, Fixtures.text_file(files))
+      attachment = upload!(sender, Fixtures.plain_pdf(files))
 
       {:ok, _message} =
         Chat.send_message(sender, conversation.id, "here", attachment_ids: [attachment.id])
 
       Pages.render(attachment)
-      for page <- Pages.list(attachment), do: Pages.page_refused(page)
+
+      # There has to be a page to refuse. `refused?/1` below is what catches a
+      # render that made none; asserting the page here names the reason.
+      assert [%ImageRow{} = page] = Pages.list(attachment)
+      Pages.page_refused(page)
 
       attachment = Repo.get!(Attachment, attachment.id)
       assert Attachment.refused?(attachment)
@@ -255,7 +295,7 @@ defmodule Vutuv.ChatAttachmentsTest do
   describe "files stay as long as the conversation does" do
     test "deleting the message takes its files off disk", %{files: files} do
       {sender, _recipient, conversation} = connected_pair()
-      attachment = upload!(sender, Fixtures.text_file(files))
+      attachment = upload!(sender, Fixtures.plain_pdf(files))
 
       {:ok, message} =
         Chat.send_message(sender, conversation.id, "here", attachment_ids: [attachment.id])
@@ -268,6 +308,8 @@ defmodule Vutuv.ChatAttachmentsTest do
       refute Repo.get(Attachment, attachment.id)
       refute AttachmentStore.served_path(attachment.token)
       refute AttachmentStore.original_path(attachment.token)
+      # Meaningful only because `settle!/1` proved there was a page here a
+      # moment ago; a file that never rendered has an empty list either way.
       assert Pages.list(attachment) == []
     end
 
@@ -281,10 +323,14 @@ defmodule Vutuv.ChatAttachmentsTest do
       follow!(sender, recipient)
       follow!(recipient, sender)
 
-      attachment = upload!(sender, Fixtures.text_file(files))
+      attachment = upload!(sender, Fixtures.plain_pdf(files))
 
       {:ok, _message} =
         Chat.send_message(sender, conversation.id, "here", attachment_ids: [attachment.id])
+
+      # The file has to be there first, or the two refutations at the end are
+      # green on a store that lost it a step earlier.
+      assert AttachmentStore.served_path(attachment.token)
 
       {:ok, _} = Chat.decline_request(recipient, conversation.id)
       # The **decliner** re-opening is what wipes the thread; the original

--- a/test/vutuv_web/message_attachment_web_test.exs
+++ b/test/vutuv_web/message_attachment_web_test.exs
@@ -12,6 +12,27 @@ defmodule VutuvWeb.MessageAttachmentWebTest do
   Not async: it points the global `:uploads_dir_prefix` at a tmp dir, opens
   `ATTACHMENT_UPLOADERS` to members and switches the AI image gate on, all of
   which every process reads.
+
+  ## Every file here is a PDF, and that is load-bearing (issue #2186)
+
+  The pages really are rendered: this module asserts a preview exists, so it
+  cannot turn previews off the way its LiveView sibling did. What it can choose
+  is the renderer. A text file's page is drawn by headless Chromium under a
+  30-second deadline, and although CI installs poppler alone, the GitHub runner
+  image ships Chrome anyway, so a loaded runner misses that deadline,
+  `Pages.render/1` records a silent strike and leaves the row at `rendering`
+  for the retry (`docs/architecture/attachments.md`). `pdftoppm` has no
+  deadline.
+
+  Which matters beyond the flake: `stage: "rendering"` reads as `:working`, and
+  this proxy answers a file that is still working with the same uniform 404 it
+  gives a refusal, an outsider and an unknown token. So a timed-out render
+  satisfies every 404 here for the wrong reason, and `settle!/1` plus the
+  premise lines below are what hold each test to its own claim.
+
+  The cost is that this module now needs poppler on the machine running it, as
+  `pages_test.exs` and the takedown tests already do: without it the upload
+  gate answers `{:error, :pdf_unavailable}` and `sent!/3` raises on the match.
   """
 
   use VutuvWeb.ConnCase, async: false
@@ -23,6 +44,7 @@ defmodule VutuvWeb.MessageAttachmentWebTest do
   alias Vutuv.Attachments.Attachment
   alias Vutuv.Attachments.Pages
   alias Vutuv.Chat
+  alias Vutuv.Images.Image, as: ImageRow
   alias Vutuv.Repo
   alias Vutuv.Social
 
@@ -72,30 +94,45 @@ defmodule VutuvWeb.MessageAttachmentWebTest do
     Repo.get!(Attachment, attachment.id)
   end
 
+  # Runs the pipeline and hands back the row it settled, asserting that it
+  # settled. That is the line that stops a render which never finished from
+  # reading as whatever each test is actually about. `plain_pdf/1` is a
+  # one-page document, so no page means a failed render rather than a short
+  # one, and the row is re-read so the assertion reads what the database holds
+  # rather than the struct the pipeline handed back.
   defp settle!(%Attachment{} = attachment) do
     Pages.render(attachment)
-    for page <- Pages.list(attachment), do: Pages.release(page.id)
-    Repo.get!(Attachment, attachment.id)
+
+    assert [%ImageRow{} = page] = Pages.list(attachment)
+    assert Pages.release(page.id) == :ok
+
+    settled = Repo.get!(Attachment, attachment.id)
+    assert Attachments.settled?(settled)
+    settled
   end
 
   describe "the file" do
     test "the recipient downloads it once it has passed", context do
       %{sender: sender, conversation: conversation, src: src} = context
-      attachment = sender |> sent!(conversation, Fixtures.text_file(src)) |> settle!()
+      source = Fixtures.plain_pdf(src)
+      attachment = sender |> sent!(conversation, source) |> settle!()
 
       conn = get(context.recipient_conn, ~p"/system/attachments/#{attachment.token}/file")
 
       assert conn.status == 200
-      assert response(conn, 200) =~ "Just some notes."
+      assert response(conn, 200) == File.read!(source)
       assert [disposition] = get_resp_header(conn, "content-disposition")
       assert disposition =~ "attachment;"
-      assert disposition =~ "notes.txt"
+      assert disposition =~ "plain.pdf"
       assert get_resp_header(conn, "cache-control") == ["private, no-store"]
     end
 
     test "the recipient gets nothing while the check is still running", context do
       %{sender: sender, conversation: conversation, src: src} = context
-      attachment = sent!(sender, conversation, Fixtures.text_file(src))
+      attachment = sent!(sender, conversation, Fixtures.plain_pdf(src))
+
+      # Which of this proxy's four 404s this is: the file is not finished.
+      refute Attachments.settled?(attachment)
 
       assert context.recipient_conn
              |> get(~p"/system/attachments/#{attachment.token}/file")
@@ -104,7 +141,11 @@ defmodule VutuvWeb.MessageAttachmentWebTest do
 
     test "the sender sees their own file at every stage", context do
       %{sender: sender, conversation: conversation, src: src} = context
-      attachment = sent!(sender, conversation, Fixtures.text_file(src))
+      attachment = sent!(sender, conversation, Fixtures.plain_pdf(src))
+
+      # "Every stage" is the claim, so name the stage: a settled file would
+      # make the 200 below the uninteresting case.
+      refute Attachments.settled?(attachment)
 
       assert context.sender_conn
              |> get(~p"/system/attachments/#{attachment.token}/file")
@@ -113,9 +154,15 @@ defmodule VutuvWeb.MessageAttachmentWebTest do
 
     test "a refused file is not handed to the recipient", context do
       %{sender: sender, conversation: conversation, src: src} = context
-      attachment = sent!(sender, conversation, Fixtures.text_file(src))
+      attachment = sent!(sender, conversation, Fixtures.plain_pdf(src))
       Pages.render(attachment)
-      for page <- Pages.list(attachment), do: Pages.page_refused(page)
+
+      # The refusal has to be a real one: with no page to refuse, the 404 below
+      # would be the unfinished file's and this test would prove nothing, which
+      # is exactly how it passed on a timed-out render (issue #2186).
+      assert [%ImageRow{} = page] = Pages.list(attachment)
+      Pages.page_refused(page)
+      assert Attachment.refused?(Repo.get!(Attachment, attachment.id))
 
       assert context.recipient_conn
              |> get(~p"/system/attachments/#{attachment.token}/file")
@@ -124,7 +171,7 @@ defmodule VutuvWeb.MessageAttachmentWebTest do
 
     test "somebody outside the conversation gets the uniform 404", context do
       %{sender: sender, conversation: conversation, src: src} = context
-      attachment = sender |> sent!(conversation, Fixtures.text_file(src)) |> settle!()
+      attachment = sender |> sent!(conversation, Fixtures.plain_pdf(src)) |> settle!()
 
       assert context.stranger_conn
              |> get(~p"/system/attachments/#{attachment.token}/file")
@@ -133,7 +180,7 @@ defmodule VutuvWeb.MessageAttachmentWebTest do
 
     test "a connection ended after the send closes the file again", context do
       %{sender: sender, recipient: recipient, conversation: conversation, src: src} = context
-      attachment = sender |> sent!(conversation, Fixtures.text_file(src)) |> settle!()
+      attachment = sender |> sent!(conversation, Fixtures.plain_pdf(src)) |> settle!()
 
       assert context.recipient_conn
              |> get(~p"/system/attachments/#{attachment.token}/file")
@@ -159,7 +206,7 @@ defmodule VutuvWeb.MessageAttachmentWebTest do
   describe "the preview" do
     test "the recipient sees the picture once it has passed", context do
       %{sender: sender, conversation: conversation, src: src} = context
-      attachment = sender |> sent!(conversation, Fixtures.text_file(src)) |> settle!()
+      attachment = sender |> sent!(conversation, Fixtures.plain_pdf(src)) |> settle!()
       assert [page] = Pages.list(attachment)
 
       conn =
@@ -172,9 +219,11 @@ defmodule VutuvWeb.MessageAttachmentWebTest do
       assert get_resp_header(conn, "content-type") == ["image/avif"]
     end
 
+    # `settle!/1` has already proved page 0 exists and is readable, so this 404
+    # is about the version name and nothing else.
     test "an unknown version is a 404, never a path", context do
       %{sender: sender, conversation: conversation, src: src} = context
-      attachment = sender |> sent!(conversation, Fixtures.text_file(src)) |> settle!()
+      attachment = sender |> sent!(conversation, Fixtures.plain_pdf(src)) |> settle!()
 
       assert context.recipient_conn
              |> get(~p"/system/attachments/#{attachment.token}/pages/0/original.avif")
@@ -186,7 +235,7 @@ defmodule VutuvWeb.MessageAttachmentWebTest do
     # instead of this proxy's uniform 404.
     test "a negative position is the same 404, not a crash", context do
       %{sender: sender, conversation: conversation, src: src} = context
-      attachment = sender |> sent!(conversation, Fixtures.text_file(src)) |> settle!()
+      attachment = sender |> sent!(conversation, Fixtures.plain_pdf(src)) |> settle!()
 
       assert context.recipient_conn
              |> get(~p"/system/attachments/#{attachment.token}/pages/-1/lite.avif")
@@ -195,9 +244,15 @@ defmodule VutuvWeb.MessageAttachmentWebTest do
 
     test "the recipient sees no preview while the check is still running", context do
       %{sender: sender, conversation: conversation, src: src} = context
-      attachment = sent!(sender, conversation, Fixtures.text_file(src))
+      attachment = sent!(sender, conversation, Fixtures.plain_pdf(src))
       Pages.render(attachment)
-      assert [page] = Pages.list(attachment)
+
+      # Drawn, and held by the AI gate: `Pending.file_state/1`'s
+      # still-`pending`-page branch. Both halves, because an unfinished render
+      # is `:working` through the stage branch instead, and then the 404 below
+      # would be its answer rather than the gate's.
+      assert %Attachment{stage: "ready"} = Repo.get!(Attachment, attachment.id)
+      assert [%ImageRow{moderation: "pending"} = page] = Pages.list(attachment)
 
       assert context.recipient_conn
              |> get(~p"/system/attachments/#{attachment.token}/pages/#{page.position}/lite.avif")


### PR DESCRIPTION
These two files turned CI red on branches that never touched attachments, three times on #2176 alone. The last one: `right: []`, row still at `stage: "rendering", render_attempts: 1`.

Both rendered a preview page for a text file, which headless Chromium draws under a 30-second deadline. CI installs poppler only, but the runner image ships Chrome anyway, so a loaded runner misses the deadline and `Pages.render/1` takes a silent strike. Previews cannot just be switched off here, because both files assert a rendered page exists, so the fixtures are PDFs now and `pdftoppm` draws them.

`message_attachment_web_test.exs:118` was worse than flaky. This proxy answers a refusal and an unfinished file with the same 404, so with no page to refuse it passed while proving nothing. `settle!/1` now insists the file settled, and the refusal is named rather than inferred. Six more assertions had that shape.

Closes #2186. Unblocks #2176.

https://claude.ai/code/session_013VnEsuePUe2CB2QvDcshcp
