### PR TITLE
Our own posts no longer count as a foreign server in the bot-wave census

### DIFF
--- a/lib/vutuv/tags/external_tag_client.ex
+++ b/lib/vutuv/tags/external_tag_client.ex
@@ -49,6 +49,10 @@ defmodule Vutuv.Tags.ExternalTagClient do
   result because the two callers want opposite things — the pull drops boosts,
   replies and anything sensitive before it counts, and a census that dropped
   them would be counting a different population than the one making the noise.
+
+  The one refusal the two share is `ExternalPost.written_here?/2` (issues #2179
+  and #2196): a post of ours is not a find, and its author is not one of the
+  servers out there either.
   """
 
   require Logger
@@ -83,10 +87,14 @@ defmodule Vutuv.Tags.ExternalTagClient do
   # A Mastodon tag's history is a week, and the reader is shown a week.
   @history_days 7
 
-  # How many statuses a trending tag is vetted on. A page's maximum, because
-  # this one is a census and its whole value is the size of the sample —
-  # measured over ten trending tags, forty statuses gave 10 to 26 distinct
-  # author domains for an ordinary one and 2 for the bot wave.
+  # How many statuses a trending tag is **asked** for when it is vetted. A
+  # page's maximum, because this one is a census and its whole value is the size
+  # of the sample — measured over ten trending tags, forty statuses gave 10 to
+  # 26 distinct author domains for an ordinary one and 2 for the bot wave. Since
+  # #2196 it is the size of the ask rather than of the sample: our own statuses
+  # come out of it, and on troet.cafe's `#vutuv` that leaves five. Asking for a
+  # second page to refill it would cost a round trip per tag to rescue a tag
+  # whose evidence is mostly our own echo, which is the one we want dropped.
   @census_limit 40
 
   # A server whose clock runs ahead, or a status dated by hand, must not pin
@@ -178,12 +186,13 @@ defmodule Vutuv.Tags.ExternalTagClient do
   end
 
   @doc """
-  Who is posting `tag_name` on `source`: `{:ok, [%{host:, bot?:}]}`, one entry
-  per status on its public tag timeline.
+  Who **else** is posting `tag_name` on `source`: `{:ok, [%{host:, bot?:}]}`,
+  one entry per status on its public tag timeline that was not written here.
 
   The two facts a trending tag is vetted on, and both are the *server's* own —
   it flags its bot accounts itself, and `acct` says where the author lives. See
-  the moduledoc for why this is not a by-product of `fetch/2`.
+  the moduledoc for why this is not a by-product of `fetch/2`, and
+  `author_entry/2` for why our own echo is left out of it.
   """
   def authors(source, tag_name) do
     with {:ok, hashtag} <- hashtag(tag_name),
@@ -197,10 +206,27 @@ defmodule Vutuv.Tags.ExternalTagClient do
       {:error, :transient}
   end
 
+  # `written_here?/2` again, one layer above where the pull asks it (issue
+  # #2196): a post of ours travels out with its hashtags, so the servers we
+  # census hold it and name it under our own host, and counting it made this
+  # installation one more independent author server on the gate meant to catch a
+  # single source. Re-measured on 11 September 2026, troet.cafe's `#vutuv`
+  # timeline was 40 statuses, **35 of them ours**, over six author servers — it
+  # cleared every gate, and five foreign statuses is not evidence of anything.
+  #
+  # Dropped here rather than subtracted in `Trending.verdict/3`, and the same
+  # measurement is why: the five remaining servers still clear
+  # `min_author_hosts`, so an exclusion that only fixed the domain count would
+  # have offered that tag anyway. Leaving the statuses out instead makes all
+  # three figures the verdict reads — servers, sample size, bot share — say the
+  # same thing about strangers, so a tag busy here and nowhere else runs out of
+  # sample instead of borrowing ours.
   defp author_entry(status, source) do
-    case {author_host(status, source), status["account"]} do
-      {host, %{} = account} when is_binary(host) -> [%{host: host, bot?: account["bot"] == true}]
-      _unusable -> []
+    with host when is_binary(host) <- author_host(status, source),
+         false <- ExternalPost.written_here?(host, permalink(status)) do
+      [%{host: host, bot?: status["account"]["bot"] == true}]
+    else
+      _refused -> []
     end
   end
 

--- a/lib/vutuv/tags/trending.ex
+++ b/lib/vutuv/tags/trending.ex
@@ -42,6 +42,19 @@ defmodule Vutuv.Tags.Trending do
   be sampled for at all is **not** offered: failing closed costs one good tag on
   a bad minute and is the only safe direction.
 
+  **The census counts strangers only** (issue #2196). Our own posts federate out
+  with their hashtags, so the servers asked here hand them straight back, and
+  counting them made this installation one more author server on the very gate
+  meant to catch a single source — `Vutuv.Tags.ExternalTagClient.author_entry/2`
+  carries the measurement and why they are dropped there rather than subtracted
+  here. Both figures above are therefore about the world outside, as is the
+  sample they are taken from. The tag's **volume** is not, and cannot be:
+  `/api/v1/trends/tags` carries no author, so a remote server's `uses` counts
+  our echo and there is nothing in the answer to subtract. Such a tag still
+  becomes a candidate and still spends one of the `vet_limit` census slots —
+  what drops it is running out of *sample*, the same failing-closed direction as
+  everything else here.
+
   ## A spike shortens the pull at once
 
   A tag this installation already pulls has a measured pace

--- a/test/support/external_tag_helpers.ex
+++ b/test/support/external_tag_helpers.ex
@@ -278,6 +278,26 @@ defmodule Vutuv.ExternalTagHelpers do
   end
 
   @doc """
+  One status **this installation wrote**, as a remote server hands it back: our
+  member's address and our permalink (issues #2179 and #2196).
+
+  Both halves, because `Vutuv.Tags.ExternalPost.written_here?/2` reads both —
+  `:host` spells both, `:acct_host` only the author, for the relay that
+  relabelled one of our posts under a name of its own. One home rather than one
+  per test file, so a third half added to that predicate is one fixture to fix.
+  """
+  def our_status(source, attrs \\ %{}) do
+    attrs = Map.new(attrs)
+    host = Map.get(attrs, :host, our_host())
+
+    remote_status(source, %{
+      "id" => Map.get(attrs, :id, "#{System.unique_integer([:positive])}"),
+      "url" => "https://#{host}/ada/posts/1",
+      "account" => %{"acct" => "ada@#{Map.get(attrs, :acct_host, host)}"}
+    })
+  end
+
+  @doc """
   One Mastodon REST status, public, in German, with an author — merge `attrs`
   over it for the field a test is actually about.
   """

--- a/test/vutuv/tags/external_tag_client_test.exs
+++ b/test/vutuv/tags/external_tag_client_test.exs
@@ -31,19 +31,10 @@ defmodule Vutuv.Tags.ExternalTagClientTest do
 
   defp status(attrs \\ %{}), do: remote_status(@source, attrs)
 
-  # A status this installation wrote, as a relay hands it back: our member's
-  # address, our permalink. `:host` spells both, `:acct_host` only the author —
-  # above the describe it belongs to, because a `defp` inside one compiles to
-  # module scope anyway and only looks scoped.
-  defp ours(attrs) do
-    host = Map.get(attrs, :host, our_host())
-
-    status(%{
-      "id" => Map.fetch!(attrs, :id),
-      "url" => "https://#{host}/ada/posts/1",
-      "account" => %{"acct" => "ada@#{Map.get(attrs, :acct_host, host)}"}
-    })
-  end
+  # A status this installation wrote, as a relay hands it back. The shape lives
+  # in the shared helpers, because the trending census reads the same predicate
+  # over the same fixture.
+  defp ours(attrs), do: our_status(@source, attrs)
 
   # Every Finch a pinned request started, by the name it registers under. Empty
   # is the claim: one instance lives for one request and is stopped in an
@@ -351,6 +342,41 @@ defmodule Vutuv.Tags.ExternalTagClientTest do
       for stranger <- ["not#{our_host()}", "mirror.#{our_host()}", "elsewhere.test"] do
         refute ExternalPost.written_here?(stranger, "https://#{stranger}/@bob/1")
       end
+    end
+  end
+
+  # The census counts who is posting a tag out there, and we are not out there
+  # (issue #2196). Same predicate as the ingest refusal above, asked one layer
+  # earlier, so the three figures the bot-wave gate reads — how many distinct
+  # servers, how many statuses, how many bots — are all about strangers.
+  describe "authors/2" do
+    test "counts the strangers on the timeline and leaves this installation out" do
+      stub_tag_timeline([
+        ours(%{id: "own"}),
+        ours(%{id: "www", host: "www.#{our_host()}"}),
+        ours(%{id: "doubled-www", host: "www.www.#{our_host()}"}),
+        ours(%{id: "shouted", host: String.upcase(our_host())}),
+        ours(%{id: "trailing-dot", host: "#{our_host()}."}),
+        ours(%{id: "tag-actor", host: Fediverse.tag_host()}),
+        # A relay that rewrote the author field still hands back our address.
+        ours(%{id: "relabelled", acct_host: "shouty.example"}),
+        # The mirror image: a host that merely contains ours is a stranger, and
+        # dropping its author would be this bug with the sign flipped.
+        status(%{"id" => "neighbour", "account" => %{"acct" => "bob@not#{our_host()}"}}),
+        status(%{"id" => "mirror", "account" => %{"acct" => "bob@mirror.#{our_host()}"}}),
+        status(%{
+          "id" => "machine",
+          "account" => %{"acct" => "bot@elsewhere.test", "bot" => true}
+        })
+      ])
+
+      assert {:ok, entries} = ExternalTagClient.authors(@source, "Elixir")
+
+      assert entries == [
+               %{host: "not#{our_host()}", bot?: false},
+               %{host: "mirror.#{our_host()}", bot?: false},
+               %{host: "elsewhere.test", bot?: true}
+             ]
     end
   end
 end

--- a/test/vutuv/tags/trending_test.exs
+++ b/test/vutuv/tags/trending_test.exs
@@ -32,9 +32,19 @@ defmodule Vutuv.Tags.TrendingTest do
   @xbox [130, 123, 87, 69, 40, 54, 117]
   @mow4 [805, 1, 0, 0, 0, 0, 0]
 
-  # A crowd: twenty statuses over five author domains, none of them a bot.
-  defp crowd(source) do
-    sample_statuses(source, 20, ~w(a.example b.example c.example d.example e.example))
+  # A crowd: `count` statuses over five author domains, none of them a bot.
+  defp crowd(source, count \\ 20) do
+    sample_statuses(source, count, ~w(a.example b.example c.example d.example e.example))
+  end
+
+  # One spiking tag, listed and sampled by both servers — whichever is busiest
+  # is the one the census asks, and a fixture that answered nothing on the other
+  # would be rejected for being too small and prove nothing.
+  defp spiking(name, history, sample) do
+    stub(
+      %{@big => [{name, history}], @small => [{name, history}]},
+      %{@big => %{name => sample.(@big)}, @small => %{name => sample.(@small)}}
+    )
   end
 
   # The stub reports every request back here, so "nobody was asked" has to be
@@ -116,15 +126,8 @@ defmodule Vutuv.Tags.TrendingTest do
   describe "the loudest tag is often a machine" do
     # `mow4` clears every gate that reads the trending list — it came from
     # nowhere and it trended on both servers — so each of these leaves exactly
-    # one thing wrong with the sample. The sample is stubbed on **both** servers
-    # because whichever is busiest is the one asked, and a fixture that answered
-    # nothing would be rejected for being too small and prove nothing.
-    defp spiking_bot_wave(sample) do
-      stub(
-        %{@big => [{"mow4", @mow4}], @small => [{"mow4", @mow4}]},
-        %{@big => %{"mow4" => sample.(@big)}, @small => %{"mow4" => sample.(@small)}}
-      )
-    end
+    # one thing wrong with the sample.
+    defp spiking_bot_wave(sample), do: spiking("mow4", @mow4, sample)
 
     test "a tag whose authors are all one domain is not offered" do
       spiking_bot_wave(&sample_statuses(&1, 20, ["social.prepedia.example"]))
@@ -146,9 +149,7 @@ defmodule Vutuv.Tags.TrendingTest do
       # Five statuses over five domains and not a bot among them: every other
       # gate is happy, and five is simply not enough to tell a crowd from a
       # machine. Failing closed is the only safe direction.
-      spiking_bot_wave(
-        &sample_statuses(&1, 5, ~w(a.example b.example c.example d.example e.example))
-      )
+      spiking_bot_wave(&crowd(&1, 5))
 
       Trending.refresh()
 
@@ -181,6 +182,74 @@ defmodule Vutuv.Tags.TrendingTest do
       assert row.author_hosts == 5
       assert row.bot_posts == 0
       assert row.sampled == 20
+    end
+  end
+
+  # A post written here goes out with its hashtags, so the servers we ask hold
+  # it and hand it back — and until #2196 it counted as one more independent
+  # author server on the very gate meant to catch a single source. The live
+  # figures behind each of these are in `Vutuv.Tags.ExternalTagClient`.
+  describe "our own echo is not one of the servers out there" do
+    defp spiking_with(sample), do: spiking("warntag", @warntag, sample)
+
+    # Our own statuses, from the one fixture that knows what those look like.
+    # Their ids are distinct from `sample_statuses/4`'s, because the two lists
+    # are concatenated into one timeline.
+    defp echo(source, count) do
+      Enum.map(1..count, &our_status(source, %{id: "echo#{&1}"}))
+    end
+
+    test "a tag that reaches the fourth author server only through us is not offered" do
+      # Three servers out there and this one: four domains, and the gate wants
+      # four. Ours is the one that must not count.
+      spiking_with(&(sample_statuses(&1, 15, ~w(a.example b.example c.example)) ++ echo(&1, 5)))
+
+      Trending.refresh()
+
+      assert Trending.offers() == []
+    end
+
+    test "the same tag with a genuine fourth server is offered" do
+      spiking_with(
+        &(sample_statuses(&1, 16, ~w(a.example b.example c.example d.example)) ++ echo(&1, 5))
+      )
+
+      Trending.refresh()
+
+      assert [row] = Trending.offers()
+      assert row.name == "warntag"
+      # The stored figures are about strangers only — 16 statuses over four
+      # servers, with our five nowhere in them.
+      assert row.author_hosts == 4
+      assert row.sampled == 16
+    end
+
+    test "a tag this installation is busy with and nobody else is not offered" do
+      # troet.cafe's `#vutuv`, shrunk: five foreign statuses over five servers
+      # under thirty of our own. The author servers alone would still clear the
+      # gate — five is more than four — so what catches it is that there is
+      # almost nothing out there to judge.
+      spiking_with(
+        &(sample_statuses(&1, 5, ~w(a.example b.example c.example d.example e.example)) ++
+            echo(&1, 30))
+      )
+
+      Trending.refresh()
+
+      assert Trending.offers() == []
+    end
+
+    test "our own posts do not water down the share that is bots" do
+      # Eight bots among ten strangers is a wave. Counted beside ten posts of
+      # ours it reads as 40 %, which is inside the threshold.
+      spiking_with(
+        &(sample_statuses(&1, 10, ~w(a.example b.example c.example d.example), 8) ++
+            echo(&1, 10))
+      )
+
+      Trending.refresh()
+
+      assert Trending.offers() == []
     end
   end
 


### PR DESCRIPTION
Before the tag card offers a tag as busy elsewhere, a census of its timeline counts author servers, and too few means bot wave. Our own posts travel out with their hashtags and come back on those timelines, so we were supplying one of the four domains. Re-measured on troet.cafe's `#vutuv`: 40 statuses, **35 of them ours**, over six author servers — offered.

`ExternalTagClient.author_entry/2` now refuses a status `ExternalPost.written_here?/2` says was written here, the predicate the pull already asks at ingest (#2179). Dropped in the census rather than subtracted in `Trending.verdict/3`: the five foreign servers left on that timeline still clear `min_author_hosts`, so leaving the statuses out is what makes server count, sample size and bot share all describe strangers.

Volume is untouched and cannot be: `/api/v1/trends/tags` carries no author.

Over today's eight live candidates nothing changes either way — none carries a post of ours.

Closes #2196

https://claude.ai/code/session_01AW11tx7rYiSEaRDjPFNghY
