### PR TITLE
Fold the copies of one foreign post into a single card

### DIFF
--- a/docs/architecture/social-graph.md
+++ b/docs/architecture/social-graph.md
@@ -229,7 +229,7 @@ under them and serves it on its own public tag timeline — and asking that serv
 about a followed tag hands the post straight back. The author then read their
 own words three times in their own feed: once as the post, then once per relay
 under a "found through …" line carrying their handle and this installation's
-host. `Vutuv.Tags.ExternalPost.written_here?/1` refuses it on the way in, asking
+host. `Vutuv.Tags.ExternalPost.written_here?/2` refuses it on the way in, asking
 `Vutuv.Fediverse.own_host?/1` about **both** the author's host and the post's
 address, since a relay that rewrote the author still hands back our permalink.
 Measured on the live timelines that produced the report, 19 of the 23 ingestable
@@ -267,10 +267,29 @@ rendered even when the two coincide: it answers "how did this get here", and one
 that vanished when the answers agreed would teach a reader that a card without
 it came from the author directly, which is never true here.
 
+**One post is one card, however many servers carried it** (issue #2163). A find
+is stored once per (tag, server, remote id), so the same status read off three
+servers stood three times in the feed and on the tag page, each card identical to
+the one above it but for that grey line — and the figure over the list counted
+rows, because rows is what there were: 78 showable rows for 49 originals on a
+copy of production, and one tag page drawing 20 cards for 9 posts.
+`Vutuv.Tags.ExternalPosts.fold_copies/1` groups them by `origin_key/1` and draws
+one, preferring the `home_copy?/1` (the rare case — 8 of those 49 — so the
+ordinary find is drawn from the copy stored first, which ids being
+`Vutuv.UUIDv7` makes the first arrival). The other servers become the card's
+provenance line instead: `Found through these servers` with the count, opening
+to the list, the geometry a post's fediverse reactions already fold into. The
+fold is asked of the **whole** scope a surface may show before that surface
+pages it (`tag_finds/1` for a tag, the reader's own corpus for a feed), so the
+count over the list counts posts and a group cut in half by a page's `LIMIT`
+cannot come back on the next page under a different representative.
+
 The row reaches **the member whose own follow named that server** — the query
 joins their `tag_follows` and its `tag_follow_sources` — so somebody following
-the same tag with vutuv alone sees none of it. Everything that governs an
-ordinary card governs these: hidden words and muted tags
+the same tag with vutuv alone sees none of it, and "found on three servers"
+therefore means three of the servers that brought it *here*, never a claim about
+the fediverse. Everything that governs an ordinary card governs these: hidden
+words and muted tags
 (`Vutuv.Posts.text/1` and `account_names/1` answer for this kind too), the
 reader's own muted servers, their language filter, and a report that empties our
 copy for everybody here at once.
@@ -309,6 +328,16 @@ production copy, and says to re-measure rather than trust them, because this
 table rolls over within hours. The first attempt at this keyed the takedown on
 the description alone, shipped as `7cdfd4dc7` and was reverted as `8b2c1a862`
 within the hour.
+
+A **folded** card meets that rule head on, and the surfaces have to hold the
+promise its dialog made. Reporting a card drawn from the author's own server
+takes every copy, so the card leaves the page. Reporting one drawn from a relay
+takes that server's rows and leaves the rest — so the card does not leave, it is
+redrawn from a row the report did not reach and says one server fewer, which is
+exactly what the reader was told before they pressed it. The feed does that per
+card (`ExternalPosts.refold/1`, keeping the entry id so the card is patched in
+place); the tag page re-reads the page, as it does for every other row-removing
+act on it.
 
 **The `www.` fold belongs to the description and to nothing else.** `www.<host>`
 is a subdomain — a dangling CNAME or an old CDN target hands it to somebody who

--- a/lib/vutuv/tags/external_post_fetcher.ex
+++ b/lib/vutuv/tags/external_post_fetcher.ex
@@ -87,9 +87,12 @@ defmodule Vutuv.Tags.ExternalPostFetcher do
 
   # Our own posts coming back as somebody else's find (issue #2179). On every
   # tick rather than with the hourly housekeeping above, and the difference from
-  # `prune/0` is what it costs: an indexed-column `in` plus a substring test over
-  # a table capped at ten thousand rows measures 7 ms there and 0.3 ms at today's
-  # size, against two correlated `NOT EXISTS` deletes across two tables. The rows
+  # `prune/0` is what it costs: a host `in` — a sequential scan, since the only
+  # index on `author_host` is partial on `reported_at IS NOT NULL` and the
+  # `OR … LIKE ANY` beside it would rule one out anyway — plus a substring test
+  # over a table capped at ten thousand rows measures 7 ms there and 0.3 ms at
+  # today's size, against two correlated `NOT EXISTS` deletes across two
+  # tables. The rows
   # it clears are filed by the *previous* release during a blue/green window, and
   # a member reading their own post three times should not wait an hour for it.
   # On an ordinary run it deletes nothing and says nothing.

--- a/lib/vutuv/tags/external_posts.ex
+++ b/lib/vutuv/tags/external_posts.ex
@@ -94,6 +94,16 @@ defmodule Vutuv.Tags.ExternalPosts do
   # for everybody here, so it is a lever worth metering.
   @report_limit 20
 
+  # How far the fold below reads before it gives up and lets a surface draw the
+  # copies separately again (issue #2163). The reader's whole external corpus is
+  # `per_tag` rows per followed tag that names a server, so this is reached only
+  # by somebody following 150 such tags — and what happens there is the behaviour
+  # of the release before this one, not an error. Ordered newest first, which is
+  # the end every surface draws from. It is deliberately the largest `fetch_n`
+  # any caller asks for (the feed calendar's `cap: 3_000`), so the fold never
+  # answers a narrower question than the one it was asked.
+  @fold_scan 3_000
+
   # --- What anybody may read (issue #2127) ----------------------------------
 
   @doc """
@@ -147,6 +157,175 @@ defmodule Vutuv.Tags.ExternalPosts do
       else: from(p in ExternalPost, as: :external, where: false)
   end
 
+  # --- One card per original (issue #2163) ----------------------------------
+
+  @doc """
+  The rows a surface may show, grouped into one **find** per original:
+  `%{post: row, copies: [row]}`, in the order the rows arrived, `copies`
+  including the row the find is drawn from.
+
+  A find is stored once per `(tag, server, remote id)`, so one status read off
+  three servers is three rows and nothing in that key relates them. Measured on
+  a copy of production the table held 78 showable rows for 49 originals, and one
+  tag page drew 20 cards for 9 posts, each of the extras identical to the one
+  above it but for its "found through" line — with the figure over the list
+  counting rows, because rows is what there were.
+
+  **What relates them is `Vutuv.Tags.ExternalPost.origin_key/1`** — the
+  normalised address of the post plus the server its author lives on — asked
+  here rather than re-derived, because the same key decides whose words a report
+  blanks and two spellings of "the same post" is how that goes wrong. A row
+  whose address will not parse has **no** key, and `nil == nil` would make every
+  such row a copy of every other, so each one is its own find.
+
+  **Which copy is drawn** is `home_copy?/1`: the row fetched from the server the
+  post and its author both live on is the one nobody else could have invented,
+  and it is also the only one whose report speaks for the copies other servers
+  filed (`reaches?/2`). It is the rare case — 7 of those 49 originals — because
+  a public tag timeline is mostly other people's posts, so the ordinary find is
+  drawn from **the copy we stored first**: ids are `Vutuv.UUIDv7`, so the oldest
+  id is the first arrival, and the choice does not wobble between two renders of
+  the same page. The copies differ in almost nothing anyway — over the 19
+  multi-copy originals in that corpus the text, the publication time and the
+  language were identical in every one, and only the author's `acct` spelling
+  differed, which `ExternalPost.address/1` normalises away.
+
+  The caller decides **what to hand over**, and that is the scope of the answer:
+  a tag page folds everything it may show under that tag, a member's feed folds
+  what the servers *they* named brought them. "Found on three servers" therefore
+  means three of the servers that carried it here, never a claim about the
+  fediverse.
+  """
+  def fold_copies(rows) when is_list(rows) do
+    keyed = Enum.map(rows, &{fold_key(&1), &1})
+    grouped = Enum.group_by(keyed, &elem(&1, 0), &elem(&1, 1))
+
+    keyed
+    |> Enum.map(&elem(&1, 0))
+    |> Enum.uniq()
+    |> Enum.map(&find(Map.fetch!(grouped, &1)))
+  end
+
+  # A row nobody can key is a find of its own, by its id — never `nil`, which
+  # would fold every unreadable address into one card.
+  defp fold_key(row), do: ExternalPost.origin_key(row) || {:unkeyed, row.id}
+
+  # "A copy from the author's own server first, then the oldest id", said once:
+  # `false` sorts before `true`, so the tuple orders the home copies ahead of the
+  # rest and the first arrival ahead of its own later twins.
+  defp find(copies),
+    do: %{post: Enum.min_by(copies, &{not ExternalPost.home_copy?(&1), &1.id}), copies: copies}
+
+  @doc """
+  The finds behind a tag page's fediverse tab — `tag_query/1`'s rows, folded.
+
+  Read as four columns rather than whole rows: the fold needs the key's two
+  halves, the server that filed the row and the id to draw it by, and a tag
+  holds at most `caps()[:per_tag]` rows, so this is one indexed read of a couple
+  of kilobytes.
+  """
+  def tag_finds(tag_id) when is_binary(tag_id) do
+    tag_id |> tag_query() |> fold_select() |> Repo.all() |> fold_copies()
+  end
+
+  @doc """
+  The ids a surface should draw, out of `finds` — the representatives.
+
+  Read by both surfaces as the same `WHERE … IN`, rather than by one as an `IN`
+  and by the other as the complementary `NOT IN`: two spellings of "which row is
+  the representative" is one more place for the `{:unkeyed, id}` branch to be
+  remembered in one and forgotten in the other.
+  """
+  def find_ids(finds), do: Enum.map(finds, & &1.post.id)
+
+  @doc """
+  The copies behind each find, keyed by the id the find is drawn by.
+  """
+  def copies_by_id(finds), do: Map.new(finds, &{&1.post.id, &1.copies})
+
+  @doc """
+  Which servers carried the post an entry stands for, the one it is **drawn
+  from** first and the rest sorted.
+
+  The one owner of that list, because four surfaces state it — the card, the
+  `.md`/`.txt`/`.json`/`.xml` siblings, `/api/2.0` and the feed — and the first
+  three had already drifted into two different orders while this change was
+  being written. Drawn first is not a preference: that row is the one a report
+  acts on, the one the header's address was built beside, and the one
+  `found_via` names in the documents, so the list leads with the server the rest
+  of the entry is about.
+
+  A group can hold two rows from one server — the same post under two followed
+  tags — so this answers servers, never rows. An entry that carries no group is
+  a surface that folds nothing, and the answer is then the one server it knows.
+  """
+  def servers(%{external_post: post} = entry) do
+    rest =
+      entry
+      |> Map.get(:copies, [])
+      |> Enum.map(& &1.source)
+      |> Enum.reject(&(&1 == post.source))
+      |> Enum.uniq()
+      |> Enum.sort()
+
+    [post.source | rest]
+  end
+
+  @doc """
+  What is left of the find `copies` described, as a card can draw it:
+  `{post, copies}`, the representative loaded in full, or `nil` when nothing
+  showable is left.
+
+  What a surface asks after a report has blanked part of a folded card — and it
+  **re-reads the rows** rather than working out which ones the report should
+  have taken. A page holds a model of the table and a report is not the only
+  thing that changes it; a card that redrew from its own arithmetic would start
+  counting a server whose copy somebody else reported an hour ago. That is
+  issue #2164's lesson one layer up: a promise and an act that agree only
+  because two modules spell the same `if`.
+
+  The choice of representative goes back through `fold_copies/1` rather than
+  being made again here, so a card that loses the row it was drawn from picks
+  the next one by the same rule the first was picked by.
+  """
+  def refold(copies) when is_list(copies) do
+    ids = Enum.map(copies, & &1.id)
+
+    with [%{post: drawn, copies: kept}] <- showable_finds(ids),
+         %ExternalPost{} = post <- Repo.get(showable_query(), drawn.id) do
+      {post, kept}
+    else
+      _gone -> nil
+    end
+  end
+
+  defp showable_finds(ids) do
+    showable_query()
+    |> where([external: p], p.id in ^ids)
+    |> fold_select()
+    |> Repo.all()
+    |> fold_copies()
+  end
+
+  @doc """
+  The projection `fold_copies/1` works on, and all a card needs of a copy it is
+  not drawn from: the key's two halves, the server that filed the row, the id to
+  draw it by and the stamp a feed orders on.
+
+  A whole row carries up to a thousand characters of somebody else's prose, and
+  a folded card holds one of these per server for as long as the page is open —
+  280 bytes measured, against 2,288 for the row.
+  """
+  def fold_select(query) do
+    select(query, [external: p], %{
+      id: p.id,
+      source: p.source,
+      url: p.url,
+      author_host: p.author_host,
+      published_at: p.published_at
+    })
+  end
+
   @doc """
   The feed source: what the servers **this** member's followed tags name have
   turned up, newest first.
@@ -167,6 +346,12 @@ defmodule Vutuv.Tags.ExternalPosts do
   and every month of the calendar's heatmap, for a table that cannot answer.
   The two sources next door short-circuit the same way and for the same reason
   (`Vutuv.Posts.feed_tag_items/3`, `Vutuv.Fediverse.feed_remote_posts/4`).
+
+  **The counting shape is answered by the fold itself**, with no second query:
+  `:marks` wants an id and a stamp, which is four of the five columns the fold
+  already read (issue #2163). That matters more than it sounds — the unread
+  badge runs on every page load — and it is also what makes the badge count
+  posts rather than the servers that carried them.
   """
   def feed_items(viewer, fetch_n, cursor, opts \\ [])
 
@@ -174,13 +359,10 @@ defmodule Vutuv.Tags.ExternalPosts do
     shape = Keyword.get(opts, :shape, :entries)
 
     if enabled?() and names_a_server?(viewer_id) do
-      viewer_id
-      |> feed_query(fetch_n, shape)
-      |> reject_muted_hosts(viewer)
-      |> Posts.language_scope(Posts.feed_language_filter(viewer))
-      |> FeedPage.time_window(cursor, :published_at, {:naive, :inserted_at})
-      |> Repo.all()
-      |> rows(shape)
+      scope =
+        feed_scope(viewer) |> FeedPage.time_window(cursor, :published_at, {:naive, :inserted_at})
+
+      scope |> feed_finds() |> feed_rows(scope, fetch_n, shape)
     else
       []
     end
@@ -203,32 +385,73 @@ defmodule Vutuv.Tags.ExternalPosts do
     )
   end
 
-  defp feed_query(viewer_id, fetch_n, shape) do
-    # The member's own follow and its own source row. One row per post: a member
-    # follows a tag once (`tag_follows` is unique on the pair) and names a
-    # server once, so this join cannot multiply a post out.
-    #
-    # `tf.user_id == ^viewer_id` is also what keeps a **page's** follow (issue
-    # #1336, the nullable pair) out of a member's feed: a page follow carries a
-    # NULL there, and NULL equals nothing.
+  # Every row of this member's that a feed page could draw, before the fold and
+  # before the page's own window and limit — which is why the ordering and the
+  # limit are not in here.
+  #
+  # The member's own follow and its own source row. One row per post: a member
+  # follows a tag once (`tag_follows` is unique on the pair) and names a server
+  # once, so this join cannot multiply a post out.
+  #
+  # `tf.user_id == ^viewer_id` is also what keeps a **page's** follow (issue
+  # #1336, the nullable pair) out of a member's feed: a page follow carries a
+  # NULL there, and NULL equals nothing.
+  defp feed_scope(%User{id: viewer_id} = viewer) do
     from([external: p] in showable_query(),
       join: tf in TagFollow,
       on: tf.tag_id == p.tag_id and tf.user_id == ^viewer_id,
       join: s in TagFollowSource,
-      on: s.tag_follow_id == tf.id and s.source == p.source,
-      order_by: [desc: p.published_at, desc: p.id],
-      limit: ^fetch_n
+      on: s.tag_follow_id == tf.id and s.source == p.source
     )
-    |> select_shape(shape)
+    |> reject_muted_hosts(viewer)
+    |> Posts.language_scope(Posts.feed_language_filter(viewer))
   end
 
-  # A counter needs two columns and a page needs the row, and here that really
-  # is all the database sends: a full row projects at 2,288 bytes against 24 for
-  # the pair, so a month of the calendar's heatmap would otherwise decode
-  # megabytes of somebody else's prose to produce thirty integers. Same shape
-  # and same reason as `Vutuv.Fediverse`'s own `:marks` select.
-  defp select_shape(query, :marks), do: select(query, [external: p], {p.id, p.published_at})
-  defp select_shape(query, _entries), do: query
+  # The reader's own corpus, folded — asked of the **same** scope the page below
+  # is drawn from, so a copy the reader cannot see (a server they never named, a
+  # host they muted) can never be the one a card is drawn from and take the post
+  # off their page with it.
+  #
+  # It is what makes the fold exact rather than a fold of whatever one page
+  # happened to fetch: a group cut in half by the page's `LIMIT` would be drawn
+  # once here and once again on the next page, under a different representative
+  # and so past the cursor's already-shown ids. Copies of one original share
+  # their publication stamp — measured, in every one of the 19 multi-copy
+  # originals on a production copy — so the window this is asked through never
+  # separates them either. The cost is five short columns over the rows one
+  # member's followed tags hold, and almost nobody holds any: measured on a copy
+  # of production, 20 of 6,027 members follow a tag at all and one names a
+  # server.
+  defp feed_finds(scope) do
+    scope
+    |> order_by([external: p], desc: p.published_at, desc: p.id)
+    |> limit(@fold_scan)
+    |> fold_select()
+    |> Repo.all()
+    |> fold_copies()
+  end
+
+  # `:marks` is `Vutuv.FeedPage.mark/1`'s shape, so the two are interchangeable
+  # and no source can be counted under a different definition than it is drawn
+  # under — which is the whole reason the counter folds too, and counts posts
+  # rather than the servers that carried them. The fold has already read both
+  # columns it needs, so this shape costs no query at all; the drawing shape
+  # goes back for the rows.
+  defp feed_rows(finds, _scope, fetch_n, :marks) do
+    for %{post: post} <- Enum.take(finds, fetch_n),
+        do: %{id: "external-" <> post.id, at: DateTime.to_naive(post.published_at)}
+  end
+
+  defp feed_rows(finds, scope, fetch_n, _entries) do
+    copies = copies_by_id(finds)
+
+    scope
+    |> where([external: p], p.id in ^find_ids(finds))
+    |> order_by([external: p], desc: p.published_at, desc: p.id)
+    |> limit(^fetch_n)
+    |> Repo.all()
+    |> Enum.map(&entry(&1, Map.get(copies, &1.id, [])))
+  end
 
   # The reader's own switched-off servers (the feed band's list), read against
   # the **author's** host: a reader who muted mastodon.social meant the people
@@ -242,29 +465,26 @@ defmodule Vutuv.Tags.ExternalPosts do
     end
   end
 
-  # `:marks` is `Vutuv.FeedPage.mark/1`'s shape, so the two are interchangeable
-  # and no source can be counted under a different definition than it is drawn
-  # under. Built from the two columns the query selected rather than by taking
-  # them off a whole entry, which would need the whole row.
-  defp rows(pairs, :marks),
-    do: for({id, at} <- pairs, do: %{id: "external-" <> id, at: DateTime.to_naive(at)})
-
-  defp rows(posts, _entries), do: Enum.map(posts, &entry/1)
-
   @doc """
-  One row as a feed entry.
+  One find as a feed entry.
 
   `post: nil` and its own `:external_post` key, which is what
   `Vutuv.Posts.external_feed_entry?/1` reads. The id prefix has to be unique
   across every source the paginator merges, and the stamp is naive UTC, which is
   what `Vutuv.FeedPage.sort_entries/1` compares.
+
+  `copies` is every row this one card stands for (issue #2163), the drawn row
+  included — what `servers/1` reads to say how many servers carried the post,
+  and what a report has to be measured against before the card is taken off a
+  page. It is always set, so nothing downstream defends against its absence.
   """
-  def entry(%ExternalPost{} = post) do
+  def entry(%ExternalPost{} = post, copies) when is_list(copies) do
     %{
       id: "external-" <> post.id,
       at: DateTime.to_naive(post.published_at),
       post: nil,
-      external_post: post
+      external_post: post,
+      copies: copies
     }
   end
 
@@ -370,10 +590,11 @@ defmodule Vutuv.Tags.ExternalPosts do
   defp possible_copies_query(rows) when is_list(rows) do
     hosts = rows |> Enum.map(& &1.author_host) |> Enum.reject(&is_nil/1) |> Enum.uniq()
 
-    from(p in ExternalPost,
-      where: p.author_host in ^hosts,
-      select: %{id: p.id, url: p.url, author_host: p.author_host, source: p.source}
-    )
+    # The same four columns the fold reads, through the same select: they are
+    # the columns `origin_key/1` and `home_copy?/1` need, so a third place
+    # listing them is a third place to forget one.
+    from(p in ExternalPost, as: :external, where: p.author_host in ^hosts)
+    |> fold_select()
   end
 
   @doc """
@@ -882,7 +1103,7 @@ defmodule Vutuv.Tags.ExternalPosts do
   Takes out every row this installation wrote itself (issue #2179). Answers how
   many went.
 
-  `Vutuv.Tags.ExternalPost.written_here?/1` is why there are any: a post written
+  `Vutuv.Tags.ExternalPost.written_here?/2` is why there are any: a post written
   here federates out with its hashtags, the servers a followed tag names index
   it and hand it back, and the author read their own post three times in their
   own feed. The gate in `Vutuv.Tags.ExternalTagClient` keeps new ones out; this

--- a/lib/vutuv/tags/external_tag_client.ex
+++ b/lib/vutuv/tags/external_tag_client.ex
@@ -315,7 +315,7 @@ defmodule Vutuv.Tags.ExternalTagClient do
     # simply false, so without this guard an unparseable author would walk past
     # the operator's blocklist rather than be refused by it.
     #
-    # `written_here?/1` is the second refusal that reads a host rather than the
+    # `written_here?/2` is the second refusal that reads a host rather than the
     # server we asked (issue #2179): our own posts travel out with their
     # hashtags, so the servers a followed tag names carry them and hand them
     # back as finds. It sits after `permalink/1` because it asks about the

--- a/lib/vutuv/tags/timeline.ex
+++ b/lib/vutuv/tags/timeline.ex
@@ -25,11 +25,14 @@ defmodule Vutuv.Tags.Timeline do
 
       %{id: "post-<uuid>",     at: ~N[…], post: %Vutuv.Posts.Post{}}
       %{id: "remote-<uuid>",   at: ~N[…], remote_post: %Vutuv.Fediverse.RemotePost{}}
-      %{id: "external-<uuid>", at: ~N[…], external_post: %Vutuv.Tags.ExternalPost{}}
+      %{id: "external-<uuid>", at: ~N[…], external_post: %Vutuv.Tags.ExternalPost{},
+        copies: [%{id:, source:, url:, author_host:}]}
 
   which is the shape the feed's renderer and `VutuvWeb.AgentDocs.PostDoc`
   already understand, so the HTML page and the `.md`/`.txt`/`.json`/`.xml`
-  siblings read the same list.
+  siblings read the same list. The third kind carries **one entry per original**
+  rather than one per server that handed it over (issue #2163), and `copies`
+  says which servers those were.
 
   ## The controls
 
@@ -148,7 +151,7 @@ defmodule Vutuv.Tags.Timeline do
   at a raw param).
   """
   def page(%Tag{} = tag, opts \\ []) do
-    filters = filters(opts)
+    filters = opts |> filters() |> with_finds(tag)
     page = max(Keyword.get(opts, :page, 1), 1)
     per_page = Keyword.get(opts, :per_page, @per_page)
 
@@ -162,7 +165,7 @@ defmodule Vutuv.Tags.Timeline do
 
     {rows, more?} = split_overflow(rows, per_page)
 
-    %{entries: load(rows), total: total(tag, filters), more?: more?}
+    %{entries: load(rows, filters), total: total(tag, filters), more?: more?}
   end
 
   @doc """
@@ -187,12 +190,14 @@ defmodule Vutuv.Tags.Timeline do
   So the rows the caller cannot render are never selected.
   """
   def walk(%Tag{} = tag, opts \\ []) do
+    filters = %{filters(opts) | external: false}
+
     tag
-    |> keys(%{filters(opts) | external: false})
+    |> keys(filters)
     |> Keyset.scope(opts)
     |> Repo.all()
     |> Keyset.restore(opts)
-    |> load()
+    |> load(filters)
   end
 
   @doc """
@@ -200,7 +205,7 @@ defmodule Vutuv.Tags.Timeline do
   beside the controls ("42 Beiträge"), read on its own so a caller that only
   wants the number does not fetch a page of rows.
   """
-  def count(%Tag{} = tag, opts \\ []), do: total(tag, filters(opts))
+  def count(%Tag{} = tag, opts \\ []), do: total(tag, opts |> filters() |> with_finds(tag))
 
   defp filters(opts) do
     %{
@@ -208,12 +213,24 @@ defmodule Vutuv.Tags.Timeline do
       # Whether the third source is in the union at all. `walk/2` is the only
       # caller that takes it out, and its doc says why.
       external: true,
+      # The third source's rows folded to one **find** per original (issue
+      # #2163), worked out once per public call and read three times: the keys
+      # query, the count over it, and the records `load/2` hands back. Without
+      # it each of the three would re-run the same small read, and the figure
+      # over the list could disagree with the cards under it.
+      finds: [],
       sort: Keyword.get(opts, :sort, :newest),
       query: Keyword.get(opts, :query),
       from: Keyword.get(opts, :from),
       until: Keyword.get(opts, :until)
     }
   end
+
+  # Read once per public call, and only where the union will actually carry the
+  # third source: `walk/2` takes it out altogether, and the **vutuv** tab drops
+  # it in `combined/2`, so neither pays for a fold nobody joins.
+  defp with_finds(%{source: :vutuv} = filters, _tag), do: filters
+  defp with_finds(filters, tag), do: %{filters | finds: ExternalPosts.tag_finds(tag.id)}
 
   defp total(tag, filters) do
     Repo.one(from(row in subquery(combined(tag, filters)), select: count()))
@@ -355,6 +372,12 @@ defmodule Vutuv.Tags.Timeline do
   defp external_query(tag, filters) do
     tag.id
     |> ExternalPosts.tag_query()
+    # One row per original, not one per server that carried it (issue #2163).
+    # The rule and the choice of which copy is drawn belong to
+    # `Vutuv.Tags.ExternalPosts.fold_copies/1`; what is spent here is a `WHERE`
+    # over its answer, so the count below the union and the cards above it are
+    # the same list.
+    |> where([external: p], p.id in ^ExternalPosts.find_ids(filters.finds))
     |> search_external(filters.query)
     |> between(filters, dynamic([external: p], p.published_at))
     |> select([external: p], %{
@@ -427,27 +450,37 @@ defmodule Vutuv.Tags.Timeline do
   end
 
   # The keys, back as renderable records, in the order the union put them.
-  defp load([]), do: []
+  defp load([], _filters), do: []
 
-  defp load(rows) do
+  defp load(rows, filters) do
     by_kind = %{
       "post" => load_posts(for %{kind: "post", id: id} <- rows, do: id),
       "remote" => load_remote(for %{kind: "remote", id: id} <- rows, do: id),
       "external" => load_external(for %{kind: "external", id: id} <- rows, do: id)
     }
 
+    copies = ExternalPosts.copies_by_id(filters.finds)
+
     for row <- rows, record = Map.get(by_kind[row.kind], row.id) do
-      entry(row, record)
+      entry(row, record, copies)
     end
   end
 
-  defp entry(%{kind: "post", at: at} = row, post),
+  defp entry(%{kind: "post", at: at} = row, post, _copies),
     do: %{id: "post-" <> row.id, at: at, post: post}
 
-  defp entry(%{kind: "external", at: at} = row, external_post),
-    do: %{id: "external-" <> row.id, at: at, external_post: external_post}
+  # `copies` is every row this one card stands for — the servers whose tag
+  # timelines carried the post, which the card names instead of drawing one
+  # identical copy per server (issue #2163).
+  defp entry(%{kind: "external", at: at} = row, external_post, copies),
+    do: %{
+      id: "external-" <> row.id,
+      at: at,
+      external_post: external_post,
+      copies: Map.get(copies, row.id, [])
+    }
 
-  defp entry(%{at: at} = row, remote_post),
+  defp entry(%{at: at} = row, remote_post, _copies),
     do: %{id: "remote-" <> row.id, at: at, remote_post: remote_post}
 
   defp load_posts([]), do: %{}

--- a/lib/vutuv_web/agent_docs/post_doc.ex
+++ b/lib/vutuv_web/agent_docs/post_doc.ex
@@ -29,6 +29,7 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
   alias Vutuv.Posts.PostVideo
   alias Vutuv.Profiles.VerifiedLinks
   alias Vutuv.Tags.ExternalPost
+  alias Vutuv.Tags.ExternalPosts
   alias VutuvWeb.AgentDocs
   alias VutuvWeb.Markdown
   alias VutuvWeb.PostTeaser
@@ -320,10 +321,16 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
   # else, so like a note it takes the shared shape unchanged — what is new is
   # `found_via`, the server we read it from, which is not where its author
   # lives and is the one fact this row carries that no other does.
+  #
+  # `servers` is the rest of that fact (issue #2163): one entry here stands for
+  # every server that carried the post, exactly as one card does, so a reader of
+  # the `.json` or `.xml` sibling counts the posts the page counts instead of
+  # meeting the same text three times. `found_via` stays the one the entry is
+  # drawn from, so nothing that already reads it changes shape.
   def timeline_entry(%{external_post: %ExternalPost{} = post} = entry) do
     entry
     |> remote_timeline_entry(post)
-    |> Map.put(:found_via, post.source)
+    |> Map.merge(%{found_via: post.source, servers: ExternalPosts.servers(entry)})
   end
 
   def timeline_entry(%{post: post} = entry) do

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -3516,6 +3516,16 @@ defmodule VutuvWeb.PostComponents do
   disappears when the answers agree would teach a reader that a card without one
   came from the author directly — which is never true here.
 
+  **Several servers carrying one post is one card** (issue #2163), and the same
+  line carries that too: where two or more of them handed the post over, it
+  becomes a disclosure — how many, and which ones a tap away — instead of a
+  second and a third card identical to this one but for that one line. It is the
+  shape a post's fediverse reactions already fold into
+  (`fediverse_details/1` above), for the same reason: nothing is lost, and the
+  common reader gets one card. `copies` is the whole group; which of its rows is
+  drawn, and what "several servers" is scoped to, is
+  `Vutuv.Tags.ExternalPosts.fold_copies/1`'s business.
+
   What it does not have, and why:
 
     * **no action bar.** A like would have to be delivered to an author this
@@ -3531,6 +3541,13 @@ defmodule VutuvWeb.PostComponents do
   """
   attr(:post, :map, required: true, doc: "a Vutuv.Tags.ExternalPost")
   attr(:viewer, :any, default: nil, doc: "the logged-in member, or nil")
+
+  attr(:servers, :list,
+    default: [],
+    doc:
+      "the servers that carried this post, the one it is drawn from first — " <>
+        "`Vutuv.Tags.ExternalPosts.servers/1` (issue #2163). Empty falls back to `post.source`."
+  )
 
   attr(:hide_rules, :any,
     default: nil,
@@ -3563,6 +3580,9 @@ defmodule VutuvWeb.PostComponents do
       # address on somebody else's server.
       |> assign(:actor_uri, post.author_url || origin)
       |> assign(:hide_names, hide_tag_names(post.text))
+      # A caller that folds nothing hands over no list, and the card then reads
+      # exactly as it did before the fold existed.
+      |> assign(:servers, if(assigns.servers == [], do: [post.source], else: assigns.servers))
 
     ~H"""
     <article data-external-post={@post.id}>
@@ -3626,11 +3646,14 @@ defmodule VutuvWeb.PostComponents do
           <%!-- How it got here. Small and grey on purpose: it is provenance,
           not a byline, and the byline is the line above it. --%>
           <p
-            data-external-source={@post.source}
+            :if={match?([_one], @servers)}
+            data-external-source={hd(@servers)}
             class="mb-0 mt-0.5 text-xs text-slate-600 dark:text-slate-400"
           >
-            {gettext("Found through %{server}", server: @post.source)}
+            {gettext("Found through %{server}", server: hd(@servers))}
           </p>
+
+          <.external_servers :if={length(@servers) > 1} id={@post.id} servers={@servers} />
 
           <.remote_body
             text={@post.text}
@@ -3642,6 +3665,70 @@ defmodule VutuvWeb.PostComponents do
         </div>
       </div>
     </article>
+    """
+  end
+
+  attr(:id, :string, required: true)
+  attr(:servers, :list, required: true)
+
+  # The provenance line when several servers carried one post (issue #2163).
+  # Deliberately the geometry of `fediverse_details/1`, down to sharing its
+  # summary row: a reader who has opened one of those has opened this one.
+  #
+  # No `data-keep-open`: this card is a stream row, and the disclosure's state
+  # would only be lost to a patch the server sent for this very card, which on
+  # a page holding no action bar means a report or a reload — both of which
+  # redraw the card anyway.
+  defp external_servers(assigns) do
+    ~H"""
+    <details
+      class="group mt-0.5 text-xs text-slate-600 dark:text-slate-400"
+      data-external-servers={length(@servers)}
+    >
+      <.fold_summary label={gettext("Found through these servers")} count={length(@servers)} />
+
+      <ul id={"external-servers-#{@id}"} class="flex flex-wrap gap-x-3 gap-y-1 px-2 pb-2 pt-1">
+        <li :for={server <- @servers} data-external-source={server} class="min-w-0 truncate">
+          {server}
+        </li>
+      </ul>
+    </details>
+    """
+  end
+
+  attr(:label, :string, required: true)
+  attr(:count, :integer, required: true)
+
+  # The one row a card folds something away behind: the globe, what is folded,
+  # how many of it, and the chevron that turns. Two wearers so far — what other
+  # networks did with one of our posts, and which servers carried one of theirs
+  # — and they are the same gesture, so they are one recipe rather than two that
+  # drift. `min-h-10` because on both cards this is the control a phone reader
+  # is meant to open.
+  defp fold_summary(assigns) do
+    ~H"""
+    <summary class="-mx-2 flex min-h-10 cursor-pointer list-none items-center gap-2 rounded-lg px-2 hover:bg-slate-100 dark:hover:bg-slate-800 [&::-webkit-details-marker]:hidden">
+      <span aria-hidden="true">🌐</span>
+      <span>{@label}</span>
+      <%!-- slate-200/700, a step off the row's own hover tint, so the pill
+            stays a pill while the summary is hovered or open. The dark text
+            step is the pill's own: the row's inherited `slate-400` reads 3.9
+            against `slate-700`, under AA, because the pill is lighter than
+            the card the row was coloured for. --%>
+      <span class="rounded-full bg-slate-200 px-1.5 text-xs font-semibold tabular-nums dark:bg-slate-700 dark:text-slate-200">
+        {compact_count(@count)}
+      </span>
+      <svg
+        class="ml-auto h-4 w-4 shrink-0 transition-transform group-open:rotate-180"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path stroke-linecap="round" stroke-linejoin="round" d="m19 9-7 7-7-7" />
+      </svg>
+    </summary>
     """
   end
 
@@ -7044,34 +7131,7 @@ defmodule VutuvWeb.PostComponents do
       data-fediverse-reactions={@reactions}
       data-fediverse-replies={@replies}
     >
-      <%!-- min-h-10: a finger-sized target, since this is the one control on
-            the card a phone reader is meant to open. --%>
-      <summary class={[
-        "-mx-2 flex min-h-10 cursor-pointer list-none items-center gap-2 rounded-lg px-2",
-        "hover:bg-slate-100 dark:hover:bg-slate-800",
-        "[&::-webkit-details-marker]:hidden"
-      ]}>
-        <span aria-hidden="true">🌐</span>
-        <span>{gettext("From other networks")}</span>
-        <%!-- slate-200/700, a step off the row's own hover tint, so the pill
-              stays a pill while the summary is hovered or open. The dark text
-              step is the pill's own: the row's inherited `slate-400` reads 3.9
-              against `slate-700`, under AA, because the pill is lighter than
-              the card the row was coloured for. --%>
-        <span class="rounded-full bg-slate-200 px-1.5 text-xs font-semibold tabular-nums dark:bg-slate-700 dark:text-slate-200">
-          {compact_count(@total)}
-        </span>
-        <svg
-          class="ml-auto h-4 w-4 shrink-0 transition-transform group-open:rotate-180"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          aria-hidden="true"
-        >
-          <path stroke-linecap="round" stroke-linejoin="round" d="m19 9-7 7-7-7" />
-        </svg>
-      </summary>
+      <.fold_summary label={gettext("From other networks")} count={@total} />
 
       <div class="space-y-2 px-2 pb-2 pt-1">
         <%!-- The split, in the same order and with the same glyphs as the

--- a/lib/vutuv_web/controllers/api_v2/post_controller.ex
+++ b/lib/vutuv_web/controllers/api_v2/post_controller.ex
@@ -25,6 +25,7 @@ defmodule VutuvWeb.ApiV2.PostController do
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Tags.ExternalPost
+  alias Vutuv.Tags.ExternalPosts
   alias VutuvWeb.AgentDocs.PostDoc
   alias VutuvWeb.ApiV2
   alias VutuvWeb.ApiV2.Problem
@@ -207,11 +208,13 @@ defmodule VutuvWeb.ApiV2.PostController do
   # A post a followed tag brought back from another server (issue #2127). The
   # same remote shape, plus the one fact only this row has: `found_via`, the
   # server whose public tag timeline we read it off — which is not, and mostly
-  # is not, where its author lives.
+  # is not, where its author lives. `servers` names the rest of them (issue
+  # #2163): one entry stands for every server that carried the post, so a client
+  # gets the post once and can still see where it was found.
   defp feed_entry(%{external_post: %ExternalPost{} = post} = entry) do
     entry
     |> remote_feed_entry(post)
-    |> Map.put(:found_via, post.source)
+    |> Map.merge(%{found_via: post.source, servers: ExternalPosts.servers(entry)})
   end
 
   defp feed_entry(%{post: post} = entry) do

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -2945,8 +2945,7 @@ defmodule VutuvWeb.PostLive.Feed do
     {entries, changed} =
       RemoteImages.restate_entries(socket.assigns.entries, remote_post_id, pictures)
 
-    socket = assign(socket, :entries, entries)
-    Enum.reduce(changed, socket, &stream_insert(&2, :posts, &1, update_only: true))
+    socket |> assign(:entries, entries) |> restream_changed(changed)
   end
 
   # Swap the refreshed entry into the retained list by its stable entry id.
@@ -3255,23 +3254,58 @@ defmodule VutuvWeb.PostLive.Feed do
   # second place for it to drift from — and this one decides what a member sees
   # leave the page, which is where they check whether the promise held.
   defp drop_external_copies(socket, external_post_id) do
-    entries = socket.assigns.entries
-
-    case Enum.find(entries, &external_entry?(&1, external_post_id)) do
-      %{external_post: reported} ->
-        drop_entries(socket, Enum.filter(entries, &external_copy?(&1, reported)))
-
-      _gone ->
-        socket
+    case Enum.find(socket.assigns.entries, &external_entry?(&1, external_post_id)) do
+      %{external_post: reported} -> settle_external(socket, reported)
+      _gone -> socket
     end
+  end
+
+  # A card stands for every copy of the original that reached this reader (issue
+  # #2163), and a report does not always take all of them: only the row the
+  # post's own server served speaks for the copies other servers filed
+  # (`reaches?/2`), which is exactly what the dialog over the button says. So
+  # the answer per card is three-way — every copy gone, some gone, none — and
+  # only the first takes the card off the page. The middle one is the case the
+  # promise lives or dies on: the post stays, drawn from a row the report did
+  # not reach, and says one server fewer.
+  defp settle_external(socket, reported) do
+    {going, kept} =
+      socket.assigns.entries
+      |> Enum.filter(&reported_copy?(&1, reported))
+      |> Enum.map(&{&1, ExternalPosts.refold(&1.copies)})
+      |> Enum.split_with(fn {_entry, find} -> is_nil(find) end)
+
+    socket
+    |> drop_entries(Enum.map(going, fn {entry, _gone} -> entry end))
+    |> restate_external(kept)
+  end
+
+  # Which cards this report could have touched — the same `reaches?/2` the
+  # takedown ran, never a second reading of it. It only picks the cards worth
+  # re-reading; what is left of one is the **table's** answer and not this
+  # page's arithmetic, or a card would go on counting a server whose copy
+  # somebody else reported an hour ago.
+  defp reported_copy?(entry, reported) do
+    Posts.external_feed_entry?(entry) and
+      Enum.any?(entry.copies, &ExternalPosts.reaches?(reported, &1))
+  end
+
+  # The card keeps the entry id it was streamed under even where the row it is
+  # drawn from changed: it is still the same find, and a new id would leave the
+  # old card standing and put a copy of it at the foot of the timeline.
+  defp restate_external(socket, kept) do
+    changed =
+      for {entry, {post, copies}} <- kept, do: %{entry | external_post: post, copies: copies}
+
+    by_id = Map.new(changed, &{&1.id, &1})
+
+    socket
+    |> update(:entries, fn entries -> Enum.map(entries, &Map.get(by_id, &1.id, &1)) end)
+    |> restream_changed(changed)
   end
 
   defp external_entry?(entry, external_post_id),
     do: Posts.external_feed_entry?(entry) and entry.external_post.id == external_post_id
-
-  defp external_copy?(entry, reported),
-    do:
-      Posts.external_feed_entry?(entry) and ExternalPosts.reaches?(reported, entry.external_post)
 
   # Taking a set of entries off the page: out of the list the page reasons with
   # and out of the stream the browser holds, then the empty state re-asked. One
@@ -3309,11 +3343,16 @@ defmodule VutuvWeb.PostLive.Feed do
     |> then(fn socket ->
       Enum.reduce(going, socket, &stream_delete_by_dom_id(&2, :posts, "feed-#{&1.id}"))
     end)
-    |> then(fn socket ->
-      Enum.reduce(changed, socket, &stream_insert(&2, :posts, &1, update_only: true))
-    end)
+    |> restream_changed(changed)
     |> then(&assign(&1, :empty?, &1.assigns.entries == [] and &1.assigns.pending_posts == []))
   end
+
+  # Hand the browser the entries that changed while staying where they are: a
+  # picture that arrived, a reply that left a thread, a folded card redrawn from
+  # a row a report did not reach. `update_only:` is what keeps a stream from
+  # re-appending them at the foot of the timeline.
+  defp restream_changed(socket, changed),
+    do: Enum.reduce(changed, socket, &stream_insert(&2, :posts, &1, update_only: true))
 
   defp note_entry?(entry, note_id),
     do: Posts.remote_reply_entry?(entry) and entry.note.id == note_id
@@ -3792,6 +3831,7 @@ defmodule VutuvWeb.PostLive.Feed do
                   server we read it from in the quiet line under it. --%>
                   <.external_post_card
                     post={entry.external_post}
+                    servers={ExternalPosts.servers(entry)}
                     viewer={@current_user}
                     hide_rules={@filter_rules}
                   />

--- a/lib/vutuv_web/live/tag_live/timeline.ex
+++ b/lib/vutuv_web/live/tag_live/timeline.ex
@@ -45,6 +45,7 @@ defmodule VutuvWeb.TagLive.Timeline do
   alias Vutuv.Fediverse
   alias Vutuv.Posts
   alias Vutuv.Repo
+  alias Vutuv.Tags.ExternalPosts
   alias Vutuv.Tags.Tag
   alias Vutuv.Tags.Timeline
   alias VutuvWeb.LayoutHTML
@@ -409,7 +410,11 @@ defmodule VutuvWeb.TagLive.Timeline do
               <%!-- What the servers a follower of this tag named carry about it
               (issue #2127) — for most topics, the only thing that fills this
               tab at all. --%>
-              <.external_post_card post={entry.external_post} viewer={@current_user} />
+              <.external_post_card
+                post={entry.external_post}
+                servers={ExternalPosts.servers(entry)}
+                viewer={@current_user}
+              />
             <% Posts.remote_feed_entry?(entry) -> %>
               <.remote_post_card
                 live?

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -165,7 +165,7 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
-#: lib/vutuv_web/components/post_components.ex:4617
+#: lib/vutuv_web/components/post_components.ex:4701
 #: lib/vutuv_web/components/ui.ex:5042
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
@@ -213,7 +213,7 @@ msgstr "Inaktivieren"
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:4582
+#: lib/vutuv_web/components/post_components.ex:4666
 #: lib/vutuv_web/components/ui.ex:5033
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
@@ -1208,7 +1208,7 @@ msgstr "Alle Tag-Synonyme"
 msgid "All tag urls"
 msgstr "Alle Tag-URLs"
 
-#: lib/vutuv_web/components/post_components.ex:5235
+#: lib/vutuv_web/components/post_components.ex:5319
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:643
@@ -2129,7 +2129,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:4614
+#: lib/vutuv_web/components/post_components.ex:4698
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2145,7 +2145,7 @@ msgstr "Beitrag bearbeiten"
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:203
 #: lib/vutuv_web/live/post_live/feed.ex:366
-#: lib/vutuv_web/live/post_live/feed.ex:3553
+#: lib/vutuv_web/live/post_live/feed.ex:3594
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1346
 #: lib/vutuv_web/live/shell_live.ex:1692
@@ -2174,8 +2174,8 @@ msgstr "Vor einer bestimmten Person verbergen…"
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:4560
-#: lib/vutuv_web/components/post_components.ex:4562
+#: lib/vutuv_web/components/post_components.ex:4644
+#: lib/vutuv_web/components/post_components.ex:4646
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
@@ -2191,7 +2191,7 @@ msgstr "Nicht eingeloggte Besucher"
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3893
+#: lib/vutuv_web/live/post_live/feed.ex:3935
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2242,13 +2242,13 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:5108
-#: lib/vutuv_web/components/post_components.ex:5112
+#: lib/vutuv_web/components/post_components.ex:5192
+#: lib/vutuv_web/components/post_components.ex:5196
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:5109
+#: lib/vutuv_web/components/post_components.ex:5193
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2348,27 +2348,27 @@ msgstr "Was gibt's Neues?"
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:4557
+#: lib/vutuv_web/components/post_components.ex:4641
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:6875
+#: lib/vutuv_web/components/post_components.ex:6959
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:6879
+#: lib/vutuv_web/components/post_components.ex:6963
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:6877
+#: lib/vutuv_web/components/post_components.ex:6961
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:6878
+#: lib/vutuv_web/components/post_components.ex:6962
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2415,7 +2415,7 @@ msgid "All posts"
 msgstr "Alle Beiträge"
 
 #: lib/vutuv_web/components/post_components.ex:2186
-#: lib/vutuv_web/components/post_components.ex:6978
+#: lib/vutuv_web/components/post_components.ex:7062
 #: lib/vutuv_web/components/ui.ex:4476
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2434,7 +2434,7 @@ msgid "Bookmarks"
 msgstr "Lesezeichen"
 
 #: lib/vutuv_web/components/post_components.ex:2130
-#: lib/vutuv_web/components/post_components.ex:7219
+#: lib/vutuv_web/components/post_components.ex:7303
 #: lib/vutuv_web/components/ui.ex:4462
 #: lib/vutuv_web/notification_line.ex:342
 #: lib/vutuv_web/views/user_html.ex:486
@@ -2443,7 +2443,7 @@ msgid "Like"
 msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1301
-#: lib/vutuv_web/components/post_components.ex:7229
+#: lib/vutuv_web/components/post_components.ex:7313
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
 #: lib/vutuv_web/live/shell_live.ex:1596
@@ -2464,13 +2464,13 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:6966
+#: lib/vutuv_web/components/post_components.ex:7050
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
 #: lib/vutuv_web/components/post_components.ex:2185
-#: lib/vutuv_web/components/post_components.ex:6977
+#: lib/vutuv_web/components/post_components.ex:7061
 #: lib/vutuv_web/live/post_live/saved.ex:822
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2478,26 +2478,26 @@ msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
 #: lib/vutuv_web/components/post_components.ex:2166
-#: lib/vutuv_web/components/post_components.ex:6962
+#: lib/vutuv_web/components/post_components.ex:7046
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
 #: lib/vutuv_web/components/post_components.ex:2759
-#: lib/vutuv_web/components/post_components.ex:5981
+#: lib/vutuv_web/components/post_components.ex:6065
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
 #: lib/vutuv_web/components/post_components.ex:2165
-#: lib/vutuv_web/components/post_components.ex:6961
+#: lib/vutuv_web/components/post_components.ex:7045
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
 #: lib/vutuv_web/components/post_components.ex:2129
-#: lib/vutuv_web/components/post_components.ex:7218
+#: lib/vutuv_web/components/post_components.ex:7302
 #: lib/vutuv_web/live/post_live/saved.ex:821
 #: lib/vutuv_web/views/user_html.ex:486
 #, elixir-autogen, elixir-format
@@ -2525,7 +2525,7 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:7273
+#: lib/vutuv_web/components/post_components.ex:7357
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
@@ -2537,8 +2537,8 @@ msgid "Replies"
 msgstr "Antworten"
 
 #: lib/vutuv_web/components/post_components.ex:2375
-#: lib/vutuv_web/components/post_components.ex:7256
-#: lib/vutuv_web/components/post_components.ex:7257
+#: lib/vutuv_web/components/post_components.ex:7340
+#: lib/vutuv_web/components/post_components.ex:7341
 #: lib/vutuv_web/live/notification_live/index.ex:993
 #: lib/vutuv_web/live/post_live/reply.ex:49
 #: lib/vutuv_web/notification_line.ex:339
@@ -2546,7 +2546,7 @@ msgstr "Antworten"
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:4516
+#: lib/vutuv_web/components/post_components.ex:4600
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
@@ -2567,7 +2567,7 @@ msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beitr
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
 
-#: lib/vutuv_web/components/post_components.ex:4034
+#: lib/vutuv_web/components/post_components.ex:4118
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:63
 #: lib/vutuv_web/live/post_live/remote_reply.ex:61
 #: lib/vutuv_web/live/post_live/reply.ex:63
@@ -2575,14 +2575,14 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:4488
+#: lib/vutuv_web/components/post_components.ex:4572
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:4479
-#: lib/vutuv_web/components/post_components.ex:4508
-#: lib/vutuv_web/components/post_components.ex:4511
+#: lib/vutuv_web/components/post_components.ex:4563
+#: lib/vutuv_web/components/post_components.ex:4592
+#: lib/vutuv_web/components/post_components.ex:4595
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
@@ -2884,7 +2884,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:6876
+#: lib/vutuv_web/components/post_components.ex:6960
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -3152,7 +3152,7 @@ msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:4455
+#: lib/vutuv_web/components/post_components.ex:4539
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solange eine Meldung zu diesem Beitrag bearbeitet wird, sehen nur Sie ihn."
@@ -3214,8 +3214,8 @@ msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
 #: lib/vutuv_web/components/post_components.ex:1467
 #: lib/vutuv_web/components/post_components.ex:3419
-#: lib/vutuv_web/components/post_components.ex:3611
-#: lib/vutuv_web/components/post_components.ex:4685
+#: lib/vutuv_web/components/post_components.ex:3627
+#: lib/vutuv_web/components/post_components.ex:4769
 #: lib/vutuv_web/live/organization_live/show.ex:684
 #: lib/vutuv_web/templates/user/show.html.heex:252
 #, elixir-autogen, elixir-format
@@ -4653,7 +4653,7 @@ msgstr "Sie haben niemanden blockiert."
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3898
+#: lib/vutuv_web/live/post_live/feed.ex:3940
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
@@ -5584,9 +5584,9 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:4765
-#: lib/vutuv_web/components/post_components.ex:5374
-#: lib/vutuv_web/components/post_components.ex:5712
+#: lib/vutuv_web/components/post_components.ex:4849
+#: lib/vutuv_web/components/post_components.ex:5458
+#: lib/vutuv_web/components/post_components.ex:5796
 #: lib/vutuv_web/live/notification_live/index.ex:1069
 #: lib/vutuv_web/views/user_html.ex:133
 #, elixir-autogen, elixir-format
@@ -5959,7 +5959,7 @@ msgid "Name (A-Z)"
 msgstr "Name (A-Z)"
 
 #: lib/vutuv_web/live/post_live/saved.ex:507
-#: lib/vutuv_web/live/tag_live/timeline.ex:449
+#: lib/vutuv_web/live/tag_live/timeline.ex:453
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr "Neueste zuerst"
@@ -5985,7 +5985,7 @@ msgid "Nothing here yet. People you like show up here."
 msgstr "Hier ist noch nichts. Personen, die Ihnen gefallen, erscheinen hier."
 
 #: lib/vutuv_web/live/post_live/saved.ex:508
-#: lib/vutuv_web/live/tag_live/timeline.ex:450
+#: lib/vutuv_web/live/tag_live/timeline.ex:454
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr "Älteste zuerst"
@@ -6832,8 +6832,8 @@ msgstr ""
 "und Antworten über Sie mit. Mit beiden aus zum Beispiel:"
 
 #: lib/vutuv_web/components/post_components.ex:3346
-#: lib/vutuv_web/components/post_components.ex:4638
-#: lib/vutuv_web/components/post_components.ex:4652
+#: lib/vutuv_web/components/post_components.ex:4722
+#: lib/vutuv_web/components/post_components.ex:4736
 #: lib/vutuv_web/components/ui.ex:3226
 #: lib/vutuv_web/live/fediverse_account_live.ex:437
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6861,7 +6861,7 @@ msgstr "Neue Nachrichten und neue Vernetzungen"
 msgid "Remove this connection? You will stop following them."
 msgstr "Diese Vernetzung entfernen? Sie folgen der Person dann nicht mehr."
 
-#: lib/vutuv_web/components/post_components.ex:4638
+#: lib/vutuv_web/components/post_components.ex:4722
 #: lib/vutuv_web/components/ui.ex:3225
 #: lib/vutuv_web/live/fediverse_account_live.ex:435
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -7579,7 +7579,7 @@ msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:7129
+#: lib/vutuv_web/components/post_components.ex:7213
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #: lib/vutuv_web/live/shell_live.ex:1830
 #, elixir-autogen, elixir-format
@@ -7692,7 +7692,7 @@ msgstr ""
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/media_live.ex:270
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:4192
+#: lib/vutuv_web/live/post_live/feed.ex:4234
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #: lib/vutuv_web/live/press_kit_live.ex:1056
 #, elixir-autogen
@@ -9151,7 +9151,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:5984
+#: lib/vutuv_web/components/post_components.ex:6068
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -13574,7 +13574,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "E-Mail-Benachrichtigungen für Ihre gespeicherte Suche „%{label}“ stoppen?"
 
-#: lib/vutuv_web/components/post_components.ex:3993
+#: lib/vutuv_web/components/post_components.ex:4077
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:788
 #: lib/vutuv_web/controllers/settings_controller.ex:806
@@ -14189,34 +14189,34 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:6672
+#: lib/vutuv_web/components/post_components.ex:6756
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6629
+#: lib/vutuv_web/components/post_components.ex:6713
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:6673
+#: lib/vutuv_web/components/post_components.ex:6757
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:6675
+#: lib/vutuv_web/components/post_components.ex:6759
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:6671
+#: lib/vutuv_web/components/post_components.ex:6755
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6628
+#: lib/vutuv_web/components/post_components.ex:6712
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
@@ -14227,12 +14227,12 @@ msgstr "Filmbesprechung"
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/components/post_components.ex:6670
+#: lib/vutuv_web/components/post_components.ex:6754
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/components/post_components.ex:6674
+#: lib/vutuv_web/components/post_components.ex:6758
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14252,7 +14252,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:6711
+#: lib/vutuv_web/components/post_components.ex:6795
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14260,30 +14260,30 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:6741
+#: lib/vutuv_web/components/post_components.ex:6825
 #: lib/vutuv_web/components/ui.ex:3884
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:6742
+#: lib/vutuv_web/components/post_components.ex:6826
 #: lib/vutuv_web/components/ui.ex:3885
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:6740
+#: lib/vutuv_web/components/post_components.ex:6824
 #: lib/vutuv_web/components/ui.ex:3877
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:6700
+#: lib/vutuv_web/components/post_components.ex:6784
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:6747
+#: lib/vutuv_web/components/post_components.ex:6831
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14313,7 +14313,7 @@ msgstr "Mit Qualifikation:"
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:6514
+#: lib/vutuv_web/components/post_components.ex:6598
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14356,7 +14356,7 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:6505
+#: lib/vutuv_web/components/post_components.ex:6589
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -14719,14 +14719,14 @@ msgstr "Konto zum Einfrieren suchen"
 msgid "See all frozen accounts"
 msgstr "Alle eingefrorenen Konten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:4282
+#: lib/vutuv_web/components/post_components.ex:4366
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "%{formatted} früheren Beitrag anzeigen"
 msgstr[1] "%{formatted} frühere Beiträge anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:4305
+#: lib/vutuv_web/components/post_components.ex:4389
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14753,7 +14753,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:7228
+#: lib/vutuv_web/components/post_components.ex:7312
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -15914,7 +15914,7 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:7174
+#: lib/vutuv_web/components/post_components.ex:7258
 #: lib/vutuv_web/live/notification_live/index.ex:1592
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -15922,7 +15922,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:7178
+#: lib/vutuv_web/components/post_components.ex:7262
 #: lib/vutuv_web/live/notification_live/index.ex:1586
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15930,7 +15930,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Like"
 msgstr[1] "%{formatted} Likes"
 
-#: lib/vutuv_web/components/post_components.ex:7182
+#: lib/vutuv_web/components/post_components.ex:7266
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15938,7 +15938,7 @@ msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1339
-#: lib/vutuv_web/components/post_components.ex:7133
+#: lib/vutuv_web/components/post_components.ex:7217
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Bereits in den Zahlen oben enthalten."
@@ -16036,8 +16036,8 @@ msgstr "Diese Antwort können Sie nicht entfernen."
 #: lib/vutuv_web/agent_docs/markdown.ex:1539
 #: lib/vutuv_web/components/post_components.ex:1503
 #: lib/vutuv_web/components/post_components.ex:1734
-#: lib/vutuv_web/components/post_components.ex:3591
-#: lib/vutuv_web/components/post_components.ex:3851
+#: lib/vutuv_web/components/post_components.ex:3607
+#: lib/vutuv_web/components/post_components.ex:3935
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "View the original"
@@ -16484,7 +16484,7 @@ msgstr "Hier ist noch nichts. Wenn Sie sich das nächste Mal anmelden oder eine 
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/admin/media_live.ex:155
 #: lib/vutuv_web/live/fediverse_following_live.ex:351
-#: lib/vutuv_web/live/tag_live/timeline.ex:474
+#: lib/vutuv_web/live/tag_live/timeline.ex:478
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr "Dazu passt nichts. Versuchen Sie eine kürzere Suche oder setzen Sie die Filter zurück."
@@ -16704,22 +16704,22 @@ msgstr "Was sich an welchem Konto geändert hat, wann, von welchem Gerät und wi
 msgid "device or detail"
 msgstr "Gerät oder Detail"
 
-#: lib/vutuv_web/components/post_components.ex:4467
+#: lib/vutuv_web/components/post_components.ex:4551
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Angehefteter Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:4601
+#: lib/vutuv_web/components/post_components.ex:4685
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "An Profil anheften"
 
-#: lib/vutuv_web/components/post_components.ex:4609
+#: lib/vutuv_web/components/post_components.ex:4693
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Vom Profil lösen"
 
-#: lib/vutuv_web/components/post_components.ex:4595
+#: lib/vutuv_web/components/post_components.ex:4679
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr "Es lässt sich nur ein Beitrag an Ihr Profil anheften. Diesen anheften und den anderen lösen?"
@@ -16848,18 +16848,18 @@ msgstr "Nächstes Foto"
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
 
-#: lib/vutuv_web/components/post_components.ex:4046
+#: lib/vutuv_web/components/post_components.ex:4130
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Fediverse-Einstellungen öffnen"
 
-#: lib/vutuv_web/components/post_components.ex:5550
+#: lib/vutuv_web/components/post_components.ex:5634
 #: lib/vutuv_web/components/press_kit_components.ex:526
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:5778
+#: lib/vutuv_web/components/post_components.ex:5862
 #: lib/vutuv_web/components/press_kit_components.ex:623
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
@@ -16873,7 +16873,7 @@ msgstr "Foto-Einstellungen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1500
 #: lib/vutuv_web/agent_docs/text.ex:909
-#: lib/vutuv_web/components/post_components.ex:5860
+#: lib/vutuv_web/components/post_components.ex:5944
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Fotos:"
@@ -16899,7 +16899,7 @@ msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qual
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:4099
+#: lib/vutuv_web/components/post_components.ex:4183
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
@@ -16919,7 +16919,7 @@ msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen S
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
 
-#: lib/vutuv_web/components/post_components.ex:4090
+#: lib/vutuv_web/components/post_components.ex:4174
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht öffentlich beantworten."
@@ -16929,12 +16929,12 @@ msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht �
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr "Diese Antwort wurde in einem anderen Netzwerk geschrieben. Sie zu beantworten heißt, Ihre Worte in dieses Netzwerk zu senden, und das tut vutuv nur für Mitglieder, die die Fediverse-Teilnahme eingeschaltet haben."
 
-#: lib/vutuv_web/components/post_components.ex:4108
+#: lib/vutuv_web/components/post_components.ex:4192
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Diese Seite nimmt nicht am Fediverse teil."
 
-#: lib/vutuv_web/components/post_components.ex:4042
+#: lib/vutuv_web/components/post_components.ex:4126
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Fediverse-Teilnahme einschalten, um zu antworten"
@@ -16949,7 +16949,7 @@ msgstr "Wer diese Fotos weiterverwenden darf"
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:4103
+#: lib/vutuv_web/components/post_components.ex:4187
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshalb werden von hier aus keine Antworten mehr gesendet."
@@ -16959,7 +16959,7 @@ msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshal
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
 
-#: lib/vutuv_web/components/post_components.ex:4056
+#: lib/vutuv_web/components/post_components.ex:4140
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fediverse-Follower. Auf vutuv ist sie ebenfalls ein öffentlicher Beitrag."
@@ -17034,13 +17034,13 @@ msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exak
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1357
-#: lib/vutuv_web/components/post_components.ex:7171
+#: lib/vutuv_web/components/post_components.ex:7255
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1355
-#: lib/vutuv_web/components/post_components.ex:7168
+#: lib/vutuv_web/components/post_components.ex:7252
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17050,7 +17050,7 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:7055
+#: lib/vutuv_web/components/post_components.ex:7139
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
@@ -17411,7 +17411,7 @@ msgstr "Nur für die Follower dieses Kontos"
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Danke. Unsere Kopie wurde sofort gelöscht."
 
-#: lib/vutuv_web/components/post_components.ex:3850
+#: lib/vutuv_web/components/post_components.ex:3934
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Beim Original abstimmen"
@@ -17436,7 +17436,7 @@ msgstr "Von Mitgliedern entfernte Inhalte aus anderen Netzwerken"
 msgid "Hide"
 msgstr "Verbergen"
 
-#: lib/vutuv_web/components/post_components.ex:3791
+#: lib/vutuv_web/components/post_components.ex:3875
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Von der verfassenden Person als sensibel markiert"
@@ -17566,12 +17566,12 @@ msgstr "Wieder verdecken"
 msgid "Sensitive. Show the picture."
 msgstr "Heikles Motiv. Bild anzeigen."
 
-#: lib/vutuv_web/components/post_components.ex:3949
+#: lib/vutuv_web/components/post_components.ex:4033
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Das sind viele Likes in einer Stunde. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:3955
+#: lib/vutuv_web/components/post_components.ex:4039
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Diesen Beitrag gibt es hier nicht mehr."
@@ -17581,7 +17581,7 @@ msgstr "Diesen Beitrag gibt es hier nicht mehr."
 msgid "Back to the feed"
 msgstr "Zurück zum Feed"
 
-#: lib/vutuv_web/components/post_components.ex:4094
+#: lib/vutuv_web/components/post_components.ex:4178
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -18233,22 +18233,22 @@ msgid_plural "%{formatted} posts"
 msgstr[0] "%{formatted} Beitrag"
 msgstr[1] "%{formatted} Beiträge"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:451
+#: lib/vutuv_web/live/tag_live/timeline.ex:455
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr "Meiste Likes"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:482
+#: lib/vutuv_web/live/tag_live/timeline.ex:486
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr "Zu diesem Tag gibt es noch keine Beiträge."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:480
+#: lib/vutuv_web/live/tag_live/timeline.ex:484
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr "Aus anderen Netzwerken gibt es zu diesem Tag noch keine Beiträge."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:477
+#: lib/vutuv_web/live/tag_live/timeline.ex:481
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr "Auf vutuv gibt es zu diesem Tag noch keine Beiträge."
@@ -18258,7 +18258,7 @@ msgstr "Auf vutuv gibt es zu diesem Tag noch keine Beiträge."
 msgid "word in a post"
 msgstr "Wort in einem Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:3952
+#: lib/vutuv_web/components/post_components.ex:4036
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Diese Antwort gibt es hier nicht mehr."
@@ -18330,19 +18330,19 @@ msgstr "Auf der Seite eines Beitrags stehen direkt unter der Zahl die Mitglieder
 msgid "Liked by"
 msgstr "Gefällt diesen Mitgliedern"
 
-#: lib/vutuv_web/components/post_components.ex:6154
+#: lib/vutuv_web/components/post_components.ex:6238
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Gefällt %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:6156
+#: lib/vutuv_web/components/post_components.ex:6240
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Gefällt %{name} und %{formatted} weiteren"
 msgstr[1] "Gefällt %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/components/post_components.ex:6167
+#: lib/vutuv_web/components/post_components.ex:6251
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr "Nur Sie sehen hier alle: Einige dieser Mitglieder werden anderen Lesern nicht genannt."
@@ -18516,7 +18516,7 @@ msgstr "Ausstellungsdatum"
 msgid "Label"
 msgstr "Bezeichnung"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3916
+#: lib/vutuv_web/live/post_live/feed.ex:3958
 #: lib/vutuv_web/live/reference_check_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -19941,7 +19941,7 @@ msgstr "Suchen Sie so oft Sie möchten und nehmen Sie dazu, was gehört. Abkürz
 msgid "Start over"
 msgstr "Von vorn beginnen"
 
-#: lib/vutuv_web/components/post_components.ex:3982
+#: lib/vutuv_web/components/post_components.ex:4066
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr "Ein Herz oder ein Repost geht zurück in das Netzwerk, aus dem dieser Beitrag stammt. Ihr Konto nimmt derzeit nicht am Fediverse teil. Einschalten können Sie das in den {settings}."
@@ -20828,27 +20828,27 @@ msgstr "Sprache"
 msgid "The language this post is written in"
 msgstr "Die Sprache, in der dieser Beitrag geschrieben ist"
 
-#: lib/vutuv_web/components/post_components.ex:6048
+#: lib/vutuv_web/components/post_components.ex:6132
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Original anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:6084
+#: lib/vutuv_web/components/post_components.ex:6168
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Übersetzen"
 
-#: lib/vutuv_web/components/post_components.ex:6093
+#: lib/vutuv_web/components/post_components.ex:6177
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Übersetzt"
 
-#: lib/vutuv_web/components/post_components.ex:6096
+#: lib/vutuv_web/components/post_components.ex:6180
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Übersetzt aus %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:6073
+#: lib/vutuv_web/components/post_components.ex:6157
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Wird übersetzt …"
@@ -20858,7 +20858,7 @@ msgstr "Wird übersetzt …"
 msgid "Feed language settings reset to the site defaults."
 msgstr "Feed-Spracheinstellungen auf die Website-Vorgaben zurückgesetzt."
 
-#: lib/vutuv_web/components/post_components.ex:6063
+#: lib/vutuv_web/components/post_components.ex:6147
 #: lib/vutuv_web/components/ui.ex:5549
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -20987,20 +20987,20 @@ msgstr "Wir haben den Link in Ihrem Profil noch nicht gefunden. Bitte versuchen 
 msgid "Your username, or paste the address of your profile page."
 msgstr "Ihr Benutzername – oder fügen Sie die Adresse Ihrer Profilseite ein."
 
-#: lib/vutuv_web/components/post_components.ex:5826
+#: lib/vutuv_web/components/post_components.ex:5910
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] "Unsere KI prüft es gerade. Sobald die Prüfung durch ist, erscheint das Foto von selbst."
 msgstr[1] "Unsere KI prüft sie gerade, %{done} von %{total} sind durch. Sobald die letzte durch ist, erscheinen die Fotos von selbst."
 
-#: lib/vutuv_web/components/post_components.ex:5823
+#: lib/vutuv_web/components/post_components.ex:5907
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Ihr Beitrag ist veröffentlicht, das Foto noch nicht."
 
 #: lib/vutuv_web/components/post_components.ex:2913
-#: lib/vutuv_web/components/post_components.ex:4892
+#: lib/vutuv_web/components/post_components.ex:4976
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -21639,7 +21639,7 @@ msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public po
 msgstr ""
 "Folgen Sie #%{tag} von Mastodon oder einer anderen Fediverse-App aus, dann landen die öffentlichen Beiträge in Ihrer Timeline. Ein vutuv-Konto brauchen Sie dafür nicht."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4086
+#: lib/vutuv_web/live/post_live/feed.ex:4128
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Andere Mitglieder begrüßen"
@@ -22137,13 +22137,13 @@ msgid "Hide a word or a whole phrase …"
 msgstr "Wort oder ganzen Satz ausblenden …"
 
 #: lib/vutuv_web/live/post_live/feed.ex:854
-#: lib/vutuv_web/live/post_live/feed.ex:4249
+#: lib/vutuv_web/live/post_live/feed.ex:4291
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Tags ausblenden"
 
 #: lib/vutuv_web/live/post_live/feed.ex:853
-#: lib/vutuv_web/live/post_live/feed.ex:4238
+#: lib/vutuv_web/live/post_live/feed.ex:4280
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Wörter ausblenden"
@@ -22210,7 +22210,7 @@ msgstr "Beiträge mit einem dieser Tags werden genauso zugeklappt."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Beiträge mit einem dieser Wörter werden auf eine Zeile zugeklappt — nicht gelöscht, und mit einem Weg, sie doch zu lesen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4112
+#: lib/vutuv_web/live/post_live/feed.ex:4154
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Weggelegt:"
@@ -22249,7 +22249,7 @@ msgid "Show posts by %{name}"
 msgstr "Beiträge von %{name} anzeigen"
 
 #: lib/vutuv_web/live/post_live/feed.ex:852
-#: lib/vutuv_web/live/post_live/feed.ex:4204
+#: lib/vutuv_web/live/post_live/feed.ex:4246
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr "Quellen"
@@ -22288,8 +22288,8 @@ msgid_plural "and %{formatted} more"
 msgstr[0] "und 1 weiterer"
 msgstr[1] "und %{formatted} weitere"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3670
-#: lib/vutuv_web/live/post_live/feed.ex:3697
+#: lib/vutuv_web/live/post_live/feed.ex:3711
+#: lib/vutuv_web/live/post_live/feed.ex:3738
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -22355,7 +22355,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} Beitrag am %{day}"
 msgstr[1] "%{count} Beiträge am %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3873
+#: lib/vutuv_web/live/post_live/feed.ex:3915
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Zurück zu jetzt"
@@ -22365,7 +22365,7 @@ msgstr "Zurück zu jetzt"
 msgid "Busy month: the shading counts at least this much."
 msgstr "Voller Monat: die Färbung zählt mindestens so viel."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3919
+#: lib/vutuv_web/live/post_live/feed.ex:3961
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -22387,7 +22387,7 @@ msgstr "Nächster Monat"
 msgid "Next year"
 msgstr "Nächstes Jahr"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3869
+#: lib/vutuv_web/live/post_live/feed.ex:3911
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Am %{day} ist nichts in Ihrem Feed angekommen."
@@ -22481,7 +22481,7 @@ msgid_plural "New (%{formatted}):"
 msgstr[0] "Neu:"
 msgstr[1] "Neu (%{formatted}):"
 
-#: lib/vutuv_web/components/post_components.ex:3718
+#: lib/vutuv_web/components/post_components.ex:3802
 #, elixir-autogen, elixir-format
 msgid "Quoted post"
 msgstr "Zitierter Beitrag"
@@ -22537,7 +22537,7 @@ msgstr "Nur diese Accounts (leer = alle) …"
 msgid "only %{account}"
 msgstr "nur %{account}"
 
-#: lib/vutuv_web/components/post_components.ex:7516
+#: lib/vutuv_web/components/post_components.ex:7600
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -22721,7 +22721,7 @@ msgctxt "phone tab bar"
 msgid "Write"
 msgstr "Schreiben"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4007
+#: lib/vutuv_web/live/post_live/feed.ex:4049
 #: lib/vutuv_web/live/post_rewrites_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "%{formatted} rule"
@@ -22791,7 +22791,7 @@ msgstr "Regeln, die den Text der Beiträge eines Kontos umschreiben, bevor Sie i
 
 #: lib/vutuv_web/components/post_components.ex:1457
 #: lib/vutuv_web/components/post_components.ex:3407
-#: lib/vutuv_web/components/post_components.ex:4682
+#: lib/vutuv_web/components/post_components.ex:4766
 #: lib/vutuv_web/components/ui.ex:5541
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
@@ -23022,7 +23022,7 @@ msgstr[1] "%{formatted} neue Follower"
 msgid "Last 30 days: %{parts}"
 msgstr "Letzte 30 Tage: %{parts}"
 
-#: lib/vutuv_web/components/post_components.ex:5244
+#: lib/vutuv_web/components/post_components.ex:5328
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Less"
@@ -23337,7 +23337,7 @@ msgid "Hidden. What they pass on stays out of your feed; their own posts do not.
 msgstr "Ausgeblendet. Was dieses Konto weiterreicht, erscheint nicht mehr in Ihrem Feed, die eigenen Beiträge schon."
 
 #: lib/vutuv_web/components/post_components.ex:3379
-#: lib/vutuv_web/components/post_components.ex:4676
+#: lib/vutuv_web/components/post_components.ex:4760
 #, elixir-autogen, elixir-format
 msgid "Hide reposts"
 msgstr "Reposts ausblenden"
@@ -23518,8 +23518,8 @@ msgstr "Beiträge in Ihrem Feed"
 msgid "Posts loaded at once"
 msgstr "Beiträge auf einmal"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3943
-#: lib/vutuv_web/live/post_live/feed.ex:3947
+#: lib/vutuv_web/live/post_live/feed.ex:3985
+#: lib/vutuv_web/live/post_live/feed.ex:3989
 #, elixir-autogen, elixir-format
 msgid "Posts per page"
 msgstr "Beiträge pro Seite"
@@ -23534,60 +23534,60 @@ msgstr "Sie können das auch direkt im Feed ändern, gleich unter „Mehr laden�
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr "feed länge seitengröße beiträge anzahl menge mehr laden scrollen blättern seite umfang page size posts number load more"
 
-#: lib/vutuv_web/components/post_components.ex:7507
-#: lib/vutuv_web/components/post_components.ex:7508
+#: lib/vutuv_web/components/post_components.ex:7591
+#: lib/vutuv_web/components/post_components.ex:7592
 #, elixir-autogen, elixir-format
 msgid "A word or phrase …"
 msgstr "Ein Wort oder eine Wortgruppe …"
 
-#: lib/vutuv_web/components/post_components.ex:7535
+#: lib/vutuv_web/components/post_components.ex:7619
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr "Für wen %{thing} ausgeblendet wird"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4004
-#: lib/vutuv_web/live/post_live/feed.ex:4168
-#: lib/vutuv_web/live/post_live/feed.ex:4177
+#: lib/vutuv_web/live/post_live/feed.ex:4046
+#: lib/vutuv_web/live/post_live/feed.ex:4210
+#: lib/vutuv_web/live/post_live/feed.ex:4219
 #, elixir-autogen, elixir-format
 msgid "Hidden"
 msgstr "Ausgeblendet"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4142
+#: lib/vutuv_web/live/post_live/feed.ex:4184
 #, elixir-autogen, elixir-format
 msgid "Hide something from your feed"
 msgstr "Etwas aus dem Feed ausblenden"
 
-#: lib/vutuv_web/components/post_components.ex:7453
+#: lib/vutuv_web/components/post_components.ex:7537
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr "Nicht mehr zeigen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4183
+#: lib/vutuv_web/live/post_live/feed.ex:4225
 #, elixir-autogen, elixir-format
 msgid "Whatever these match is folded to a single line in your feed."
 msgstr "Was hiervon getroffen wird, klappt im Feed auf eine Zeile zu."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4203
+#: lib/vutuv_web/live/post_live/feed.ex:4245
 #, elixir-autogen, elixir-format
 msgid "Words & tags"
 msgstr "Wörter & Tags"
 
-#: lib/vutuv_web/components/post_components.ex:7539
+#: lib/vutuv_web/components/post_components.ex:7623
 #, elixir-autogen, elixir-format
 msgid "everyone"
 msgstr "bei allen"
 
-#: lib/vutuv_web/components/post_components.ex:7542
+#: lib/vutuv_web/components/post_components.ex:7626
 #, elixir-autogen, elixir-format
 msgid "only %{handle}"
 msgstr "nur %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:7511
+#: lib/vutuv_web/components/post_components.ex:7595
 #, elixir-autogen, elixir-format
 msgid "this word"
 msgstr "dieses Wort"
 
-#: lib/vutuv_web/components/post_components.ex:7552
+#: lib/vutuv_web/components/post_components.ex:7636
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr "nur %{server}"
@@ -23639,7 +23639,7 @@ msgstr "Diese Website ist gerade offline."
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr "Die Website läuft, nur diese Adresse gibt es hier nicht. Wahrscheinlich ist der Link alt oder enthält einen Tippfehler."
 
-#: lib/vutuv_web/components/post_components.ex:6857
+#: lib/vutuv_web/components/post_components.ex:6941
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr "Screenshot vergrößern"
@@ -23730,7 +23730,7 @@ msgid "Hidden. What other people pass on of them stays out of your feed; their o
 msgstr "Ausgeblendet. Was andere von diesem Konto weiterreichen, erscheint nicht mehr in Ihrem Feed, die eigenen Beiträge schon."
 
 #: lib/vutuv_web/components/post_components.ex:3365
-#: lib/vutuv_web/components/post_components.ex:4664
+#: lib/vutuv_web/components/post_components.ex:4748
 #, elixir-autogen, elixir-format
 msgid "Hide when others repost them"
 msgstr "Ausblenden, wenn andere reposten"
@@ -24493,13 +24493,13 @@ msgstr "das Meldeformular"
 msgid "“%{note}”"
 msgstr "„%{note}“"
 
-#: lib/vutuv_web/components/post_components.ex:5422
+#: lib/vutuv_web/components/post_components.ex:5506
 #: lib/vutuv_web/components/press_kit_components.ex:216
 #, elixir-autogen, elixir-format
 msgid "Show these photos larger"
 msgstr "Fotos vergrößern"
 
-#: lib/vutuv_web/components/post_components.ex:5608
+#: lib/vutuv_web/components/post_components.ex:5692
 #, elixir-autogen, elixir-format
 msgid "Show this photo larger"
 msgstr "Foto vergrößern"
@@ -24933,8 +24933,8 @@ msgstr "Sie können diesem Media Kit kein Bild hinzufügen."
 msgid "press kit media journalist photographer download original print logo svg credit copyright presse pressefotos pressemappe medienkit mediakit fotos logo herunterladen bildnachweis"
 msgstr "media kit medienkit mediakit pressemappe presse medien redaktion journalist fotograf download original druck logo svg bildnachweis urheberrecht pressefotos herunterladen press kit"
 
-#: lib/vutuv_web/components/post_components.ex:4580
-#: lib/vutuv_web/components/post_components.ex:4630
+#: lib/vutuv_web/components/post_components.ex:4664
+#: lib/vutuv_web/components/post_components.ex:4714
 #, elixir-autogen, elixir-format
 msgid "Copy link to post"
 msgstr "Link zum Beitrag kopieren"
@@ -25212,7 +25212,7 @@ msgstr "abgelehnt"
 msgid "Your post appears as soon as the video is ready"
 msgstr "Ihr Beitrag erscheint, sobald das Video fertig ist"
 
-#: lib/vutuv_web/components/post_components.ex:3632
+#: lib/vutuv_web/components/post_components.ex:3649
 #, elixir-autogen, elixir-format
 msgid "Found through %{server}"
 msgstr "Gefunden über %{server}"
@@ -25501,7 +25501,7 @@ msgstr "Dieses Bild konnte nicht gelesen werden."
 msgid "You can only send files to members you are connected with."
 msgstr "Dateien können Sie nur an Mitglieder senden, mit denen Sie vernetzt sind."
 
-#: lib/vutuv_web/components/post_components.ex:3655
+#: lib/vutuv_web/components/post_components.ex:3739
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Every copy of it disappears right away, for everyone on this vutuv."
 msgstr "Diesen Beitrag als unangemessen melden? Jede Kopie verschwindet sofort für alle auf diesem vutuv."
@@ -25511,7 +25511,7 @@ msgstr "Diesen Beitrag als unangemessen melden? Jede Kopie verschwindet sofort f
 msgid "Thank you. Every copy on this vutuv is gone."
 msgstr "Danke. Jede Kopie auf diesem vutuv ist weg."
 
-#: lib/vutuv_web/components/post_components.ex:3660
+#: lib/vutuv_web/components/post_components.ex:3744
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? This copy disappears right away, for everyone on this vutuv. Copies other servers sent us stay."
 msgstr "Diesen Beitrag als unangemessen melden? Diese Kopie verschwindet sofort für alle auf diesem vutuv. Kopien von anderen Servern bleiben stehen."
@@ -25590,3 +25590,8 @@ msgstr "ein Inhalt von %{page} auf vutuv wurde gemeldet."
 #, elixir-autogen, elixir-format
 msgid "the page %{page} itself was reported on vutuv."
 msgstr "die Seite %{page} selbst wurde auf vutuv gemeldet."
+
+#: lib/vutuv_web/components/post_components.ex:3707
+#, elixir-autogen, elixir-format
+msgid "Found through these servers"
+msgstr "Gefunden über diese Server"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -165,7 +165,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4617
+#: lib/vutuv_web/components/post_components.ex:4701
 #: lib/vutuv_web/components/ui.ex:5042
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
@@ -213,7 +213,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4582
+#: lib/vutuv_web/components/post_components.ex:4666
 #: lib/vutuv_web/components/ui.ex:5033
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
@@ -1189,7 +1189,7 @@ msgstr ""
 msgid "All tag urls"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5235
+#: lib/vutuv_web/components/post_components.ex:5319
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:643
@@ -2091,7 +2091,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4614
+#: lib/vutuv_web/components/post_components.ex:4698
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2107,7 +2107,7 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:203
 #: lib/vutuv_web/live/post_live/feed.ex:366
-#: lib/vutuv_web/live/post_live/feed.ex:3553
+#: lib/vutuv_web/live/post_live/feed.ex:3594
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1346
 #: lib/vutuv_web/live/shell_live.ex:1692
@@ -2136,8 +2136,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4560
-#: lib/vutuv_web/components/post_components.ex:4562
+#: lib/vutuv_web/components/post_components.ex:4644
+#: lib/vutuv_web/components/post_components.ex:4646
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2153,7 +2153,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3893
+#: lib/vutuv_web/live/post_live/feed.ex:3935
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2202,13 +2202,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5108
-#: lib/vutuv_web/components/post_components.ex:5112
+#: lib/vutuv_web/components/post_components.ex:5192
+#: lib/vutuv_web/components/post_components.ex:5196
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5109
+#: lib/vutuv_web/components/post_components.ex:5193
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2306,27 +2306,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4557
+#: lib/vutuv_web/components/post_components.ex:4641
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6875
+#: lib/vutuv_web/components/post_components.ex:6959
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6879
+#: lib/vutuv_web/components/post_components.ex:6963
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6877
+#: lib/vutuv_web/components/post_components.ex:6961
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6878
+#: lib/vutuv_web/components/post_components.ex:6962
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2373,7 +2373,7 @@ msgid "All posts"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2186
-#: lib/vutuv_web/components/post_components.ex:6978
+#: lib/vutuv_web/components/post_components.ex:7062
 #: lib/vutuv_web/components/ui.ex:4476
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2392,7 +2392,7 @@ msgid "Bookmarks"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2130
-#: lib/vutuv_web/components/post_components.ex:7219
+#: lib/vutuv_web/components/post_components.ex:7303
 #: lib/vutuv_web/components/ui.ex:4462
 #: lib/vutuv_web/notification_line.ex:342
 #: lib/vutuv_web/views/user_html.ex:486
@@ -2401,7 +2401,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1301
-#: lib/vutuv_web/components/post_components.ex:7229
+#: lib/vutuv_web/components/post_components.ex:7313
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
 #: lib/vutuv_web/live/shell_live.ex:1596
@@ -2422,13 +2422,13 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6966
+#: lib/vutuv_web/components/post_components.ex:7050
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2185
-#: lib/vutuv_web/components/post_components.ex:6977
+#: lib/vutuv_web/components/post_components.ex:7061
 #: lib/vutuv_web/live/post_live/saved.ex:822
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2436,26 +2436,26 @@ msgid "Remove bookmark"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2166
-#: lib/vutuv_web/components/post_components.ex:6962
+#: lib/vutuv_web/components/post_components.ex:7046
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2759
-#: lib/vutuv_web/components/post_components.ex:5981
+#: lib/vutuv_web/components/post_components.ex:6065
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2165
-#: lib/vutuv_web/components/post_components.ex:6961
+#: lib/vutuv_web/components/post_components.ex:7045
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2129
-#: lib/vutuv_web/components/post_components.ex:7218
+#: lib/vutuv_web/components/post_components.ex:7302
 #: lib/vutuv_web/live/post_live/saved.ex:821
 #: lib/vutuv_web/views/user_html.ex:486
 #, elixir-autogen, elixir-format
@@ -2483,7 +2483,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7273
+#: lib/vutuv_web/components/post_components.ex:7357
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2495,8 +2495,8 @@ msgid "Replies"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2375
-#: lib/vutuv_web/components/post_components.ex:7256
-#: lib/vutuv_web/components/post_components.ex:7257
+#: lib/vutuv_web/components/post_components.ex:7340
+#: lib/vutuv_web/components/post_components.ex:7341
 #: lib/vutuv_web/live/notification_live/index.ex:993
 #: lib/vutuv_web/live/post_live/reply.ex:49
 #: lib/vutuv_web/notification_line.ex:339
@@ -2504,7 +2504,7 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4516
+#: lib/vutuv_web/components/post_components.ex:4600
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2525,7 +2525,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4034
+#: lib/vutuv_web/components/post_components.ex:4118
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:63
 #: lib/vutuv_web/live/post_live/remote_reply.ex:61
 #: lib/vutuv_web/live/post_live/reply.ex:63
@@ -2533,14 +2533,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4488
+#: lib/vutuv_web/components/post_components.ex:4572
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4479
-#: lib/vutuv_web/components/post_components.ex:4508
-#: lib/vutuv_web/components/post_components.ex:4511
+#: lib/vutuv_web/components/post_components.ex:4563
+#: lib/vutuv_web/components/post_components.ex:4592
+#: lib/vutuv_web/components/post_components.ex:4595
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2840,7 +2840,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6876
+#: lib/vutuv_web/components/post_components.ex:6960
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4455
+#: lib/vutuv_web/components/post_components.ex:4539
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3152,8 +3152,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1467
 #: lib/vutuv_web/components/post_components.ex:3419
-#: lib/vutuv_web/components/post_components.ex:3611
-#: lib/vutuv_web/components/post_components.ex:4685
+#: lib/vutuv_web/components/post_components.ex:3627
+#: lib/vutuv_web/components/post_components.ex:4769
 #: lib/vutuv_web/live/organization_live/show.ex:684
 #: lib/vutuv_web/templates/user/show.html.heex:252
 #, elixir-autogen, elixir-format
@@ -4495,7 +4495,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3898
+#: lib/vutuv_web/live/post_live/feed.ex:3940
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -5372,9 +5372,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4765
-#: lib/vutuv_web/components/post_components.ex:5374
-#: lib/vutuv_web/components/post_components.ex:5712
+#: lib/vutuv_web/components/post_components.ex:4849
+#: lib/vutuv_web/components/post_components.ex:5458
+#: lib/vutuv_web/components/post_components.ex:5796
 #: lib/vutuv_web/live/notification_live/index.ex:1069
 #: lib/vutuv_web/views/user_html.ex:133
 #, elixir-autogen, elixir-format
@@ -5740,7 +5740,7 @@ msgid "Name (A-Z)"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:507
-#: lib/vutuv_web/live/tag_live/timeline.ex:449
+#: lib/vutuv_web/live/tag_live/timeline.ex:453
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr ""
@@ -5766,7 +5766,7 @@ msgid "Nothing here yet. People you like show up here."
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:508
-#: lib/vutuv_web/live/tag_live/timeline.ex:450
+#: lib/vutuv_web/live/tag_live/timeline.ex:454
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr ""
@@ -6566,8 +6566,8 @@ msgid "Turn a switch off and the matching opt-out rides along on the pages and r
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3346
-#: lib/vutuv_web/components/post_components.ex:4638
-#: lib/vutuv_web/components/post_components.ex:4652
+#: lib/vutuv_web/components/post_components.ex:4722
+#: lib/vutuv_web/components/post_components.ex:4736
 #: lib/vutuv_web/components/ui.ex:3226
 #: lib/vutuv_web/live/fediverse_account_live.ex:437
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6595,7 +6595,7 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4638
+#: lib/vutuv_web/components/post_components.ex:4722
 #: lib/vutuv_web/components/ui.ex:3225
 #: lib/vutuv_web/live/fediverse_account_live.ex:435
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -7288,7 +7288,7 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:7129
+#: lib/vutuv_web/components/post_components.ex:7213
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #: lib/vutuv_web/live/shell_live.ex:1830
 #, elixir-autogen, elixir-format
@@ -7393,7 +7393,7 @@ msgstr ""
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/media_live.ex:270
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:4192
+#: lib/vutuv_web/live/post_live/feed.ex:4234
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #: lib/vutuv_web/live/press_kit_live.ex:1056
 #, elixir-autogen
@@ -8734,7 +8734,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5984
+#: lib/vutuv_web/components/post_components.ex:6068
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -12936,7 +12936,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3993
+#: lib/vutuv_web/components/post_components.ex:4077
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:788
 #: lib/vutuv_web/controllers/settings_controller.ex:806
@@ -13536,34 +13536,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6672
+#: lib/vutuv_web/components/post_components.ex:6756
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6629
+#: lib/vutuv_web/components/post_components.ex:6713
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6673
+#: lib/vutuv_web/components/post_components.ex:6757
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6675
+#: lib/vutuv_web/components/post_components.ex:6759
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6671
+#: lib/vutuv_web/components/post_components.ex:6755
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6628
+#: lib/vutuv_web/components/post_components.ex:6712
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13574,12 +13574,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6670
+#: lib/vutuv_web/components/post_components.ex:6754
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6674
+#: lib/vutuv_web/components/post_components.ex:6758
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13599,7 +13599,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6711
+#: lib/vutuv_web/components/post_components.ex:6795
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13607,30 +13607,30 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6741
+#: lib/vutuv_web/components/post_components.ex:6825
 #: lib/vutuv_web/components/ui.ex:3884
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6742
+#: lib/vutuv_web/components/post_components.ex:6826
 #: lib/vutuv_web/components/ui.ex:3885
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6740
+#: lib/vutuv_web/components/post_components.ex:6824
 #: lib/vutuv_web/components/ui.ex:3877
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6700
+#: lib/vutuv_web/components/post_components.ex:6784
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6747
+#: lib/vutuv_web/components/post_components.ex:6831
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13660,7 +13660,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6514
+#: lib/vutuv_web/components/post_components.ex:6598
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13703,7 +13703,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6505
+#: lib/vutuv_web/components/post_components.ex:6589
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14050,14 +14050,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4282
+#: lib/vutuv_web/components/post_components.ex:4366
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4305
+#: lib/vutuv_web/components/post_components.ex:4389
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14084,7 +14084,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7228
+#: lib/vutuv_web/components/post_components.ex:7312
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -15229,7 +15229,7 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7174
+#: lib/vutuv_web/components/post_components.ex:7258
 #: lib/vutuv_web/live/notification_live/index.ex:1592
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -15237,7 +15237,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:7178
+#: lib/vutuv_web/components/post_components.ex:7262
 #: lib/vutuv_web/live/notification_live/index.ex:1586
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15245,7 +15245,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:7182
+#: lib/vutuv_web/components/post_components.ex:7266
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15253,7 +15253,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1339
-#: lib/vutuv_web/components/post_components.ex:7133
+#: lib/vutuv_web/components/post_components.ex:7217
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15351,8 +15351,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1539
 #: lib/vutuv_web/components/post_components.ex:1503
 #: lib/vutuv_web/components/post_components.ex:1734
-#: lib/vutuv_web/components/post_components.ex:3591
-#: lib/vutuv_web/components/post_components.ex:3851
+#: lib/vutuv_web/components/post_components.ex:3607
+#: lib/vutuv_web/components/post_components.ex:3935
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "View the original"
@@ -15795,7 +15795,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/admin/media_live.ex:155
 #: lib/vutuv_web/live/fediverse_following_live.ex:351
-#: lib/vutuv_web/live/tag_live/timeline.ex:474
+#: lib/vutuv_web/live/tag_live/timeline.ex:478
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr ""
@@ -16015,22 +16015,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4467
+#: lib/vutuv_web/components/post_components.ex:4551
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4601
+#: lib/vutuv_web/components/post_components.ex:4685
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4609
+#: lib/vutuv_web/components/post_components.ex:4693
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4595
+#: lib/vutuv_web/components/post_components.ex:4679
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16153,18 +16153,18 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4046
+#: lib/vutuv_web/components/post_components.ex:4130
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5550
+#: lib/vutuv_web/components/post_components.ex:5634
 #: lib/vutuv_web/components/press_kit_components.ex:526
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5778
+#: lib/vutuv_web/components/post_components.ex:5862
 #: lib/vutuv_web/components/press_kit_components.ex:623
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
@@ -16178,7 +16178,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1500
 #: lib/vutuv_web/agent_docs/text.ex:909
-#: lib/vutuv_web/components/post_components.ex:5860
+#: lib/vutuv_web/components/post_components.ex:5944
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr ""
@@ -16204,7 +16204,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4099
+#: lib/vutuv_web/components/post_components.ex:4183
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16224,7 +16224,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4090
+#: lib/vutuv_web/components/post_components.ex:4174
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16234,12 +16234,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4108
+#: lib/vutuv_web/components/post_components.ex:4192
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4042
+#: lib/vutuv_web/components/post_components.ex:4126
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16254,7 +16254,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4103
+#: lib/vutuv_web/components/post_components.ex:4187
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16264,7 +16264,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4056
+#: lib/vutuv_web/components/post_components.ex:4140
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16339,13 +16339,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1357
-#: lib/vutuv_web/components/post_components.ex:7171
+#: lib/vutuv_web/components/post_components.ex:7255
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1355
-#: lib/vutuv_web/components/post_components.ex:7168
+#: lib/vutuv_web/components/post_components.ex:7252
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16355,7 +16355,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7055
+#: lib/vutuv_web/components/post_components.ex:7139
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
@@ -16707,7 +16707,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3850
+#: lib/vutuv_web/components/post_components.ex:3934
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16732,7 +16732,7 @@ msgstr ""
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3791
+#: lib/vutuv_web/components/post_components.ex:3875
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr ""
@@ -16862,12 +16862,12 @@ msgstr ""
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3949
+#: lib/vutuv_web/components/post_components.ex:4033
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3955
+#: lib/vutuv_web/components/post_components.ex:4039
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr ""
@@ -16877,7 +16877,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4094
+#: lib/vutuv_web/components/post_components.ex:4178
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17513,22 +17513,22 @@ msgid_plural "%{formatted} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:451
+#: lib/vutuv_web/live/tag_live/timeline.ex:455
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:482
+#: lib/vutuv_web/live/tag_live/timeline.ex:486
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:480
+#: lib/vutuv_web/live/tag_live/timeline.ex:484
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:477
+#: lib/vutuv_web/live/tag_live/timeline.ex:481
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr ""
@@ -17538,7 +17538,7 @@ msgstr ""
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3952
+#: lib/vutuv_web/components/post_components.ex:4036
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -17610,19 +17610,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6154
+#: lib/vutuv_web/components/post_components.ex:6238
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6156
+#: lib/vutuv_web/components/post_components.ex:6240
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6167
+#: lib/vutuv_web/components/post_components.ex:6251
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -17794,7 +17794,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3916
+#: lib/vutuv_web/live/post_live/feed.ex:3958
 #: lib/vutuv_web/live/reference_check_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -19205,7 +19205,7 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3982
+#: lib/vutuv_web/components/post_components.ex:4066
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -20073,27 +20073,27 @@ msgstr ""
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6048
+#: lib/vutuv_web/components/post_components.ex:6132
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6084
+#: lib/vutuv_web/components/post_components.ex:6168
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6093
+#: lib/vutuv_web/components/post_components.ex:6177
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6096
+#: lib/vutuv_web/components/post_components.ex:6180
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6073
+#: lib/vutuv_web/components/post_components.ex:6157
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
@@ -20103,7 +20103,7 @@ msgstr ""
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6063
+#: lib/vutuv_web/components/post_components.ex:6147
 #: lib/vutuv_web/components/ui.ex:5549
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -20232,20 +20232,20 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5826
+#: lib/vutuv_web/components/post_components.ex:5910
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5823
+#: lib/vutuv_web/components/post_components.ex:5907
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2913
-#: lib/vutuv_web/components/post_components.ex:4892
+#: lib/vutuv_web/components/post_components.ex:4976
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -20883,7 +20883,7 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4086
+#: lib/vutuv_web/live/post_live/feed.ex:4128
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
@@ -21356,13 +21356,13 @@ msgid "Hide a word or a whole phrase …"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:854
-#: lib/vutuv_web/live/post_live/feed.ex:4249
+#: lib/vutuv_web/live/post_live/feed.ex:4291
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:853
-#: lib/vutuv_web/live/post_live/feed.ex:4238
+#: lib/vutuv_web/live/post_live/feed.ex:4280
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr ""
@@ -21429,7 +21429,7 @@ msgstr ""
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4112
+#: lib/vutuv_web/live/post_live/feed.ex:4154
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
@@ -21468,7 +21468,7 @@ msgid "Show posts by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:852
-#: lib/vutuv_web/live/post_live/feed.ex:4204
+#: lib/vutuv_web/live/post_live/feed.ex:4246
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr ""
@@ -21507,8 +21507,8 @@ msgid_plural "and %{formatted} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3670
-#: lib/vutuv_web/live/post_live/feed.ex:3697
+#: lib/vutuv_web/live/post_live/feed.ex:3711
+#: lib/vutuv_web/live/post_live/feed.ex:3738
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -21570,7 +21570,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3873
+#: lib/vutuv_web/live/post_live/feed.ex:3915
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr ""
@@ -21580,7 +21580,7 @@ msgstr ""
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3919
+#: lib/vutuv_web/live/post_live/feed.ex:3961
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -21602,7 +21602,7 @@ msgstr ""
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3869
+#: lib/vutuv_web/live/post_live/feed.ex:3911
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
@@ -21696,7 +21696,7 @@ msgid_plural "New (%{formatted}):"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3718
+#: lib/vutuv_web/components/post_components.ex:3802
 #, elixir-autogen, elixir-format
 msgid "Quoted post"
 msgstr ""
@@ -21752,7 +21752,7 @@ msgstr ""
 msgid "only %{account}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7516
+#: lib/vutuv_web/components/post_components.ex:7600
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -21936,7 +21936,7 @@ msgctxt "phone tab bar"
 msgid "Write"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4007
+#: lib/vutuv_web/live/post_live/feed.ex:4049
 #: lib/vutuv_web/live/post_rewrites_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "%{formatted} rule"
@@ -22006,7 +22006,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1457
 #: lib/vutuv_web/components/post_components.ex:3407
-#: lib/vutuv_web/components/post_components.ex:4682
+#: lib/vutuv_web/components/post_components.ex:4766
 #: lib/vutuv_web/components/ui.ex:5541
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
@@ -22237,7 +22237,7 @@ msgstr[1] ""
 msgid "Last 30 days: %{parts}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5244
+#: lib/vutuv_web/components/post_components.ex:5328
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Less"
@@ -22552,7 +22552,7 @@ msgid "Hidden. What they pass on stays out of your feed; their own posts do not.
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3379
-#: lib/vutuv_web/components/post_components.ex:4676
+#: lib/vutuv_web/components/post_components.ex:4760
 #, elixir-autogen, elixir-format
 msgid "Hide reposts"
 msgstr ""
@@ -22733,8 +22733,8 @@ msgstr ""
 msgid "Posts loaded at once"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3943
-#: lib/vutuv_web/live/post_live/feed.ex:3947
+#: lib/vutuv_web/live/post_live/feed.ex:3985
+#: lib/vutuv_web/live/post_live/feed.ex:3989
 #, elixir-autogen, elixir-format
 msgid "Posts per page"
 msgstr ""
@@ -22749,60 +22749,60 @@ msgstr ""
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7507
-#: lib/vutuv_web/components/post_components.ex:7508
+#: lib/vutuv_web/components/post_components.ex:7591
+#: lib/vutuv_web/components/post_components.ex:7592
 #, elixir-autogen, elixir-format
 msgid "A word or phrase …"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7535
+#: lib/vutuv_web/components/post_components.ex:7619
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4004
-#: lib/vutuv_web/live/post_live/feed.ex:4168
-#: lib/vutuv_web/live/post_live/feed.ex:4177
+#: lib/vutuv_web/live/post_live/feed.ex:4046
+#: lib/vutuv_web/live/post_live/feed.ex:4210
+#: lib/vutuv_web/live/post_live/feed.ex:4219
 #, elixir-autogen, elixir-format
 msgid "Hidden"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4142
+#: lib/vutuv_web/live/post_live/feed.ex:4184
 #, elixir-autogen, elixir-format
 msgid "Hide something from your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7453
+#: lib/vutuv_web/components/post_components.ex:7537
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4183
+#: lib/vutuv_web/live/post_live/feed.ex:4225
 #, elixir-autogen, elixir-format
 msgid "Whatever these match is folded to a single line in your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4203
+#: lib/vutuv_web/live/post_live/feed.ex:4245
 #, elixir-autogen, elixir-format
 msgid "Words & tags"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7539
+#: lib/vutuv_web/components/post_components.ex:7623
 #, elixir-autogen, elixir-format
 msgid "everyone"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7542
+#: lib/vutuv_web/components/post_components.ex:7626
 #, elixir-autogen, elixir-format
 msgid "only %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7511
+#: lib/vutuv_web/components/post_components.ex:7595
 #, elixir-autogen, elixir-format
 msgid "this word"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7552
+#: lib/vutuv_web/components/post_components.ex:7636
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr ""
@@ -22854,7 +22854,7 @@ msgstr ""
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6857
+#: lib/vutuv_web/components/post_components.ex:6941
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr ""
@@ -22945,7 +22945,7 @@ msgid "Hidden. What other people pass on of them stays out of your feed; their o
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3365
-#: lib/vutuv_web/components/post_components.ex:4664
+#: lib/vutuv_web/components/post_components.ex:4748
 #, elixir-autogen, elixir-format
 msgid "Hide when others repost them"
 msgstr ""
@@ -23660,13 +23660,13 @@ msgstr ""
 msgid "“%{note}”"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5422
+#: lib/vutuv_web/components/post_components.ex:5506
 #: lib/vutuv_web/components/press_kit_components.ex:216
 #, elixir-autogen, elixir-format
 msgid "Show these photos larger"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5608
+#: lib/vutuv_web/components/post_components.ex:5692
 #, elixir-autogen, elixir-format
 msgid "Show this photo larger"
 msgstr ""
@@ -24100,8 +24100,8 @@ msgstr ""
 msgid "press kit media journalist photographer download original print logo svg credit copyright presse pressefotos pressemappe medienkit mediakit fotos logo herunterladen bildnachweis"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4580
-#: lib/vutuv_web/components/post_components.ex:4630
+#: lib/vutuv_web/components/post_components.ex:4664
+#: lib/vutuv_web/components/post_components.ex:4714
 #, elixir-autogen, elixir-format
 msgid "Copy link to post"
 msgstr ""
@@ -24379,7 +24379,7 @@ msgstr ""
 msgid "Your post appears as soon as the video is ready"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3632
+#: lib/vutuv_web/components/post_components.ex:3649
 #, elixir-autogen, elixir-format
 msgid "Found through %{server}"
 msgstr ""
@@ -24668,7 +24668,7 @@ msgstr ""
 msgid "You can only send files to members you are connected with."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3655
+#: lib/vutuv_web/components/post_components.ex:3739
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Every copy of it disappears right away, for everyone on this vutuv."
 msgstr ""
@@ -24678,7 +24678,7 @@ msgstr ""
 msgid "Thank you. Every copy on this vutuv is gone."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3660
+#: lib/vutuv_web/components/post_components.ex:3744
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? This copy disappears right away, for everyone on this vutuv. Copies other servers sent us stay."
 msgstr ""
@@ -24756,4 +24756,9 @@ msgstr ""
 #: lib/vutuv_web/views/report_html.ex:236
 #, elixir-autogen, elixir-format
 msgid "the page %{page} itself was reported on vutuv."
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:3707
+#, elixir-autogen, elixir-format
+msgid "Found through these servers"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -163,7 +163,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4617
+#: lib/vutuv_web/components/post_components.ex:4701
 #: lib/vutuv_web/components/ui.ex:5042
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
@@ -211,7 +211,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4582
+#: lib/vutuv_web/components/post_components.ex:4666
 #: lib/vutuv_web/components/ui.ex:5033
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
@@ -1187,7 +1187,7 @@ msgstr ""
 msgid "All tag urls"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5235
+#: lib/vutuv_web/components/post_components.ex:5319
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:643
@@ -2089,7 +2089,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4614
+#: lib/vutuv_web/components/post_components.ex:4698
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2105,7 +2105,7 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:203
 #: lib/vutuv_web/live/post_live/feed.ex:366
-#: lib/vutuv_web/live/post_live/feed.ex:3553
+#: lib/vutuv_web/live/post_live/feed.ex:3594
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1346
 #: lib/vutuv_web/live/shell_live.ex:1692
@@ -2134,8 +2134,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4560
-#: lib/vutuv_web/components/post_components.ex:4562
+#: lib/vutuv_web/components/post_components.ex:4644
+#: lib/vutuv_web/components/post_components.ex:4646
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2151,7 +2151,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3893
+#: lib/vutuv_web/live/post_live/feed.ex:3935
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2200,13 +2200,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5108
-#: lib/vutuv_web/components/post_components.ex:5112
+#: lib/vutuv_web/components/post_components.ex:5192
+#: lib/vutuv_web/components/post_components.ex:5196
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5109
+#: lib/vutuv_web/components/post_components.ex:5193
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2304,27 +2304,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4557
+#: lib/vutuv_web/components/post_components.ex:4641
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6875
+#: lib/vutuv_web/components/post_components.ex:6959
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6879
+#: lib/vutuv_web/components/post_components.ex:6963
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6877
+#: lib/vutuv_web/components/post_components.ex:6961
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6878
+#: lib/vutuv_web/components/post_components.ex:6962
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2371,7 +2371,7 @@ msgid "All posts"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2186
-#: lib/vutuv_web/components/post_components.ex:6978
+#: lib/vutuv_web/components/post_components.ex:7062
 #: lib/vutuv_web/components/ui.ex:4476
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2390,7 +2390,7 @@ msgid "Bookmarks"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2130
-#: lib/vutuv_web/components/post_components.ex:7219
+#: lib/vutuv_web/components/post_components.ex:7303
 #: lib/vutuv_web/components/ui.ex:4462
 #: lib/vutuv_web/notification_line.ex:342
 #: lib/vutuv_web/views/user_html.ex:486
@@ -2399,7 +2399,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1301
-#: lib/vutuv_web/components/post_components.ex:7229
+#: lib/vutuv_web/components/post_components.ex:7313
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
 #: lib/vutuv_web/live/shell_live.ex:1596
@@ -2420,13 +2420,13 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6966
+#: lib/vutuv_web/components/post_components.ex:7050
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2185
-#: lib/vutuv_web/components/post_components.ex:6977
+#: lib/vutuv_web/components/post_components.ex:7061
 #: lib/vutuv_web/live/post_live/saved.ex:822
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2434,26 +2434,26 @@ msgid "Remove bookmark"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2166
-#: lib/vutuv_web/components/post_components.ex:6962
+#: lib/vutuv_web/components/post_components.ex:7046
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2759
-#: lib/vutuv_web/components/post_components.ex:5981
+#: lib/vutuv_web/components/post_components.ex:6065
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2165
-#: lib/vutuv_web/components/post_components.ex:6961
+#: lib/vutuv_web/components/post_components.ex:7045
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2129
-#: lib/vutuv_web/components/post_components.ex:7218
+#: lib/vutuv_web/components/post_components.ex:7302
 #: lib/vutuv_web/live/post_live/saved.ex:821
 #: lib/vutuv_web/views/user_html.ex:486
 #, elixir-autogen, elixir-format
@@ -2481,7 +2481,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7273
+#: lib/vutuv_web/components/post_components.ex:7357
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2493,8 +2493,8 @@ msgid "Replies"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2375
-#: lib/vutuv_web/components/post_components.ex:7256
-#: lib/vutuv_web/components/post_components.ex:7257
+#: lib/vutuv_web/components/post_components.ex:7340
+#: lib/vutuv_web/components/post_components.ex:7341
 #: lib/vutuv_web/live/notification_live/index.ex:993
 #: lib/vutuv_web/live/post_live/reply.ex:49
 #: lib/vutuv_web/notification_line.ex:339
@@ -2502,7 +2502,7 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4516
+#: lib/vutuv_web/components/post_components.ex:4600
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2523,7 +2523,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4034
+#: lib/vutuv_web/components/post_components.ex:4118
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:63
 #: lib/vutuv_web/live/post_live/remote_reply.ex:61
 #: lib/vutuv_web/live/post_live/reply.ex:63
@@ -2531,14 +2531,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4488
+#: lib/vutuv_web/components/post_components.ex:4572
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4479
-#: lib/vutuv_web/components/post_components.ex:4508
-#: lib/vutuv_web/components/post_components.ex:4511
+#: lib/vutuv_web/components/post_components.ex:4563
+#: lib/vutuv_web/components/post_components.ex:4592
+#: lib/vutuv_web/components/post_components.ex:4595
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2838,7 +2838,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6876
+#: lib/vutuv_web/components/post_components.ex:6960
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3090,7 +3090,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4455
+#: lib/vutuv_web/components/post_components.ex:4539
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3150,8 +3150,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1467
 #: lib/vutuv_web/components/post_components.ex:3419
-#: lib/vutuv_web/components/post_components.ex:3611
-#: lib/vutuv_web/components/post_components.ex:4685
+#: lib/vutuv_web/components/post_components.ex:3627
+#: lib/vutuv_web/components/post_components.ex:4769
 #: lib/vutuv_web/live/organization_live/show.ex:684
 #: lib/vutuv_web/templates/user/show.html.heex:252
 #, elixir-autogen, elixir-format
@@ -4493,7 +4493,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3898
+#: lib/vutuv_web/live/post_live/feed.ex:3940
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -5370,9 +5370,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4765
-#: lib/vutuv_web/components/post_components.ex:5374
-#: lib/vutuv_web/components/post_components.ex:5712
+#: lib/vutuv_web/components/post_components.ex:4849
+#: lib/vutuv_web/components/post_components.ex:5458
+#: lib/vutuv_web/components/post_components.ex:5796
 #: lib/vutuv_web/live/notification_live/index.ex:1069
 #: lib/vutuv_web/views/user_html.ex:133
 #, elixir-autogen, elixir-format
@@ -5738,7 +5738,7 @@ msgid "Name (A-Z)"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:507
-#: lib/vutuv_web/live/tag_live/timeline.ex:449
+#: lib/vutuv_web/live/tag_live/timeline.ex:453
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr ""
@@ -5764,7 +5764,7 @@ msgid "Nothing here yet. People you like show up here."
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:508
-#: lib/vutuv_web/live/tag_live/timeline.ex:450
+#: lib/vutuv_web/live/tag_live/timeline.ex:454
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr ""
@@ -6564,8 +6564,8 @@ msgid "Turn a switch off and the matching opt-out rides along on the pages and r
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3346
-#: lib/vutuv_web/components/post_components.ex:4638
-#: lib/vutuv_web/components/post_components.ex:4652
+#: lib/vutuv_web/components/post_components.ex:4722
+#: lib/vutuv_web/components/post_components.ex:4736
 #: lib/vutuv_web/components/ui.ex:3226
 #: lib/vutuv_web/live/fediverse_account_live.ex:437
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6593,7 +6593,7 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4638
+#: lib/vutuv_web/components/post_components.ex:4722
 #: lib/vutuv_web/components/ui.ex:3225
 #: lib/vutuv_web/live/fediverse_account_live.ex:435
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -7286,7 +7286,7 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:7129
+#: lib/vutuv_web/components/post_components.ex:7213
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #: lib/vutuv_web/live/shell_live.ex:1830
 #, elixir-autogen, elixir-format
@@ -7391,7 +7391,7 @@ msgstr ""
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/media_live.ex:270
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:4192
+#: lib/vutuv_web/live/post_live/feed.ex:4234
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #: lib/vutuv_web/live/press_kit_live.ex:1056
 #, elixir-autogen
@@ -8732,7 +8732,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5984
+#: lib/vutuv_web/components/post_components.ex:6068
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -12934,7 +12934,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3993
+#: lib/vutuv_web/components/post_components.ex:4077
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:788
 #: lib/vutuv_web/controllers/settings_controller.ex:806
@@ -13534,34 +13534,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6672
+#: lib/vutuv_web/components/post_components.ex:6756
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6629
+#: lib/vutuv_web/components/post_components.ex:6713
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6673
+#: lib/vutuv_web/components/post_components.ex:6757
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6675
+#: lib/vutuv_web/components/post_components.ex:6759
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6671
+#: lib/vutuv_web/components/post_components.ex:6755
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6628
+#: lib/vutuv_web/components/post_components.ex:6712
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13572,12 +13572,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6670
+#: lib/vutuv_web/components/post_components.ex:6754
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6674
+#: lib/vutuv_web/components/post_components.ex:6758
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13597,7 +13597,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6711
+#: lib/vutuv_web/components/post_components.ex:6795
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13605,30 +13605,30 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6741
+#: lib/vutuv_web/components/post_components.ex:6825
 #: lib/vutuv_web/components/ui.ex:3884
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6742
+#: lib/vutuv_web/components/post_components.ex:6826
 #: lib/vutuv_web/components/ui.ex:3885
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6740
+#: lib/vutuv_web/components/post_components.ex:6824
 #: lib/vutuv_web/components/ui.ex:3877
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6700
+#: lib/vutuv_web/components/post_components.ex:6784
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6747
+#: lib/vutuv_web/components/post_components.ex:6831
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13658,7 +13658,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6514
+#: lib/vutuv_web/components/post_components.ex:6598
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13701,7 +13701,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6505
+#: lib/vutuv_web/components/post_components.ex:6589
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14048,14 +14048,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4282
+#: lib/vutuv_web/components/post_components.ex:4366
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4305
+#: lib/vutuv_web/components/post_components.ex:4389
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14082,7 +14082,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7228
+#: lib/vutuv_web/components/post_components.ex:7312
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -15227,7 +15227,7 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7174
+#: lib/vutuv_web/components/post_components.ex:7258
 #: lib/vutuv_web/live/notification_live/index.ex:1592
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
@@ -15235,7 +15235,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:7178
+#: lib/vutuv_web/components/post_components.ex:7262
 #: lib/vutuv_web/live/notification_live/index.ex:1586
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15243,7 +15243,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:7182
+#: lib/vutuv_web/components/post_components.ex:7266
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15251,7 +15251,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1339
-#: lib/vutuv_web/components/post_components.ex:7133
+#: lib/vutuv_web/components/post_components.ex:7217
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15349,8 +15349,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1539
 #: lib/vutuv_web/components/post_components.ex:1503
 #: lib/vutuv_web/components/post_components.ex:1734
-#: lib/vutuv_web/components/post_components.ex:3591
-#: lib/vutuv_web/components/post_components.ex:3851
+#: lib/vutuv_web/components/post_components.ex:3607
+#: lib/vutuv_web/components/post_components.ex:3935
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "View the original"
@@ -15793,7 +15793,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/admin/media_live.ex:155
 #: lib/vutuv_web/live/fediverse_following_live.ex:351
-#: lib/vutuv_web/live/tag_live/timeline.ex:474
+#: lib/vutuv_web/live/tag_live/timeline.ex:478
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr ""
@@ -16013,22 +16013,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4467
+#: lib/vutuv_web/components/post_components.ex:4551
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4601
+#: lib/vutuv_web/components/post_components.ex:4685
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4609
+#: lib/vutuv_web/components/post_components.ex:4693
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4595
+#: lib/vutuv_web/components/post_components.ex:4679
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16151,18 +16151,18 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4046
+#: lib/vutuv_web/components/post_components.ex:4130
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5550
+#: lib/vutuv_web/components/post_components.ex:5634
 #: lib/vutuv_web/components/press_kit_components.ex:526
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5778
+#: lib/vutuv_web/components/post_components.ex:5862
 #: lib/vutuv_web/components/press_kit_components.ex:623
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
@@ -16176,7 +16176,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1500
 #: lib/vutuv_web/agent_docs/text.ex:909
-#: lib/vutuv_web/components/post_components.ex:5860
+#: lib/vutuv_web/components/post_components.ex:5944
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
 msgstr ""
@@ -16202,7 +16202,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4099
+#: lib/vutuv_web/components/post_components.ex:4183
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16222,7 +16222,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4090
+#: lib/vutuv_web/components/post_components.ex:4174
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16232,12 +16232,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4108
+#: lib/vutuv_web/components/post_components.ex:4192
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4042
+#: lib/vutuv_web/components/post_components.ex:4126
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16252,7 +16252,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4103
+#: lib/vutuv_web/components/post_components.ex:4187
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16262,7 +16262,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4056
+#: lib/vutuv_web/components/post_components.ex:4140
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16337,13 +16337,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1357
-#: lib/vutuv_web/components/post_components.ex:7171
+#: lib/vutuv_web/components/post_components.ex:7255
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1355
-#: lib/vutuv_web/components/post_components.ex:7168
+#: lib/vutuv_web/components/post_components.ex:7252
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16353,7 +16353,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7055
+#: lib/vutuv_web/components/post_components.ex:7139
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
@@ -16705,7 +16705,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3850
+#: lib/vutuv_web/components/post_components.ex:3934
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16730,7 +16730,7 @@ msgstr ""
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3791
+#: lib/vutuv_web/components/post_components.ex:3875
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Marked as sensitive by its author"
 msgstr ""
@@ -16860,12 +16860,12 @@ msgstr ""
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3949
+#: lib/vutuv_web/components/post_components.ex:4033
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3955
+#: lib/vutuv_web/components/post_components.ex:4039
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That post is not here any more."
 msgstr ""
@@ -16875,7 +16875,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4094
+#: lib/vutuv_web/components/post_components.ex:4178
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17511,22 +17511,22 @@ msgid_plural "%{formatted} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:451
+#: lib/vutuv_web/live/tag_live/timeline.ex:455
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:482
+#: lib/vutuv_web/live/tag_live/timeline.ex:486
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:480
+#: lib/vutuv_web/live/tag_live/timeline.ex:484
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:477
+#: lib/vutuv_web/live/tag_live/timeline.ex:481
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr ""
@@ -17536,7 +17536,7 @@ msgstr ""
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3952
+#: lib/vutuv_web/components/post_components.ex:4036
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -17608,19 +17608,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6154
+#: lib/vutuv_web/components/post_components.ex:6238
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6156
+#: lib/vutuv_web/components/post_components.ex:6240
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6167
+#: lib/vutuv_web/components/post_components.ex:6251
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -17792,7 +17792,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3916
+#: lib/vutuv_web/live/post_live/feed.ex:3958
 #: lib/vutuv_web/live/reference_check_live.ex:169
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Loading…"
@@ -19203,7 +19203,7 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3982
+#: lib/vutuv_web/components/post_components.ex:4066
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -20071,27 +20071,27 @@ msgstr ""
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6048
+#: lib/vutuv_web/components/post_components.ex:6132
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6084
+#: lib/vutuv_web/components/post_components.ex:6168
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6093
+#: lib/vutuv_web/components/post_components.ex:6177
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6096
+#: lib/vutuv_web/components/post_components.ex:6180
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6073
+#: lib/vutuv_web/components/post_components.ex:6157
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
@@ -20101,7 +20101,7 @@ msgstr ""
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6063
+#: lib/vutuv_web/components/post_components.ex:6147
 #: lib/vutuv_web/components/ui.ex:5549
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -20230,20 +20230,20 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5826
+#: lib/vutuv_web/components/post_components.ex:5910
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5823
+#: lib/vutuv_web/components/post_components.ex:5907
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2913
-#: lib/vutuv_web/components/post_components.ex:4892
+#: lib/vutuv_web/components/post_components.ex:4976
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -20881,7 +20881,7 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4086
+#: lib/vutuv_web/live/post_live/feed.ex:4128
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
@@ -21354,13 +21354,13 @@ msgid "Hide a word or a whole phrase …"
 msgstr "Hide a word or a whole phrase …"
 
 #: lib/vutuv_web/live/post_live/feed.ex:854
-#: lib/vutuv_web/live/post_live/feed.ex:4249
+#: lib/vutuv_web/live/post_live/feed.ex:4291
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Hide tags"
 
 #: lib/vutuv_web/live/post_live/feed.ex:853
-#: lib/vutuv_web/live/post_live/feed.ex:4238
+#: lib/vutuv_web/live/post_live/feed.ex:4280
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Hide words"
@@ -21427,7 +21427,7 @@ msgstr "Posts carrying one of these tags are folded the same way."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4112
+#: lib/vutuv_web/live/post_live/feed.ex:4154
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
@@ -21466,7 +21466,7 @@ msgid "Show posts by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:852
-#: lib/vutuv_web/live/post_live/feed.ex:4204
+#: lib/vutuv_web/live/post_live/feed.ex:4246
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sources"
 msgstr ""
@@ -21505,8 +21505,8 @@ msgid_plural "and %{formatted} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3670
-#: lib/vutuv_web/live/post_live/feed.ex:3697
+#: lib/vutuv_web/live/post_live/feed.ex:3711
+#: lib/vutuv_web/live/post_live/feed.ex:3738
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -21568,7 +21568,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3873
+#: lib/vutuv_web/live/post_live/feed.ex:3915
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Back to now"
 msgstr ""
@@ -21578,7 +21578,7 @@ msgstr ""
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3919
+#: lib/vutuv_web/live/post_live/feed.ex:3961
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -21600,7 +21600,7 @@ msgstr ""
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3869
+#: lib/vutuv_web/live/post_live/feed.ex:3911
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
@@ -21694,7 +21694,7 @@ msgid_plural "New (%{formatted}):"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3718
+#: lib/vutuv_web/components/post_components.ex:3802
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Quoted post"
 msgstr ""
@@ -21750,7 +21750,7 @@ msgstr ""
 msgid "only %{account}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7516
+#: lib/vutuv_web/components/post_components.ex:7600
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -21934,7 +21934,7 @@ msgctxt "phone tab bar"
 msgid "Write"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4007
+#: lib/vutuv_web/live/post_live/feed.ex:4049
 #: lib/vutuv_web/live/post_rewrites_live.ex:287
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} rule"
@@ -22004,7 +22004,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1457
 #: lib/vutuv_web/components/post_components.ex:3407
-#: lib/vutuv_web/components/post_components.ex:4682
+#: lib/vutuv_web/components/post_components.ex:4766
 #: lib/vutuv_web/components/ui.ex:5541
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
@@ -22235,7 +22235,7 @@ msgstr[1] ""
 msgid "Last 30 days: %{parts}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5244
+#: lib/vutuv_web/components/post_components.ex:5328
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Less"
@@ -22550,7 +22550,7 @@ msgid "Hidden. What they pass on stays out of your feed; their own posts do not.
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3379
-#: lib/vutuv_web/components/post_components.ex:4676
+#: lib/vutuv_web/components/post_components.ex:4760
 #, elixir-autogen, elixir-format
 msgid "Hide reposts"
 msgstr ""
@@ -22731,8 +22731,8 @@ msgstr ""
 msgid "Posts loaded at once"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3943
-#: lib/vutuv_web/live/post_live/feed.ex:3947
+#: lib/vutuv_web/live/post_live/feed.ex:3985
+#: lib/vutuv_web/live/post_live/feed.ex:3989
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posts per page"
 msgstr ""
@@ -22747,60 +22747,60 @@ msgstr ""
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7507
-#: lib/vutuv_web/components/post_components.ex:7508
+#: lib/vutuv_web/components/post_components.ex:7591
+#: lib/vutuv_web/components/post_components.ex:7592
 #, elixir-autogen, elixir-format, fuzzy
 msgid "A word or phrase …"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7535
+#: lib/vutuv_web/components/post_components.ex:7619
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4004
-#: lib/vutuv_web/live/post_live/feed.ex:4168
-#: lib/vutuv_web/live/post_live/feed.ex:4177
+#: lib/vutuv_web/live/post_live/feed.ex:4046
+#: lib/vutuv_web/live/post_live/feed.ex:4210
+#: lib/vutuv_web/live/post_live/feed.ex:4219
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Hidden"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4142
+#: lib/vutuv_web/live/post_live/feed.ex:4184
 #, elixir-autogen, elixir-format
 msgid "Hide something from your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7453
+#: lib/vutuv_web/components/post_components.ex:7537
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4183
+#: lib/vutuv_web/live/post_live/feed.ex:4225
 #, elixir-autogen, elixir-format
 msgid "Whatever these match is folded to a single line in your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4203
+#: lib/vutuv_web/live/post_live/feed.ex:4245
 #, elixir-autogen, elixir-format
 msgid "Words & tags"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7539
+#: lib/vutuv_web/components/post_components.ex:7623
 #, elixir-autogen, elixir-format, fuzzy
 msgid "everyone"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7542
+#: lib/vutuv_web/components/post_components.ex:7626
 #, elixir-autogen, elixir-format, fuzzy
 msgid "only %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7511
+#: lib/vutuv_web/components/post_components.ex:7595
 #, elixir-autogen, elixir-format, fuzzy
 msgid "this word"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7552
+#: lib/vutuv_web/components/post_components.ex:7636
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr "only %{server}"
@@ -22852,7 +22852,7 @@ msgstr ""
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6857
+#: lib/vutuv_web/components/post_components.ex:6941
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr ""
@@ -22943,7 +22943,7 @@ msgid "Hidden. What other people pass on of them stays out of your feed; their o
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3365
-#: lib/vutuv_web/components/post_components.ex:4664
+#: lib/vutuv_web/components/post_components.ex:4748
 #, elixir-autogen, elixir-format
 msgid "Hide when others repost them"
 msgstr ""
@@ -23658,13 +23658,13 @@ msgstr ""
 msgid "“%{note}”"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5422
+#: lib/vutuv_web/components/post_components.ex:5506
 #: lib/vutuv_web/components/press_kit_components.ex:216
 #, elixir-autogen, elixir-format
 msgid "Show these photos larger"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5608
+#: lib/vutuv_web/components/post_components.ex:5692
 #, elixir-autogen, elixir-format
 msgid "Show this photo larger"
 msgstr ""
@@ -24098,8 +24098,8 @@ msgstr ""
 msgid "press kit media journalist photographer download original print logo svg credit copyright presse pressefotos pressemappe medienkit mediakit fotos logo herunterladen bildnachweis"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4580
-#: lib/vutuv_web/components/post_components.ex:4630
+#: lib/vutuv_web/components/post_components.ex:4664
+#: lib/vutuv_web/components/post_components.ex:4714
 #, elixir-autogen, elixir-format
 msgid "Copy link to post"
 msgstr ""
@@ -24377,7 +24377,7 @@ msgstr ""
 msgid "Your post appears as soon as the video is ready"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3632
+#: lib/vutuv_web/components/post_components.ex:3649
 #, elixir-autogen, elixir-format
 msgid "Found through %{server}"
 msgstr ""
@@ -24666,7 +24666,7 @@ msgstr ""
 msgid "You can only send files to members you are connected with."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3655
+#: lib/vutuv_web/components/post_components.ex:3739
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report this post as not appropriate? Every copy of it disappears right away, for everyone on this vutuv."
 msgstr ""
@@ -24676,7 +24676,7 @@ msgstr ""
 msgid "Thank you. Every copy on this vutuv is gone."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3660
+#: lib/vutuv_web/components/post_components.ex:3744
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report this post as not appropriate? This copy disappears right away, for everyone on this vutuv. Copies other servers sent us stay."
 msgstr ""
@@ -24754,4 +24754,9 @@ msgstr ""
 #: lib/vutuv_web/views/report_html.ex:236
 #, elixir-autogen, elixir-format
 msgid "the page %{page} itself was reported on vutuv."
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:3707
+#, elixir-autogen, elixir-format
+msgid "Found through these servers"
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -165,7 +165,7 @@ msgstr "Contatto"
 msgid "Couldn't follow back to %{name}."
 msgstr "Non è stato possibile ricambiare il follow a %{name}."
 
-#: lib/vutuv_web/components/post_components.ex:4617
+#: lib/vutuv_web/components/post_components.ex:4701
 #: lib/vutuv_web/components/ui.ex:5042
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
@@ -213,7 +213,7 @@ msgstr "Disattiva"
 msgid "Download"
 msgstr "Scarica"
 
-#: lib/vutuv_web/components/post_components.ex:4582
+#: lib/vutuv_web/components/post_components.ex:4666
 #: lib/vutuv_web/components/ui.ex:5033
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
@@ -1210,7 +1210,7 @@ msgstr "Tutti i sinonimi dei tag"
 msgid "All tag urls"
 msgstr "Tutti gli URL dei tag"
 
-#: lib/vutuv_web/components/post_components.ex:5235
+#: lib/vutuv_web/components/post_components.ex:5319
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:643
@@ -2131,7 +2131,7 @@ msgstr "Annulla il caricamento"
 msgid "Delete post"
 msgstr "Elimina il post"
 
-#: lib/vutuv_web/components/post_components.ex:4614
+#: lib/vutuv_web/components/post_components.ex:4698
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2147,7 +2147,7 @@ msgstr "Modifica il post"
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:203
 #: lib/vutuv_web/live/post_live/feed.ex:366
-#: lib/vutuv_web/live/post_live/feed.ex:3553
+#: lib/vutuv_web/live/post_live/feed.ex:3594
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1346
 #: lib/vutuv_web/live/shell_live.ex:1692
@@ -2176,8 +2176,8 @@ msgstr "Nascondi a una persona specifica…"
 msgid "Hide this post from…"
 msgstr "Nascondi questo post a…"
 
-#: lib/vutuv_web/components/post_components.ex:4560
-#: lib/vutuv_web/components/post_components.ex:4562
+#: lib/vutuv_web/components/post_components.ex:4644
+#: lib/vutuv_web/components/post_components.ex:4646
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Pubblico limitato"
@@ -2193,7 +2193,7 @@ msgstr "Visitatori non connessi"
 msgid "No more than %{max} images per post."
 msgstr "Non più di %{max} immagini per post."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3893
+#: lib/vutuv_web/live/post_live/feed.ex:3935
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2244,13 +2244,13 @@ msgstr "Post eliminato."
 msgid "Posts"
 msgstr "Post"
 
-#: lib/vutuv_web/components/post_components.ex:5108
-#: lib/vutuv_web/components/post_components.ex:5112
+#: lib/vutuv_web/components/post_components.ex:5192
+#: lib/vutuv_web/components/post_components.ex:5196
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Leggi tutto"
 
-#: lib/vutuv_web/components/post_components.ex:5109
+#: lib/vutuv_web/components/post_components.ex:5193
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2350,27 +2350,27 @@ msgstr "Che c'è di nuovo?"
 msgid "What's new? Markdown is supported."
 msgstr "Che c'è di nuovo? Markdown è supportato."
 
-#: lib/vutuv_web/components/post_components.ex:4557
+#: lib/vutuv_web/components/post_components.ex:4641
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "modificato"
 
-#: lib/vutuv_web/components/post_components.ex:6875
+#: lib/vutuv_web/components/post_components.ex:6959
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "tutti gli altri"
 
-#: lib/vutuv_web/components/post_components.ex:6879
+#: lib/vutuv_web/components/post_components.ex:6963
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "visitatori non connessi"
 
-#: lib/vutuv_web/components/post_components.ex:6877
+#: lib/vutuv_web/components/post_components.ex:6961
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "persone che non La seguono"
 
-#: lib/vutuv_web/components/post_components.ex:6878
+#: lib/vutuv_web/components/post_components.ex:6962
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "persone che non segue"
@@ -2417,7 +2417,7 @@ msgid "All posts"
 msgstr "Tutti i post"
 
 #: lib/vutuv_web/components/post_components.ex:2186
-#: lib/vutuv_web/components/post_components.ex:6978
+#: lib/vutuv_web/components/post_components.ex:7062
 #: lib/vutuv_web/components/ui.ex:4476
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2436,7 +2436,7 @@ msgid "Bookmarks"
 msgstr "Salvati"
 
 #: lib/vutuv_web/components/post_components.ex:2130
-#: lib/vutuv_web/components/post_components.ex:7219
+#: lib/vutuv_web/components/post_components.ex:7303
 #: lib/vutuv_web/components/ui.ex:4462
 #: lib/vutuv_web/notification_line.ex:342
 #: lib/vutuv_web/views/user_html.ex:486
@@ -2445,7 +2445,7 @@ msgid "Like"
 msgstr "Mi piace"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1301
-#: lib/vutuv_web/components/post_components.ex:7229
+#: lib/vutuv_web/components/post_components.ex:7313
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
 #: lib/vutuv_web/live/shell_live.ex:1596
@@ -2466,13 +2466,13 @@ msgstr "Qui non c'è ancora nulla. I post che salva compaiono qui."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Qui non c'è ancora nulla. I post a cui mette Mi piace compaiono qui."
 
-#: lib/vutuv_web/components/post_components.ex:6966
+#: lib/vutuv_web/components/post_components.ex:7050
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Solo i post pubblici possono essere ripubblicati."
 
 #: lib/vutuv_web/components/post_components.ex:2185
-#: lib/vutuv_web/components/post_components.ex:6977
+#: lib/vutuv_web/components/post_components.ex:7061
 #: lib/vutuv_web/live/post_live/saved.ex:822
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2480,26 +2480,26 @@ msgid "Remove bookmark"
 msgstr "Rimuovi dai salvati"
 
 #: lib/vutuv_web/components/post_components.ex:2166
-#: lib/vutuv_web/components/post_components.ex:6962
+#: lib/vutuv_web/components/post_components.ex:7046
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Ripubblica"
 
 #: lib/vutuv_web/components/post_components.ex:2759
-#: lib/vutuv_web/components/post_components.ex:5981
+#: lib/vutuv_web/components/post_components.ex:6065
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Ripubblicato da %{name}"
 
 #: lib/vutuv_web/components/post_components.ex:2165
-#: lib/vutuv_web/components/post_components.ex:6961
+#: lib/vutuv_web/components/post_components.ex:7045
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Annulla la ripubblicazione"
 
 #: lib/vutuv_web/components/post_components.ex:2129
-#: lib/vutuv_web/components/post_components.ex:7218
+#: lib/vutuv_web/components/post_components.ex:7302
 #: lib/vutuv_web/live/post_live/saved.ex:821
 #: lib/vutuv_web/views/user_html.ex:486
 #, elixir-autogen, elixir-format
@@ -2527,7 +2527,7 @@ msgstr "Non seguire più"
 msgid "Welcome to vutuv!"
 msgstr "Benvenuto su vutuv."
 
-#: lib/vutuv_web/components/post_components.ex:7273
+#: lib/vutuv_web/components/post_components.ex:7357
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Solo ai post pubblici si può rispondere."
@@ -2539,8 +2539,8 @@ msgid "Replies"
 msgstr "Risposte"
 
 #: lib/vutuv_web/components/post_components.ex:2375
-#: lib/vutuv_web/components/post_components.ex:7256
-#: lib/vutuv_web/components/post_components.ex:7257
+#: lib/vutuv_web/components/post_components.ex:7340
+#: lib/vutuv_web/components/post_components.ex:7341
 #: lib/vutuv_web/live/notification_live/index.ex:993
 #: lib/vutuv_web/live/post_live/reply.ex:49
 #: lib/vutuv_web/notification_line.ex:339
@@ -2548,7 +2548,7 @@ msgstr "Risposte"
 msgid "Reply"
 msgstr "Rispondi"
 
-#: lib/vutuv_web/components/post_components.ex:4516
+#: lib/vutuv_web/components/post_components.ex:4600
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Risposta a un post eliminato"
@@ -2574,7 +2574,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr "ha risposto al Suo post."
 
-#: lib/vutuv_web/components/post_components.ex:4034
+#: lib/vutuv_web/components/post_components.ex:4118
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:63
 #: lib/vutuv_web/live/post_live/remote_reply.ex:61
 #: lib/vutuv_web/live/post_live/reply.ex:63
@@ -2582,14 +2582,14 @@ msgstr "ha risposto al Suo post."
 msgid "Reply to %{handle}"
 msgstr "Rispondi a %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:4488
+#: lib/vutuv_web/components/post_components.ex:4572
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Risposta a un post di %{handle} ora eliminato"
 
-#: lib/vutuv_web/components/post_components.ex:4479
-#: lib/vutuv_web/components/post_components.ex:4508
-#: lib/vutuv_web/components/post_components.ex:4511
+#: lib/vutuv_web/components/post_components.ex:4563
+#: lib/vutuv_web/components/post_components.ex:4592
+#: lib/vutuv_web/components/post_components.ex:4595
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "In risposta a %{handle}"
@@ -2891,7 +2891,7 @@ msgid_plural "connections"
 msgstr[0] "collegamento"
 msgstr[1] "collegamenti"
 
-#: lib/vutuv_web/components/post_components.ex:6876
+#: lib/vutuv_web/components/post_components.ex:6960
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "persone che non sono Suoi collegamenti"
@@ -3158,7 +3158,7 @@ msgstr "Nudità, violenza o altri contenuti che non hanno posto su vutuv."
 msgid "Only visible to you"
 msgstr "Visibile solo a Lei"
 
-#: lib/vutuv_web/components/post_components.ex:4455
+#: lib/vutuv_web/components/post_components.ex:4539
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solo Lei può vedere questo post finché la segnalazione è in corso."
@@ -3220,8 +3220,8 @@ msgstr "Lo rimuova. La segnalazione si chiude, senza altre domande."
 
 #: lib/vutuv_web/components/post_components.ex:1467
 #: lib/vutuv_web/components/post_components.ex:3419
-#: lib/vutuv_web/components/post_components.ex:3611
-#: lib/vutuv_web/components/post_components.ex:4685
+#: lib/vutuv_web/components/post_components.ex:3627
+#: lib/vutuv_web/components/post_components.ex:4769
 #: lib/vutuv_web/live/organization_live/show.ex:684
 #: lib/vutuv_web/templates/user/show.html.heex:252
 #, elixir-autogen, elixir-format
@@ -4661,7 +4661,7 @@ msgstr "Non ha bloccato nessuno."
 msgid "You unblocked @%{slug}."
 msgstr "Ha sbloccato @%{slug}."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3898
+#: lib/vutuv_web/live/post_live/feed.ex:3940
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Scopra persone da seguire"
@@ -5578,9 +5578,9 @@ msgstr "Navigazione principale"
 msgid "Footer navigation"
 msgstr "Navigazione a piè di pagina"
 
-#: lib/vutuv_web/components/post_components.ex:4765
-#: lib/vutuv_web/components/post_components.ex:5374
-#: lib/vutuv_web/components/post_components.ex:5712
+#: lib/vutuv_web/components/post_components.ex:4849
+#: lib/vutuv_web/components/post_components.ex:5458
+#: lib/vutuv_web/components/post_components.ex:5796
 #: lib/vutuv_web/live/notification_live/index.ex:1069
 #: lib/vutuv_web/views/user_html.ex:133
 #, elixir-autogen, elixir-format
@@ -5950,7 +5950,7 @@ msgid "Name (A-Z)"
 msgstr "Nome (A-Z)"
 
 #: lib/vutuv_web/live/post_live/saved.ex:507
-#: lib/vutuv_web/live/tag_live/timeline.ex:449
+#: lib/vutuv_web/live/tag_live/timeline.ex:453
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr "Prima i più recenti"
@@ -5977,7 +5977,7 @@ msgstr ""
 "Qui non c'è ancora nulla. Le persone a cui mette Mi piace compaiono qui."
 
 #: lib/vutuv_web/live/post_live/saved.ex:508
-#: lib/vutuv_web/live/tag_live/timeline.ex:450
+#: lib/vutuv_web/live/tag_live/timeline.ex:454
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr "Prima i meno recenti"
@@ -6821,8 +6821,8 @@ msgstr ""
 "risposte che La riguardano. Con entrambe disattivate, ad esempio:"
 
 #: lib/vutuv_web/components/post_components.ex:3346
-#: lib/vutuv_web/components/post_components.ex:4638
-#: lib/vutuv_web/components/post_components.ex:4652
+#: lib/vutuv_web/components/post_components.ex:4722
+#: lib/vutuv_web/components/post_components.ex:4736
 #: lib/vutuv_web/components/ui.ex:3226
 #: lib/vutuv_web/live/fediverse_account_live.ex:437
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6850,7 +6850,7 @@ msgstr "Nuovi messaggi e nuovi collegamenti"
 msgid "Remove this connection? You will stop following them."
 msgstr "Rimuovere questo collegamento? Smetterà di seguire questa persona."
 
-#: lib/vutuv_web/components/post_components.ex:4638
+#: lib/vutuv_web/components/post_components.ex:4722
 #: lib/vutuv_web/components/ui.ex:3225
 #: lib/vutuv_web/live/fediverse_account_live.ex:435
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -7567,7 +7567,7 @@ msgid "applies to the whole list, not just this page"
 msgstr "vale per l'intero elenco, non solo per questa pagina"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:7129
+#: lib/vutuv_web/components/post_components.ex:7213
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #: lib/vutuv_web/live/shell_live.ex:1830
 #, elixir-autogen, elixir-format
@@ -7677,7 +7677,7 @@ msgstr "Si aggiorna da sola. Può lasciare questa pagina: l'invio prosegue."
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/media_live.ex:270
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:4192
+#: lib/vutuv_web/live/post_live/feed.ex:4234
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #: lib/vutuv_web/live/press_kit_live.ex:1056
 #, elixir-autogen
@@ -9122,7 +9122,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Download del CV"
 
-#: lib/vutuv_web/components/post_components.ex:5984
+#: lib/vutuv_web/components/post_components.ex:6068
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -13605,7 +13605,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "Interrompere gli avvisi via e-mail per la Sua ricerca salvata \"%{label}\"?"
 
-#: lib/vutuv_web/components/post_components.ex:3993
+#: lib/vutuv_web/components/post_components.ex:4077
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:788
 #: lib/vutuv_web/controllers/settings_controller.ex:806
@@ -14271,34 +14271,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr "ha aggiunto %{count} nuove voci al proprio CV:"
 
-#: lib/vutuv_web/components/post_components.ex:6672
+#: lib/vutuv_web/components/post_components.ex:6756
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Audiolibro"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6629
+#: lib/vutuv_web/components/post_components.ex:6713
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Recensione di un libro"
 
-#: lib/vutuv_web/components/post_components.ex:6673
+#: lib/vutuv_web/components/post_components.ex:6757
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Cinema"
 
-#: lib/vutuv_web/components/post_components.ex:6675
+#: lib/vutuv_web/components/post_components.ex:6759
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:6671
+#: lib/vutuv_web/components/post_components.ex:6755
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6628
+#: lib/vutuv_web/components/post_components.ex:6712
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Recensione di un film"
@@ -14309,12 +14309,12 @@ msgstr "Recensione di un film"
 msgid "Look up"
 msgstr "Cerca"
 
-#: lib/vutuv_web/components/post_components.ex:6670
+#: lib/vutuv_web/components/post_components.ex:6754
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Libro cartaceo"
 
-#: lib/vutuv_web/components/post_components.ex:6674
+#: lib/vutuv_web/components/post_components.ex:6758
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14334,7 +14334,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Anno"
 
-#: lib/vutuv_web/components/post_components.ex:6711
+#: lib/vutuv_web/components/post_components.ex:6795
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14342,30 +14342,30 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} pagina"
 msgstr[1] "%{formatted} pagine"
 
-#: lib/vutuv_web/components/post_components.ex:6741
+#: lib/vutuv_web/components/post_components.ex:6825
 #: lib/vutuv_web/components/ui.ex:3884
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} h"
 
-#: lib/vutuv_web/components/post_components.ex:6742
+#: lib/vutuv_web/components/post_components.ex:6826
 #: lib/vutuv_web/components/ui.ex:3885
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} h %{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:6740
+#: lib/vutuv_web/components/post_components.ex:6824
 #: lib/vutuv_web/components/ui.ex:3877
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:6700
+#: lib/vutuv_web/components/post_components.ex:6784
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(edizione cartacea)"
 
-#: lib/vutuv_web/components/post_components.ex:6747
+#: lib/vutuv_web/components/post_components.ex:6831
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "circa %{duration}"
@@ -14397,7 +14397,7 @@ msgstr "Con certificazione:"
 msgid "With qualification: %{name}"
 msgstr "Con certificazione: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:6514
+#: lib/vutuv_web/components/post_components.ex:6598
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Editore:"
@@ -14440,7 +14440,7 @@ msgstr "ora La seguono."
 msgid "endorsed you for %{tags}."
 msgstr "L'ha confermata per %{tags}."
 
-#: lib/vutuv_web/components/post_components.ex:6505
+#: lib/vutuv_web/components/post_components.ex:6589
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "di:"
@@ -14817,14 +14817,14 @@ msgstr "Cerchi un account da bloccare"
 msgid "See all frozen accounts"
 msgstr "Vedi tutti gli account bloccati"
 
-#: lib/vutuv_web/components/post_components.ex:4282
+#: lib/vutuv_web/components/post_components.ex:4366
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "Mostra %{formatted} post precedente"
 msgstr[1] "Mostra %{formatted} post precedenti"
 
-#: lib/vutuv_web/components/post_components.ex:4305
+#: lib/vutuv_web/components/post_components.ex:4389
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14853,7 +14853,7 @@ msgstr ""
 "Digiti un nome, un @handle o un indirizzo e-mail per trovare un account da "
 "bloccare."
 
-#: lib/vutuv_web/components/post_components.ex:7228
+#: lib/vutuv_web/components/post_components.ex:7312
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Non può mettere Mi piace al Suo stesso post."
@@ -16119,7 +16119,7 @@ msgstr ""
 " vedere dove va a finire. Modificare o eliminare un post su vutuv è solo una"
 " richiesta rivolta a quei server, e non tutti la rispettano."
 
-#: lib/vutuv_web/components/post_components.ex:7174
+#: lib/vutuv_web/components/post_components.ex:7258
 #: lib/vutuv_web/live/notification_live/index.ex:1592
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -16127,7 +16127,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} risposta"
 msgstr[1] "%{formatted} risposte"
 
-#: lib/vutuv_web/components/post_components.ex:7178
+#: lib/vutuv_web/components/post_components.ex:7262
 #: lib/vutuv_web/live/notification_live/index.ex:1586
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -16135,7 +16135,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Mi piace"
 msgstr[1] "%{formatted} Mi piace"
 
-#: lib/vutuv_web/components/post_components.ex:7182
+#: lib/vutuv_web/components/post_components.ex:7266
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16143,7 +16143,7 @@ msgstr[0] "%{formatted} ripubblicazione"
 msgstr[1] "%{formatted} ripubblicazioni"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1339
-#: lib/vutuv_web/components/post_components.ex:7133
+#: lib/vutuv_web/components/post_components.ex:7217
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Già conteggiate nei numeri qui sopra."
@@ -16247,8 +16247,8 @@ msgstr "Questa risposta non spetta a Lei rimuoverla."
 #: lib/vutuv_web/agent_docs/markdown.ex:1539
 #: lib/vutuv_web/components/post_components.ex:1503
 #: lib/vutuv_web/components/post_components.ex:1734
-#: lib/vutuv_web/components/post_components.ex:3591
-#: lib/vutuv_web/components/post_components.ex:3851
+#: lib/vutuv_web/components/post_components.ex:3607
+#: lib/vutuv_web/components/post_components.ex:3935
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "View the original"
@@ -16711,7 +16711,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/admin/media_live.ex:155
 #: lib/vutuv_web/live/fediverse_following_live.ex:351
-#: lib/vutuv_web/live/tag_live/timeline.ex:474
+#: lib/vutuv_web/live/tag_live/timeline.ex:478
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr ""
@@ -16943,22 +16943,22 @@ msgstr ""
 msgid "device or detail"
 msgstr "dispositivo o dettaglio"
 
-#: lib/vutuv_web/components/post_components.ex:4467
+#: lib/vutuv_web/components/post_components.ex:4551
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Post fissato"
 
-#: lib/vutuv_web/components/post_components.ex:4601
+#: lib/vutuv_web/components/post_components.ex:4685
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "Fissa sul profilo"
 
-#: lib/vutuv_web/components/post_components.ex:4609
+#: lib/vutuv_web/components/post_components.ex:4693
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Togli dal profilo"
 
-#: lib/vutuv_web/components/post_components.ex:4595
+#: lib/vutuv_web/components/post_components.ex:4679
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -17090,18 +17090,18 @@ msgstr "Foto successiva"
 msgid "No image description yet"
 msgstr "Ancora nessuna descrizione dell'immagine"
 
-#: lib/vutuv_web/components/post_components.ex:4046
+#: lib/vutuv_web/components/post_components.ex:4130
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Apri le impostazioni del Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:5550
+#: lib/vutuv_web/components/post_components.ex:5634
 #: lib/vutuv_web/components/press_kit_components.ex:526
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} di %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:5778
+#: lib/vutuv_web/components/post_components.ex:5862
 #: lib/vutuv_web/components/press_kit_components.ex:623
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
@@ -17115,7 +17115,7 @@ msgstr "Opzioni della foto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1500
 #: lib/vutuv_web/agent_docs/text.ex:909
