### PR TITLE
Keep the busy-tag row in place at night, and size its pills like the row above

### DIFF
--- a/docs/architecture/social-graph.md
+++ b/docs/architecture/social-graph.md
@@ -453,7 +453,21 @@ all. Measured on 10 September 2026 against the shipped ten, `#warntag` stood at
 what `#xbox` does every day, and a rule that read volume alone would offer it
 forever. Each pill wears those seven days as six quiet strokes and one accent
 bar, so the reader can see the judgement rather than take it on trust; the same
-figures are in the control's accessible name, grouped for the locale.
+figures are in the control's accessible name, grouped for the locale. The pill
+is the same pill as the tags offered a few pixels above it, with the week sized
+to fit inside it (issue #2180) — three rows of pills in one 309px card, and a
+bottom row drawn to a recipe of its own read as a fault rather than as
+emphasis.
+
+**The row keeps its place when the offer is empty** (issue #2165). Judging on
+today's volume means nothing anywhere can clear the bar for the first few hours
+of a day, so the offer empties nightly; taking the label with it left a member
+who saw five suggestions in the evening looking at a bare plus sign. The label
+now stands and one muted line says what and why. What decides whether the row
+exists at all is `Vutuv.Tags.Trending.asking?/0` — the flag plus a non-empty
+`TAG_SOURCE_SERVERS` — because "nothing stood out today" is only honest where
+somebody was asked, and an intranet installation reading no other server gets no
+row rather than a nightly report about servers it never touches.
 
 **The loudest tag is often a machine, and the spread does not catch it.**
 `#mow4` trended on seven of the nine servers that answered — a bot farm that

--- a/lib/vutuv/tags/source_servers.ex
+++ b/lib/vutuv/tags/source_servers.ex
@@ -94,6 +94,17 @@ defmodule Vutuv.Tags.SourceServers do
   """
   def offered, do: offered(blocked_hosts(configured()))
 
+  @doc """
+  Whether the operator names any other server at all — the intranet question,
+  and the one a per-request caller may ask.
+
+  `offered/0` answers who, and pays a blocklist query for it; this answers
+  whether, from configuration alone. Blocking one of the ten does not make an
+  installation an air-gapped one, so the rare operator who blocks *every* server
+  they themselves configured is the one case where the two disagree.
+  """
+  def configured?, do: configured() != []
+
   defp offered(blocked) do
     if enabled?() do
       configured() |> Enum.reject(&MapSet.member?(blocked, &1)) |> Enum.uniq()

--- a/lib/vutuv/tags/trending.ex
+++ b/lib/vutuv/tags/trending.ex
@@ -119,6 +119,23 @@ defmodule Vutuv.Tags.Trending do
     ExternalPosts.enabled?() and Application.get_env(:vutuv, @flag, true) == true
   end
 
+  @doc """
+  Whether this installation asks anybody at all what is trending on them.
+
+  The row draws an empty state rather than vanishing (issue #2165), and "nothing
+  stood out today" is only honest where somebody was asked. An installation with
+  the flag off, or an intranet one whose `TAG_SOURCE_SERVERS` is the empty list
+  that `Vutuv.Tags.SourceServers` documents as a real setting, reads no other
+  servers at all — it gets no row, not a nightly report about servers it never
+  touches.
+
+  Every feed page load asks this, so it is deliberately `configured?/0` and not
+  `offered/0`: the second answers *whom* and pays a blocklist query for it
+  (measured at 417 µs and one round trip), while the question here is whether
+  there is anybody to ask, which is configuration.
+  """
+  def asking?, do: enabled?() and SourceServers.configured?()
+
   @doc "The thresholds and the pace — see the moduledoc for where each number comes from."
   def settings, do: Application.get_env(:vutuv, :tag_trending, @settings)
 

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -336,7 +336,11 @@ defmodule VutuvWeb.PostLive.Feed do
         # And what is suddenly busy on those servers (issue #2129), which the
         # last pass already worked out — a select of at most eight stored rows,
         # never anything outbound.
-        trending_tags: trending_offers(followed)
+        trending_tags: trending_offers(followed),
+        # Whether anybody is asked at all (`VutuvWeb.PostLive.TrendingTags`).
+        # Read once here and never again: it is configuration, so the
+        # socket-side redraws below deliberately leave it alone.
+        trending_asking?: Trending.asking?()
       },
       newcomer_rail(user)
     )
@@ -1014,6 +1018,7 @@ defmodule VutuvWeb.PostLive.Feed do
   attr(:panel_rows, :list, default: [])
   attr(:panel_error, :any, default: nil)
   attr(:trending, :list, default: [])
+  attr(:trending_asking?, :boolean, required: true)
 
   defp followed_tags_body(assigns) do
     ~H"""
@@ -1103,7 +1108,7 @@ defmodule VutuvWeb.PostLive.Feed do
       <%!-- What is spiking on the servers this installation reads from (issue
       #2129), under the tags this reader's own feed is already carrying — the
       near neighbourhood first, then the wider one. --%>
-      <.trending_row tags={@trending} />
+      <.trending_row tags={@trending} asking?={@trending_asking?} />
     </div>
     """
   end
@@ -4105,6 +4110,7 @@ defmodule VutuvWeb.PostLive.Feed do
                       panel_rows={@tag_panel_rows}
                       panel_error={@tag_panel_error}
                       trending={@trending_tags}
+                      trending_asking?={@trending_asking?}
                     />
                   </.rail_block>
                 <% "newcomers" -> %>

--- a/lib/vutuv_web/live/post_live/trending_tags.ex
+++ b/lib/vutuv_web/live/post_live/trending_tags.ex
@@ -16,6 +16,32 @@ defmodule VutuvWeb.PostLive.TrendingTags do
   decorative (`aria-hidden`); the same fact is in the control's own name, in
   words and in grouped figures.
 
+  **The week is sized to the pill, never the other way round** (issue #2180).
+  This is the third row of pills in one card and the two above it are the
+  reader's yardstick, so it wears their recipe to the utility — `text-xs`,
+  `px-2.5 py-1`, `font-medium` — and the sparkline fits inside it: `h-4` is
+  exactly that type's line box, so the whole pill is 24px tall like its
+  neighbours, and the strokes are hairlines (`w-0.5`, 20px for the week against
+  34px before). Drawn to its own bigger recipe with a 40px box it cost five
+  lines of a 309px rail where two do, and each tag landed on a line of its own
+  while the row above sat three to a line — which reads as a fault rather than
+  as emphasis. Keep the two literals in step; `feed_trending_tags_test.exs`
+  measures them against each other rather than against a number typed here.
+
+  ## The row keeps its place when there is nothing on it
+
+  A tag qualifies on today's volume against its own six-day median, so shortly
+  after midnight nothing anywhere can clear the bar and the offer is empty for
+  a few hours, every night (issue #2165). Taking the label away with it left a
+  member who saw five suggestions in the evening looking at a bare plus sign,
+  with nothing saying the row exists — a nightly occurrence that reads as
+  breakage. So the label stands and one muted line says what and why.
+
+  What must **not** draw that line is an installation nobody is asked on:
+  `asking?` carries `Vutuv.Tags.Trending.asking?/0`, and an intranet vutuv with
+  no source servers gets no row at all rather than a nightly report about
+  servers it never reads.
+
   ## One press, and it is a follow like any other
 
   The pill is the whole control. Pressing it mints the tag here if nothing
@@ -38,18 +64,35 @@ defmodule VutuvWeb.PostLive.TrendingTags do
   # fault rather than as a quiet Tuesday.
   @min_bar 8
 
-  @doc "The offered tags, or nothing at all when there are none."
+  @doc """
+  The offered tags, and the row's own empty state.
+
+  `asking?` is `Vutuv.Tags.Trending.asking?/0`, and it is the row's whole gate:
+  an empty list means two opposite things, and only one of them is worth a line
+  of the card — see the moduledoc.
+  """
   attr(:tags, :list, required: true)
+  attr(:asking?, :boolean, required: true)
 
   def trending_row(assigns) do
     ~H"""
-    <div :if={@tags != []} id="trending-tags" class="pt-2">
+    <div :if={@asking?} id="trending-tags" class="pt-2">
       <p class="pb-1 text-xs text-slate-500 dark:text-slate-400">
         {gettext("Very busy on other servers right now:")}
       </p>
-      <div class="flex flex-wrap gap-2">
-        <.trending_pill :for={tag <- @tags} tag={tag} />
-      </div>
+      <%!-- One condition, two arms: the empty line and the pills are exclusive,
+      and a pair of sibling `:if`s leaves that to a convention two lines apart. --%>
+      <%= if @tags == [] do %>
+        <p class="text-xs text-slate-500 dark:text-slate-400">
+          {gettext(
+            "Nothing yet today. A topic has to run well ahead of its own last week, which takes a few hours."
+          )}
+        </p>
+      <% else %>
+        <div class="flex flex-wrap gap-2">
+          <.trending_pill :for={tag <- @tags} tag={tag} />
+        </div>
+      <% end %>
     </div>
     """
   end
@@ -72,17 +115,17 @@ defmodule VutuvWeb.PostLive.TrendingTags do
       phx-value-name={@tag.name}
       title={@label}
       aria-label={@label}
-      class="flex min-h-10 max-w-full items-center gap-2 rounded-lg bg-slate-100 px-3 py-1.5 text-sm font-semibold text-slate-700 transition hover:bg-slate-200 hover:text-slate-900 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700 dark:hover:text-slate-100"
+      class="flex max-w-full items-center gap-1.5 rounded-lg bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-600 hover:bg-slate-200 hover:text-slate-900 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-slate-100"
     >
       <span class="min-w-0 truncate">{@tag.name}</span>
       <span aria-hidden="true" class="flex h-4 flex-shrink-0 items-end gap-px">
         <span
           :for={height <- @bars.previous}
-          class="w-1 rounded-sm bg-slate-300 dark:bg-slate-600"
+          class="w-0.5 bg-slate-300 dark:bg-slate-600"
           style={"height:#{height}%"}
         >
         </span>
-        <span class="w-1 rounded-sm bg-accent" style={"height:#{@bars.today}%"}></span>
+        <span class="w-0.5 bg-accent" style={"height:#{@bars.today}%"}></span>
       </span>
     </button>
     """

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1711,7 +1711,7 @@ msgstr "Empfehlen"
 #: lib/vutuv_web/live/organization_live/following.ex:421
 #: lib/vutuv_web/live/organization_live/show.ex:602
 #: lib/vutuv_web/live/organization_live/show.ex:639
-#: lib/vutuv_web/live/post_live/feed.ex:1055
+#: lib/vutuv_web/live/post_live/feed.ex:1060
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
 #: lib/vutuv_web/templates/user/show.html.heex:1350
 #: lib/vutuv_web/views/user_html.ex:643
@@ -2144,8 +2144,8 @@ msgstr "Beitrag bearbeiten"
 #: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:203
-#: lib/vutuv_web/live/post_live/feed.ex:366
-#: lib/vutuv_web/live/post_live/feed.ex:3592
+#: lib/vutuv_web/live/post_live/feed.ex:370
+#: lib/vutuv_web/live/post_live/feed.ex:3597
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1346
 #: lib/vutuv_web/live/shell_live.ex:1692
@@ -2191,7 +2191,7 @@ msgstr "Nicht eingeloggte Besucher"
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3933
+#: lib/vutuv_web/live/post_live/feed.ex:3938
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2289,7 +2289,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2714
+#: lib/vutuv_web/live/post_live/feed.ex:2719
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2512,7 +2512,7 @@ msgstr "Gefällt mir entfernen"
 #: lib/vutuv_web/live/organization_live/following.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:476
 #: lib/vutuv_web/live/organization_live/show.ex:644
-#: lib/vutuv_web/live/post_live/feed.ex:1042
+#: lib/vutuv_web/live/post_live/feed.ex:1047
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:42
 #: lib/vutuv_web/views/user_html.ex:633
@@ -2830,7 +2830,7 @@ msgstr[0] "1 Vernetzung"
 msgstr[1] "%{formatted} Vernetzungen"
 
 #: lib/vutuv_web/live/job_board_live.ex:458
-#: lib/vutuv_web/live/post_live/feed.ex:1186
+#: lib/vutuv_web/live/post_live/feed.ex:1191
 #: lib/vutuv_web/templates/user/card_list.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -4653,7 +4653,7 @@ msgstr "Sie haben niemanden blockiert."
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3938
+#: lib/vutuv_web/live/post_live/feed.ex:3943
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
@@ -7692,7 +7692,7 @@ msgstr ""
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/media_live.ex:270
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:4232
+#: lib/vutuv_web/live/post_live/feed.ex:4238
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #: lib/vutuv_web/live/press_kit_live.ex:1081
 #, elixir-autogen
@@ -8171,7 +8171,7 @@ msgstr "Administratoren"
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
 #: lib/vutuv_web/live/job_board_live.ex:468
-#: lib/vutuv_web/live/post_live/feed.ex:1195
+#: lib/vutuv_web/live/post_live/feed.ex:1200
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr "Alle Mitglieder"
@@ -14029,7 +14029,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5556
 #: lib/vutuv_web/controllers/settings_controller.ex:643
-#: lib/vutuv_web/live/post_live/feed.ex:855
+#: lib/vutuv_web/live/post_live/feed.ex:859
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
@@ -14932,7 +14932,7 @@ msgstr ""
 "Wählen Sie unten einen Abschluss oder eine Schule, um ihn statt eines "
 "Jobtitels oben in Ihrem Profil anzuzeigen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1255
+#: lib/vutuv_web/live/post_live/feed.ex:1260
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr "Trotzdem anzeigen"
@@ -18516,7 +18516,7 @@ msgstr "Ausstellungsdatum"
 msgid "Label"
 msgstr "Bezeichnung"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3956
+#: lib/vutuv_web/live/post_live/feed.ex:3961
 #: lib/vutuv_web/live/reference_check_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -21018,7 +21018,7 @@ msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Empfohlen: quadratisch, mindestens %{width} × %{height} Pixel."
 
 #: lib/vutuv_web/live/job_board_live.ex:431
-#: lib/vutuv_web/live/post_live/feed.ex:1132
+#: lib/vutuv_web/live/post_live/feed.ex:1137
 #: lib/vutuv_web/views/user_html.ex:355
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -21639,12 +21639,12 @@ msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public po
 msgstr ""
 "Folgen Sie #%{tag} von Mastodon oder einer anderen Fediverse-App aus, dann landen die öffentlichen Beiträge in Ihrer Timeline. Ein vutuv-Konto brauchen Sie dafür nicht."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4126
+#: lib/vutuv_web/live/post_live/feed.ex:4132
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Andere Mitglieder begrüßen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:856
+#: lib/vutuv_web/live/post_live/feed.ex:860
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr "Neu dabei"
@@ -21690,7 +21690,7 @@ msgstr "Der beste Weg: Folgen Sie %{name} hier. Neue Beiträge landen in Ihrem F
 msgid "With a vutuv account"
 msgstr "Mit einem vutuv-Konto"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1124
+#: lib/vutuv_web/live/post_live/feed.ex:1129
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
@@ -22067,7 +22067,7 @@ msgstr "Alle vutuv Mitglieder, alphabetisch nach Nachname sortiert."
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr "Alle vutuv Mitglieder, gruppiert nach dem Anfangsbuchstaben des Nachnamens."
 
-#: lib/vutuv_web/live/post_live/feed.ex:981
+#: lib/vutuv_web/live/post_live/feed.ex:985
 #: lib/vutuv_web/live/post_live/filter_band.ex:350
 #, elixir-autogen, elixir-format
 msgid "A photo"
@@ -22083,7 +22083,7 @@ msgstr "Auch in längeren Wörtern: %{word} trifft auch %{example}."
 msgid "A–Z"
 msgstr "A–Z"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1082
+#: lib/vutuv_web/live/post_live/feed.ex:1087
 #, elixir-autogen, elixir-format
 msgid "Browse the tags"
 msgstr "Alle Tags ansehen"
@@ -22098,7 +22098,7 @@ msgstr "Aktivste zuerst"
 msgid "Clear all"
 msgstr "Alle löschen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:893
+#: lib/vutuv_web/live/post_live/feed.ex:897
 #, elixir-autogen, elixir-format
 msgid "Drag, or use the arrow keys"
 msgstr "Ziehen, oder die Pfeiltasten benutzen"
@@ -22113,13 +22113,13 @@ msgstr "Auf- und zuklappen"
 msgid "Find an account or a server …"
 msgstr "Konto oder Server suchen …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:917
+#: lib/vutuv_web/live/post_live/feed.ex:921
 #, elixir-autogen, elixir-format
 msgid "Fold %{card}"
 msgstr "%{card} einklappen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1053
-#: lib/vutuv_web/live/post_live/feed.ex:1054
+#: lib/vutuv_web/live/post_live/feed.ex:1058
+#: lib/vutuv_web/live/post_live/feed.ex:1059
 #, elixir-autogen, elixir-format
 msgid "Follow a tag …"
 msgstr "Einem Tag folgen …"
@@ -22136,19 +22136,19 @@ msgstr "Tag ausblenden …"
 msgid "Hide a word or a whole phrase …"
 msgstr "Wort oder ganzen Satz ausblenden …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:854
-#: lib/vutuv_web/live/post_live/feed.ex:4289
+#: lib/vutuv_web/live/post_live/feed.ex:858
+#: lib/vutuv_web/live/post_live/feed.ex:4295
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Tags ausblenden"
 
-#: lib/vutuv_web/live/post_live/feed.ex:853
-#: lib/vutuv_web/live/post_live/feed.ex:4278
+#: lib/vutuv_web/live/post_live/feed.ex:857
+#: lib/vutuv_web/live/post_live/feed.ex:4284
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Wörter ausblenden"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1088
+#: lib/vutuv_web/live/post_live/feed.ex:1093
 #: lib/vutuv_web/live/post_live/filter_band.ex:394
 #, elixir-autogen, elixir-format
 msgid "In your feed right now:"
@@ -22164,7 +22164,7 @@ msgstr "Trifft gerade nichts in Ihrem Feed — für alles Neue gilt die Regel tr
 msgid "More of your %{formatted} accounts"
 msgstr "Mehr Ihrer %{formatted} Konten"
 
-#: lib/vutuv_web/live/post_live/feed.ex:892
+#: lib/vutuv_web/live/post_live/feed.ex:896
 #, elixir-autogen, elixir-format
 msgid "Move %{card}"
 msgstr "%{card} verschieben"
@@ -22175,12 +22175,12 @@ msgstr "%{card} verschieben"
 msgid "No account found."
 msgstr "Kein Konto gefunden."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1077
+#: lib/vutuv_web/live/post_live/feed.ex:1082
 #, elixir-autogen, elixir-format
 msgid "No tag called %{name} yet."
 msgstr "Noch kein Tag namens %{name}."
 
-#: lib/vutuv_web/live/post_live/feed.ex:846
+#: lib/vutuv_web/live/post_live/feed.ex:850
 #, elixir-autogen, elixir-format
 msgid "Not read yet"
 msgstr "Noch nicht gelesen"
@@ -22210,13 +22210,13 @@ msgstr "Beiträge mit einem dieser Tags werden genauso zugeklappt."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Beiträge mit einem dieser Wörter werden auf eine Zeile zugeklappt — nicht gelöscht, und mit einem Weg, sie doch zu lesen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4152
+#: lib/vutuv_web/live/post_live/feed.ex:4158
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Weggelegt:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:938
-#: lib/vutuv_web/live/post_live/feed.ex:939
+#: lib/vutuv_web/live/post_live/feed.ex:942
+#: lib/vutuv_web/live/post_live/feed.ex:943
 #, elixir-autogen, elixir-format
 msgid "Remove %{card}"
 msgstr "%{card} entfernen"
@@ -22248,8 +22248,8 @@ msgstr "Nur %{source} anzeigen"
 msgid "Show posts by %{name}"
 msgstr "Beiträge von %{name} anzeigen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:852
-#: lib/vutuv_web/live/post_live/feed.ex:4244
+#: lib/vutuv_web/live/post_live/feed.ex:856
+#: lib/vutuv_web/live/post_live/feed.ex:4250
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr "Quellen"
@@ -22259,12 +22259,12 @@ msgstr "Quellen"
 msgid "Switching off means muting, not unfollowing. You stay a follower, the posts just stop reaching your feed: permanently and on every device, until you switch them back on here."
 msgstr "Ausschalten heißt stumm schalten, nicht entfolgen. Sie folgen weiter, die Beiträge bleiben nur aus Ihrem Feed: dauerhaft und auf allen Geräten, bis Sie hier wieder einschalten."
 
-#: lib/vutuv_web/live/post_live/feed.ex:916
+#: lib/vutuv_web/live/post_live/feed.ex:920
 #, elixir-autogen, elixir-format
 msgid "Unfold %{card}"
 msgstr "%{card} ausklappen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1043
+#: lib/vutuv_web/live/post_live/feed.ex:1048
 #, elixir-autogen, elixir-format
 msgid "Unfollow the tag %{tag}"
 msgstr "Dem Tag %{tag} nicht mehr folgen"
@@ -22288,20 +22288,20 @@ msgid_plural "and %{formatted} more"
 msgstr[0] "und 1 weiterer"
 msgstr[1] "und %{formatted} weitere"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3709
-#: lib/vutuv_web/live/post_live/feed.ex:3736
+#: lib/vutuv_web/live/post_live/feed.ex:3714
+#: lib/vutuv_web/live/post_live/feed.ex:3741
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
 msgstr "Filter"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1263
+#: lib/vutuv_web/live/post_live/feed.ex:1268
 #, elixir-autogen, elixir-format
 msgctxt "filtered post"
 msgid "Hidden:"
 msgstr "Ausgeblendet:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:991
+#: lib/vutuv_web/live/post_live/feed.ex:995
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} post in the feed"
 msgid_plural "Show %{formatted} posts in the feed"
@@ -22355,7 +22355,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} Beitrag am %{day}"
 msgstr[1] "%{count} Beiträge am %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3913
+#: lib/vutuv_web/live/post_live/feed.ex:3918
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Zurück zu jetzt"
@@ -22365,7 +22365,7 @@ msgstr "Zurück zu jetzt"
 msgid "Busy month: the shading counts at least this much."
 msgstr "Voller Monat: die Färbung zählt mindestens so viel."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3959
+#: lib/vutuv_web/live/post_live/feed.ex:3964
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -22387,7 +22387,7 @@ msgstr "Nächster Monat"
 msgid "Next year"
 msgstr "Nächstes Jahr"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3909
+#: lib/vutuv_web/live/post_live/feed.ex:3914
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Am %{day} ist nichts in Ihrem Feed angekommen."
@@ -22474,7 +22474,7 @@ msgstr "Neue Version bereit."
 msgid "Page management"
 msgstr "Verwaltung"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2708
+#: lib/vutuv_web/live/post_live/feed.ex:2713
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
@@ -22506,7 +22506,7 @@ msgstr "Ein Konto erwähnen"
 msgid "{used} of {max} mentions"
 msgstr "{used} von {max} Erwähnungen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2820
+#: lib/vutuv_web/live/post_live/feed.ex:2825
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr "Bis hier neu"
@@ -22721,7 +22721,7 @@ msgctxt "phone tab bar"
 msgid "Write"
 msgstr "Schreiben"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4047
+#: lib/vutuv_web/live/post_live/feed.ex:4052
 #: lib/vutuv_web/live/post_rewrites_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "%{formatted} rule"
@@ -23518,8 +23518,8 @@ msgstr "Beiträge in Ihrem Feed"
 msgid "Posts loaded at once"
 msgstr "Beiträge auf einmal"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3983
-#: lib/vutuv_web/live/post_live/feed.ex:3987
+#: lib/vutuv_web/live/post_live/feed.ex:3988
+#: lib/vutuv_web/live/post_live/feed.ex:3992
 #, elixir-autogen, elixir-format
 msgid "Posts per page"
 msgstr "Beiträge pro Seite"
@@ -23545,14 +23545,14 @@ msgstr "Ein Wort oder eine Wortgruppe …"
 msgid "For whom %{thing} is hidden"
 msgstr "Für wen %{thing} ausgeblendet wird"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4044
-#: lib/vutuv_web/live/post_live/feed.ex:4208
-#: lib/vutuv_web/live/post_live/feed.ex:4217
+#: lib/vutuv_web/live/post_live/feed.ex:4049
+#: lib/vutuv_web/live/post_live/feed.ex:4214
+#: lib/vutuv_web/live/post_live/feed.ex:4223
 #, elixir-autogen, elixir-format
 msgid "Hidden"
 msgstr "Ausgeblendet"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4182
+#: lib/vutuv_web/live/post_live/feed.ex:4188
 #, elixir-autogen, elixir-format
 msgid "Hide something from your feed"
 msgstr "Etwas aus dem Feed ausblenden"
@@ -23562,12 +23562,12 @@ msgstr "Etwas aus dem Feed ausblenden"
 msgid "Stop showing"
 msgstr "Nicht mehr zeigen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4223
+#: lib/vutuv_web/live/post_live/feed.ex:4229
 #, elixir-autogen, elixir-format
 msgid "Whatever these match is folded to a single line in your feed."
 msgstr "Was hiervon getroffen wird, klappt im Feed auf eine Zeile zu."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4243
+#: lib/vutuv_web/live/post_live/feed.ex:4249
 #, elixir-autogen, elixir-format
 msgid "Words & tags"
 msgstr "Wörter & Tags"
@@ -25399,14 +25399,14 @@ msgctxt "content type"
 msgid "File"
 msgstr "Datei"
 
-#: lib/vutuv_web/live/post_live/trending_tags.ex:96
+#: lib/vutuv_web/live/post_live/trending_tags.ex:139
 #, elixir-autogen, elixir-format
 msgid "Follow %{tag}. %{uses} uses today on %{servers} server, against %{baseline} on an ordinary day."
 msgid_plural "Follow %{tag}. %{uses} uses today on %{servers} servers, against %{baseline} on an ordinary day."
 msgstr[0] "%{tag} folgen. Heute %{uses} Beiträge auf %{servers} Server, an einem gewöhnlichen Tag %{baseline}."
 msgstr[1] "%{tag} folgen. Heute %{uses} Beiträge auf %{servers} Servern, an einem gewöhnlichen Tag %{baseline}."
 
-#: lib/vutuv_web/live/post_live/trending_tags.ex:48
+#: lib/vutuv_web/live/post_live/trending_tags.ex:81
 #, elixir-autogen, elixir-format
 msgid "Very busy on other servers right now:"
 msgstr "Gerade sehr aktiv auf anderen Servern:"
@@ -25610,6 +25610,11 @@ msgstr "Dieses Logo enthält %{marker}, was vutuv als eingebettete Datei liest u
 #, elixir-autogen, elixir-format
 msgid "This logo has a file embedded in it, usually a web font, that vutuv cannot check. Export it again with the text converted to outlines."
 msgstr "Dieses Logo enthält eine eingebettete Datei, meist eine Web-Schrift, die vutuv nicht prüfen kann. Bitte exportieren Sie es erneut mit in Pfade umgewandelter Schrift."
+
+#: lib/vutuv_web/live/post_live/trending_tags.ex:87
+#, elixir-autogen, elixir-format
+msgid "Nothing yet today. A topic has to run well ahead of its own last week, which takes a few hours."
+msgstr "Heute noch nichts. Ein Thema muss deutlich über seiner eigenen Vorwoche liegen, und das dauert ein paar Stunden."
 
 #: lib/vutuv_web/components/pending_post_components.ex:64
 #, elixir-autogen, elixir-format

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1684,7 +1684,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:421
 #: lib/vutuv_web/live/organization_live/show.ex:602
 #: lib/vutuv_web/live/organization_live/show.ex:639
-#: lib/vutuv_web/live/post_live/feed.ex:1055
+#: lib/vutuv_web/live/post_live/feed.ex:1060
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
 #: lib/vutuv_web/templates/user/show.html.heex:1350
 #: lib/vutuv_web/views/user_html.ex:643
@@ -2106,8 +2106,8 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:203
-#: lib/vutuv_web/live/post_live/feed.ex:366
-#: lib/vutuv_web/live/post_live/feed.ex:3592
+#: lib/vutuv_web/live/post_live/feed.ex:370
+#: lib/vutuv_web/live/post_live/feed.ex:3597
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1346
 #: lib/vutuv_web/live/shell_live.ex:1692
@@ -2153,7 +2153,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3933
+#: lib/vutuv_web/live/post_live/feed.ex:3938
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2247,7 +2247,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2714
+#: lib/vutuv_web/live/post_live/feed.ex:2719
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2470,7 +2470,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:476
 #: lib/vutuv_web/live/organization_live/show.ex:644
-#: lib/vutuv_web/live/post_live/feed.ex:1042
+#: lib/vutuv_web/live/post_live/feed.ex:1047
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:42
 #: lib/vutuv_web/views/user_html.ex:633
@@ -2786,7 +2786,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/live/job_board_live.ex:458
-#: lib/vutuv_web/live/post_live/feed.ex:1186
+#: lib/vutuv_web/live/post_live/feed.ex:1191
 #: lib/vutuv_web/templates/user/card_list.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -4495,7 +4495,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3938
+#: lib/vutuv_web/live/post_live/feed.ex:3943
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -7393,7 +7393,7 @@ msgstr ""
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/media_live.ex:270
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:4232
+#: lib/vutuv_web/live/post_live/feed.ex:4238
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #: lib/vutuv_web/live/press_kit_live.ex:1081
 #, elixir-autogen
@@ -7836,7 +7836,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
 #: lib/vutuv_web/live/job_board_live.ex:468
-#: lib/vutuv_web/live/post_live/feed.ex:1195
+#: lib/vutuv_web/live/post_live/feed.ex:1200
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr ""
@@ -13378,7 +13378,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5556
 #: lib/vutuv_web/controllers/settings_controller.ex:643
-#: lib/vutuv_web/live/post_live/feed.ex:855
+#: lib/vutuv_web/live/post_live/feed.ex:859
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
@@ -14261,7 +14261,7 @@ msgstr ""
 msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1255
+#: lib/vutuv_web/live/post_live/feed.ex:1260
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -17794,7 +17794,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3956
+#: lib/vutuv_web/live/post_live/feed.ex:3961
 #: lib/vutuv_web/live/reference_check_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -20263,7 +20263,7 @@ msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:431
-#: lib/vutuv_web/live/post_live/feed.ex:1132
+#: lib/vutuv_web/live/post_live/feed.ex:1137
 #: lib/vutuv_web/views/user_html.ex:355
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -20883,12 +20883,12 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4126
+#: lib/vutuv_web/live/post_live/feed.ex:4132
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:856
+#: lib/vutuv_web/live/post_live/feed.ex:860
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr ""
@@ -20934,7 +20934,7 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1124
+#: lib/vutuv_web/live/post_live/feed.ex:1129
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
@@ -21286,7 +21286,7 @@ msgstr ""
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:981
+#: lib/vutuv_web/live/post_live/feed.ex:985
 #: lib/vutuv_web/live/post_live/filter_band.ex:350
 #, elixir-autogen, elixir-format
 msgid "A photo"
@@ -21302,7 +21302,7 @@ msgstr ""
 msgid "A–Z"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1082
+#: lib/vutuv_web/live/post_live/feed.ex:1087
 #, elixir-autogen, elixir-format
 msgid "Browse the tags"
 msgstr ""
@@ -21317,7 +21317,7 @@ msgstr ""
 msgid "Clear all"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:893
+#: lib/vutuv_web/live/post_live/feed.ex:897
 #, elixir-autogen, elixir-format
 msgid "Drag, or use the arrow keys"
 msgstr ""
@@ -21332,13 +21332,13 @@ msgstr ""
 msgid "Find an account or a server …"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:917
+#: lib/vutuv_web/live/post_live/feed.ex:921
 #, elixir-autogen, elixir-format
 msgid "Fold %{card}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1053
-#: lib/vutuv_web/live/post_live/feed.ex:1054
+#: lib/vutuv_web/live/post_live/feed.ex:1058
+#: lib/vutuv_web/live/post_live/feed.ex:1059
 #, elixir-autogen, elixir-format
 msgid "Follow a tag …"
 msgstr ""
@@ -21355,19 +21355,19 @@ msgstr ""
 msgid "Hide a word or a whole phrase …"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:854
-#: lib/vutuv_web/live/post_live/feed.ex:4289
+#: lib/vutuv_web/live/post_live/feed.ex:858
+#: lib/vutuv_web/live/post_live/feed.ex:4295
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:853
-#: lib/vutuv_web/live/post_live/feed.ex:4278
+#: lib/vutuv_web/live/post_live/feed.ex:857
+#: lib/vutuv_web/live/post_live/feed.ex:4284
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1088
+#: lib/vutuv_web/live/post_live/feed.ex:1093
 #: lib/vutuv_web/live/post_live/filter_band.ex:394
 #, elixir-autogen, elixir-format
 msgid "In your feed right now:"
@@ -21383,7 +21383,7 @@ msgstr ""
 msgid "More of your %{formatted} accounts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:892
+#: lib/vutuv_web/live/post_live/feed.ex:896
 #, elixir-autogen, elixir-format
 msgid "Move %{card}"
 msgstr ""
@@ -21394,12 +21394,12 @@ msgstr ""
 msgid "No account found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1077
+#: lib/vutuv_web/live/post_live/feed.ex:1082
 #, elixir-autogen, elixir-format
 msgid "No tag called %{name} yet."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:846
+#: lib/vutuv_web/live/post_live/feed.ex:850
 #, elixir-autogen, elixir-format
 msgid "Not read yet"
 msgstr ""
@@ -21429,13 +21429,13 @@ msgstr ""
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4152
+#: lib/vutuv_web/live/post_live/feed.ex:4158
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:938
-#: lib/vutuv_web/live/post_live/feed.ex:939
+#: lib/vutuv_web/live/post_live/feed.ex:942
+#: lib/vutuv_web/live/post_live/feed.ex:943
 #, elixir-autogen, elixir-format
 msgid "Remove %{card}"
 msgstr ""
@@ -21467,8 +21467,8 @@ msgstr ""
 msgid "Show posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:852
-#: lib/vutuv_web/live/post_live/feed.ex:4244
+#: lib/vutuv_web/live/post_live/feed.ex:856
+#: lib/vutuv_web/live/post_live/feed.ex:4250
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr ""
@@ -21478,12 +21478,12 @@ msgstr ""
 msgid "Switching off means muting, not unfollowing. You stay a follower, the posts just stop reaching your feed: permanently and on every device, until you switch them back on here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:916
+#: lib/vutuv_web/live/post_live/feed.ex:920
 #, elixir-autogen, elixir-format
 msgid "Unfold %{card}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1043
+#: lib/vutuv_web/live/post_live/feed.ex:1048
 #, elixir-autogen, elixir-format
 msgid "Unfollow the tag %{tag}"
 msgstr ""
@@ -21507,20 +21507,20 @@ msgid_plural "and %{formatted} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3709
-#: lib/vutuv_web/live/post_live/feed.ex:3736
+#: lib/vutuv_web/live/post_live/feed.ex:3714
+#: lib/vutuv_web/live/post_live/feed.ex:3741
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1263
+#: lib/vutuv_web/live/post_live/feed.ex:1268
 #, elixir-autogen, elixir-format
 msgctxt "filtered post"
 msgid "Hidden:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:991
+#: lib/vutuv_web/live/post_live/feed.ex:995
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} post in the feed"
 msgid_plural "Show %{formatted} posts in the feed"
@@ -21570,7 +21570,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3913
+#: lib/vutuv_web/live/post_live/feed.ex:3918
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr ""
@@ -21580,7 +21580,7 @@ msgstr ""
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3959
+#: lib/vutuv_web/live/post_live/feed.ex:3964
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -21602,7 +21602,7 @@ msgstr ""
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3909
+#: lib/vutuv_web/live/post_live/feed.ex:3914
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
@@ -21689,7 +21689,7 @@ msgstr ""
 msgid "Page management"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2708
+#: lib/vutuv_web/live/post_live/feed.ex:2713
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
@@ -21721,7 +21721,7 @@ msgstr ""
 msgid "{used} of {max} mentions"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2820
+#: lib/vutuv_web/live/post_live/feed.ex:2825
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr ""
@@ -21936,7 +21936,7 @@ msgctxt "phone tab bar"
 msgid "Write"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4047
+#: lib/vutuv_web/live/post_live/feed.ex:4052
 #: lib/vutuv_web/live/post_rewrites_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "%{formatted} rule"
@@ -22733,8 +22733,8 @@ msgstr ""
 msgid "Posts loaded at once"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3983
-#: lib/vutuv_web/live/post_live/feed.ex:3987
+#: lib/vutuv_web/live/post_live/feed.ex:3988
+#: lib/vutuv_web/live/post_live/feed.ex:3992
 #, elixir-autogen, elixir-format
 msgid "Posts per page"
 msgstr ""
@@ -22760,14 +22760,14 @@ msgstr ""
 msgid "For whom %{thing} is hidden"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4044
-#: lib/vutuv_web/live/post_live/feed.ex:4208
-#: lib/vutuv_web/live/post_live/feed.ex:4217
+#: lib/vutuv_web/live/post_live/feed.ex:4049
+#: lib/vutuv_web/live/post_live/feed.ex:4214
+#: lib/vutuv_web/live/post_live/feed.ex:4223
 #, elixir-autogen, elixir-format
 msgid "Hidden"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4182
+#: lib/vutuv_web/live/post_live/feed.ex:4188
 #, elixir-autogen, elixir-format
 msgid "Hide something from your feed"
 msgstr ""
@@ -22777,12 +22777,12 @@ msgstr ""
 msgid "Stop showing"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4223
+#: lib/vutuv_web/live/post_live/feed.ex:4229
 #, elixir-autogen, elixir-format
 msgid "Whatever these match is folded to a single line in your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4243
+#: lib/vutuv_web/live/post_live/feed.ex:4249
 #, elixir-autogen, elixir-format
 msgid "Words & tags"
 msgstr ""
@@ -24566,14 +24566,14 @@ msgctxt "content type"
 msgid "File"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/trending_tags.ex:96
+#: lib/vutuv_web/live/post_live/trending_tags.ex:139
 #, elixir-autogen, elixir-format
 msgid "Follow %{tag}. %{uses} uses today on %{servers} server, against %{baseline} on an ordinary day."
 msgid_plural "Follow %{tag}. %{uses} uses today on %{servers} servers, against %{baseline} on an ordinary day."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/trending_tags.ex:48
+#: lib/vutuv_web/live/post_live/trending_tags.ex:81
 #, elixir-autogen, elixir-format
 msgid "Very busy on other servers right now:"
 msgstr ""
@@ -24776,6 +24776,11 @@ msgstr ""
 #: lib/vutuv_web/live/press_kit_live.ex:549
 #, elixir-autogen, elixir-format
 msgid "This logo has a file embedded in it, usually a web font, that vutuv cannot check. Export it again with the text converted to outlines."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/trending_tags.ex:87
+#, elixir-autogen, elixir-format
+msgid "Nothing yet today. A topic has to run well ahead of its own last week, which takes a few hours."
 msgstr ""
 
 #: lib/vutuv_web/components/pending_post_components.ex:64

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1682,7 +1682,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:421
 #: lib/vutuv_web/live/organization_live/show.ex:602
 #: lib/vutuv_web/live/organization_live/show.ex:639
-#: lib/vutuv_web/live/post_live/feed.ex:1055
+#: lib/vutuv_web/live/post_live/feed.ex:1060
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
 #: lib/vutuv_web/templates/user/show.html.heex:1350
 #: lib/vutuv_web/views/user_html.ex:643
@@ -2104,8 +2104,8 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:203
-#: lib/vutuv_web/live/post_live/feed.ex:366
-#: lib/vutuv_web/live/post_live/feed.ex:3592
+#: lib/vutuv_web/live/post_live/feed.ex:370
+#: lib/vutuv_web/live/post_live/feed.ex:3597
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1346
 #: lib/vutuv_web/live/shell_live.ex:1692
@@ -2151,7 +2151,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3933
+#: lib/vutuv_web/live/post_live/feed.ex:3938
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2245,7 +2245,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2714
+#: lib/vutuv_web/live/post_live/feed.ex:2719
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2468,7 +2468,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:476
 #: lib/vutuv_web/live/organization_live/show.ex:644
-#: lib/vutuv_web/live/post_live/feed.ex:1042
+#: lib/vutuv_web/live/post_live/feed.ex:1047
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:42
 #: lib/vutuv_web/views/user_html.ex:633
@@ -2784,7 +2784,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/live/job_board_live.ex:458
-#: lib/vutuv_web/live/post_live/feed.ex:1186
+#: lib/vutuv_web/live/post_live/feed.ex:1191
 #: lib/vutuv_web/templates/user/card_list.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -4493,7 +4493,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3938
+#: lib/vutuv_web/live/post_live/feed.ex:3943
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -7391,7 +7391,7 @@ msgstr ""
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/media_live.ex:270
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:4232
+#: lib/vutuv_web/live/post_live/feed.ex:4238
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #: lib/vutuv_web/live/press_kit_live.ex:1081
 #, elixir-autogen
@@ -7834,7 +7834,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
 #: lib/vutuv_web/live/job_board_live.ex:468
-#: lib/vutuv_web/live/post_live/feed.ex:1195
+#: lib/vutuv_web/live/post_live/feed.ex:1200
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr ""
@@ -13376,7 +13376,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5556
 #: lib/vutuv_web/controllers/settings_controller.ex:643
-#: lib/vutuv_web/live/post_live/feed.ex:855
+#: lib/vutuv_web/live/post_live/feed.ex:859
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
@@ -14259,7 +14259,7 @@ msgstr ""
 msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1255
+#: lib/vutuv_web/live/post_live/feed.ex:1260
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -17792,7 +17792,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3956
+#: lib/vutuv_web/live/post_live/feed.ex:3961
 #: lib/vutuv_web/live/reference_check_live.ex:169
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Loading…"
@@ -20261,7 +20261,7 @@ msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:431
-#: lib/vutuv_web/live/post_live/feed.ex:1132
+#: lib/vutuv_web/live/post_live/feed.ex:1137
 #: lib/vutuv_web/views/user_html.ex:355
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -20881,12 +20881,12 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4126
+#: lib/vutuv_web/live/post_live/feed.ex:4132
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:856
+#: lib/vutuv_web/live/post_live/feed.ex:860
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr ""
@@ -20932,7 +20932,7 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1124
+#: lib/vutuv_web/live/post_live/feed.ex:1129
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
@@ -21284,7 +21284,7 @@ msgstr ""
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:981
+#: lib/vutuv_web/live/post_live/feed.ex:985
 #: lib/vutuv_web/live/post_live/filter_band.ex:350
 #, elixir-autogen, elixir-format
 msgid "A photo"
@@ -21300,7 +21300,7 @@ msgstr ""
 msgid "A–Z"
 msgstr "A–Z"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1082
+#: lib/vutuv_web/live/post_live/feed.ex:1087
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Browse the tags"
 msgstr ""
@@ -21315,7 +21315,7 @@ msgstr "Busiest first"
 msgid "Clear all"
 msgstr "Clear all"
 
-#: lib/vutuv_web/live/post_live/feed.ex:893
+#: lib/vutuv_web/live/post_live/feed.ex:897
 #, elixir-autogen, elixir-format
 msgid "Drag, or use the arrow keys"
 msgstr ""
@@ -21330,13 +21330,13 @@ msgstr "Expand or collapse"
 msgid "Find an account or a server …"
 msgstr "Find an account …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:917
+#: lib/vutuv_web/live/post_live/feed.ex:921
 #, elixir-autogen, elixir-format
 msgid "Fold %{card}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1053
-#: lib/vutuv_web/live/post_live/feed.ex:1054
+#: lib/vutuv_web/live/post_live/feed.ex:1058
+#: lib/vutuv_web/live/post_live/feed.ex:1059
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follow a tag …"
 msgstr ""
@@ -21353,19 +21353,19 @@ msgstr "Hide a tag …"
 msgid "Hide a word or a whole phrase …"
 msgstr "Hide a word or a whole phrase …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:854
-#: lib/vutuv_web/live/post_live/feed.ex:4289
+#: lib/vutuv_web/live/post_live/feed.ex:858
+#: lib/vutuv_web/live/post_live/feed.ex:4295
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Hide tags"
 
-#: lib/vutuv_web/live/post_live/feed.ex:853
-#: lib/vutuv_web/live/post_live/feed.ex:4278
+#: lib/vutuv_web/live/post_live/feed.ex:857
+#: lib/vutuv_web/live/post_live/feed.ex:4284
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Hide words"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1088
+#: lib/vutuv_web/live/post_live/feed.ex:1093
 #: lib/vutuv_web/live/post_live/filter_band.ex:394
 #, elixir-autogen, elixir-format
 msgid "In your feed right now:"
@@ -21381,7 +21381,7 @@ msgstr "Matches nothing in your feed right now — the rule still holds for what
 msgid "More of your %{formatted} accounts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:892
+#: lib/vutuv_web/live/post_live/feed.ex:896
 #, elixir-autogen, elixir-format
 msgid "Move %{card}"
 msgstr ""
@@ -21392,12 +21392,12 @@ msgstr ""
 msgid "No account found."
 msgstr "No account found."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1077
+#: lib/vutuv_web/live/post_live/feed.ex:1082
 #, elixir-autogen, elixir-format
 msgid "No tag called %{name} yet."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:846
+#: lib/vutuv_web/live/post_live/feed.ex:850
 #, elixir-autogen, elixir-format
 msgid "Not read yet"
 msgstr "Not read yet"
@@ -21427,13 +21427,13 @@ msgstr "Posts carrying one of these tags are folded the same way."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4152
+#: lib/vutuv_web/live/post_live/feed.ex:4158
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:938
-#: lib/vutuv_web/live/post_live/feed.ex:939
+#: lib/vutuv_web/live/post_live/feed.ex:942
+#: lib/vutuv_web/live/post_live/feed.ex:943
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove %{card}"
 msgstr ""
@@ -21465,8 +21465,8 @@ msgstr ""
 msgid "Show posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:852
-#: lib/vutuv_web/live/post_live/feed.ex:4244
+#: lib/vutuv_web/live/post_live/feed.ex:856
+#: lib/vutuv_web/live/post_live/feed.ex:4250
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sources"
 msgstr ""
@@ -21476,12 +21476,12 @@ msgstr ""
 msgid "Switching off means muting, not unfollowing. You stay a follower, the posts just stop reaching your feed: permanently and on every device, until you switch them back on here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:916
+#: lib/vutuv_web/live/post_live/feed.ex:920
 #, elixir-autogen, elixir-format
 msgid "Unfold %{card}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1043
+#: lib/vutuv_web/live/post_live/feed.ex:1048
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unfollow the tag %{tag}"
 msgstr ""
@@ -21505,20 +21505,20 @@ msgid_plural "and %{formatted} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3709
-#: lib/vutuv_web/live/post_live/feed.ex:3736
+#: lib/vutuv_web/live/post_live/feed.ex:3714
+#: lib/vutuv_web/live/post_live/feed.ex:3741
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "feed filter sheet"
 msgid "Filter"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1263
+#: lib/vutuv_web/live/post_live/feed.ex:1268
 #, elixir-autogen, elixir-format
 msgctxt "filtered post"
 msgid "Hidden:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:991
+#: lib/vutuv_web/live/post_live/feed.ex:995
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} post in the feed"
 msgid_plural "Show %{formatted} posts in the feed"
