### PR TITLE
An empty post archive tells crawlers it is not worth keeping

### DIFF
--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -5627,6 +5627,45 @@ defmodule Vutuv.Posts do
   end
 
   @doc """
+  Whether `author`'s archive lists nothing at all for an **anonymous** reader —
+  the whole of `/:slug/posts`, or the slice one period page shows (`period` as
+  `author_posts_page/6` takes it).
+
+  The one input behind every `noindex` that address answers with, through
+  `VutuvWeb.AgentDocs.PostDoc.archive_robots_axes/2`: the HTML page's response
+  header and its `<meta name="robots">`, and the flag (plus header) of each
+  agent document. Every member has the address whether or not they ever wrote
+  a line, and almost nobody has — **5,941 of 6,025** archives listed nothing on
+  the dev copy of production (2026-09-11), close to 30,000 addresses with the
+  agent siblings, each worth reading once and never again (issue #2172).
+
+  **Always `viewer = nil`, on the owner's own request too.** A post is visible
+  to some readers and not others, so "empty" depends on who asks — and the
+  header speaks to a crawler, which is never signed in. An archive holding
+  nothing but members-only posts therefore says `noindex` to its owner as well:
+  that is the honest word about the page the rest of the world is served.
+
+  Its own query rather than the `total` the caller already holds. That number
+  answers correctly on the agent-document path, where it is this query's own
+  count; on the signed-in HTML page it is the *viewer's* count and narrowed by
+  `?type=`, and on `/api/2.0` the viewer's too. Reading it would make the
+  answer depend on which surface is holding the other one, and that is the
+  disagreement at one URL `PostDoc.robots_axes/2` is named after.
+
+  It is an **added** query, not a replacement — the archive still counts its
+  own page — and a cheap one: it stops at the first row, every leg of the union
+  filters on an indexed `user_id`, and on the dev copy it plans to
+  `Limit → Result → Append` at 6 buffer hits and 0.2 ms of execution (about
+  0.9 ms end to end from Elixir). It is paid on the 98.6 % of archives whose
+  `noindex` then keeps a crawler from coming back for them.
+  """
+  def public_archive_empty?(%User{} = author, period) do
+    query = author |> author_timeline_query(nil, :all) |> scope_period(period)
+
+    not Repo.exists?(query)
+  end
+
+  @doc """
   How many entries one page of the **HTML** archive (`/:slug/posts`) carries.
 
   Its own number rather than the site-wide `Vutuv.Pages.max_page_items/0`,

--- a/lib/vutuv_web/agent_docs/post_doc.ex
+++ b/lib/vutuv_web/agent_docs/post_doc.ex
@@ -55,6 +55,32 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
     do: {restricted? or author.noindex?, restricted? or author.noai?}
 
   @doc """
+  The same for the author **archive**, which has an answer of its own (issue
+  #2172): a page listing nothing for an anonymous reader
+  (`Vutuv.Posts.public_archive_empty?/2`) adds `noindex`.
+
+  It only ever adds. The member's axes are worked out first and emptiness is
+  ored into one of them, so a second condition arriving later composes with
+  this one rather than replacing it, and nothing about an empty page can
+  re-open what its author closed.
+
+  **`noindex` and only that**, for the reason `Vutuv.PressKit.robots_axes/2`
+  states next door: emptiness says what is on the page, not what its author
+  permits, and moving `noai` too would tell an agent a member refused
+  something they never refused.
+
+  Its own function rather than a third argument on `robots_axes/2`, because
+  the emptiness question is *always* the anonymous one and always this
+  query — a caller that could pass the answer in is a caller that can get it
+  wrong, and getting it wrong here means offering an empty page for indexing.
+  """
+  def archive_robots_axes(author, period) do
+    {noindex?, noai?} = robots_axes(author, false)
+
+    {noindex? or Posts.public_archive_empty?(author, period), noai?}
+  end
+
+  @doc """
   The permalink page: the post itself plus its visible replies. Anonymous
   by default; `viewer:` switches the reply list (and its count) to what
   that user sees — the authenticated `/api/2.0` reads. Never pass a viewer
@@ -231,12 +257,18 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
   reposts), whole or scoped to a year / month / day (`period_label`).
   `path` is the extension-free request path, so the doc describes exactly
   the page that was asked for (including the period segments).