-#: lib/vutuv_web/components/post_components.ex:5860
+#: lib/vutuv_web/components/post_components.ex:5944
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Foto:"
@@ -17143,7 +17143,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr "Mostra le impostazioni della fotocamera"
 
-#: lib/vutuv_web/components/post_components.ex:4099
+#: lib/vutuv_web/components/post_components.ex:4183
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -17169,7 +17169,7 @@ msgstr ""
 "Questa foto porta con sé il luogo in cui è stata scattata. Chiunque scarichi"
 " il file esatto può leggerlo."
 
-#: lib/vutuv_web/components/post_components.ex:4090
+#: lib/vutuv_web/components/post_components.ex:4174
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -17184,12 +17184,12 @@ msgstr ""
 "inviare le Sue parole a quella rete, cosa che vutuv fa solo per i membri che"
 " hanno attivato la partecipazione al Fediverso."
 
-#: lib/vutuv_web/components/post_components.ex:4108
+#: lib/vutuv_web/components/post_components.ex:4192
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Questo sito non partecipa al Fediverso."
 
-#: lib/vutuv_web/components/post_components.ex:4042
+#: lib/vutuv_web/components/post_components.ex:4126
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Attivi la partecipazione al Fediverso per rispondere"
@@ -17205,7 +17205,7 @@ msgid "You have sent a lot of answers to other networks in the past hour. Please
 msgstr ""
 "Nell'ultima ora ha inviato molte risposte ad altre reti. Riprovi più tardi."
 