@@ -21568,7 +21568,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3913
+#: lib/vutuv_web/live/post_live/feed.ex:3918
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Back to now"
 msgstr ""
@@ -21578,7 +21578,7 @@ msgstr ""
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3959
+#: lib/vutuv_web/live/post_live/feed.ex:3964
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -21600,7 +21600,7 @@ msgstr ""
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3909
+#: lib/vutuv_web/live/post_live/feed.ex:3914
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
@@ -21687,7 +21687,7 @@ msgstr ""
 msgid "Page management"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2708
+#: lib/vutuv_web/live/post_live/feed.ex:2713
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
@@ -21719,7 +21719,7 @@ msgstr ""
 msgid "{used} of {max} mentions"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2820
+#: lib/vutuv_web/live/post_live/feed.ex:2825
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr ""
@@ -21934,7 +21934,7 @@ msgctxt "phone tab bar"
 msgid "Write"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4047
+#: lib/vutuv_web/live/post_live/feed.ex:4052
 #: lib/vutuv_web/live/post_rewrites_live.ex:287
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} rule"
@@ -22731,8 +22731,8 @@ msgstr ""
 msgid "Posts loaded at once"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3983
-#: lib/vutuv_web/live/post_live/feed.ex:3987
+#: lib/vutuv_web/live/post_live/feed.ex:3988
+#: lib/vutuv_web/live/post_live/feed.ex:3992
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posts per page"
 msgstr ""
