### PR TITLE
Pin the test suite's Chromium to a path that does not exist, and guard the renders that read on regardless

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -8,6 +8,14 @@ config :vutuv, :serve_uploads_locally, true
 # under async tests) and make a live HTTP request / launch headless Chromium.
 config :vutuv, :generate_screenshots, false
 config :vutuv, :fetch_gravatar, false
+# No test may find a real browser either: `PageScreenshot.binary/0` otherwise
+# walks $PATH and the macOS app bundles, and a render that misses the capture's
+# 30-second deadline leaves the row at `stage: "rendering"` with no page and no
+# log (issues #2178, #2186, #2189). A path that does not exist makes
+# `PageRender.renderable?/1` answer false, the way a host without a browser
+# behaves. See docs/architecture/attachments.md, "The suite never runs that
+# browser". A test that wants a stub sets its own value, which wins over this.
+config :vutuv, :chromium_path, "/vutuv/no/chromium/in/tests"
 # Ads ship disabled (config/config.exs); the test suite exercises the full ad
 # flow, so it runs with the system on. ads_disabled_test.exs flips it off.
 config :vutuv, :ads_enabled, true

--- a/docs/architecture/attachments.md
+++ b/docs/architecture/attachments.md
@@ -262,6 +262,30 @@ all. Loosening that pipeline (raw HTML pass-through, another renderer) is
 therefore a change to the preview renderer's threat model too, and needs a
 navigation answer of its own first.
 
