### PR TITLE
Refuse posts written here when reading other servers' tag timelines

### DIFF
--- a/docs/architecture/social-graph.md
+++ b/docs/architecture/social-graph.md
@@ -223,6 +223,23 @@ what bounds it: handing `Req` a per-host `connect_options` instead starts a
 `Finch` instance per distinct hostname and never reaps it, and which hostnames
 appear is decided by what members type into a follow's sources.
 
+**A fourth refusal: our own posts** (issue #2179). A post written here goes out
+with its hashtags in its `tag` array, so every server holding it indexes it
+under them and serves it on its own public tag timeline — and asking that server
+about a followed tag hands the post straight back. The author then read their
+own words three times in their own feed: once as the post, then once per relay
+under a "found through …" line carrying their handle and this installation's
+host. `Vutuv.Tags.ExternalPost.written_here?/1` refuses it on the way in, asking
+`Vutuv.Fediverse.own_host?/1` about **both** the author's host and the post's
+address, since a relay that rewrote the author still hands back our permalink.
+Measured on the live timelines that produced the report, 19 of the 23 ingestable
+statuses on troet.cafe's `#vutuv` and 17 of 19 on mastodon.social's were this
+installation's own. The rows already stored go with
+`ExternalPosts.drop_written_here/0` on every fetcher tick — deleted rather than
+blanked, because the gate means the delete cannot undo itself, and a standing
+pass rather than a migration, because the release still serving traffic during a
+blue/green switch files rows behind a migration that has already run.
+
 What bounds the table is `EXTERNAL_TAG_POST_CAPS` (twenty posts per tag, its
 servers sharing those slots, ten thousand rows overall) plus `prune/0`, which
 takes a pair's schedule and its posts away with the last follow that wanted

--- a/lib/vutuv/tags/external_post.ex
+++ b/lib/vutuv/tags/external_post.ex
@@ -271,6 +271,40 @@ defmodule Vutuv.Tags.ExternalPost do
 
   def home_copy?(_unusable), do: false
 
+  @doc """
+  Whether these words were written **here** — on this installation — and so are
+  not a find at all (issue #2179).
+
+  A post written here goes out to the fediverse with its hashtags in its `tag`
+  array, so every server that holds it indexes it under them and serves it on
+  its own public tag timeline. Asking such a server about a followed tag
+  therefore hands our own member's post straight back, and it stood in the
+  author's feed a second and a third time under a "found through …" line naming
+  the relay, with their own handle and this installation's host on the card.
+
+  **Both halves are asked, and either one is enough.** The author's host is the
+  one the reported case carried; the address is what a relay that rewrote the
+  author field would still be handing over, since a post of ours keeps our
+  permalink wherever it travels. Measured over 150 ingestable statuses on the
+  live timelines that produced the report, the two never disagreed — 36 were
+  ours and both halves said so — so the second is insurance rather than reach,
+  and it is the refusing direction, which is where insurance belongs.
+
+  `Vutuv.Fediverse.own_host?/1` rather than `local_host?/1`, because the
+  question is about the installation and not about one member: a tag's actor
+  lives on `tags.<host>` (issue #1330) and anything under that name is ours too.
+  It folds every leading `www.` (`Vutuv.Fediverse.strip_www/1`), so the alias,
+  the doubled spelling, a shouted host and a trailing dot all answer the same —
+  and folding is safe here for the reason `same_site?/2` gives: this answer is
+  only ever read as **refuse to ingest**, never as permission for one host to
+  speak for another.
+
+  Read it the other way and it would be this bug with the sign flipped, so a
+  host that merely resembles ours (`mirror.<host>`, `not<host>`) is a stranger
+  and its posts are finds like anybody else's.
+  """
+  def written_here?(host, url), do: Fediverse.own_host?(host) or Fediverse.own_host?(url)
+
   # A host as this test is allowed to read it, and the name is the point: the
   # difference from `canonical_host/1` below is a **fold**, and a difference
   # spelled as an absence is one a tidy-up merges back by accident. Whoever

--- a/lib/vutuv/tags/external_post_fetcher.ex
+++ b/lib/vutuv/tags/external_post_fetcher.ex
@@ -53,6 +53,7 @@ defmodule Vutuv.Tags.ExternalPostFetcher do
     try do
       log(ExternalPosts.fetch_due())
       log_trending(Trending.refresh())
+      log_own(ExternalPosts.drop_written_here())
       if rem(runs, @prune_every) == 0, do: log_prune(ExternalPosts.prune())
     rescue
       error -> Logger.error("External tag fetch failed: #{inspect(error)}")
@@ -83,6 +84,19 @@ defmodule Vutuv.Tags.ExternalPostFetcher do
         "#{tally.hurried} pull(s) hurried, #{tally.skipped} skipped, #{tally.failed} failed"
     )
   end