@@ -22758,14 +22758,14 @@ msgstr ""
 msgid "For whom %{thing} is hidden"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4044
-#: lib/vutuv_web/live/post_live/feed.ex:4208
-#: lib/vutuv_web/live/post_live/feed.ex:4217
+#: lib/vutuv_web/live/post_live/feed.ex:4049
+#: lib/vutuv_web/live/post_live/feed.ex:4214
+#: lib/vutuv_web/live/post_live/feed.ex:4223
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Hidden"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4182
+#: lib/vutuv_web/live/post_live/feed.ex:4188
 #, elixir-autogen, elixir-format
 msgid "Hide something from your feed"
 msgstr ""
@@ -22775,12 +22775,12 @@ msgstr ""
 msgid "Stop showing"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4223
+#: lib/vutuv_web/live/post_live/feed.ex:4229
 #, elixir-autogen, elixir-format
 msgid "Whatever these match is folded to a single line in your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:4243
+#: lib/vutuv_web/live/post_live/feed.ex:4249
 #, elixir-autogen, elixir-format
 msgid "Words & tags"
 msgstr ""
@@ -24564,14 +24564,14 @@ msgctxt "content type"
 msgid "File"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/trending_tags.ex:96
+#: lib/vutuv_web/live/post_live/trending_tags.ex:139
 #, elixir-autogen, elixir-format
 msgid "Follow %{tag}. %{uses} uses today on %{servers} server, against %{baseline} on an ordinary day."
 msgid_plural "Follow %{tag}. %{uses} uses today on %{servers} servers, against %{baseline} on an ordinary day."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/trending_tags.ex:48