-#: lib/vutuv_web/components/post_components.ex:4103
+#: lib/vutuv_web/components/post_components.ex:4187
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -17219,7 +17219,7 @@ msgstr ""
 "Al momento le Sue impostazioni del Fediverso non consentono di inviare una "
 "risposta."
 
-#: lib/vutuv_web/components/post_components.ex:4056
+#: lib/vutuv_web/components/post_components.ex:4140
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -17302,13 +17302,13 @@ msgstr[1] ""
 "il file esatto lo rivela."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1357
-#: lib/vutuv_web/components/post_components.ex:7171
+#: lib/vutuv_web/components/post_components.ex:7255
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "A %{handle} è piaciuto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1355
-#: lib/vutuv_web/components/post_components.ex:7168
+#: lib/vutuv_web/components/post_components.ex:7252
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} lo ha condiviso"
@@ -17318,7 +17318,7 @@ msgstr "%{handle} lo ha condiviso"
 msgid "Fediverse reactions"
 msgstr "Reazioni dal Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:7055
+#: lib/vutuv_web/components/post_components.ex:7139
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Da altre reti"
@@ -17716,7 +17716,7 @@ msgstr "Solo per i follower di questo account"
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Grazie. La nostra copia è stata eliminata subito."
 
-#: lib/vutuv_web/components/post_components.ex:3850
+#: lib/vutuv_web/components/post_components.ex:3934
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Vota sull'originale"
@@ -17747,7 +17747,7 @@ msgstr "Contenuti da altre reti rimossi dai membri"
 msgid "Hide"
 msgstr "Nascondi"
 