+
+  # Our own posts coming back as somebody else's find (issue #2179). On every
+  # tick rather than with the hourly housekeeping above, and the difference from
+  # `prune/0` is what it costs: an indexed-column `in` plus a substring test over
+  # a table capped at ten thousand rows measures 7 ms there and 0.3 ms at today's
+  # size, against two correlated `NOT EXISTS` deletes across two tables. The rows
+  # it clears are filed by the *previous* release during a blue/green window, and
+  # a member reading their own post three times should not wait an hour for it.
+  # On an ordinary run it deletes nothing and says nothing.
+  defp log_own(0), do: :ok
+
+  defp log_own(dropped),
+    do: Logger.info("External tag posts: dropped #{dropped} post(s) written here")
 
   defp log_prune(%{fetches: 0, posts: 0}), do: :ok
 

--- a/lib/vutuv/tags/external_posts.ex
+++ b/lib/vutuv/tags/external_posts.ex
@@ -878,6 +878,61 @@ defmodule Vutuv.Tags.ExternalPosts do
   """
   def enforce_ceiling, do: trim(ExternalPost, caps()[:total])
 
+  @doc """
+  Takes out every row this installation wrote itself (issue #2179). Answers how
+  many went.
+
+  `Vutuv.Tags.ExternalPost.written_here?/1` is why there are any: a post written
+  here federates out with its hashtags, the servers a followed tag names index
+  it and hand it back, and the author read their own post three times in their
+  own feed. The gate in `Vutuv.Tags.ExternalTagClient` keeps new ones out; this
+  is for the ones already stored, and for the handful the **previous** release
+  writes during a blue/green window — which is why it is a standing pass on the
+  fetcher's tick rather than a migration. A migration runs once, against
+  whatever the table held at that instant, and the release still serving traffic
+  goes on filing rows behind it.
+
+  **Deleted, not blanked.** A report has to leave a tombstone because the pull
+  would write the same status straight back, and a reported row is the one thing
+  `trim/2` never touches; here the gate refuses the status on the way in, so the
+  delete cannot undo itself and a tombstone would protect nothing. That is also
+  why our own reported rows go with the rest.
+
+  **SQL narrows, the predicate decides** — the shape `possible_copies_query/1`
+  above already uses, and here it is what keeps one spelling of the rule. The
+  prefilter is a superset it is easy to see is one: the author's host in
+  `Vutuv.Fediverse.own_hosts/0`, or the address containing one of our host names
+  anywhere at all. A fold only ever *removes* leading labels, so a host the
+  predicate calls ours always contains ours as a substring — and the slack the
+  substring lets through (`elsewhere.test/@bob/vutuv.de-notes`) is exactly what
+  `written_here?/2` then refuses, which is why the predicate has to be the one
+  that answers. Measured at the table's ten-thousand-row ceiling: 3 ms for the
+  author half, 7 ms with the address half beside it, against 23 ms for reading
+  the address's host out with a regex in SQL, and 300 ms for handing every row
+  to the predicate. On an ordinary run the prefilter returns nothing and the
+  predicate is never asked.
+  """
+  def drop_written_here do
+    hosts = Fediverse.own_hosts()
+    patterns = hosts |> Enum.map(&("%" <> Fediverse.strip_www(&1) <> "%")) |> Enum.uniq()
+
+    ids =
+      from(p in ExternalPost,
+        where:
+          p.author_host in ^hosts or
+            fragment("lower(?) like any(?)", p.url, type(^patterns, {:array, :string})),
+        select: %{id: p.id, author_host: p.author_host, url: p.url}
+      )
+      |> Repo.all()
+      |> Enum.filter(&ExternalPost.written_here?(&1.author_host, &1.url))
+      |> Enum.map(& &1.id)
+
+    case ids do
+      [] -> 0
+      ids -> Repo.delete_all(from(p in ExternalPost, where: p.id in ^ids)) |> elem(0)
+    end
+  end
+
   # Keeps the newest `cap` rows of `scope` and deletes the rest, by the keyset
   # the table's index is built on. One shape for both caps: the per-tag one is
   # this scoped to a tag, and reading them as two algorithms is how the two

--- a/lib/vutuv/tags/external_tag_client.ex
+++ b/lib/vutuv/tags/external_tag_client.ex
@@ -314,11 +314,19 @@ defmodule Vutuv.Tags.ExternalTagClient do
     # degraded path, and it fails **closed**: `MapSet.member?(blocked, nil)` is
     # simply false, so without this guard an unparseable author would walk past
     # the operator's blocklist rather than be refused by it.
+    #
+    # `written_here?/1` is the second refusal that reads a host rather than the
+    # server we asked (issue #2179): our own posts travel out with their
+    # hashtags, so the servers a followed tag names carry them and hand them
+    # back as finds. It sits after `permalink/1` because it asks about the
+    # address as well as the author, and a status with no address is refused on
+    # the next line anyway.
     with true <- is_binary(host),
          true <- showable?(status),
          false <- MapSet.member?(blocked, host),
          text when text != "" <- text_of(status),
          url when is_binary(url) <- permalink(status),
+         false <- ExternalPost.written_here?(host, url),
          id when is_binary(id) <- remote_id(status),
          language when is_nil(language) or is_binary(language) <- language(status),
          {:ok, published_at} <- published_at(status, now) do

--- a/test/support/external_tag_helpers.ex
+++ b/test/support/external_tag_helpers.ex
@@ -226,6 +226,16 @@ defmodule Vutuv.ExternalTagHelpers do
   def author_host, do: "mastodon.example"
 
   @doc """
+  What this installation calls itself in the test environment — the host a post
+  written here carries when a stranger's timeline hands it back (issue #2179).
+
+  A function rather than a module attribute: the endpoint answers from a
+  `:persistent_term` it writes when it starts, so reading it at compile time
+  raises.
+  """
+  def our_host, do: VutuvWeb.Endpoint.host()
+
+  @doc """
   A member following `tag` through `source` — the follow this whole feature
   hangs off. `Vutuv.Tags.follow_tag/2` writes the local source itself; naming a
   server is what makes the pair wanted.

--- a/test/vutuv/tags/external_posts_test.exs
+++ b/test/vutuv/tags/external_posts_test.exs
@@ -358,6 +358,70 @@ defmodule Vutuv.Tags.ExternalPostsTest do
     end
   end
 
+  # The rows the release before #2179 wrote: a member's own post, federated out
+  # with its hashtags, read back off the servers their followed tag names and
+  # standing in their own feed as somebody else's find. The gate keeps new ones
+  # out; these are the ones already in the table, and they go rather than being
+  # blanked, because the gate means a delete here cannot undo itself.
+  describe "posts written on this installation" do
+    test "the stored ones go and every foreign one stays" do
+      tag = followed_tag()
+      _own = external_post(tag, author_host: our_host(), url: "https://#{our_host()}/ada/posts/1")
+
+      _doubled_www =
+        external_post(tag,
+          author_host: "www.www.#{our_host()}",
+          url: "https://www.www.#{our_host()}/ada/posts/2"
+        )
+
+      # Only the address is ours — the shape a relay that rewrote the author
+      # would hand back, and the one the SQL prefilter alone cannot answer.
+      _relabelled =
+        external_post(tag, author_host: @other_source, url: "https://#{our_host()}/ada/posts/3")
+
+      _tag_actor = external_post(tag, author_host: Fediverse.tag_host())
+      foreign = external_post(tag, author_host: @source)
+
+      # A stranger whose name merely contains ours, and a stranger whose address
+      # does: both walk into the prefilter and out again, because the predicate
+      # and not the prefilter is what answers.
+      neighbour = external_post(tag, author_host: "not#{our_host()}")
+
+      near_miss =
+        external_post(tag,
+          author_host: @source,
+          url: "https://#{@source}/@bob/#{our_host()}-notes"
+        )
+
+      assert ExternalPosts.drop_written_here() == 4
+
+      assert ExternalPost |> select([p], p.id) |> Repo.all() |> Enum.sort() ==
+               Enum.sort([foreign.id, neighbour.id, near_miss.id])
+    end
+
+    # A tombstone on one of our own posts protects nothing the gate does not
+    # already refuse, so it goes with the rest instead of sitting in the table
+    # for good — the one place `trim/2`'s "never delete a reported row" does not
+    # apply.
+    test "a reported one goes too" do
+      tag = followed_tag()
+
+      reported =
+        external_post(tag,
+          author_host: our_host(),
+          url: "https://#{our_host()}/ada/posts/4",
+          reported_at: DateTime.utc_now(:second)
+        )
+
+      assert ExternalPosts.drop_written_here() == 1
+      refute Repo.get(ExternalPost, reported.id)
+    end
+
+    test "an empty table answers nothing" do
+      assert ExternalPosts.drop_written_here() == 0
+    end
+  end
+
   describe "the outbound flag" do
     test "off means no request at all and nothing due" do
       put_config(:fetch_external_tag_posts, false)

--- a/test/vutuv/tags/external_tag_client_test.exs
+++ b/test/vutuv/tags/external_tag_client_test.exs
@@ -15,6 +15,7 @@ defmodule Vutuv.Tags.ExternalTagClientTest do
 
   alias Vutuv.Fediverse
   alias Vutuv.SocialFeed.Http
+  alias Vutuv.Tags.ExternalPost
   alias Vutuv.Tags.ExternalTagClient
 
   @source "mastodon.example"
@@ -29,6 +30,20 @@ defmodule Vutuv.Tags.ExternalTagClientTest do
   end
 
   defp status(attrs \\ %{}), do: remote_status(@source, attrs)
+
+  # A status this installation wrote, as a relay hands it back: our member's
+  # address, our permalink. `:host` spells both, `:acct_host` only the author —
+  # above the describe it belongs to, because a `defp` inside one compiles to
+  # module scope anyway and only looks scoped.
+  defp ours(attrs) do
+    host = Map.get(attrs, :host, our_host())
+
+    status(%{
+      "id" => Map.fetch!(attrs, :id),
+      "url" => "https://#{host}/ada/posts/1",
+      "account" => %{"acct" => "ada@#{Map.get(attrs, :acct_host, host)}"}
+    })
+  end
 
   # Every Finch a pinned request started, by the name it registers under. Empty
   # is the claim: one instance lives for one request and is stopped in an
@@ -277,6 +292,65 @@ defmodule Vutuv.Tags.ExternalTagClientTest do
 
       assert ExternalTagClient.fetch(@source, "???") == {:error, :gone}
       refute_received {:req, _host, _path, _query, _headers}
+    end
+  end
+
+  # A post written here federates out with its hashtags, so the servers a
+  # followed tag names carry it on their public tag timelines and hand it
+  # straight back — as somebody else's find, under our own member's handle
+  # (issue #2179). Measured on the live timelines the report names: 19 of the 23
+  # ingestable statuses on troet.cafe's `#vutuv` were vutuv.de's own, and 17 of
+  # 19 on mastodon.social's.
+  describe "a post written on this installation" do
+    test "is not a find, whichever half of it names us" do
+      stub_tag_timeline([
+        ours(%{id: "own"}),
+        ours(%{id: "doubled-www", host: "www.www.#{our_host()}"}),
+        # The author field is one line of a stranger's JSON and the permalink is
+        # the other: a server that relays one of our posts under an author of
+        # its own still hands back the address the post really lives at.
+        ours(%{id: "relabelled", acct_host: "shouty.example"}),
+        status(%{"id" => "theirs"})
+      ])
+
+      assert {:ok, [post]} = ExternalTagClient.fetch(@source, "Elixir")
+      assert post.remote_id == "theirs"
+    end
+
+    # The refusing direction only: a host that merely *contains* ours is another
+    # server, and dropping its posts would be this bug with the sign flipped.
+    test "a server whose name only looks like ours is still a find" do
+      stub_tag_timeline([
+        ours(%{id: "neighbour", host: "not#{our_host()}"}),
+        ours(%{id: "subdomain", host: "mirror.#{our_host()}"})
+      ])
+
+      assert {:ok, posts} = ExternalTagClient.fetch(@source, "Elixir")
+      assert Enum.map(posts, & &1.remote_id) == ["neighbour", "subdomain"]
+    end
+
+    # The spellings themselves, asked of the predicate rather than through a
+    # stubbed round trip per spelling: the fold is `written_here?/2`'s business,
+    # and the two tests above are what prove the client asks it.
+    test "every spelling of our host answers the same" do
+      for host <- [
+            our_host(),
+            "www.#{our_host()}",
+            "www.www.#{our_host()}",
+            String.upcase(our_host()),
+            "#{our_host()}.",
+            Fediverse.tag_host()
+          ] do
+        assert ExternalPost.written_here?(host, "https://elsewhere.test/@bob/1"),
+               "expected #{host} to count as this installation"
+
+        assert ExternalPost.written_here?("elsewhere.test", "https://#{host}/ada/posts/1"),
+               "expected an address on #{host} to count as this installation"
+      end
+
+      for stranger <- ["not#{our_host()}", "mirror.#{our_host()}", "elsewhere.test"] do
+        refute ExternalPost.written_here?(stranger, "https://#{stranger}/@bob/1")
+      end
     end
   end
 end


### PR DESCRIPTION
A member's own post stood three times in their own feed: once as the post, then once per server their followed tag names. Posts written here federate out with their hashtags, so those servers index them and serve them on the public tag timeline the pull reads.

`Vutuv.Tags.ExternalPost.written_here?/2` now refuses such a status in `ExternalTagClient.to_post/5`, beside the blocklist refusal, asking `Fediverse.own_host?/1` about the author's host **and** the permalink, since a relay can rewrite the author but not our address. Rows already stored go in `ExternalPosts.drop_written_here/0` on every fetcher tick, not in a migration: a migration runs once while the release still serving traffic keeps filing rows behind it.

Measured on the timelines from the report: 36 of 150 ingestable statuses were ours, 114 foreign ones untouched; a stranger whose host merely contains ours stays. Driven in a German browser at `/feed`: three cards before, one after.

Closes #2179

https://claude.ai/code/session_01AW11tx7rYiSEaRDjPFNghY