+#: lib/vutuv_web/live/post_live/trending_tags.ex:81
 #, elixir-autogen, elixir-format
 msgid "Very busy on other servers right now:"
 msgstr ""
@@ -24774,6 +24774,11 @@ msgstr ""
 #: lib/vutuv_web/live/press_kit_live.ex:549
 #, elixir-autogen, elixir-format
 msgid "This logo has a file embedded in it, usually a web font, that vutuv cannot check. Export it again with the text converted to outlines."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/trending_tags.ex:87
+#, elixir-autogen, elixir-format
+msgid "Nothing yet today. A topic has to run well ahead of its own last week, which takes a few hours."
 msgstr ""
 
 #: lib/vutuv_web/components/pending_post_components.ex:64

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -1712,7 +1712,7 @@ msgstr "Conferma"
 #: lib/vutuv_web/live/organization_live/following.ex:421
 #: lib/vutuv_web/live/organization_live/show.ex:602
 #: lib/vutuv_web/live/organization_live/show.ex:639
-#: lib/vutuv_web/live/post_live/feed.ex:1055
+#: lib/vutuv_web/live/post_live/feed.ex:1060
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
 #: lib/vutuv_web/templates/user/show.html.heex:1350
 #: lib/vutuv_web/views/user_html.ex:643