-#: lib/vutuv_web/components/post_components.ex:3791
+#: lib/vutuv_web/components/post_components.ex:3875
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Contrassegnato come sensibile dal suo autore"
@@ -17892,12 +17892,12 @@ msgstr "Coprila di nuovo"
 msgid "Sensitive. Show the picture."
 msgstr "Contenuto sensibile. Mostra l'immagine."
 
-#: lib/vutuv_web/components/post_components.ex:3949
+#: lib/vutuv_web/components/post_components.ex:4033
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Sono molti Mi piace in un'ora. Riprovi più tardi."
 
-#: lib/vutuv_web/components/post_components.ex:3955
+#: lib/vutuv_web/components/post_components.ex:4039
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Quel post non è più qui."
@@ -17907,7 +17907,7 @@ msgstr "Quel post non è più qui."
 msgid "Back to the feed"
 msgstr "Torna al feed"
 
-#: lib/vutuv_web/components/post_components.ex:4094
+#: lib/vutuv_web/components/post_components.ex:4178
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -18614,22 +18614,22 @@ msgid_plural "%{formatted} posts"
 msgstr[0] "%{formatted} post"
 msgstr[1] "%{formatted} post"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:451
+#: lib/vutuv_web/live/tag_live/timeline.ex:455
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr "Più apprezzati"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:482
+#: lib/vutuv_web/live/tag_live/timeline.ex:486
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr "Nessun post porta ancora questo tag."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:480
+#: lib/vutuv_web/live/tag_live/timeline.ex:484
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr "Nessun post da altre reti porta ancora questo tag."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:477
+#: lib/vutuv_web/live/tag_live/timeline.ex:481
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr "Nessun post su vutuv porta ancora questo tag."
@@ -18639,7 +18639,7 @@ msgstr "Nessun post su vutuv porta ancora questo tag."
 msgid "word in a post"
 msgstr "parola in un post"
 