+
+  `period` is that scope as a `{from, to}` pair, the label's machine twin, and
+  the only reason it is passed: the document asks `archive_robots_axes/2`
+  whether the page it describes has anything on it (issue #2172). A caller
+  with no period scope (`/api/2.0`) leaves it out.
   """
-  def build_archive(author, path, entries, total, period_label) do
-    # Both axes, like the permalink: an archive is the member's own posts under
-    # their own handle, so their opt-outs apply to it exactly as they do to the
-    # profile it hangs off.
-    {noindex?, noai?} = robots_axes(author, false)
+  def build_archive(author, path, entries, total, period_label, period \\ nil) do
+    # The member's own opt-outs, which reach an archive exactly as they reach
+    # the profile it hangs off, narrowed by the page's emptiness. Asked rather
+    # than read off `total` — see `Posts.public_archive_empty?/2`, which holds
+    # the reason and the measurement.
+    {noindex?, noai?} = archive_robots_axes(author, period)
 
     AgentDocs.doc_meta("post_archive", path, noindex: noindex?, noai: noai?)
     |> Map.merge(%{

--- a/lib/vutuv_web/controllers/page_controller.ex
+++ b/lib/vutuv_web/controllers/page_controller.ex
@@ -402,6 +402,13 @@ defmodule VutuvWeb.PageController do
 
   - `/<username>` — member profile (also `/<username>.vcf` as vCard 3.0)
   - `/<username>/posts` — post archive, also `/<username>/posts/<year>[/<month>[/<day>]]`
+    (the unscoped `/<username>/posts.xml` redirects to the RSS feed below).
+    **Most members have written nothing.** An archive with nothing on it still
+    answers 200 — it belongs to its member — but answers
+    `X-Robots-Tag: noindex`, the page and its documents alike, and so does a
+    year or a month holding no post. Every post worth reading is listed one by
+    one in the sitemap's `posts` and `organization_posts` chunks, so walk those
+    rather than this pattern
   - `/<username>/posts/<id>` — a single post with replies
   - `/<username>/followers`, `/<username>/following`, `/<username>/connections` — people lists
   - `/<username>/<section>` — the profile sections in full: `work_experiences`,

--- a/lib/vutuv_web/controllers/post_controller.ex
+++ b/lib/vutuv_web/controllers/post_controller.ex
@@ -37,7 +37,7 @@ defmodule VutuvWeb.PostController do
   # browse pages. Lists only what the viewer may see, so it is as crawlable
   # as the permalinks it links to.
   # Also served as Markdown / text / JSON (.md/.txt/.json or Accept
-  # negotiation), rendered from VutuvWeb.AgentDocs.PostDoc.build_archive/5 —
+  # negotiation), rendered from VutuvWeb.AgentDocs.PostDoc.build_archive/6 —
   # always the anonymous view. Keep index.html and the doc builder in sync
   # (agent_docs_drift_test.exs).
   def index(conn, params) do
@@ -60,7 +60,11 @@ defmodule VutuvWeb.PostController do
             Posts.author_posts_per_page()
           )
 
-        {noindex?, noai?} = PostDoc.robots_axes(author, false)
+        # The member's opt-outs, narrowed by whether this page lists anything
+        # (issue #2172) — asked of the **anonymous** archive whoever is reading,
+        # so this header, the four documents at the same URL and the meta tag
+        # below are one answer.
+        {noindex?, noai?} = PostDoc.archive_robots_axes(author, period)
 
         conn
         |> AgentDocs.put_html_alternates()
@@ -71,6 +75,11 @@ defmodule VutuvWeb.PostController do
         # The archive never stamped this at all, so a member's opt-outs reached
         # the page's meta tag and nothing else.
         |> VutuvWeb.ContentPolicy.put_robots_header(noindex?, noai?)
+        # …and the same answer into that meta tag, which
+        # `VutuvWeb.LayoutHTML.robots_directives/1` would otherwise derive a
+        # second time from the member's own two flags — which know nothing
+        # about whether this page lists anything.
+        |> assign(:robots_directives, VutuvWeb.ContentPolicy.robots_directives(noindex?, noai?))
         |> render("index.html",
           author: author,
           posts: posts,
@@ -104,7 +113,7 @@ defmodule VutuvWeb.PostController do
         # Agent-format siblings always render the plain archive (no ?type=), so
         # the .md/.txt/.json stay one canonical document (drift test).
         {posts, total} = Posts.author_posts_page(author, nil, params, period)
-        doc = PostDoc.build_archive(author, conn.request_path, posts, total, period_label)
+        doc = PostDoc.build_archive(author, conn.request_path, posts, total, period_label, period)
         AgentDocs.send_doc(conn, format, doc)
 
       {:error, _format} ->

--- a/lib/vutuv_web/views/layout_html.ex
+++ b/lib/vutuv_web/views/layout_html.ex
@@ -261,10 +261,11 @@ defmodule VutuvWeb.LayoutHTML do
 
   A controller that already worked the answer out assigns
   `:robots_directives` and that wins — the member's two flags are the
-  *fallback*, not the source. The Media Kit is the page that needs it: it
-  adds `noindex` when the kit is empty (issue #2143), and a tag derived a
-  second time from the member would have said nothing while the response
-  header said `noindex`.
+  *fallback*, not the source. Two pages need it, and for one reason: both add
+  `noindex` when there is nothing on them — the Media Kit when the kit is empty
+  (issue #2143) and the post archive when it lists nothing (issue #2172) — and
+  a tag derived a second time from the member would have said nothing while the
+  response header said `noindex`.
 
   **Where this wants to end up:** in `ContentPolicy.put_robots_header/3`
   itself, so every page whose header it stamps also gets the matching tag.

--- a/test/vutuv_web/empty_post_archive_test.exs
+++ b/test/vutuv_web/empty_post_archive_test.exs
@@ -1,0 +1,267 @@
+defmodule VutuvWeb.EmptyPostArchiveTest do
+  @moduledoc """
+  An empty post archive tells a crawler it is not worth keeping (issue #2172).
+
+  Every member has `/<username>/posts` whether or not they ever wrote a line,
+  and almost nobody has: **5,941 of 6,025** archives in the dev copy of
+  production list nothing for an anonymous reader (measured 2026-09-11). Each
+  answered 200 with an empty state and no `x-robots-tag` at all, and
+  `/llms.txt` published the bare `/<username>/posts` pattern — close to 30,000
+  addresses with the agent siblings, worth reading once and never again.
+
+  The Media Kit had the same shape one URL family over (issue #2143) and this
+  is its answer, with three differences the archive brings of its own:
+
+    * **whose emptiness.** A post can be visible to some readers and not
+      others, so "empty" depends on who asks. The header speaks to a crawler
+      and a crawler is anonymous, so `Vutuv.Posts.public_archive_empty?/2`
+      always asks with `viewer = nil` — on the owner's own request too. An
+      archive holding nothing but members-only posts says `noindex` to its
+      owner, because that is what the page says to everyone it is crawled by.
+      Emptiness is ored onto the member's own axes
+      (`PostDoc.archive_robots_axes/2`), never written over them, so an empty
+      archive whose author also excluded machines carries **both** directives;
+    * **a reshare is content.** Two of the 84 non-empty archives hold no post
+      of their own at all, only reposts, so a rule reading "has this member
+      written a post" would have noindexed a page with entries on it;
+    * **the period pages and the `.xml` sibling.** The archive scopes to a
+      year / month / day, and each scope is its own address that can be empty
+      while the archive is not. The unscoped `.xml` is a 301 to the member's
+      RSS feed, so the unscoped path has four surfaces and a period-scoped one
+      five.
+
+  `?type=` and `?page=` are deliberately *not* in the derivation: both are
+  query strings on the same address, `rel="canonical"` already points them at
+  the plain path, and the four documents there ignore them — so a filter with
+  nothing under it must not make the page disagree with its own `.md`.
+
+  Calibrated against the un-fixed code: every `== ["noindex"]` below is `[]`
+  there, the `.md` frontmatter carries no `noindex: true`, and the `/llms.txt`
+  test fails on the sentence that is not in the file yet.
+  """
+  use VutuvWeb.ConnCase, async: true
+
+  import Vutuv.PostsHelpers
+
+  alias Vutuv.Posts
+  alias Vutuv.Repo
+
+  # `.xml` is absent on purpose — see the moduledoc. The period-scoped tests
+  # below add it back.
+  @formats ~w(.md .txt .json)
+
+  defp de(conn), do: put_req_header(conn, "accept-language", "de-DE,de;q=0.9")
+
+  defp robots(conn), do: get_resp_header(conn, "x-robots-tag")
+
+  setup do
+    {:ok,
+     user: insert_activated_user(username: "leeres.archiv", first_name: "Ada", last_name: "King")}
+  end
+
+  describe "an empty archive" do
+    test "still answers 200 to a stranger and to its owner", %{conn: conn, user: user} do
+      assert conn |> get(~p"/#{user}/posts") |> html_response(200) =~ "Nothing here yet."
+
+      {owner_conn, owner} = create_and_login_user(conn)
+
+      assert owner_conn |> get(~p"/#{owner}/posts") |> html_response(200) =~ "Nothing here yet."
+    end
+
+    test "and says so in German", %{conn: conn, user: user} do
+      html = conn |> de() |> get(~p"/#{user}/posts") |> html_response(200)
+
+      assert html =~ "Hier gibt es noch nichts."
+      assert html =~ "Beiträge von Ada King"
+    end
+
+    test "carries noindex in the header and in the meta tag", %{conn: conn, user: user} do
+      conn = get(conn, ~p"/#{user}/posts")
+
+      assert robots(conn) == ["noindex"]
+      assert html_response(conn, 200) =~ ~s(<meta name="robots" content="noindex")
+    end
+
+    test "carries it in the agent documents too", %{conn: conn, user: user} do
+      for format <- @formats do
+        sibling = get(conn, "/#{user.username}/posts#{format}")
+
+        assert sibling.status == 200, "#{format} answered #{sibling.status}"
+        assert robots(sibling) == ["noindex"], "#{format} carried #{inspect(robots(sibling))}"
+
+        assert get_resp_header(sibling, "content-signal") == [
+                 "ai-train=yes, search=no, ai-input=yes"
+               ]
+      end
+    end
+
+    test "and the document body says it, without ever serving HTML", %{conn: conn, user: user} do
+      markdown = get(conn, "/#{user.username}/posts.md")
+
+      assert ["text/markdown; charset=utf-8"] = get_resp_header(markdown, "content-type")
+      refute markdown.resp_body =~ "<!doctype html"
+      # The frontmatter is where a `.md` reader meets the flag; `.json` speaks
+      # through the headers alone.
+      assert markdown.resp_body =~ "noindex: true"
+      refute markdown.resp_body =~ "noai: true"
+
+      doc = conn |> get("/#{user.username}/posts.json") |> json_response(200)
+
+      assert doc["total"] == 0
+      assert doc["posts"] == []
+    end
+
+    test "never invents the member's AI opt-out, and never overwrites it", %{
+      conn: conn,
+      user: user
+    } do
+      assert robots(get(conn, ~p"/#{user}/posts")) == ["noindex"]
+
+      # The composition case: emptiness contributes one axis, the member's own
+      # choice the other, and the response carries both.
+      Repo.update!(Ecto.Changeset.change(user, noai?: true))
+
+      assert robots(get(conn, ~p"/#{user}/posts")) == ["noindex, noai, noimageai"]
+      assert robots(get(conn, "/#{user.username}/posts.json")) == ["noindex, noai, noimageai"]
+    end
+  end
+
+  describe "an archive with something on it" do
+    test "the first post takes the noindex away, deleting it puts it back", %{
+      conn: conn,
+      user: user
+    } do
+      assert robots(get(conn, ~p"/#{user}/posts")) == ["noindex"]
+
+      post = create_post!(user, %{body: "Ada schreibt ihren ersten Beitrag."})
+
+      assert robots(get(conn, ~p"/#{user}/posts")) == []
+
+      for format <- @formats do
+        assert robots(get(conn, "/#{user.username}/posts#{format}")) == [],
+               "#{format} still says noindex with a post on the page"
+      end
+
+      {:ok, _deleted} = Posts.delete_post(post)
+
+      assert robots(get(conn, ~p"/#{user}/posts")) == ["noindex"]
+      assert robots(get(conn, "/#{user.username}/posts.json")) == ["noindex"]
+    end
+
+    test "a reshare alone is content", %{conn: conn, user: user} do
+      author = insert_activated_user(username: "schreiberin")
+      post = create_post!(author, %{body: "Ein Beitrag, den jemand teilt."})
+
+      assert robots(get(conn, ~p"/#{user}/posts")) == ["noindex"]
+
+      assert Posts.repost_post(user, post) == :ok
+
+      assert robots(get(conn, ~p"/#{user}/posts")) == []
+      assert robots(get(conn, "/#{user.username}/posts.json")) == []
+    end
+
+    test "a members-only post is nothing a crawler can see, owner included", %{conn: conn} do
+      {owner_conn, owner} = create_and_login_user(conn)
+
+      create_post!(owner, %{body: "Nur für Mitglieder.", denials: [%{"wildcard" => "logged_out"}]})
+
+      # The owner's own page draws the post…
+      owner_page = get(owner_conn, ~p"/#{owner}/posts")
+      assert html_response(owner_page, 200) =~ "Nur für Mitglieder."
+      # …and still says noindex, because the header describes the page a
+      # crawler is served, and a crawler is never signed in.
+      assert robots(owner_page) == ["noindex"]
+
+      assert robots(get(conn, ~p"/#{owner}/posts")) == ["noindex"]
+      assert robots(get(conn, "/#{owner.username}/posts.json")) == ["noindex"]
+    end
+
+    # The other direction of the same claim: a page with something on it must
+    # not *clear* an axis the member set, which is what a derivation writing
+    # over the axes instead of oring into them would do.
+    test "a member's own search opt-out still reaches a full archive", %{conn: conn, user: user} do
+      create_post!(user, %{body: "Ein Beitrag wie jeder andere."})
+      Repo.update!(Ecto.Changeset.change(user, noindex?: true))
+
+      assert robots(get(conn, ~p"/#{user}/posts")) == ["noindex"]
+      assert robots(get(conn, "/#{user.username}/posts.json")) == ["noindex"]
+    end
+
+    test "a filter with nothing under it does not disagree with its own document", %{
+      conn: conn,
+      user: user
+    } do
+      create_post!(user, %{body: "Ein Beitrag, aber keine Antwort."})
+
+      filtered = get(conn, ~p"/#{user}/posts?#{[type: "replies"]}")
+
+      assert html_response(filtered, 200) =~ "No replies yet."
+      assert robots(filtered) == []
+      # …because `?type=` is a view of the same address, and the page says so.
+      assert filtered.resp_body =~ ~s(rel="canonical")
+      assert filtered.resp_body =~ ~s(/#{user.username}/posts")
+    end
+  end
+
+  describe "a period-scoped archive" do
+    setup %{user: user} do
+      post = create_post!(user, %{body: "Ein Beitrag aus diesem Jahr."})
+      {:ok, year: post.published_on.year}
+    end
+
+    test "an empty year says noindex while the year with the post does not", %{
+      conn: conn,
+      user: user,
+      year: year
+    } do
+      empty_year = year - 3
+
+      assert robots(get(conn, ~p"/#{user}/posts/#{year}")) == []
+      assert robots(get(conn, ~p"/#{user}/posts/#{empty_year}")) == ["noindex"]
+    end
+
+    test "and all five surfaces of that year agree", %{conn: conn, user: user, year: year} do
+      empty = "/#{user.username}/posts/#{year - 3}"
+
+      assert html_response(get(conn, empty), 200) =~ ~s(<meta name="robots" content="noindex")
+
+      for format <- @formats ++ [".xml"] do
+        sibling = get(conn, empty <> format)
+
+        assert sibling.status == 200, "#{format} answered #{sibling.status}"
+        assert robots(sibling) == ["noindex"], "#{format} carried #{inspect(robots(sibling))}"
+      end
+    end
+  end
+
+  describe "what a machine is told to walk" do
+    test "/llms.txt says most members have written nothing and names the sitemap", %{conn: conn} do
+      body = conn |> get(~p"/llms.txt") |> Map.fetch!(:resp_body)
+
+      assert body =~ "/<username>/posts"
+      assert body =~ "Most members have written nothing"
+      assert body =~ "sitemap"
+    end
+
+    test "every archive the sitemap's posts chunk points into answers without noindex", %{
+      conn: conn,
+      user: user
+    } do
+      writer = insert_activated_user(username: "schreiberin")
+      create_post!(writer, %{body: "Ein öffentlicher Beitrag."})
+
+      slugs =
+        Vutuv.Sitemap.post_entries(1)
+        |> Enum.map(fn {path, _date} -> path |> String.split("/", trim: true) |> hd() end)
+        |> Enum.uniq()
+
+      assert writer.username in slugs
+      refute user.username in slugs
+
+      for slug <- slugs do
+        assert robots(get(conn, "/#{slug}/posts")) == [],
+               "the sitemap lists a post of #{slug}, whose archive says noindex"
+      end
+    end
+  end
+end


### PR DESCRIPTION
5,941 of 6,025 members have nothing at `/<username>/posts`. Each empty archive answered 200 with no `x-robots-tag`, and `/llms.txt` handed out the bare pattern: close to 30,000 addresses counting the `.md`/`.txt`/`.json` siblings.

An empty archive keeps its 200 and now says `noindex` in the header, in the page's own `<meta>` tag and in every agent document, from one derivation (`Vutuv.Posts.public_archive_empty?/2` via `PostDoc.archive_robots_axes/2`). It only adds, so a member who also excluded machines still gets both directives. `/llms.txt` now points at the sitemap's `posts` chunks.

Three things differ from the Media Kit (#2143): emptiness is asked anonymously, on the owner's own request too, since a crawler is never signed in; a reshare counts as content (2 of the 84 non-empty archives hold nothing else); an empty year is its own address.

Where: `VutuvWeb.PostController.index/2`, `Vutuv.Posts.public_archive_empty?/2`.

Closes #2172

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01WPMGFtmCZNip8EJiRrx6ch