@@ -2146,8 +2146,8 @@ msgstr "Modifica il post"
 #: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:203
-#: lib/vutuv_web/live/post_live/feed.ex:366
-#: lib/vutuv_web/live/post_live/feed.ex:3592
+#: lib/vutuv_web/live/post_live/feed.ex:370
+#: lib/vutuv_web/live/post_live/feed.ex:3597
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1346
 #: lib/vutuv_web/live/shell_live.ex:1692
@@ -2193,7 +2193,7 @@ msgstr "Visitatori non connessi"
 msgid "No more than %{max} images per post."
 msgstr "Non più di %{max} immagini per post."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3933
+#: lib/vutuv_web/live/post_live/feed.ex:3938
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2291,7 +2291,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Salvataggio…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2714
+#: lib/vutuv_web/live/post_live/feed.ex:2719
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2514,7 +2514,7 @@ msgstr "Togli Mi piace"
 #: lib/vutuv_web/live/organization_live/following.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:476
 #: lib/vutuv_web/live/organization_live/show.ex:644
-#: lib/vutuv_web/live/post_live/feed.ex:1042
+#: lib/vutuv_web/live/post_live/feed.ex:1047
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:42
 #: lib/vutuv_web/views/user_html.ex:633
@@ -2837,7 +2837,7 @@ msgstr[0] "1 collegamento"
 msgstr[1] "%{formatted} collegamenti"
 
 #: lib/vutuv_web/live/job_board_live.ex:458