-#: lib/vutuv_web/components/post_components.ex:3952
+#: lib/vutuv_web/components/post_components.ex:4036
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Quella risposta non è più qui."
@@ -18717,19 +18717,19 @@ msgstr ""
 msgid "Liked by"
 msgstr "Piace a"
 
-#: lib/vutuv_web/components/post_components.ex:6154
+#: lib/vutuv_web/components/post_components.ex:6238
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Piace a %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:6156
+#: lib/vutuv_web/components/post_components.ex:6240
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Piace a %{name} e a %{formatted} altro"
 msgstr[1] "Piace a %{name} e ad altri %{formatted}"
 
-#: lib/vutuv_web/components/post_components.ex:6167
+#: lib/vutuv_web/components/post_components.ex:6251
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -18910,7 +18910,7 @@ msgstr "Rilasciato il"
 msgid "Label"
 msgstr "Etichetta"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3916
+#: lib/vutuv_web/live/post_live/feed.ex:3958
 #: lib/vutuv_web/live/reference_check_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -20461,7 +20461,7 @@ msgstr ""
 msgid "Start over"
 msgstr "Ricomincia"
 
-#: lib/vutuv_web/components/post_components.ex:3982
+#: lib/vutuv_web/components/post_components.ex:4066
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -21423,27 +21423,27 @@ msgstr "Lingua"
 msgid "The language this post is written in"
 msgstr "La lingua in cui è scritto questo post"
 