+### The suite never runs that browser
+
+`config/test.exs` points `:chromium_path` at a path that does not exist, so
+`PageRender.renderable?/1` answers false and a text or Markdown file settles
+with no pages wherever the suite runs. Without it, `PageScreenshot.binary/0`
+walks `$PATH` and the macOS app bundles and finds a real browser — on a
+developer machine, and on the GitHub runner image, which ships Chrome although
+CI installs only poppler and ffmpeg. A loaded runner then misses the capture's
+30-second deadline, the render takes a strike that only logs on the third one,
+and the row stays at `stage: "rendering"` while every assertion after it reads
+a file that never settled. Three unrelated pull requests went red that way
+(issues #2178, #2186, #2189); it cost no coverage, because a full suite run on
+a machine with Chrome reached `PageScreenshot.capture/3` four times and every
+one of them went through a stub the test had configured itself. The config line
+has one reader that holds it honest: `pages_test.exs`'s "degrades to no pages
+where there is no browser" opens with `refute PageRender.renderable?/1`, so
+deleting the line turns a test red instead of bringing the flakiness back.
+
+So a test that wants a real preview page uses a **PDF**: `pdftoppm` has no
+deadline. `Vutuv.AttachmentHelpers.settle!/1` is what runs the pipeline and
+asserts it finished — an unfinished file and four different rules produce the
+same 404, the same refused read and the same empty page list, so without it a
+test is green for a reason that has nothing to do with its name.
+
 ### Each page is a picture
 
 A rendered page is a row on the shared `images` table of kind

--- a/test/support/attachment_helpers.ex
+++ b/test/support/attachment_helpers.ex
@@ -1,0 +1,60 @@
+defmodule Vutuv.AttachmentHelpers do
+  @moduledoc """
+  Running a file's preview pipeline in a test, and proving that it finished
+  (issues #2178, #2186, #2189).
+
+  `Vutuv.Attachments.Pages.render/1` is synchronous, and a renderer that misses
+  its deadline leaves nothing an assertion trips over: the row keeps
+  `stage: "rendering"` for the retry and only the third strike logs. A file in
+  that state has no preview page, is unreadable for its recipient, and answers
+  the attachment proxy's uniform 404, which is also what a refusal, an outsider
+  and an unknown token get. So a render that never happened is quietly green for
+  whatever the test is named after.
+  """
+
+  import ExUnit.Assertions
+
+  alias Vutuv.Attachments
+  alias Vutuv.Attachments.Attachment
+  alias Vutuv.Attachments.Pages
+  alias Vutuv.Repo
+
+  @doc """
+  Renders `attachment`'s pages and hands back the row the pipeline settled,
+  having asserted that it settled and that its page is there.
+
+  Exactly one page: every fixture that reaches this is a one-page document or a
+  single picture, so an empty list is a render that failed. `stage: "ready"`
+  alone would not do, because the pipeline settles a file it has no renderer for
+  at `ready` too, with no pages at all, which is the shape that reads as success.
+
+  `Pages.release/1` clears the AI gate in the modules that switch
+  `:moderate_images` on; its answer is not the claim, `settled?/1` is.
+  """
+  def settle!(%Attachment{} = attachment) do
+    Pages.render(attachment)
+
+    assert [page] = Pages.list(attachment)
+    Pages.release(page.id)
+
+    assert_settled(attachment)
+  end
+
+  @doc """
+  The same claim for a module that asks for no pages at all
+  (`preview_pages: 0`), where the pipeline settles the file itself.
+  """
+  def settled!(%Attachment{} = attachment) do
+    Pages.render(attachment)
+    assert_settled(attachment)
+  end
+
+  # The row is re-read rather than taken from `render/1`: that function writes
+  # the stage and answers a struct saying so in one breath, so its return value
+  # cannot corroborate itself.
+  defp assert_settled(%Attachment{id: id}) do
+    settled = Repo.get!(Attachment, id)
+    assert Attachments.settled?(settled)
+    settled
+  end
+end

--- a/test/vutuv/attachment_reporting_test.exs
+++ b/test/vutuv/attachment_reporting_test.exs
@@ -21,10 +21,18 @@ defmodule Vutuv.AttachmentReportingTest do
   `async: false`: the freeze moves files on disk, and the module flips
   `:uploads_dir_prefix` and `:attachments`, which `Application.put_env/3` makes
   global state the SQL sandbox does not roll back.
+
+  Every file here is rendered through `settle!/1` rather than a bare
+  `Pages.render/1` (issue #2189). Half of what these tests say about a page is
+  said *inside* a loop over `Pages.list/1`, so a render that produced nothing
+  left the loop empty and the test green — and `stage: "ready"` does not rule
+  that out, since the pipeline settles a file it has no renderer for at `ready`
+  with no pages at all.
   """
 
   use Vutuv.DataCase, async: false
 
+  import Vutuv.AttachmentHelpers, only: [settle!: 1]
   import Vutuv.OrganizationsHelpers, only: [active_organization: 0]
   import Vutuv.WebPushHelpers, only: [put_config: 2]
 
@@ -230,12 +238,11 @@ defmodule Vutuv.AttachmentReportingTest do
       files: files
     } do
       insert(:email, user: author)
-      attachment = published_file(author, files)
-      %Attachment{stage: "ready"} = Pages.render(attachment)
+      attachment = author |> published_file(files) |> settle!()
 
-      pages = Pages.list(attachment)
-      assert pages != []
-      page_bytes = for page <- pages, do: {page.id, File.read!(Pages.bytes_path(page))}
+      page_bytes =
+        for page <- Pages.list(attachment), do: {page.id, File.read!(Pages.bytes_path(page))}
+
       served = AttachmentStore.served_path(attachment.token)
       file_bytes = File.read!(served)
 
@@ -278,8 +285,7 @@ defmodule Vutuv.AttachmentReportingTest do
     } do
       insert(:email, user: author)
       admin = insert_activated_user(admin?: true)
-      attachment = published_file(author, files)
-      %Attachment{stage: "ready"} = Pages.render(attachment)
+      attachment = author |> published_file(files) |> settle!()
 
       before = tree(tmp)
       # The served copy, the private original, and the page's derived sizes in
@@ -331,8 +337,7 @@ defmodule Vutuv.AttachmentReportingTest do
       insert(:email, user: author)
       admin = insert_activated_user(admin?: true)
       post = insert(:post, user: author)
-      attachment = published_file(author, files, post: post)
-      %Attachment{stage: "ready"} = Pages.render(attachment)
+      attachment = author |> published_file(files, post: post) |> settle!()
 
       {:ok, case_record} = Moderation.report_content(reporter, attachment, @copyright)
 
@@ -374,9 +379,8 @@ defmodule Vutuv.AttachmentReportingTest do
       reporter: reporter,
       files: files
     } do
-      attachment = published_file(author, files)
-      %Attachment{stage: "ready"} = Pages.render(attachment)
-      [page | _] = Pages.list(attachment)
+      attachment = author |> published_file(files) |> settle!()
+      [page] = Pages.list(attachment)
 
       # The strategy registry is what makes the freeze work at all...
       assert Images.takedown_ready?(page)
@@ -396,8 +400,7 @@ defmodule Vutuv.AttachmentReportingTest do
       files: files
     } do
       insert(:email, user: author)
-      attachment = published_file(author, files)
-      %Attachment{stage: "ready"} = Pages.render(attachment)
+      attachment = author |> published_file(files) |> settle!()
 
       {:ok, _case_record} = Moderation.report_content(reporter, attachment, @copyright)
       frozen = reload(attachment)

--- a/test/vutuv/attachments/pages_test.exs
+++ b/test/vutuv/attachments/pages_test.exs
@@ -6,10 +6,9 @@ defmodule Vutuv.Attachments.PagesTest do
   table so the AI scan applies to it as it does to a photo.
 
   `async: false`, and for the reason the rules file names: this module flips
-  `:vutuv, :attachments` (read by the chokepoint, the composer and the
-  sweeper) and `:vutuv, :chromium_path` (read by every screenshot pipeline),
-  and `Application.put_env/3` is global state the SQL sandbox does not roll
-  back.
+  `:vutuv, :attachments` (read by the chokepoint, the composer and the sweeper)
+  and `:vutuv, :moderate_images`, and `Application.put_env/3` is global state
+  the SQL sandbox does not roll back.
 
   Two of these tests are about a deploy rather than about a picture. The
   **interrupt** test kills the rendering task mid-loop and asserts the sweeper
@@ -139,7 +138,10 @@ defmodule Vutuv.Attachments.PagesTest do
 
       Pages.render(attachment)
 
-      for page <- Pages.list(attachment) do
+      pages = Pages.list(attachment)
+      assert length(pages) == 2
+
+      for page <- pages do
         assert page.moderation == ImageScans.initial_state()
 
         assert %ImageScan{} =
@@ -322,8 +324,13 @@ defmodule Vutuv.Attachments.PagesTest do
   describe "a text file" do
     test "degrades to no pages where there is no browser", %{user: user, files: files} do
       Fixtures.put_config(preview_pages: 3)
-      put_config(:chromium_path, "/vutuv/no/such/chromium")
       attachment = stored!(user, Fixtures.markdown_file(files))
+
+      # The premise, and the one place the suite-wide `:chromium_path` in
+      # `config/test.exs` is read as a claim rather than assumed: without it
+      # this test finds whatever browser the machine happens to carry and
+      # measures nothing (issue #2189).
+      refute PageRender.renderable?(attachment)
 
       assert %Attachment{stage: "ready"} = Pages.render(attachment)
       assert Pages.list(attachment) == []

--- a/test/vutuv/chat_attachments_test.exs
+++ b/test/vutuv/chat_attachments_test.exs
@@ -38,6 +38,7 @@ defmodule Vutuv.ChatAttachmentsTest do
 
   use Vutuv.DataCase, async: false
 
+  import Vutuv.AttachmentHelpers, only: [settle!: 1]
   import Vutuv.WebPushHelpers, only: [put_config: 2]
 
   alias Vutuv.AttachmentFixtures, as: Fixtures
@@ -104,24 +105,6 @@ defmodule Vutuv.ChatAttachmentsTest do
     {:ok, image} = Image.new(120, 80, color: [40, 90, 160])
     {:ok, _} = Image.write(image, path)
     path
-  end
-
-  # Everything the pipeline does after the upload, run here rather than waited
-  # for, and asserted rather than assumed: an unfinished file is unreadable for
-  # the recipient for the same reason a disconnected one is, so without these
-  # lines the tests that refute a read would be green on a render that never
-  # happened (issue #2186). One page, because every fixture here is a
-  # single-page document or one picture. The row is re-read so the assertion
-  # reads what the database holds rather than the struct the pipeline returned.
-  defp settle!(%Attachment{} = attachment) do
-    Pages.render(attachment)
-
-    assert [%ImageRow{} = page] = Pages.list(attachment)
-    assert Pages.release(page.id) == :ok
-
-    settled = Repo.get!(Attachment, attachment.id)
-    assert Attachments.settled?(settled)
-    settled
   end
 
   describe "the connection gate" do

--- a/test/vutuv/moderation_image_takedown_test.exs
+++ b/test/vutuv/moderation_image_takedown_test.exs
@@ -16,6 +16,7 @@ defmodule Vutuv.ModerationImageTakedownTest do
   # Not async: flips the global :uploads_dir_prefix.
   use Vutuv.DataCase, async: false
 
+  import Vutuv.AttachmentHelpers, only: [settle!: 1]
   import Vutuv.WebPushHelpers, only: [put_config: 2]
 
   alias Vutuv.Accounts
@@ -89,8 +90,10 @@ defmodule Vutuv.ModerationImageTakedownTest do
     {:ok, attachment} =
       Attachments.create_pending(owner, AttachmentFixtures.plain_pdf(dir), "paper.pdf")
 
-    Pages.render(attachment)
-    List.first(Pages.list(attachment))
+    # `settle!/1`, not a bare render: `List.first/1` on the empty page list a
+    # host without poppler leaves behind handed back `nil`, and the caller's own
+    # assertion then blamed the takedown registry (issue #2189).
+    attachment |> settle!() |> Pages.list() |> hd()
   end
 
   defp notice(attrs \\ %{}) do

--- a/test/vutuv_web/live/message_attachment_live_test.exs
+++ b/test/vutuv_web/live/message_attachment_live_test.exs
@@ -14,14 +14,13 @@ defmodule VutuvWeb.MessageAttachmentLiveTest do
   use VutuvWeb.ConnCase, async: false
 
   import Phoenix.LiveViewTest
+  import Vutuv.AttachmentHelpers, only: [settled!: 1]
   import Vutuv.WebPushHelpers, only: [put_config: 2]
 
   alias Vutuv.AttachmentFixtures, as: Fixtures
   alias Vutuv.Attachments
   alias Vutuv.Attachments.Attachment
-  alias Vutuv.Attachments.Pages
   alias Vutuv.Chat
-  alias Vutuv.Posts.Pending
   alias Vutuv.Repo
   alias Vutuv.Social
 
@@ -34,16 +33,12 @@ defmodule VutuvWeb.MessageAttachmentLiveTest do
     on_exit(fn -> File.rm_rf(tmp) end)
 
     # **No preview pages anywhere in this module.** What is under test is the
-    # bubble, never the renderer, but a text file's preview page is drawn by
-    # the headless Chromium the link previews use — which CI does not install
-    # and the GitHub runner image happens to carry anyway, so the capture
-    # really runs there. A loaded runner misses its deadline, `Pages.render/1`
-    # records a strike and leaves the row `rendering` for the retry, and the
-    # recipient's half of the bubble keeps saying the file is being checked
-    # instead of carrying its address (#2178, and one red run before it on
-    # 2026-09-11). Nothing there is a race to wait out: the render is
-    # synchronous and has already failed by the time the bubble is read. With
-    # no pages wanted the pipeline settles the file itself, deterministically.
+    # bubble, never the renderer, and with no pages wanted the pipeline settles
+    # a file itself rather than asking a renderer that can fail. A file left
+    # unfinished and a bubble deliberately withholding its address are the same
+    # HTML, so a failed render would read as the rule under test (#2178; the
+    # browser it used to reach is gone from the suite since #2189, and
+    # `docs/architecture/attachments.md` has the mechanism).
     Fixtures.put_config(uploaders: :members, preview_pages: 0)
 
     # Both logins in one place: each drives the real PIN flow and reads the
@@ -71,18 +66,6 @@ defmodule VutuvWeb.MessageAttachmentLiveTest do
   defp stranger_conversation(sender, other) do
     {:ok, conversation} = Chat.find_or_create_conversation(sender, other)
     conversation
-  end
-
-  # Runs the pipeline and hands back the row it settled. The assertion belongs
-  # here rather than at the call sites because a file that never finished and a
-  # bubble deliberately withholding its address are the same HTML, and because
-  # it has to read the **row**: `Pages.render/1` writes the stage and answers a
-  # struct saying so in one breath, so its return value cannot corroborate it.
-  defp settled!(%Attachment{} = attachment) do
-    Pages.render(attachment)
-    settled = Repo.get!(Attachment, attachment.id)
-    assert Pending.file_state(settled) == :done
-    settled
   end
 
   describe "the picker" do

--- a/test/vutuv_web/message_attachment_web_test.exs
+++ b/test/vutuv_web/message_attachment_web_test.exs
@@ -37,6 +37,7 @@ defmodule VutuvWeb.MessageAttachmentWebTest do
 
   use VutuvWeb.ConnCase, async: false
 
+  import Vutuv.AttachmentHelpers, only: [settle!: 1]
   import Vutuv.WebPushHelpers, only: [put_config: 2]
 
   alias Vutuv.AttachmentFixtures, as: Fixtures
@@ -92,23 +93,6 @@ defmodule VutuvWeb.MessageAttachmentWebTest do
       Chat.send_message(sender, conversation.id, "here", attachment_ids: [attachment.id])
 
     Repo.get!(Attachment, attachment.id)
-  end
-
-  # Runs the pipeline and hands back the row it settled, asserting that it
-  # settled. That is the line that stops a render which never finished from
-  # reading as whatever each test is actually about. `plain_pdf/1` is a
-  # one-page document, so no page means a failed render rather than a short
-  # one, and the row is re-read so the assertion reads what the database holds
-  # rather than the struct the pipeline handed back.
-  defp settle!(%Attachment{} = attachment) do
-    Pages.render(attachment)
-
-    assert [%ImageRow{} = page] = Pages.list(attachment)
-    assert Pages.release(page.id) == :ok
-
-    settled = Repo.get!(Attachment, attachment.id)
-    assert Attachments.settled?(settled)
-    settled
   end
 
   describe "the file" do


### PR DESCRIPTION
Three pull requests went red this week on attachment tests whose diffs touched no attachment code. A text or Markdown preview page is drawn by headless Chromium under a 30-second deadline a loaded CI runner misses, and the row then stays at `stage: "rendering"` with no page and no log, so everything after it reads a file that never settled.

`config/test.exs` now points `:chromium_path` at a path that does not exist, so `PageRender.renderable?/1` answers false and such a file settles deterministically. The coverage cost was measured, not assumed: a full run on a machine with Chrome reached `PageScreenshot.capture/3` four times, each through a stub the test set itself. Six places read on from a render without checking it finished, three of them provably vacuous; `Vutuv.AttachmentHelpers.settle!/1` replaces the three copied helpers and guards the rest.

To decide: with that default a link-preview capture answers a spawn failure rather than `:chromium_not_found`, because `PageScreenshot.binary/0` returns a configured path unchecked. Moving `PageRender.executable/1` down into it fixes that and changes production behaviour, so it is not here.

Closes #2189

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_013VnEsuePUe2CB2QvDcshcp