-#: lib/vutuv_web/live/post_live/feed.ex:1186
+#: lib/vutuv_web/live/post_live/feed.ex:1191
 #: lib/vutuv_web/templates/user/card_list.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -4661,7 +4661,7 @@ msgstr "Non ha bloccato nessuno."
 msgid "You unblocked @%{slug}."
 msgstr "Ha sbloccato @%{slug}."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3938
+#: lib/vutuv_web/live/post_live/feed.ex:3943
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Scopra persone da seguire"
@@ -7677,7 +7677,7 @@ msgstr "Si aggiorna da sola. Può lasciare questa pagina: l'invio prosegue."
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/media_live.ex:270
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:4232
+#: lib/vutuv_web/live/post_live/feed.ex:4238
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #: lib/vutuv_web/live/press_kit_live.ex:1081
 #, elixir-autogen
@@ -8157,7 +8157,7 @@ msgstr "Amministratori"
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
 #: lib/vutuv_web/live/job_board_live.ex:468
-#: lib/vutuv_web/live/post_live/feed.ex:1195
+#: lib/vutuv_web/live/post_live/feed.ex:1200
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr "Tutti i membri"
@@ -14103,7 +14103,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5556
 #: lib/vutuv_web/controllers/settings_controller.ex:643
-#: lib/vutuv_web/live/post_live/feed.ex:855
+#: lib/vutuv_web/live/post_live/feed.ex:859
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
@@ -15053,7 +15053,7 @@ msgstr ""
 "Scelga qui sotto un titolo di studio o un istituto da mostrare in cima al "
 "Suo profilo al posto di una qualifica."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1255
+#: lib/vutuv_web/live/post_live/feed.ex:1260
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr "Mostra comunque"
@@ -18910,7 +18910,7 @@ msgstr "Rilasciato il"
 msgid "Label"
 msgstr "Etichetta"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3956
+#: lib/vutuv_web/live/post_live/feed.ex:3961
 #: lib/vutuv_web/live/reference_check_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -21634,7 +21634,7 @@ msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Consigliato: quadrata, almeno %{width} × %{height} pixel."
 
 #: lib/vutuv_web/live/job_board_live.ex:431
-#: lib/vutuv_web/live/post_live/feed.ex:1132
+#: lib/vutuv_web/live/post_live/feed.ex:1137
 #: lib/vutuv_web/views/user_html.ex:355
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -22330,12 +22330,12 @@ msgstr ""
 "Segua #%{tag} da Mastodon o da qualsiasi altra app del Fediverso e i suoi "
 "post pubblici arriveranno nella Sua cronologia. Non serve un account vutuv."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4126
+#: lib/vutuv_web/live/post_live/feed.ex:4132
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Saluti gli altri membri"
 
-#: lib/vutuv_web/live/post_live/feed.ex:856
+#: lib/vutuv_web/live/post_live/feed.ex:860
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr "Nuovi qui"
@@ -22385,7 +22385,7 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr "Con un account vutuv"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1124
+#: lib/vutuv_web/live/post_live/feed.ex:1129
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr "Alcuni fra i membri più recenti. Seguirli è un bel benvenuto."
@@ -22746,7 +22746,7 @@ msgstr "Tutti i membri vutuv, in ordine alfabetico per cognome."
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr "Tutti i membri vutuv, raggruppati per la prima lettera del cognome."
 
-#: lib/vutuv_web/live/post_live/feed.ex:981
+#: lib/vutuv_web/live/post_live/feed.ex:985
 #: lib/vutuv_web/live/post_live/filter_band.ex:350
 #, elixir-autogen, elixir-format
 msgid "A photo"
@@ -22762,7 +22762,7 @@ msgstr "Anche dentro parole più lunghe: %{word} trova anche %{example}."
 msgid "A–Z"
 msgstr "A–Z"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1082
+#: lib/vutuv_web/live/post_live/feed.ex:1087
 #, elixir-autogen, elixir-format
 msgid "Browse the tags"
 msgstr "Sfoglia i tag"