-#: lib/vutuv_web/components/post_components.ex:6048
+#: lib/vutuv_web/components/post_components.ex:6132
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Mostra l'originale"
 
-#: lib/vutuv_web/components/post_components.ex:6084
+#: lib/vutuv_web/components/post_components.ex:6168
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Traduci"
 
-#: lib/vutuv_web/components/post_components.ex:6093
+#: lib/vutuv_web/components/post_components.ex:6177
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Tradotto"
 
-#: lib/vutuv_web/components/post_components.ex:6096
+#: lib/vutuv_web/components/post_components.ex:6180
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Tradotto da %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:6073
+#: lib/vutuv_web/components/post_components.ex:6157
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Traduzione in corso…"
@@ -21454,7 +21454,7 @@ msgid "Feed language settings reset to the site defaults."
 msgstr ""
 "Impostazioni delle lingue del feed riportate ai valori predefiniti del sito."
 
-#: lib/vutuv_web/components/post_components.ex:6063
+#: lib/vutuv_web/components/post_components.ex:6147
 #: lib/vutuv_web/components/ui.ex:5549
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -21597,7 +21597,7 @@ msgid "Your username, or paste the address of your profile page."
 msgstr ""
 "Il Suo nome utente, oppure incolli l'indirizzo della Sua pagina di profilo."
 