@@ -22777,7 +22777,7 @@ msgstr "Più attivi per primi"
 msgid "Clear all"
 msgstr "Cancella tutto"
 
-#: lib/vutuv_web/live/post_live/feed.ex:893
+#: lib/vutuv_web/live/post_live/feed.ex:897
 #, elixir-autogen, elixir-format
 msgid "Drag, or use the arrow keys"
 msgstr "Trascina, oppure usa i tasti freccia"
@@ -22792,13 +22792,13 @@ msgstr "Espandi o comprimi"
 msgid "Find an account or a server …"
 msgstr "Cerca un account o un server …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:917
+#: lib/vutuv_web/live/post_live/feed.ex:921
 #, elixir-autogen, elixir-format
 msgid "Fold %{card}"
 msgstr "Riduci %{card}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1053
-#: lib/vutuv_web/live/post_live/feed.ex:1054
+#: lib/vutuv_web/live/post_live/feed.ex:1058
+#: lib/vutuv_web/live/post_live/feed.ex:1059
 #, elixir-autogen, elixir-format
 msgid "Follow a tag …"
 msgstr "Segui un tag …"
@@ -22815,19 +22815,19 @@ msgstr "Nascondi un tag …"
 msgid "Hide a word or a whole phrase …"
 msgstr "Nascondi una parola o un'intera frase …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:854
-#: lib/vutuv_web/live/post_live/feed.ex:4289
+#: lib/vutuv_web/live/post_live/feed.ex:858
+#: lib/vutuv_web/live/post_live/feed.ex:4295
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Nascondi tag"
 
-#: lib/vutuv_web/live/post_live/feed.ex:853
-#: lib/vutuv_web/live/post_live/feed.ex:4278
+#: lib/vutuv_web/live/post_live/feed.ex:857
+#: lib/vutuv_web/live/post_live/feed.ex:4284
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Nascondi parole"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1088
+#: lib/vutuv_web/live/post_live/feed.ex:1093
 #: lib/vutuv_web/live/post_live/filter_band.ex:394
 #, elixir-autogen, elixir-format
 msgid "In your feed right now:"
@@ -22843,7 +22843,7 @@ msgstr "Ora non corrisponde a nulla nel suo feed — la regola vale comunque per
 msgid "More of your %{formatted} accounts"
 msgstr "Altri dei tuoi %{formatted} account"
 
-#: lib/vutuv_web/live/post_live/feed.ex:892
+#: lib/vutuv_web/live/post_live/feed.ex:896
 #, elixir-autogen, elixir-format
 msgid "Move %{card}"
 msgstr "Sposta %{card}"
@@ -22854,12 +22854,12 @@ msgstr "Sposta %{card}"
 msgid "No account found."
 msgstr "Nessun account trovato."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1077
+#: lib/vutuv_web/live/post_live/feed.ex:1082
 #, elixir-autogen, elixir-format
 msgid "No tag called %{name} yet."
 msgstr "Nessun tag chiamato %{name} finora."
 
-#: lib/vutuv_web/live/post_live/feed.ex:846
+#: lib/vutuv_web/live/post_live/feed.ex:850
 #, elixir-autogen, elixir-format
 msgid "Not read yet"
 msgstr "Non ancora letti"
@@ -22889,13 +22889,13 @@ msgstr "I post con uno di questi tag vengono ridotti allo stesso modo."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "I post che contengono una di queste parole vengono ridotti a una riga — non eliminati, e con un modo per aprirli comunque."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4152
+#: lib/vutuv_web/live/post_live/feed.ex:4158
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Messe da parte:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:938
-#: lib/vutuv_web/live/post_live/feed.ex:939
+#: lib/vutuv_web/live/post_live/feed.ex:942
+#: lib/vutuv_web/live/post_live/feed.ex:943
 #, elixir-autogen, elixir-format
 msgid "Remove %{card}"
 msgstr "Rimuovi %{card}"
@@ -22927,8 +22927,8 @@ msgstr "Mostra solo %{source}"
 msgid "Show posts by %{name}"
 msgstr "Mostra i post di %{name}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:852
-#: lib/vutuv_web/live/post_live/feed.ex:4244
+#: lib/vutuv_web/live/post_live/feed.ex:856
+#: lib/vutuv_web/live/post_live/feed.ex:4250
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr "Fonti"
@@ -22938,12 +22938,12 @@ msgstr "Fonti"
 msgid "Switching off means muting, not unfollowing. You stay a follower, the posts just stop reaching your feed: permanently and on every device, until you switch them back on here."
 msgstr "Disattivare significa silenziare, non smettere di seguire. Continui a seguire, ma i post non arrivano più nel tuo feed: in modo permanente e su tutti i dispositivi, finché non li riattivi qui."
 
-#: lib/vutuv_web/live/post_live/feed.ex:916
+#: lib/vutuv_web/live/post_live/feed.ex:920
 #, elixir-autogen, elixir-format
 msgid "Unfold %{card}"
 msgstr "Espandi %{card}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1043
+#: lib/vutuv_web/live/post_live/feed.ex:1048
 #, elixir-autogen, elixir-format
 msgid "Unfollow the tag %{tag}"
 msgstr "Smetti di seguire il tag %{tag}"
@@ -22967,20 +22967,20 @@ msgid_plural "and %{formatted} more"
 msgstr[0] "e 1 altro"
 msgstr[1] "e altri %{formatted}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3709
-#: lib/vutuv_web/live/post_live/feed.ex:3736
+#: lib/vutuv_web/live/post_live/feed.ex:3714
+#: lib/vutuv_web/live/post_live/feed.ex:3741
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
 msgstr "Filtri"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1263
+#: lib/vutuv_web/live/post_live/feed.ex:1268
 #, elixir-autogen, elixir-format
 msgctxt "filtered post"
 msgid "Hidden:"
 msgstr "Nascosto:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:991
+#: lib/vutuv_web/live/post_live/feed.ex:995
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} post in the feed"
 msgid_plural "Show %{formatted} posts in the feed"
@@ -23034,7 +23034,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} post il %{day}"
 msgstr[1] "%{count} post il %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3913
+#: lib/vutuv_web/live/post_live/feed.ex:3918
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Torna al presente"
@@ -23044,7 +23044,7 @@ msgstr "Torna al presente"
 msgid "Busy month: the shading counts at least this much."
 msgstr "Mese intenso: la tonalità indica almeno questo valore."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3959
+#: lib/vutuv_web/live/post_live/feed.ex:3964
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -23066,7 +23066,7 @@ msgstr "Mese successivo"
 msgid "Next year"
 msgstr "Anno successivo"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3909
+#: lib/vutuv_web/live/post_live/feed.ex:3914
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Il %{day} non è arrivato nulla nel Suo feed."
@@ -23153,7 +23153,7 @@ msgstr "È pronta una nuova versione."
 msgid "Page management"
 msgstr "Gestione"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2708
+#: lib/vutuv_web/live/post_live/feed.ex:2713
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
@@ -23185,7 +23185,7 @@ msgstr "Menziona un account"
 msgid "{used} of {max} mentions"
 msgstr "{used} di {max} menzioni"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2820
+#: lib/vutuv_web/live/post_live/feed.ex:2825
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr ""
@@ -23400,7 +23400,7 @@ msgctxt "phone tab bar"
 msgid "Write"
 msgstr "Scrivi"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4047
+#: lib/vutuv_web/live/post_live/feed.ex:4052
 #: lib/vutuv_web/live/post_rewrites_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "%{formatted} rule"
@@ -24197,8 +24197,8 @@ msgstr ""
 msgid "Posts loaded at once"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3983
-#: lib/vutuv_web/live/post_live/feed.ex:3987
+#: lib/vutuv_web/live/post_live/feed.ex:3988
+#: lib/vutuv_web/live/post_live/feed.ex:3992
 #, elixir-autogen, elixir-format
 msgid "Posts per page"
 msgstr "Post per pagina"
@@ -24224,14 +24224,14 @@ msgstr "Una parola o un'espressione …"
 msgid "For whom %{thing} is hidden"
 msgstr "Per chi %{thing} viene nascosto"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4044
-#: lib/vutuv_web/live/post_live/feed.ex:4208
-#: lib/vutuv_web/live/post_live/feed.ex:4217
+#: lib/vutuv_web/live/post_live/feed.ex:4049
+#: lib/vutuv_web/live/post_live/feed.ex:4214
+#: lib/vutuv_web/live/post_live/feed.ex:4223
 #, elixir-autogen, elixir-format
 msgid "Hidden"
 msgstr "Nascosti"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4182
+#: lib/vutuv_web/live/post_live/feed.ex:4188
 #, elixir-autogen, elixir-format
 msgid "Hide something from your feed"
 msgstr "Nascondi qualcosa dal tuo feed"
@@ -24241,12 +24241,12 @@ msgstr "Nascondi qualcosa dal tuo feed"
 msgid "Stop showing"
 msgstr "Non mostrare più"
 
-#: lib/vutuv_web/live/post_live/feed.ex:4223
+#: lib/vutuv_web/live/post_live/feed.ex:4229
 #, elixir-autogen, elixir-format
 msgid "Whatever these match is folded to a single line in your feed."
 msgstr "Ciò che corrisponde viene ridotto a una riga nel tuo feed."
 
-#: lib/vutuv_web/live/post_live/feed.ex:4243
+#: lib/vutuv_web/live/post_live/feed.ex:4249
 #, elixir-autogen, elixir-format
 msgid "Words & tags"
 msgstr "Parole e tag"
@@ -26077,14 +26077,14 @@ msgctxt "content type"
 msgid "File"
 msgstr "File"
 
-#: lib/vutuv_web/live/post_live/trending_tags.ex:96
+#: lib/vutuv_web/live/post_live/trending_tags.ex:139
 #, elixir-autogen, elixir-format
 msgid "Follow %{tag}. %{uses} uses today on %{servers} server, against %{baseline} on an ordinary day."
 msgid_plural "Follow %{tag}. %{uses} uses today on %{servers} servers, against %{baseline} on an ordinary day."
 msgstr[0] "Segui %{tag}. Oggi %{uses} post su %{servers} server, contro %{baseline} in un giorno normale."
 msgstr[1] "Segui %{tag}. Oggi %{uses} post su %{servers} server, contro %{baseline} in un giorno normale."
 
-#: lib/vutuv_web/live/post_live/trending_tags.ex:48
+#: lib/vutuv_web/live/post_live/trending_tags.ex:81
 #, elixir-autogen, elixir-format
 msgid "Very busy on other servers right now:"
 msgstr "Ora molto attivi su altri server:"
@@ -26290,6 +26290,11 @@ msgstr "Questo logo contiene %{marker}, che vutuv legge come file incorporato e 
 #, elixir-autogen, elixir-format
 msgid "This logo has a file embedded in it, usually a web font, that vutuv cannot check. Export it again with the text converted to outlines."
 msgstr "Questo logo contiene un file incorporato, di solito un font web, che vutuv non può verificare. Lo esporti di nuovo convertendo il testo in tracciati."
+
+#: lib/vutuv_web/live/post_live/trending_tags.ex:87
+#, elixir-autogen, elixir-format
+msgid "Nothing yet today. A topic has to run well ahead of its own last week, which takes a few hours."
+msgstr "Oggi ancora niente. Un argomento deve superare nettamente la propria settimana precedente, e ci vogliono alcune ore."
 
 #: lib/vutuv_web/components/pending_post_components.ex:64
 #, elixir-autogen, elixir-format

--- a/test/vutuv_web/live/feed_trending_tags_test.exs
+++ b/test/vutuv_web/live/feed_trending_tags_test.exs
@@ -28,6 +28,12 @@ defmodule VutuvWeb.PostLive.FeedTrendingTagsTest do
   # As measured on 10 September 2026: 1,084 uses against a median of 3.
   @warntag [1084, 16, 11, 3, 1, 3, 2]
 
+  # Everything the trending pill may wear that the pill above it does not: it is
+  # the one that lays a sparkline out beside its label. Named as the whole
+  # allowed difference rather than as a list of size spellings — an allowlist of
+  # utilities to compare reads green for every spelling nobody thought of.
+  @layout_extras MapSet.new(~w(flex max-w-full items-center gap-1.5))
+
   setup %{conn: conn} do
     put_config(:fetch_external_tag_posts, true)
     put_config(:fetch_trending_tags, true)
@@ -49,6 +55,24 @@ defmodule VutuvWeb.PostLive.FeedTrendingTagsTest do
   end
 
   defp pill(live), do: element(live, "#trending-tags button")
+
+  defp classes(live, selector) do
+    [element] = live |> render() |> elements(selector)
+
+    element |> attribute("class") |> String.split() |> MapSet.new()
+  end
+
+  # A tag on a post in the reader's own feed, which is what the card offers a
+  # few pixels above the trending row — the pill #2180 measures against.
+  defp tag_on_the_page(user) do
+    friend = insert(:activated_user)
+    insert(:follow, follower: user, followee: friend)
+
+    name = Vutuv.Factory.unique_tag_name("Bremen")
+    Vutuv.PostsHelpers.create_post!(friend, %{body: "moin", tags: name})
+
+    name
+  end
 
   describe "the row" do
     test "offers what is spiking, with the week it was judged on", %{conn: conn} do
@@ -72,12 +96,41 @@ defmodule VutuvWeb.PostLive.FeedTrendingTagsTest do
                "2,168 uses today on 2 servers, against 6 on an ordinary day"
     end
 
-    test "draws nothing at all when this installation reads no other servers", %{conn: conn} do
+    test "draws nothing at all when the feature is switched off", %{conn: conn} do
       put_config(:fetch_trending_tags, false)
 
       {:ok, _live, html} = live(conn, ~p"/feed")
 
       refute html =~ "Very busy on other servers right now:"
+    end
+
+    # An intranet installation names no servers at all (`SourceServers`'s empty
+    # list is a real setting), so nobody is asked and the empty state below
+    # would be a nightly report about servers this installation never reads.
+    test "draws nothing at all when no server is configured to ask", %{conn: conn} do
+      put_config(:tag_source_servers, [])
+
+      {:ok, _live, html} = live(conn, ~p"/feed")
+
+      refute html =~ "Very busy on other servers right now:"
+    end
+
+    # Issue #2165: a tag qualifies on today's volume against its own six-day
+    # median, so shortly after midnight nothing can clear the bar. The row used
+    # to take its label with it, which reads as breakage rather than as quiet.
+    test "keeps its place and says why when there is nothing to offer", %{conn: conn} do
+      {:ok, live, _html} = live(conn, ~p"/feed")
+
+      # Following the one tag on offer empties it, exactly as midnight does.
+      render_click(pill(live))
+      html = render(live)
+
+      assert html =~ "Very busy on other servers right now:"
+
+      assert html =~
+               "Nothing yet today. A topic has to run well ahead of its own last week, which takes a few hours."
+
+      refute has_element?(live, "#trending-tags button")
     end
   end
 
@@ -96,10 +149,10 @@ defmodule VutuvWeb.PostLive.FeedTrendingTagsTest do
       assert @big in sources
 
       # And it is a followed tag like any other from here on: the chip above
-      # counts its servers, and the row no longer offers it.
-      html = render(live)
-      assert html =~ "tag-sources-chip-#{tag.id}"
-      refute html =~ "trending-tags"
+      # counts its servers, and the row no longer offers it. What the row shows
+      # instead is the empty-state test's business (issue #2165).
+      assert render(live) =~ "tag-sources-chip-#{tag.id}"
+      refute has_element?(live, "#trending-tags button")
     end
 
     test "a pushed name nobody is offering follows nothing", %{conn: conn, user: user} do
@@ -126,6 +179,57 @@ defmodule VutuvWeb.PostLive.FeedTrendingTagsTest do
       # wrong rules is misread rather than untidy.
       assert render(pill(live)) =~
                "warntag folgen. Heute 2.168 Beiträge auf 2 Servern, an einem gewöhnlichen Tag 6."
+    end
+
+    # A short new msgid is the likeliest thing `gettext.extract --merge` fuzzy-
+    # fills with a neighbour's translation, and the least likely to be noticed —
+    # so the empty row's German is asserted by name.
+    test "the empty row says so in German too", %{conn: conn} do
+      {:ok, live, _html} =
+        conn
+        |> recycle()
+        |> put_req_header("accept-language", "de-DE,de")
+        |> live(~p"/feed")
+
+      render_click(pill(live))
+      html = render(live)
+
+      assert html =~ "Gerade sehr aktiv auf anderen Servern:"
+
+      assert html =~
+               "Heute noch nichts. Ein Thema muss deutlich über seiner eigenen Vorwoche liegen, und das dauert ein paar Stunden."
+    end
+  end
+
+  # Issue #2180: the card stacks three rows of pills and the bottom one was
+  # drawn to a recipe of its own — bigger type, more padding, a 40px box — so in
+  # a 309px rail each trending tag landed on a line of its own while the tags
+  # above sat three to a row.
+  describe "the pill" do
+    test "is the same size as the tags offered a few pixels above it", %{conn: conn, user: user} do
+      name = tag_on_the_page(user)
+
+      {:ok, live, _html} = live(conn, ~p"/feed")
+
+      trending = classes(live, "#trending-tags button")
+      offered = classes(live, ~s(#rail-followed_tags button[phx-value-name="#{name}"]))
+
+      # Both directions: the trending pill may add the layout its sparkline
+      # needs and nothing else, and it may drop nothing the pill above wears.
+      assert MapSet.difference(trending, offered) == @layout_extras
+      assert MapSet.difference(offered, trending) == MapSet.new()
+    end
+
+    test "sizes the seven-day sparkline to fit that pill", %{conn: conn} do
+      {:ok, live, _html} = live(conn, ~p"/feed")
+
+      bars = live |> element("#trending-tags button span[aria-hidden]") |> render()
+
+      # The sparkline is as tall as the pill's own line box (h-4 = 1rem, the
+      # `text-xs` line height) and all seven strokes are hairlines, so the week
+      # rides inside the pill instead of setting its size.
+      assert bars =~ "h-4"
+      assert length(Regex.scan(~r/w-0\.5/, bars)) == 7
     end
   end
 


### PR DESCRIPTION
Two small things in the feed's tag card, `VutuvWeb.PostLive.TrendingTags` on `/feed`.

**The row vanished every night.** A tag qualifies on today's volume against its own six-day median, so shortly after midnight nothing clears the bar, the offer empties and the whole block went with it, label and all. It keeps its place now and says why it is empty in one muted line. Kept the judgement window as it is and fixed the presentation: a rolling window is tuning, and #2160 owns that. The row is drawn only where `Vutuv.Tags.Trending.asking?/0` is true, so an intranet installation with no source servers gets no row rather than a nightly report about servers it never reads.

**The pills were a size of their own.** Measured in a 309px rail at 1280px: 14px/600 type, 6/12px padding, a 40px box, five tags over four lines. They now wear the pill above them exactly (12px/500, 4/10px, 24px) with the sparkline sized to fit, three lines instead of four.

Closes #2165
Closes #2180

https://claude.ai/code/session_01AW11tx7rYiSEaRDjPFNghY