-#: lib/vutuv_web/components/post_components.ex:5826
+#: lib/vutuv_web/components/post_components.ex:5910
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
@@ -21608,13 +21608,13 @@ msgstr[1] ""
 "La nostra IA le sta ancora controllando, %{done} su %{total} fatte. Appena "
 "avrà finito con l'ultima, le foto compariranno da sé."
 
-#: lib/vutuv_web/components/post_components.ex:5823
+#: lib/vutuv_web/components/post_components.ex:5907
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Il Suo post è pubblicato, la foto non c'è ancora."
 
 #: lib/vutuv_web/components/post_components.ex:2913
-#: lib/vutuv_web/components/post_components.ex:4892
+#: lib/vutuv_web/components/post_components.ex:4976
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -22330,7 +22330,7 @@ msgstr ""
 "Segua #%{tag} da Mastodon o da qualsiasi altra app del Fediverso e i suoi "
 "post pubblici arriveranno nella Sua cronologia. Non serve un account vutuv."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4086
+#: lib/vutuv_web/live/post_live/feed.ex:4128
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Saluti gli altri membri"
@@ -22816,13 +22816,13 @@ msgid "Hide a word or a whole phrase …"
 msgstr "Nascondi una parola o un'intera frase …"
 
 #: lib/vutuv_web/live/post_live/feed.ex:854
-#: lib/vutuv_web/live/post_live/feed.ex:4249
+#: lib/vutuv_web/live/post_live/feed.ex:4291
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Nascondi tag"
 
 #: lib/vutuv_web/live/post_live/feed.ex:853
-#: lib/vutuv_web/live/post_live/feed.ex:4238
+#: lib/vutuv_web/live/post_live/feed.ex:4280
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Nascondi parole"
@@ -22889,7 +22889,7 @@ msgstr "I post con uno di questi tag vengono ridotti allo stesso modo."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "I post che contengono una di queste parole vengono ridotti a una riga — non eliminati, e con un modo per aprirli comunque."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4112
+#: lib/vutuv_web/live/post_live/feed.ex:4154
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Messe da parte:"
@@ -22928,7 +22928,7 @@ msgid "Show posts by %{name}"
 msgstr "Mostra i post di %{name}"
 
 #: lib/vutuv_web/live/post_live/feed.ex:852
-#: lib/vutuv_web/live/post_live/feed.ex:4204
+#: lib/vutuv_web/live/post_live/feed.ex:4246
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr "Fonti"
@@ -22967,8 +22967,8 @@ msgid_plural "and %{formatted} more"
 msgstr[0] "e 1 altro"
 msgstr[1] "e altri %{formatted}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3670
-#: lib/vutuv_web/live/post_live/feed.ex:3697
+#: lib/vutuv_web/live/post_live/feed.ex:3711
+#: lib/vutuv_web/live/post_live/feed.ex:3738
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -23034,7 +23034,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} post il %{day}"
 msgstr[1] "%{count} post il %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3873
+#: lib/vutuv_web/live/post_live/feed.ex:3915
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Torna al presente"
@@ -23044,7 +23044,7 @@ msgstr "Torna al presente"
 msgid "Busy month: the shading counts at least this much."
 msgstr "Mese intenso: la tonalità indica almeno questo valore."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3919
+#: lib/vutuv_web/live/post_live/feed.ex:3961
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -23066,7 +23066,7 @@ msgstr "Mese successivo"
 msgid "Next year"
 msgstr "Anno successivo"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3869
+#: lib/vutuv_web/live/post_live/feed.ex:3911
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Il %{day} non è arrivato nulla nel Suo feed."
@@ -23160,7 +23160,7 @@ msgid_plural "New (%{formatted}):"
 msgstr[0] "Nuovo:"
 msgstr[1] "Nuovi (%{formatted}):"
 
-#: lib/vutuv_web/components/post_components.ex:3718
+#: lib/vutuv_web/components/post_components.ex:3802
 #, elixir-autogen, elixir-format
 msgid "Quoted post"
 msgstr "Post citato"
@@ -23216,7 +23216,7 @@ msgstr "Solo questi account (vuoto = tutti) …"
 msgid "only %{account}"
 msgstr "solo %{account}"
 
-#: lib/vutuv_web/components/post_components.ex:7516
+#: lib/vutuv_web/components/post_components.ex:7600
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -23400,7 +23400,7 @@ msgctxt "phone tab bar"
 msgid "Write"
 msgstr "Scrivi"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4007
+#: lib/vutuv_web/live/post_live/feed.ex:4049
 #: lib/vutuv_web/live/post_rewrites_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "%{formatted} rule"
@@ -23470,7 +23470,7 @@ msgstr "Regole che riscrivono il testo dei post di un account prima che Lei li l
 
 #: lib/vutuv_web/components/post_components.ex:1457
 #: lib/vutuv_web/components/post_components.ex:3407
-#: lib/vutuv_web/components/post_components.ex:4682
+#: lib/vutuv_web/components/post_components.ex:4766
 #: lib/vutuv_web/components/ui.ex:5541
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
@@ -23701,7 +23701,7 @@ msgstr[1] "%{formatted} nuovi follower"
 msgid "Last 30 days: %{parts}"
 msgstr "Ultimi 30 giorni: %{parts}"
 
-#: lib/vutuv_web/components/post_components.ex:5244
+#: lib/vutuv_web/components/post_components.ex:5328
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Less"
@@ -24016,7 +24016,7 @@ msgid "Hidden. What they pass on stays out of your feed; their own posts do not.
 msgstr "Nascosto. Ciò che questo account ripubblica non compare più nel Suo feed, i suoi post sì."
 
 #: lib/vutuv_web/components/post_components.ex:3379
-#: lib/vutuv_web/components/post_components.ex:4676
+#: lib/vutuv_web/components/post_components.ex:4760
 #, elixir-autogen, elixir-format
 msgid "Hide reposts"
 msgstr "Nascondi le ripubblicazioni"
@@ -24197,8 +24197,8 @@ msgstr ""
 msgid "Posts loaded at once"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3943
-#: lib/vutuv_web/live/post_live/feed.ex:3947
+#: lib/vutuv_web/live/post_live/feed.ex:3985
+#: lib/vutuv_web/live/post_live/feed.ex:3989
 #, elixir-autogen, elixir-format
 msgid "Posts per page"
 msgstr "Post per pagina"
@@ -24213,60 +24213,60 @@ msgstr ""
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7507
-#: lib/vutuv_web/components/post_components.ex:7508
+#: lib/vutuv_web/components/post_components.ex:7591
+#: lib/vutuv_web/components/post_components.ex:7592
 #, elixir-autogen, elixir-format
 msgid "A word or phrase …"
 msgstr "Una parola o un'espressione …"
 
-#: lib/vutuv_web/components/post_components.ex:7535
+#: lib/vutuv_web/components/post_components.ex:7619
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr "Per chi %{thing} viene nascosto"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4004
-#: lib/vutuv_web/live/post_live/feed.ex:4168
-#: lib/vutuv_web/live/post_live/feed.ex:4177
+#: lib/vutuv_web/live/post_live/feed.ex:4046
+#: lib/vutuv_web/live/post_live/feed.ex:4210
+#: lib/vutuv_web/live/post_live/feed.ex:4219
 #, elixir-autogen, elixir-format
 msgid "Hidden"
 msgstr "Nascosti"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4142
+#: lib/vutuv_web/live/post_live/feed.ex:4184
 #, elixir-autogen, elixir-format
 msgid "Hide something from your feed"
 msgstr "Nascondi qualcosa dal tuo feed"
 
-#: lib/vutuv_web/components/post_components.ex:7453
+#: lib/vutuv_web/components/post_components.ex:7537
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr "Non mostrare più"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4183
+#: lib/vutuv_web/live/post_live/feed.ex:4225
 #, elixir-autogen, elixir-format
 msgid "Whatever these match is folded to a single line in your feed."
 msgstr "Ciò che corrisponde viene ridotto a una riga nel tuo feed."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4203
+#: lib/vutuv_web/live/post_live/feed.ex:4245
 #, elixir-autogen, elixir-format
 msgid "Words & tags"
 msgstr "Parole e tag"
 
-#: lib/vutuv_web/components/post_components.ex:7539
+#: lib/vutuv_web/components/post_components.ex:7623
 #, elixir-autogen, elixir-format
 msgid "everyone"
 msgstr "per tutti"
 
-#: lib/vutuv_web/components/post_components.ex:7542
+#: lib/vutuv_web/components/post_components.ex:7626
 #, elixir-autogen, elixir-format
 msgid "only %{handle}"
 msgstr "solo %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:7511
+#: lib/vutuv_web/components/post_components.ex:7595
 #, elixir-autogen, elixir-format
 msgid "this word"
 msgstr "questa parola"
 
-#: lib/vutuv_web/components/post_components.ex:7552
+#: lib/vutuv_web/components/post_components.ex:7636
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr "solo %{server}"
@@ -24318,7 +24318,7 @@ msgstr "Questo sito è offline in questo momento."
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr "Il sito funziona, è questo indirizzo a non essere uno dei nostri. Probabilmente il link è vecchio oppure contiene un errore di battitura."
 
-#: lib/vutuv_web/components/post_components.ex:6857
+#: lib/vutuv_web/components/post_components.ex:6941
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr "Ingrandisci lo screenshot"
@@ -24409,7 +24409,7 @@ msgid "Hidden. What other people pass on of them stays out of your feed; their o
 msgstr "Nascosto. Ciò che altri ripubblicano di questo account non compare più nel Suo feed, i suoi post sì."
 
 #: lib/vutuv_web/components/post_components.ex:3365
-#: lib/vutuv_web/components/post_components.ex:4664
+#: lib/vutuv_web/components/post_components.ex:4748
 #, elixir-autogen, elixir-format
 msgid "Hide when others repost them"
 msgstr "Nascondi quando altri lo ripubblicano"
@@ -25171,13 +25171,13 @@ msgstr "il modulo di segnalazione"
 msgid "“%{note}”"
 msgstr "“%{note}”"
 
-#: lib/vutuv_web/components/post_components.ex:5422
+#: lib/vutuv_web/components/post_components.ex:5506
 #: lib/vutuv_web/components/press_kit_components.ex:216
 #, elixir-autogen, elixir-format
 msgid "Show these photos larger"
 msgstr "Ingrandisci le foto"
 
-#: lib/vutuv_web/components/post_components.ex:5608
+#: lib/vutuv_web/components/post_components.ex:5692
 #, elixir-autogen, elixir-format
 msgid "Show this photo larger"
 msgstr "Ingrandisci la foto"
@@ -25611,8 +25611,8 @@ msgstr "Non può aggiungere un'immagine a questo Media Kit."
 msgid "press kit media journalist photographer download original print logo svg credit copyright presse pressefotos pressemappe medienkit mediakit fotos logo herunterladen bildnachweis"
 msgstr "media kit mediakit kit stampa media redazione giornalista fotografo download originale stampa logo svg crediti copyright foto scaricare"
 
-#: lib/vutuv_web/components/post_components.ex:4580
-#: lib/vutuv_web/components/post_components.ex:4630
+#: lib/vutuv_web/components/post_components.ex:4664
+#: lib/vutuv_web/components/post_components.ex:4714
 #, elixir-autogen, elixir-format
 msgid "Copy link to post"
 msgstr "Copia il link al post"
@@ -25890,7 +25890,7 @@ msgstr "rifiutato"
 msgid "Your post appears as soon as the video is ready"
 msgstr "Il suo post apparirà non appena il video sarà pronto"
 
-#: lib/vutuv_web/components/post_components.ex:3632
+#: lib/vutuv_web/components/post_components.ex:3649
 #, elixir-autogen, elixir-format
 msgid "Found through %{server}"
 msgstr "Trovato tramite %{server}"
@@ -26179,7 +26179,7 @@ msgstr "Non è stato possibile leggere questa immagine."
 msgid "You can only send files to members you are connected with."
 msgstr "Può inviare file solo ai membri con cui è in contatto."
 
-#: lib/vutuv_web/components/post_components.ex:3655
+#: lib/vutuv_web/components/post_components.ex:3739
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Every copy of it disappears right away, for everyone on this vutuv."
 msgstr ""
@@ -26191,7 +26191,7 @@ msgstr ""
 msgid "Thank you. Every copy on this vutuv is gone."
 msgstr "Grazie. Ogni copia su questo vutuv è sparita."
 
-#: lib/vutuv_web/components/post_components.ex:3660
+#: lib/vutuv_web/components/post_components.ex:3744
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? This copy disappears right away, for everyone on this vutuv. Copies other servers sent us stay."
 msgstr "Segnalare questo post come non appropriato? Questa copia sparisce subito, per tutti su questo vutuv. Le copie che altri server ci hanno inviato restano."
@@ -26270,3 +26270,8 @@ msgstr "un contenuto di %{page} su vutuv è stato segnalato."
 #, elixir-autogen, elixir-format
 msgid "the page %{page} itself was reported on vutuv."
 msgstr "la pagina %{page} stessa è stata segnalata su vutuv."
+
+#: lib/vutuv_web/components/post_components.ex:3707
+#, elixir-autogen, elixir-format
+msgid "Found through these servers"
+msgstr "Trovato su questi server"

--- a/test/vutuv_web/live/external_tag_cards_test.exs
+++ b/test/vutuv_web/live/external_tag_cards_test.exs
@@ -128,11 +128,12 @@ defmodule VutuvWeb.ExternalTagCardsTest do
       refute again =~ "EIN FUND VON DRUEBEN"
     end
 
-    # The same post read off two servers under two tags is two rows and two
-    # cards, and a member who reports one of them has been told the post is
-    # gone from this site. It has to be — the reader who then meets the twin
-    # under another "Gefunden über" line is watching us break that promise
-    # (issue #2164).
+    # The same post read off two servers under two tags is two rows and, since
+    # issue #2163, **one** card — drawn from the author's own server's copy,
+    # which is the one whose report speaks for the other. What is pinned here is
+    # what happens to the twin: a member who reports this has been told the post
+    # is gone from this site, and the reader who then met it under another
+    # "Gefunden über" line was watching us break that promise (issue #2164).
     test "reporting the author's own copy takes every copy of that original with it", %{
       conn: conn,
       user: user
@@ -152,7 +153,10 @@ defmodule VutuvWeb.ExternalTagCardsTest do
         )
 
       {:ok, view, html} = live(conn, ~p"/feed")
-      assert html =~ ~s(data-external-post="#{twin.id}")
+      # One card for the pair, drawn from the author's own server's copy.
+      assert html =~ ~s(data-external-post="#{clicked.id}")
+      refute html =~ ~s(data-external-post="#{twin.id}")
+      assert html =~ ~s(data-external-servers="2")
 
       html =
         view

--- a/test/vutuv_web/live/external_tag_copies_test.exs
+++ b/test/vutuv_web/live/external_tag_copies_test.exs
@@ -1,0 +1,256 @@
+defmodule VutuvWeb.ExternalTagCopiesTest do
+  @moduledoc """
+  One post found on several servers is one card (issue #2163).
+
+  A find is stored once per (tag, server, remote id), so the same status read
+  off three servers is three rows with nothing in that key to relate them — and
+  the feed and the tag page drew all three, identical but for their "found
+  through" line, while the figure above the list counted rows. Measured on a
+  copy of production: 78 rows for 49 originals, and one tag page showing 20
+  cards for 9 posts.
+
+  What is asserted here is the fold and what it may not do: several copies read
+  as one card, the card is the copy the author's **own** server served when we
+  hold one, the figure counts posts, the disclosure names every server that
+  carried it, and two genuinely different posts stay two cards. Plus the German,
+  by name, because `gettext.extract --merge` has fuzzy-filled a new string with a
+  neighbour's translation three times on this milestone.
+
+  `async: false`: the module holds `:fetch_external_tag_posts` down, which
+  `Vutuv.Tags.ExternalPosts.enabled?/0` and the supervision tree both read.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Vutuv.ExternalTagHelpers
+
+  alias Vutuv.Repo
+  alias Vutuv.Tags.ExternalPost
+
+  @author_host Vutuv.ExternalTagHelpers.author_host()
+
+  # Three servers this installation asked, none of them the author's home, so a
+  # card that picked one of them by accident cannot pass by looking right.
+  @relay_a Vutuv.ExternalTagHelpers.tag_source()
+  @relay_b "social.example"
+  @relay_c "hachyderm.example"
+
+  setup do
+    put_config(:fetch_external_tag_posts, true)
+    :ok
+  end
+
+  defp followed_tag(user, sources) do
+    tag = insert(:tag)
+
+    Enum.each(List.wrap(sources), &follow_tag_through(user, tag, &1))
+
+    tag
+  end
+
+  # The same status, as each of `sources` handed it over: one row per server,
+  # one address, one author. Returned oldest first, which is the order they
+  # were stored in.
+  defp copies_of(tag, sources) do
+    Enum.map(sources, fn source ->
+      external_post(tag,
+        source: source,
+        author_host: @author_host,
+        url: "https://#{@author_host}/@ada/4711",
+        text: "EIN FUND AUF MEHREREN SERVERN"
+      )
+    end)
+  end
+
+  # Every card on the page, by the id of the row it is drawn from.
+  defp cards(html) do
+    ~r/data-external-post="([0-9a-f-]+)"/
+    |> Regex.scan(html)
+    |> Enum.map(fn [_whole, id] -> id end)
+  end
+
+  describe "the feed" do
+    setup %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      {:ok, conn: conn, user: user}
+    end
+
+    test "three copies of one original are one card", %{conn: conn, user: user} do
+      tag = followed_tag(user, [@relay_a, @relay_b, @relay_c])
+      copies_of(tag, [@relay_a, @relay_b, @relay_c])
+
+      {:ok, _view, html} = live(conn, ~p"/feed")
+
+      assert length(cards(html)) == 1
+    end
+
+    test "the card is the copy the author's own server served", %{conn: conn, user: user} do
+      tag = followed_tag(user, [@relay_a, @author_host])
+      [relayed, home] = copies_of(tag, [@relay_a, @author_host])
+
+      {:ok, _view, html} = live(conn, ~p"/feed")
+
+      assert cards(html) == [home.id]
+      refute html =~ relayed.id
+    end
+
+    test "with no copy from the author's own server the card is the one we stored first", %{
+      conn: conn,
+      user: user
+    } do
+      tag = followed_tag(user, [@relay_a, @relay_b])
+      [first, _second] = copies_of(tag, [@relay_a, @relay_b])
+
+      {:ok, _view, html} = live(conn, ~p"/feed")
+
+      assert cards(html) == [first.id]
+    end
+
+    test "a genuinely different post is not folded into it", %{conn: conn, user: user} do
+      tag = followed_tag(user, [@relay_a, @relay_b])
+      copies_of(tag, [@relay_a, @relay_b])
+
+      other =
+        external_post(tag,
+          source: @relay_a,
+          author_host: @author_host,
+          url: "https://#{@author_host}/@ada/4712",
+          text: "EIN ZWEITER FUND"
+        )
+
+      {:ok, _view, html} = live(conn, ~p"/feed")
+
+      assert length(cards(html)) == 2
+      assert html =~ other.id
+      assert html =~ "EIN ZWEITER FUND"
+    end
+  end
+
+  describe "the tag page" do
+    setup do
+      user = insert(:activated_user)
+      {:ok, user: user}
+    end
+
+    test "the figure above the list counts posts and not rows", %{conn: conn, user: user} do
+      tag = followed_tag(user, [@relay_a, @relay_b, @relay_c])
+      copies_of(tag, [@relay_a, @relay_b, @relay_c])
+
+      external_post(tag,
+        source: @relay_a,
+        author_host: @author_host,
+        url: "https://#{@author_host}/@ada/4712",
+        text: "EIN ZWEITER FUND"
+      )
+
+      html = conn |> get(~p"/tags/#{tag.slug}?source=fediverse") |> html_response(200)
+
+      assert length(cards(html)) == 2
+      assert html =~ ~r/data-timeline-total[^>]*>\s*2 posts/
+    end
+
+    test "the disclosure names every server that carried it", %{conn: conn, user: user} do
+      tag = followed_tag(user, [@relay_a, @relay_b, @relay_c])
+      copies_of(tag, [@relay_a, @relay_b, @relay_c])
+
+      html = conn |> get(~p"/tags/#{tag.slug}?source=fediverse") |> html_response(200)
+
+      assert html =~ ~s(data-external-servers="3")
+      assert html =~ ~s(data-external-source="#{@relay_a}")
+      assert html =~ ~s(data-external-source="#{@relay_b}")
+      assert html =~ ~s(data-external-source="#{@relay_c}")
+    end
+
+    test "one server keeps the quiet line it always had", %{conn: conn, user: user} do
+      tag = followed_tag(user, @relay_a)
+      copies_of(tag, [@relay_a])
+
+      html = conn |> get(~p"/tags/#{tag.slug}?source=fediverse") |> html_response(200)
+
+      assert html =~ ~s(data-external-source="#{@relay_a}")
+      refute html =~ "data-external-servers"
+    end
+
+    test "the German reads the servers out by name", %{conn: conn, user: user} do
+      tag = followed_tag(user, [@relay_a, @relay_b])
+      copies_of(tag, [@relay_a, @relay_b])
+
+      html =
+        conn
+        |> put_req_header("accept-language", "de-DE,de;q=0.9")
+        |> get(~p"/tags/#{tag.slug}?source=fediverse")
+        |> html_response(200)
+
+      assert html =~ "Gefunden über diese Server"
+      assert html =~ ~r/data-timeline-total[^>]*>\s*1 Beitrag/
+    end
+
+    # One entry, not one per server — and the list leads with the server the
+    # entry is drawn from, which is the one `found_via` names.
+    test "the agent formats name every server too", %{conn: conn, user: user} do
+      tag = followed_tag(user, [@relay_a, @relay_b])
+      copies_of(tag, [@relay_a, @relay_b])
+
+      json = conn |> get("/tags/#{tag.slug}.json") |> json_response(200)
+
+      assert [entry] = json["posts"]
+      assert entry["found_via"] == @relay_a
+      assert entry["servers"] == [@relay_a, @relay_b]
+    end
+  end
+
+  describe "a report from a folded card" do
+    setup %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      {:ok, conn: conn, user: user}
+    end
+
+    # The dialog over a relayed card promises one copy and says the others
+    # stay, and that is what has to happen: the card does not vanish, it loses
+    # the server that filed the reported row.
+    test "a relayed card takes its own server's copy and keeps the rest", %{
+      conn: conn,
+      user: user
+    } do
+      tag = followed_tag(user, [@relay_a, @relay_b])
+      [first, second] = copies_of(tag, [@relay_a, @relay_b])
+
+      {:ok, view, before} = live(conn, ~p"/feed")
+
+      assert cards(before) == [first.id]
+      assert before =~ ~s(data-external-servers="2")
+
+      html =
+        view
+        |> element(~s([data-external-post="#{first.id}"] [phx-click="report-external-post"]))
+        |> render_click()
+
+      assert Repo.get!(ExternalPost, first.id).reported_at
+      refute Repo.get!(ExternalPost, second.id).reported_at
+
+      assert html =~ "EIN FUND AUF MEHREREN SERVERN"
+      assert cards(html) == [second.id]
+      refute html =~ "data-external-servers"
+    end
+
+    # And the other half: the author's own server's card speaks for every copy,
+    # so the post really does leave the page.
+    test "the author's own card takes every copy and the card goes", %{conn: conn, user: user} do
+      tag = followed_tag(user, [@relay_a, @author_host])
+      [relayed, home] = copies_of(tag, [@relay_a, @author_host])
+
+      {:ok, view, before} = live(conn, ~p"/feed")
+
+      assert cards(before) == [home.id]
+      assert before =~ ~s(data-external-servers="2")
+
+      html =
+        view
+        |> element(~s([data-external-post="#{home.id}"] [phx-click="report-external-post"]))
+        |> render_click()
+
+      assert Repo.get!(ExternalPost, relayed.id).reported_at
+      refute html =~ "EIN FUND AUF MEHREREN SERVERN"
+    end
+  end
+end


### PR DESCRIPTION
The same post read off three servers was three cards in the feed and on the tag page, each identical to the one above it but for its "found through" line, and the figure over the list counted rows: on a production copy 78 stored rows for 50 originals, and `/tags/internationalsandwichasong?source=fediverse` drawing 20 cards for 9 posts.

One card now stands for the original. It is drawn from the copy the author's own server served where we hold one (6 of the 50) and otherwise from the copy stored first; the other servers become a disclosure — "Found through these servers" with the count, opening to the list — in the geometry a post's fediverse reactions already fold into, which both now share. The fold runs over the whole scope a surface may show before it pages it, so the count is right and a group split by a page's `LIMIT` cannot come back on the next page.

Reporting is unchanged and the surfaces now hold its promise: a relayed card loses one server and stays, the author's own card takes every copy and goes.

Where: `Vutuv.Tags.ExternalPosts.fold_copies/1`, `<.external_post_card>`.

Closes #2163

https://claude.ai/code/session_01AW11tx7rYiSEaRDjPFNghY
